### PR TITLE
fix issue when some network components aren't being taken down on mak…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ build:
 	docker compose build
 
 down:
-	docker compose down
+	@for ep in $$(docker network inspect aurora_default -f '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null); do docker network disconnect -f aurora_default $$ep 2>/dev/null; done; true
+	docker compose down --remove-orphans
 
 logs:
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \


### PR DESCRIPTION
Issue where if a container failed during creation, make down would not down the network components associated with it. Would print this sort of message: "! Network aurora_default               Resource is still in use " 

This PR is simply better cleanup on make down