### PR TITLE
fix(db): set correlated_alert_count default to 0 instead of 1

### DIFF
--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1134,7 +1134,7 @@ def initialize_tables():
             try:
                 cursor.execute("""
                     ALTER TABLE incidents
-                    ADD COLUMN IF NOT EXISTS correlated_alert_count INTEGER DEFAULT 1;
+                    ADD COLUMN IF NOT EXISTS correlated_alert_count INTEGER DEFAULT 0;
                 """)
                 logging.info(
                     "Added correlated_alert_count column to incidents table (if not exists)."


### PR DESCRIPTION
The count should represent additional correlated alerts, not including the original alert. Changed default from 1 to 0 so incidents show '0 related' when they have no correlated alerts.