### PR TITLE
Inject incident ID and prevent incident fix suggestions being deleted

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -485,6 +485,12 @@ def with_forced_context(func):
             logging.error(f"with_forced_context: No session_id in context for {func.__name__}")
             raise ValueError(f"No session_id available in context for {func.__name__}")
         
+        # Inject incident_id if available (for RCA sessions)
+        context_incident_id = context_state.incident_id if context_state and hasattr(context_state, 'incident_id') else None
+        if context_incident_id:
+            kwargs['incident_id'] = context_incident_id
+            logging.info(f"with_forced_context: Forced incident_id from context: {context_incident_id} for {func.__name__}")
+        
         # Validate user_id format
         user_id = kwargs['user_id']
         from utils.auth.stateless_auth import is_valid_user_id

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -110,9 +110,12 @@ def _save_fix_suggestion(
             )
             result = cursor.fetchone()
             conn.commit()
-            return result[0] if result else None
+            suggestion_id = result[0] if result else None
+            if suggestion_id:
+                logger.info(f"Saved fix suggestion {suggestion_id} for incident {incident_id}")
+            return suggestion_id
     except Exception as e:
-        logger.error(f"Failed to save fix suggestion: {e}")
+        logger.error(f"Failed to save fix suggestion: {e}", exc_info=True)
         return None
 
 

--- a/server/chat/backend/agent/utils/state.py
+++ b/server/chat/backend/agent/utils/state.py
@@ -9,6 +9,7 @@ class State(BaseModel):
     refined_question: Optional[str] = None
     user_id: Optional[str] = None
     session_id: Optional[str] = None  # Add session ID for tracking chat sessions
+    incident_id: Optional[str] = None  # Incident ID for RCA sessions
     provider_preference: Optional[List[str]] = None  # Must be explicitly set, e.g. ["gcp", "aws", "azure"]
     selected_project_id: Optional[str] = None  # Selected project ID from frontend UI
     attachments: Optional[List[Dict[str, Any]]] = None  # File attachments

--- a/server/chat/background/suggestion_extractor.py
+++ b/server/chat/background/suggestion_extractor.py
@@ -293,9 +293,10 @@ def save_incident_suggestions(incident_id: str, suggestions: List[Suggestion]) -
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                # Delete existing suggestions for this incident
+                # Delete existing NON-FIX suggestions for this incident
+                # Preserve fix suggestions created by github_fix tool
                 cursor.execute(
-                    "DELETE FROM incident_suggestions WHERE incident_id = %s",
+                    "DELETE FROM incident_suggestions WHERE incident_id = %s AND type != 'fix'",
                     (incident_id,),
                 )
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -406,6 +406,7 @@ async def _execute_background_chat(
         state = State(
             user_id=user_id,
             session_id=session_id,
+            incident_id=incident_id,
             provider_preference=provider_preference,
             selected_project_id=None,
             messages=[human_message],


### PR DESCRIPTION
## Fix: GitHub fix suggestions not appearing in RCA summaries

### Problem
The `github_fix` tool was failing during RCA sessions with error "Incident ID is required" and even when executing successfully, fix suggestions were being deleted and replaced by generic diagnostic suggestions during the summarization phase.

### Root Causes
1. **Missing incident_id in workflow context**: The `State` class and `with_forced_context` decorator did not pass `incident_id` to tools during background RCA sessions
2. **Race condition in summarization**: The `save_incident_suggestions` function deleted ALL existing suggestions before inserting new ones, removing fix suggestions created by `github_fix`

### Changes Made

**1. Added incident_id to workflow state** (3 files, 7 lines)
- Added `incident_id` field to `State` class in `server/chat/backend/agent/utils/state.py`
- Updated `with_forced_context` decorator in `server/chat/backend/agent/tools/cloud_tools.py` to inject `incident_id` from state context
- Pass `incident_id` when creating State in `server/chat/background/task.py`

**2. Preserved fix suggestions during summarization** (2 files, 5 lines)
- Modified `save_incident_suggestions` in `server/chat/background/suggestion_extractor.py` to only delete non-fix type suggestions
- Added logging to `_save_fix_suggestion` in `server/chat/backend/agent/tools/github_fix_tool.py` for better debugging

### Testing
- Sent test Datadog alert to trigger RCA
- Verified `github_fix` tool executes successfully with incident_id injected
- Confirmed fix suggestions (type='fix') are saved to database and preserved after summarization
- Verified fix suggestions appear in RCA summaries with proper file paths and repository info

### Impact
- RCA sessions can now create actionable code fix suggestions
- Fix suggestions are preserved and displayed in the Incidents UI
- Users can review, edit, and create PRs from fix suggestions