### PR TITLE
Pin SeaweedFS to 4.07 to avoid S3 nil pointer panic in 4.09

### DIFF
--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -452,7 +452,7 @@ services:
   # ═══════════════════════════════════════════════════════════════════════════
 
   seaweedfs-master:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-master
     command: >
       master
@@ -475,7 +475,7 @@ services:
       start_period: 10s
 
   seaweedfs-volume:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-volume
     command: >
       volume
@@ -500,7 +500,7 @@ services:
       start_period: 10s
 
   seaweedfs-filer:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-filer
     command: >
       filer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -432,7 +432,7 @@ services:
   # ═══════════════════════════════════════════════════════════════════════════
 
   seaweedfs-master:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-master
     command: >
       master
@@ -455,7 +455,7 @@ services:
       start_period: 10s
 
   seaweedfs-volume:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-volume
     command: >
       volume
@@ -480,7 +480,7 @@ services:
       start_period: 10s
 
   seaweedfs-filer:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.07
     container_name: aurora-seaweedfs-filer
     command: >
       filer


### PR DESCRIPTION
## Summary                                                                                                                                                                        
  - Pin SeaweedFS Docker image from `latest` to `4.07` across both `docker-compose.yaml` and `docker-compose.prod-local.yml`                                                        
  - SeaweedFS `latest` (4.09, built 2026-02-03) has a nil pointer dereference bug in `s3.go:308` during S3 gateway startup, causing the filer container to crash repeatedly         
  - Reproduced on clean volumes with isolated Docker network — confirmed upstream regression, not a config issue                                                                    
  - `4.07` (2026-01-19) is the last stable release before the broken `4.08`/`4.09` builds                                                                                           
                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                      
  - [x] Verified `latest` (4.09) panics on fresh volumes with our `s3.json` config                                                                                                  
  - [x] Verify `make dev` starts all containers successfully with `4.07`                                                                                                            
  - [x] Verify S3 operations work (bucket creation, file upload/download)                                                                                                           
  - [x] Verify `make prod` works with `4.07` 