### PR TITLE
Fix button overflow in on-premises SSH connector card

### DIFF
--- a/client/src/components/connectors/ConnectorCard.tsx
+++ b/client/src/components/connectors/ConnectorCard.tsx
@@ -240,20 +240,20 @@ export default function ConnectorCard({ connector }: ConnectorCardProps) {
         <CardFooter className="flex flex-col gap-2">
           {connector.id === 'onprem' ? (
             // On Prem always shows both buttons
-            <div className="flex gap-2 w-full">
+            <div className="flex gap-2 w-full flex-wrap">
               <Button
                 onClick={() => router.push("/settings/ssh-keys")}
-                className="w-full bg-white text-black hover:bg-gray-100"
+                className="flex-1 min-w-[120px] bg-white text-black hover:bg-gray-100"
               >
-                <KeyRound className="h-4 w-4 mr-2" />
-                SSH Keys
+                <KeyRound className="h-4 w-4 mr-2 shrink-0" />
+                <span className="truncate">SSH Keys</span>
               </Button>
               <Button
                 onClick={() => router.push("/vm-config")}
-                className="w-full bg-white text-black hover:bg-gray-100"
+                className="flex-1 min-w-[120px] bg-white text-black hover:bg-gray-100"
               >
-                <Settings className="h-4 w-4 mr-2" />
-                VM Config
+                <Settings className="h-4 w-4 mr-2 shrink-0" />
+                <span className="truncate">VM Config</span>
               </Button>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- Fixed horizontal overflow of SSH Keys and VM Config buttons in the on-premises connector card
- Added `flex-wrap` to allow buttons to wrap on narrow screens
- Changed buttons from fixed `w-full` to flexible `flex-1` with `min-w-[120px]` to allow proportional shrinking
- Added `shrink-0` to icons to prevent icon compression
- Wrapped button text in `truncate` spans for graceful text overflow handling

## Test plan
- [x] Verify buttons display correctly at various screen widths
- [x] Confirm no horizontal overflow occurs on the connector card
- [x] Test that buttons wrap to two rows on very narrow screens if needed
- [x] Verify icons maintain their size and don't get compressed