### PR TITLE
Add context trim middleware to prevent context overflow during long RCA runs

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -166,6 +166,7 @@ class Agent:
             from langchain.agents import create_agent
             from langchain_core.callbacks import BaseCallbackHandler
             from .tools.cloud_tools import get_cloud_tools, set_user_context, set_tool_capture
+            from .middleware import ContextTrimMiddleware
 
             logging.info(f"agentic_tool_flow: State has user_id {state.user_id} and session_id {state.session_id}")
             # Set user context for tools
@@ -452,10 +453,14 @@ class Agent:
                 )
             
             # Create the agent using new LangChain 1.2.6+ API
+            # ContextTrimMiddleware prevents context overflow during long ReAct loops
+            # (e.g., RCA with 240 iterations) by trimming messages before each LLM call.
+            # Only affects what the LLM sees — full history is preserved in graph state.
             agent_graph = create_agent(
                 model=streaming_llm,
                 tools=tools,
-                system_prompt=system_prompt_text
+                system_prompt=system_prompt_text,
+                middleware=[ContextTrimMiddleware(model_name=model_name)],
             )
 
       

--- a/server/chat/backend/agent/middleware/__init__.py
+++ b/server/chat/backend/agent/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .context_trim import ContextTrimMiddleware
+
+__all__ = ["ContextTrimMiddleware"]

--- a/server/chat/backend/agent/middleware/context_trim.py
+++ b/server/chat/backend/agent/middleware/context_trim.py
@@ -1,0 +1,84 @@
+"""
+Context trimming middleware for LangChain create_agent.
+
+Prevents context overflow during long-running ReAct loops (e.g., RCA investigations
+with 240 recursion limit) by trimming messages before each LLM call. Only affects
+what the LLM sees — the full message history is preserved in graph state.
+"""
+
+import logging
+from typing import Awaitable, Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages.utils import trim_messages, count_tokens_approximately
+
+from ..utils.chat_context_manager import ChatContextManager
+
+logger = logging.getLogger(__name__)
+
+# Use 75% of the model's context limit, leaving headroom for the response
+_CONTEXT_USAGE_RATIO = 0.75
+
+
+class ContextTrimMiddleware(AgentMiddleware):
+    """Trims messages before each LLM call to prevent context overflow.
+
+    During a ReAct agent loop, tool outputs accumulate in the message list
+    without any trimming between iterations. With a high recursion limit
+    (e.g., 240 for RCA), the context can grow far beyond the model's limit.
+
+    This middleware intercepts each LLM call via awrap_model_call and trims
+    the ModelRequest.messages to fit within the model's context window.
+    Because it modifies the request (not the graph state), the full message
+    history is preserved for persistence.
+
+    Args:
+        model_name: Model name in OpenRouter format (e.g., "anthropic/claude-opus-4.5").
+            Used to look up the context limit from ChatContextManager.MODEL_CONTEXT_LIMITS.
+    """
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.max_tokens = int(
+            ChatContextManager.get_context_limit(model_name) * _CONTEXT_USAGE_RATIO
+        )
+        logger.info(
+            f"ContextTrimMiddleware initialized: model={model_name}, "
+            f"max_tokens={self.max_tokens}"
+        )
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        original_count = len(request.messages)
+        estimated_tokens = count_tokens_approximately(request.messages)
+
+        if estimated_tokens <= self.max_tokens:
+            return await handler(request)
+
+        logger.warning(
+            f"Context trimming triggered: {estimated_tokens} tokens "
+            f"(limit: {self.max_tokens}) across {original_count} messages"
+        )
+
+        trimmed = trim_messages(
+            request.messages,
+            strategy="last",
+            token_counter=count_tokens_approximately,
+            max_tokens=self.max_tokens,
+            start_on="human",
+            end_on=("human", "tool"),
+        )
+
+        trimmed_count = len(trimmed)
+        trimmed_tokens = count_tokens_approximately(trimmed)
+
+        logger.info(
+            f"Context trimmed: {original_count} -> {trimmed_count} messages, "
+            f"~{estimated_tokens} -> ~{trimmed_tokens} tokens"
+        )
+
+        return await handler(request.override(messages=trimmed))


### PR DESCRIPTION
Implements automatic context trimming to manage token usage and prevent context window overflow when processing extended root cause analysis sessions. Includes middleware integration and context manager updates.