### PR TITLE
chore: pause build validation workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build Validation
 
+# Temporarily paused - uncomment to re-enable
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main, release ]
+  # pull_request:
+  #   branches: [ main, release ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Temporarily disable automatic build validation on pull requests by commenting out the pull_request trigger. The workflow can still be triggered manually via workflow_dispatch.