### PR TITLE
fix: clean up incidents UI and remove New Chat from navigation

### DIFF
--- a/client/src/app/components/AppLayout.tsx
+++ b/client/src/app/components/AppLayout.tsx
@@ -7,7 +7,7 @@ import { signOut } from "next-auth/react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
-import { Edit3, Settings, LogOut } from "lucide-react";
+import { Settings, LogOut } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -96,23 +96,6 @@ const SidebarStrip = ({
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={5}>
               <p>Open Sidebar</p>
-            </TooltipContent>
-          </Tooltip>
-          
-          {/* New Chat button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onClick={onNewChatClick}
-                variant="outline"
-                size="sm"
-                className="h-10 w-10 rounded-full p-0 shadow-md border border-border bg-card flex items-center justify-center"
-              >
-                <Edit3 className="h-5 w-5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>New Chat</p>
             </TooltipContent>
           </Tooltip>
         </div>

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -146,10 +146,9 @@ export default function IncidentsPage() {
     <div className="max-w-4xl mx-auto py-8 px-4">
       <div className="mb-8">
         <h1 className="text-3xl font-bold flex items-center gap-2">
-          <Zap className="h-6 w-6 text-orange-500" />
+          <Zap className="h-6 w-6 text-foreground" />
           Incidents
         </h1>
-        <p className="text-muted-foreground mt-1">Aurora automatically investigates all incoming alerts</p>
       </div>
 
       {loading ? (
@@ -163,8 +162,8 @@ export default function IncidentsPage() {
             <div>
               <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
                 <span className="relative flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-orange-500"></span>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground"></span>
                 </span>
                 Investigating ({activeIncidents.length})
               </h2>
@@ -180,7 +179,7 @@ export default function IncidentsPage() {
           {analyzedIncidents.length > 0 && (
             <div>
               <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4 text-blue-500" />
+                <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
                 Analyzed
               </h2>
               <div className="space-y-2">
@@ -230,7 +229,7 @@ function IncidentRow({ incident }: { incident: Incident }) {
 
   return (
     <Link href={`/incidents/${incident.id}`} aria-label={`View incident: ${incident.alert.title}`}>
-      <Card className={`hover:border-primary/50 transition-colors cursor-pointer ${isActive ? 'border-l-4 border-l-orange-500' : ''}`}>
+      <Card className={`hover:border-primary/50 transition-colors cursor-pointer ${isActive ? 'border-l-4 border-l-muted-foreground' : ''}`}>
         <CardContent className="py-3 px-4">
           <div className="flex items-center gap-4">
             {/* Severity - hide if unknown during investigation */}
@@ -250,7 +249,7 @@ function IncidentRow({ incident }: { incident: Incident }) {
                   {incidentsService.formatDuration(incident.startedAt)}
                 </span>
                 {isActive && (
-                  <span className="flex items-center gap-1 text-orange-400">
+                  <span className="flex items-center gap-1 text-muted-foreground">
                     <Loader2 className="h-3 w-3 animate-spin" />
                     Aurora investigating
                   </span>

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { ChevronLeft, List, Settings, Edit3, LogOut, User, HelpCircle, Bug, Sparkles, Plug, Zap } from "lucide-react"
+import { ChevronLeft, List, Settings, LogOut, User, HelpCircle, Bug, Sparkles, Plug, Zap } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import ChatHistory from "@/components/ChatHistory"
@@ -154,13 +154,13 @@ export default function Navigation({
                 )}
               >
                 <div className="flex items-center">
-                  <Zap size={16} className="text-orange-400" />
+                  <Zap size={16} className="text-foreground" />
                   <span className="ml-2">Incidents</span>
                 </div>
                 {/* Running indicator - shows when Aurora is investigating */}
                 <span className="relative flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-orange-500"></span>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground"></span>
                 </span>
               </Link>
             </li>
@@ -181,34 +181,6 @@ export default function Navigation({
                 <span className="ml-2">Connectors</span>
               </div>
             </Link>
-          </li>
-
-          {/* New Chat Button - accessible from all pages */}
-          <li>
-            <div
-              onClick={() => {
-                if (pathname === "/chat") {
-                  // If already on chat page, just add the query parameter to trigger new chat
-                  window.location.href = "/chat?newChat=true";
-                } else {
-                  // Otherwise, navigate to chat page for new chat
-                  // Add a parameter to indicate this is a new chat request
-                  router.push("/chat?newChat=true");
-                }
-              }}
-              className={cn(
-                "w-full flex items-center justify-between px-2.5 py-1.5 rounded-md hover:bg-primary/10 transition-colors text-sm border border-transparent hover:border-border/50 cursor-pointer",
-                pathname === "/chat" 
-                  ? "bg-card rounded-lg border border-border shadow-sm" 
-                  : "text-muted-foreground"
-              )}
-            >
-              <div className="flex items-center">
-                <Edit3 size={16} />
-                <span className="ml-2">New Chat</span>
-              </div>
-
-            </div>
           </li>
 
           {/* Chat History Section */}


### PR DESCRIPTION
## Summary
- Remove orange accent colors from incidents page (lightning bolt icon, investigating indicator dots, active card borders)
- Remove blue accent from analyzed section checkmark
- Remove subtitle text "Aurora automatically investigates all incoming alerts"
- Remove New Chat button from sidebar navigation and collapsed mini-bar

Severity badge colors are preserved.

## Test plan
- [x] Verify incidents page header shows neutral-colored lightning bolt
- [x] Verify "Investigating" section has neutral indicator dot
- [x] Verify "Analyzed" section has neutral checkmark icon
- [x] Verify active incident cards have neutral left border
- [x] Verify New Chat button no longer appears in sidebar or collapsed view