### PR TITLE
fix: update SSH Keys and VM Config buttons to white background

### DIFF
--- a/client/src/components/connectors/ConnectorCard.tsx
+++ b/client/src/components/connectors/ConnectorCard.tsx
@@ -223,16 +223,14 @@ export default function ConnectorCard({ connector }: ConnectorCardProps) {
             <div className="flex gap-2 w-full">
               <Button
                 onClick={() => router.push("/settings/ssh-keys")}
-                className="w-full"
-                variant="outline"
+                className="w-full bg-white text-black hover:bg-gray-100"
               >
                 <KeyRound className="h-4 w-4 mr-2" />
                 SSH Keys
               </Button>
               <Button
                 onClick={() => router.push("/vm-config")}
-                className="w-full"
-                variant="outline"
+                className="w-full bg-white text-black hover:bg-gray-100"
               >
                 <Settings className="h-4 w-4 mr-2" />
                 VM Config

--- a/client/src/components/connectors/OnPremCard.tsx
+++ b/client/src/components/connectors/OnPremCard.tsx
@@ -37,8 +37,7 @@ export default function OnPremCard() {
       <CardFooter className="flex gap-2">
         <Button 
           onClick={() => router.push("/settings/ssh-keys")}
-          className="w-full bg-white hover:bg-gray-50 text-black border"
-          variant="outline"
+          className="w-full bg-white text-black hover:bg-gray-100"
         >
           <KeyRound className="h-4 w-4 mr-2" />
           SSH Keys
@@ -46,8 +45,7 @@ export default function OnPremCard() {
         
         <Button
           onClick={() => router.push("/vm-config")}
-          className="w-full bg-white hover:bg-gray-50 text-black border"
-          variant="outline"
+          className="w-full bg-white text-black hover:bg-gray-100"
         >
           <Settings className="h-4 w-4 mr-2" />
           VM Config


### PR DESCRIPTION
## Summary
- Updated SSH Keys and VM Config button styling from outline variant to solid white background with black text
- Applied consistent styling across both `ConnectorCard.tsx` and `OnPremCard.tsx`
- Improves button visibility and consistency with other UI elements

## Test plan
- [x] Verify buttons appear with white background and black text on the Instances SSH Access card
- [x] Confirm hover state shows slightly darker gray (`hover:bg-gray-100`)