### PR TITLE
fix(correlation): add exact service match check to topology strategy

### DIFF
--- a/server/services/correlation/strategies/topology.py
+++ b/server/services/correlation/strategies/topology.py
@@ -81,6 +81,10 @@ class TopologyStrategy(CorrelationStrategy):
 
             best_score = 0.0
             for svc in incident_services:
+                # Exact match: same service -> perfect correlation
+                if svc == alert_service:
+                    return 1.0
+                
                 # Upstream check (alert depends on incident service)
                 if svc in upstream_map:
                     depth = upstream_map[svc]


### PR DESCRIPTION
## Summary
- Add exact service match check to topology correlation strategy
- Returns perfect score (1.0) when alert service matches incident service
- Prevents topology scoring from giving lower weights to same-service alerts

## Test plan
- [x] Code review
- [ ] Test with PagerDuty alerts from same service
- [ ] Verify correlation scores are 1.0 for exact matches