### PR TITLE
fix(ui): show visualization button for incidents in idle status

### DIFF
--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -521,7 +521,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
             </button>
           )}
           
-          {(incident.auroraStatus === 'complete' || incident.auroraStatus === 'running') && (
+          {incident.auroraStatus !== 'error' && (
             <button
               onClick={() => setShowVisualization(!showVisualization)}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors bg-zinc-800 hover:bg-zinc-700 text-white border border-zinc-700 hover:border-zinc-600"
@@ -546,7 +546,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
       )}
 
       {/* Infrastructure Visualization */}
-      {showVisualization && (incident.auroraStatus === 'complete' || incident.auroraStatus === 'running') && (
+      {showVisualization && incident.auroraStatus !== 'error' && (
         <>
           <div className="border-t border-zinc-800" />
           <div>

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -8,7 +8,7 @@
 
 export type AlertSource = 'netdata' | 'datadog' | 'grafana' | 'prometheus' | 'pagerduty';
 export type IncidentStatus = 'investigating' | 'analyzed' | 'merged';
-export type AuroraStatus = 'running' | 'complete' | 'error';
+export type AuroraStatus = 'idle' | 'running' | 'complete' | 'error';
 export type SuggestionRisk = 'safe' | 'low' | 'medium' | 'high';
 export type SuggestionType = 'diagnostic' | 'mitigation' | 'communication' | 'fix';
 


### PR DESCRIPTION
## Summary
- Show visualization button for incidents in `idle` status (not just `running` or `complete`)
- Add `idle` to the `AuroraStatus` TypeScript type definition
- Change button visibility logic from whitelist to blacklist (show unless `error`)

## Problem
The visualization button was only visible when `auroraStatus === 'running'` or `auroraStatus === 'complete'`. However, incidents start in `'idle'` status (the backend default), so users couldn't access the visualization feature even though:
1. The visualization component exists and works
2. The incident may already have topology data
3. Users need to manually click to expand it anyway

This caused confusion when users expected to see the visualization button but it was missing.

## Solution
- Added `'idle'` to the `AuroraStatus` type (was missing but used by backend)
- Changed button condition from `(status === 'complete' || status === 'running')` to `status !== 'error'`
- Updated visualization render condition to match
- No status pill is shown for `'idle'` (existing behavior preserved)

Now the button appears for `idle`, `running`, and `complete` statuses, and only hides for `error` status.

## Test plan
- [x] Code review
- [ ] Test with incident in `idle` status - button should appear
- [ ] Test with incident in `running` status - button should appear (no regression)
- [ ] Test with incident in `complete` status - button should appear (no regression)
- [ ] Test with incident in `error` status - button should NOT appear
- [ ] Click button to expand/collapse visualization - should work correctly