### PR TITLE
fix(rca): fix chat session linking for PagerDuty incidents

### DIFF
--- a/server/routes/pagerduty/tasks.py
+++ b/server/routes/pagerduty/tasks.py
@@ -380,6 +380,7 @@ def trigger_delayed_rca(
                         "incident_number": incident_number,
                         "urgency": incident_urgency,
                     },
+                    incident_id=incident_db_id,  # Link session to incident
                 )
                 # Start RCA task and immediately store task ID for cancellation support
                 task = run_background_chat.delay(


### PR DESCRIPTION
## Summary
- Fixed missing `rca_celery_task_id` column causing session linking to fail
- Added `incident_id` parameter to `create_background_chat_session` call
- Enables proper bidirectional linking between incidents and RCA chat sessions

## Problem
RCA investigations were completing successfully but failing to link the chat session to the incident. This caused:
- No "Root Cause Analysis" button on incident detail page
- `incidents.aurora_chat_session_id` remained NULL
- `incidents.aurora_status` never updated from 'idle' to 'running'
- `chat_sessions.incident_id` was NULL (no back-reference)

### Root Causes
1. **Missing database column**: Code tried to query `incidents.rca_celery_task_id` but column didn't exist, causing exception that prevented session linking
2. **Missing parameter**: `trigger_delayed_rca` called `create_background_chat_session()` without passing `incident_id` parameter

## Solution
1. Added migration to create `rca_celery_task_id VARCHAR(255)` column in incidents table
2. Updated `trigger_delayed_rca` to pass `incident_id=incident_db_id` when creating session

## Testing
Created test PagerDuty incidents and verified:
- ✅ `incidents.aurora_chat_session_id` properly set
- ✅ `chat_sessions.incident_id` properly set (bidirectional)
- ✅ `incidents.aurora_status` updates from 'idle' → 'running' → 'complete'
- ✅ RCA button appears on frontend with working link

## Files Changed
- `server/utils/db/db_utils.py` - Added migration for missing column
- `server/routes/pagerduty/tasks.py` - Pass incident_id to session creation

## Test plan
- [x] Code review
- [x] Tested with PagerDuty webhook
- [x] Verified bidirectional linking works
- [x] Verified status updates work
- [ ] Test on staging environment