### PR TITLE
fix(db): add missing merged_into_incident_id column to incidents table

### DIFF
--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -545,12 +545,14 @@ def initialize_tables():
                          active_tab VARCHAR(10) DEFAULT 'thoughts',
                          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                         merged_into_incident_id UUID REFERENCES incidents(id) ON DELETE SET NULL,
                          UNIQUE(source_type, source_alert_id, user_id)
                      );
                      
                      CREATE INDEX IF NOT EXISTS idx_incidents_user_id ON incidents(user_id, started_at DESC);
                      CREATE INDEX IF NOT EXISTS idx_incidents_status ON incidents(status);
                      CREATE INDEX IF NOT EXISTS idx_incidents_source ON incidents(source_type, source_alert_id);
+                     CREATE INDEX IF NOT EXISTS idx_incidents_merged ON incidents(merged_into_incident_id) WHERE merged_into_incident_id IS NOT NULL;
                  """,
                 "incident_alerts": """
                     CREATE TABLE IF NOT EXISTS incident_alerts (


### PR DESCRIPTION
## Summary
- Fixes 500 error on incidents page caused by missing `merged_into_incident_id` column
- Adds the column to the incidents table schema in `db_utils.py`
- Adds index for query performance on merged incidents

## Problem
The incidents API (`/api/incidents`) was querying `merged_into_incident_id` but the column was missing from the table, causing this error:
```
psycopg2.errors.UndefinedColumn: column i.merged_into_incident_id does not exist
```

## Solution
- Added `merged_into_incident_id UUID REFERENCES incidents(id) ON DELETE SET NULL` to incidents table
- Added index `idx_incidents_merged` for better performance
- Applied fix directly to running database and updated schema for new installations

## Test plan
- [x] Fix applied to running database
- [x] Incidents page now loads without errors
- [x] Schema updated for future database initializations
- [ ] Test incident merging functionality (if implemented)