### PR TITLE
fix(db): add missing visualization columns migration to incidents table

### DIFF
--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1179,6 +1179,23 @@ def initialize_tables():
                 )
                 conn.rollback()
 
+            # Add visualization columns to incidents table
+            try:
+                cursor.execute("""
+                    ALTER TABLE incidents
+                    ADD COLUMN IF NOT EXISTS visualization_code TEXT,
+                    ADD COLUMN IF NOT EXISTS visualization_updated_at TIMESTAMPTZ;
+                """)
+                logging.info(
+                    "Added visualization_code and visualization_updated_at columns to incidents table (if not exists)."
+                )
+                conn.commit()
+            except Exception as e:
+                logging.warning(
+                    f"Error adding visualization columns to incidents: {e}"
+                )
+                conn.rollback()
+
             # Add fix-type columns to incident_suggestions for code fix suggestions
             try:
                 cursor.execute(


### PR DESCRIPTION
## Summary                                                                                                                                                                   
  - Added missing `visualization_code` (TEXT) and `visualization_updated_at` (TIMESTAMPTZ) columns to the `incidents` table via ALTER TABLE migration                          
                                                                                                                                                                               
  ## Problem                                                                                                                                                                   
  The visualization generator and stream routes were querying/updating `visualization_code` on the `incidents` table, but the column was never added to it — it was mistakenly only defined in the `incident_alerts` CREATE TABLE schema. This caused a PostgreSQL error:     column "visualization_code" of relation "incidents" does not exist

  ## Fix
  Added an ALTER TABLE migration in `db_utils.py` (following existing migration patterns) that adds both columns to the `incidents` table on startup.