### PR TITLE
feat: add Traefik reverse proxy and security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,18 @@ STORAGE_CACHE_TTL=60
 # These NEXT_PUBLIC_* vars are injected at container startup (not baked at build).
 # Change them in .env and recreate the frontend container to take effect:
 #   docker compose -f docker-compose.prod-local.yml up -d frontend
+#
+# LOCAL DEVELOPMENT (no Traefik, direct ports):
+#   FRONTEND_URL=http://localhost:3000
+#   NEXT_PUBLIC_BACKEND_URL=http://localhost:5080
+#   NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:5006
+#
+# PRODUCTION WITH TRAEFIK (TLS via Let's Encrypt):
+#   FRONTEND_URL=https://${DOMAIN}
+#   NEXT_PUBLIC_BACKEND_URL=https://${API_DOMAIN}
+#   NEXT_PUBLIC_WEBSOCKET_URL=wss://${WS_DOMAIN}
+#
+# BACKEND_URL is always internal (Docker-to-Docker), not via Traefik:
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://aurora-server:5080
 NEXT_PUBLIC_BACKEND_URL=http://localhost:5080
@@ -193,6 +205,14 @@ DISCOVERY_INTERVAL_HOURS=1
 RATE_LIMITING_ENABLED=false
 RATE_LIMIT_BYPASS_TOKEN=
 RATE_LIMIT_HEADERS_ENABLED=true
+
+# -----------------------------------------------------------------------------
+# Traefik Reverse Proxy (prod-local only)
+# -----------------------------------------------------------------------------
+DOMAIN=aurora.example.com
+API_DOMAIN=api.aurora.example.com
+WS_DOMAIN=ws.aurora.example.com
+ACME_EMAIL=admin@example.com
 
 # -----------------------------------------------------------------------------
 # Development

--- a/.env.example
+++ b/.env.example
@@ -207,7 +207,7 @@ RATE_LIMIT_BYPASS_TOKEN=
 RATE_LIMIT_HEADERS_ENABLED=true
 
 # -----------------------------------------------------------------------------
-# Traefik Reverse Proxy (prod-local only)
+# Traefik Reverse Proxy (optional, via: make prod-traefik)
 # -----------------------------------------------------------------------------
 DOMAIN=aurora.example.com
 API_DOMAIN=api.aurora.example.com

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev down logs rebuild-server restart prod prod-build prod-logs prod-down clean nuke build-no-cache dev-fresh prod-clean prod-nuke prod-build-no-cache prod-fresh prod-prebuilt prod-local init prod-local-logs prod-local-down prod-local-clean prod-local-nuke deploy-build deploy
+.PHONY: help dev down logs rebuild-server restart prod prod-build prod-logs prod-down clean nuke build-no-cache dev-fresh prod-clean prod-nuke prod-build-no-cache prod-fresh prod-prebuilt prod-local prod-traefik init prod-local-logs prod-local-down prod-local-clean prod-local-nuke deploy-build deploy
 
 help:
 	@echo "Available commands:"
@@ -29,6 +29,7 @@ help:
 	@echo "  make prod-prebuilt      - Pull prebuilt images from GHCR and start (no build)"
 	@echo "                            Use VERSION=v1.2.3 to pin a specific release"
 	@echo "  make prod-local         - Build from source and start"
+	@echo "  make prod-traefik       - Build from source with Traefik TLS reverse proxy"
 	@echo "  make prod-local-logs    - Show logs for production containers"
 	@echo "  make down               - Stop production containers (same as dev)"
 	@echo "  make prod-local-clean   - Stop and remove production volumes"
@@ -63,6 +64,7 @@ build:
 
 down:
 	@docker compose down --remove-orphans 2>/dev/null || true
+	@docker compose -f docker-compose.prod-local.yml -f docker-compose.traefik.yml down --remove-orphans 2>/dev/null || true
 	@docker compose -f docker-compose.prod-local.yml down --remove-orphans 2>/dev/null || true
 	@for ep in $$(docker network inspect aurora_default -f '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null); do docker network disconnect -f aurora_default $$ep 2>/dev/null; done; true
 	@docker network rm aurora_default 2>/dev/null || true
@@ -193,6 +195,20 @@ prod-local:
 	@echo "  - Frontend: $$(v=$$(grep -E '^FRONTEND_URL=' .env | cut -d= -f2- | tr -d '\"'); echo $${v:-http://localhost:3000})"
 	@echo "  - Backend API: $$(v=$$(grep -E '^NEXT_PUBLIC_BACKEND_URL=' .env | cut -d= -f2- | tr -d '\"'); echo $${v:-http://localhost:5080})"
 	@echo "  - Chatbot WebSocket: $$(v=$$(grep -E '^NEXT_PUBLIC_WEBSOCKET_URL=' .env | cut -d= -f2- | tr -d '\"'); echo $${v:-ws://localhost:5006})"
+
+prod-traefik:
+	@if [ ! -f .env ]; then \
+		echo "Error: .env file not found."; \
+		echo "Please run 'make init' first to set up your environment."; \
+		exit 1; \
+	fi
+	@echo "Building from source and starting Aurora with Traefik reverse proxy..."
+	@docker compose -f docker-compose.prod-local.yml -f docker-compose.traefik.yml up --build -d
+	@echo ""
+	@echo "Aurora is starting with Traefik TLS proxy!"
+	@echo "  - Frontend: https://$$(grep -E '^DOMAIN=' .env | cut -d= -f2- | tr -d '\"')"
+	@echo "  - Backend API: https://$$(grep -E '^API_DOMAIN=' .env | cut -d= -f2- | tr -d '\"')"
+	@echo "  - WebSocket: wss://$$(grep -E '^WS_DOMAIN=' .env | cut -d= -f2- | tr -d '\"')"
 
 prod-local-logs:
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \

--- a/config/traefik/dynamic/middlewares.yml
+++ b/config/traefik/dynamic/middlewares.yml
@@ -1,0 +1,30 @@
+# Traefik Dynamic Configuration — Security Middlewares
+# Applied via Docker labels: middlewares=security-headers@file
+
+http:
+  middlewares:
+    security-headers:
+      headers:
+        # HSTS — force HTTPS for 1 year, include subdomains, allow preload list
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        # Prevent clickjacking
+        frameDeny: true
+        # Prevent MIME-type sniffing
+        contentTypeNosniff: true
+        # XSS protection (legacy, but still useful for older browsers)
+        browserXssFilter: true
+        # Referrer policy — send origin only on cross-origin, full on same-origin
+        referrerPolicy: "strict-origin-when-cross-origin"
+        # Permissions policy — disable unnecessary browser features
+        permissionsPolicy: "camera=(), microphone=(), geolocation=(), payment=()"
+        customResponseHeaders:
+          # Prevent Adobe Flash/PDF cross-domain requests
+          X-Permitted-Cross-Domain-Policies: "none"
+    # Rate limiting at the reverse proxy level (additional layer over Flask-Limiter)
+    rate-limit:
+      rateLimit:
+        average: 100
+        burst: 200
+        period: 1s

--- a/config/traefik/dynamic/tls.yml
+++ b/config/traefik/dynamic/tls.yml
@@ -1,0 +1,14 @@
+# Traefik Dynamic Configuration — TLS Options
+# Enforce TLS 1.2 minimum with strong cipher suites
+
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -1,0 +1,44 @@
+# Traefik Static Configuration for Aurora
+# TLS termination, HTTP->HTTPS redirect, Let's Encrypt ACME
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: ":443"
+
+# Enable ping endpoint (required for healthcheck)
+ping: {}
+
+providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      # Email set via TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL env var
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+
+log:
+  level: WARN
+
+accessLog:
+  filePath: /var/log/traefik/access.log
+  bufferingSize: 100
+  filters:
+    statusCodes:
+      - "400-599"
+
+api:
+  dashboard: false

--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -107,6 +107,40 @@ x-common-env: &common-env
   FRONTEND_URL: ${FRONTEND_URL}
 
 services:
+  traefik:
+    image: traefik:v3.3
+    container_name: aurora-traefik
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
+      - traefik-certs:/letsencrypt
+      - traefik-logs:/var/log/traefik
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - proxy
+      - backend
+
   aurora-server:
     build:
       context: ./server
@@ -114,8 +148,13 @@ services:
       target: prod
     image: aurora_server:latest
     container_name: aurora-server
-    ports:
-      - "${FLASK_PORT}:${FLASK_PORT}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.api.loadbalancer.server.port=${FLASK_PORT}"
     volumes:
       - terraform-workdir:/app/terraform_workdir
       - /var/run/docker.sock:/var/run/docker.sock
@@ -189,6 +228,9 @@ services:
       memgraph:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - proxy
+      - backend
 
   celery_worker:
     build:
@@ -234,6 +276,8 @@ services:
       - vault
       - memgraph
     restart: unless-stopped
+    networks:
+      - backend
 
   celery_beat:
     build:
@@ -256,30 +300,36 @@ services:
     depends_on:
       - redis
     restart: unless-stopped
+    networks:
+      - backend
 
   redis:
     image: redis:7-alpine
     container_name: aurora-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 3s
       retries: 3
+    networks:
+      - backend
 
   searxng:
     image: searxng/searxng:2025.5.8-7ca24eee4
     container_name: aurora-searxng
     ports:
-      - "8082:8080"
+      - "127.0.0.1:8082:8080"
     volumes:
       - ./config/searxng:/etc/searxng
     environment:
       - SEARXNG_BASE_URL=${SEARXNG_BASE_URL}
       - SEARXNG_SECRET=${SEARXNG_SECRET}
     restart: unless-stopped
+    networks:
+      - backend
 
   # Vault in file storage mode (persistent, production-like)
   # NOTE: Uses file storage with persistent volumes and auto-initialization.
@@ -288,7 +338,7 @@ services:
     image: hashicorp/vault:1.15
     container_name: aurora-vault
     ports:
-      - "8200:8200"
+      - "127.0.0.1:8200:8200"
     environment:
       VAULT_ADDR: http://127.0.0.1:8200
       VAULT_LOG_LEVEL: info
@@ -307,6 +357,8 @@ services:
       timeout: 3s
       retries: 3
     restart: unless-stopped
+    networks:
+      - backend
 
   vault-init:
     image: busybox:latest
@@ -322,7 +374,8 @@ services:
     depends_on:
       vault:
         condition: service_healthy
-
+    networks:
+      - backend
 
   chatbot:
     build:
@@ -332,8 +385,13 @@ services:
     image: aurora_chatbot:latest
     stdin_open: true
     tty: true
-    ports:
-      - "5006:5006"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ws.rule=Host(`${WS_DOMAIN}`)"
+      - "traefik.http.routers.ws.entrypoints=websecure"
+      - "traefik.http.routers.ws.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ws.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.ws.loadbalancer.server.port=5006"
     command: ["python", "main_chatbot.py"]
     volumes:
       - terraform-workdir:/app/terraform_workdir
@@ -360,12 +418,15 @@ services:
       vault:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - proxy
+      - backend
 
   postgres:
     image: postgres:15-alpine
     container_name: aurora-postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -378,6 +439,8 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    networks:
+      - backend
 
   weaviate:
     image: cr.weaviate.io/semitechnologies/weaviate:1.27.6
@@ -393,8 +456,8 @@ services:
       - --scheme
       - http
     ports:
-      - "8080:8080"
-      - "50051:50051"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:50051:50051"
     volumes:
       - weaviate_data:/var/lib/weaviate
     restart: unless-stopped
@@ -417,12 +480,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    networks:
+      - backend
 
   t2v-transformers:
     image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
     environment:
       ENABLE_CUDA: '0'
     restart: unless-stopped
+    networks:
+      - backend
 
   frontend:
     build:
@@ -455,11 +522,18 @@ services:
 
       # Auth.js configuration (required)
       AUTH_SECRET: ${AUTH_SECRET}
-    ports:
-      - "3000:3000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.frontend.entrypoints=websecure"
+      - "traefik.http.routers.frontend.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.frontend.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
     depends_on:
       - aurora-server
     restart: unless-stopped
+    networks:
+      - proxy
 
   # SeaweedFS - S3-compatible Object Storage (Apache 2.0 licensed)
   # ═══════════════════════════════════════════════════════════════════════════
@@ -475,8 +549,8 @@ services:
       -mdir=/data/master
       -defaultReplication=000
     ports:
-      - "9333:9333"
-      - "19333:19333"
+      - "127.0.0.1:9333:9333"
+      - "127.0.0.1:19333:19333"
     volumes:
       - seaweedfs_master_data:/data/master
     restart: unless-stopped
@@ -486,6 +560,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    networks:
+      - backend
 
   seaweedfs-volume:
     image: chrislusf/seaweedfs:4.07
@@ -498,7 +574,7 @@ services:
       -dir=/data
       -max=100
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     volumes:
       - seaweedfs_volume_data:/data
     depends_on:
@@ -511,6 +587,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    networks:
+      - backend
 
   seaweedfs-filer:
     image: chrislusf/seaweedfs:4.07
@@ -525,8 +603,8 @@ services:
       -s3.allowEmptyFolder=true
       -s3.config=/etc/seaweedfs/s3.json
     ports:
-      - "8888:8888"
-      - "8333:8333"
+      - "127.0.0.1:8888:8888"
+      - "127.0.0.1:8333:8333"
     volumes:
       - seaweedfs_filer_data:/data
       - ./config/seaweedfs/s3.json:/etc/seaweedfs/s3.json:ro
@@ -542,6 +620,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+    networks:
+      - backend
 
   seaweedfs-init:
     image: amazon/aws-cli:latest
@@ -563,6 +643,8 @@ services:
     depends_on:
       seaweedfs-filer:
         condition: service_healthy
+    networks:
+      - backend
 
   # Memgraph - In-memory Graph Database
   # ═══════════════════════════════════════════════════════════════════════════
@@ -571,8 +653,8 @@ services:
     image: memgraph/memgraph-mage:latest
     container_name: aurora-memgraph
     ports:
-      - "7687:7687"
-      - "7444:7444"
+      - "127.0.0.1:7687:7687"
+      - "127.0.0.1:7444:7444"
     volumes:
       - memgraph-data:/var/lib/memgraph
     environment:
@@ -588,18 +670,22 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    networks:
+      - backend
 
   memgraph-lab:
     image: memgraph/lab:latest
     container_name: aurora-memgraph-lab
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     depends_on:
       - memgraph
     environment:
       - QUICK_CONNECT_MG_HOST=memgraph
       - QUICK_CONNECT_MG_PORT=7687
     restart: unless-stopped
+    networks:
+      - backend
 
 volumes:
   postgres-data:
@@ -611,3 +697,11 @@ volumes:
   vault-data:
   vault-init:
   memgraph-data:
+  traefik-certs:
+  traefik-logs:
+
+networks:
+  proxy:
+    name: aurora-proxy
+  backend:
+    name: aurora-backend

--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -107,40 +107,6 @@ x-common-env: &common-env
   FRONTEND_URL: ${FRONTEND_URL}
 
 services:
-  traefik:
-    image: traefik:v3.3
-    container_name: aurora-traefik
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: ${ACME_EMAIL}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./config/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
-      - traefik-certs:/letsencrypt
-      - traefik-logs:/var/log/traefik
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    cap_add:
-      - NET_BIND_SERVICE
-    read_only: true
-    tmpfs:
-      - /tmp
-    healthcheck:
-      test: ["CMD", "traefik", "healthcheck"]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
-    restart: unless-stopped
-    networks:
-      - proxy
-      - backend
-
   aurora-server:
     build:
       context: ./server
@@ -148,13 +114,8 @@ services:
       target: prod
     image: aurora_server:latest
     container_name: aurora-server
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api.middlewares=security-headers@file,rate-limit@file"
-      - "traefik.http.services.api.loadbalancer.server.port=${FLASK_PORT}"
+    ports:
+      - "${FLASK_PORT:-5080}:${FLASK_PORT:-5080}"
     volumes:
       - terraform-workdir:/app/terraform_workdir
       - /var/run/docker.sock:/var/run/docker.sock
@@ -229,7 +190,6 @@ services:
         condition: service_healthy
     restart: unless-stopped
     networks:
-      - proxy
       - backend
 
   celery_worker:
@@ -385,13 +345,8 @@ services:
     image: aurora_chatbot:latest
     stdin_open: true
     tty: true
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.ws.rule=Host(`${WS_DOMAIN}`)"
-      - "traefik.http.routers.ws.entrypoints=websecure"
-      - "traefik.http.routers.ws.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.ws.middlewares=security-headers@file,rate-limit@file"
-      - "traefik.http.services.ws.loadbalancer.server.port=5006"
+    ports:
+      - "5006:5006"
     command: ["python", "main_chatbot.py"]
     volumes:
       - terraform-workdir:/app/terraform_workdir
@@ -417,9 +372,13 @@ services:
         condition: service_healthy
       vault:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.socket(); s.settimeout(2); s.connect(('localhost',5006)); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
     networks:
-      - proxy
       - backend
 
   postgres:
@@ -522,18 +481,13 @@ services:
 
       # Auth.js configuration (required)
       AUTH_SECRET: ${AUTH_SECRET}
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.frontend.entrypoints=websecure"
-      - "traefik.http.routers.frontend.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.frontend.middlewares=security-headers@file,rate-limit@file"
-      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
+    ports:
+      - "3000:3000"
     depends_on:
       - aurora-server
     restart: unless-stopped
     networks:
-      - proxy
+      - backend
 
   # SeaweedFS - S3-compatible Object Storage (Apache 2.0 licensed)
   # ═══════════════════════════════════════════════════════════════════════════
@@ -697,11 +651,7 @@ volumes:
   vault-data:
   vault-init:
   memgraph-data:
-  traefik-certs:
-  traefik-logs:
 
 networks:
-  proxy:
-    name: aurora-proxy
   backend:
     name: aurora-backend

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,89 @@
+# Traefik TLS reverse proxy overlay for Aurora
+# Usage: docker compose -f docker-compose.prod-local.yml -f docker-compose.traefik.yml up -d
+# Or:    make prod-traefik
+#
+# Requires DOMAIN, API_DOMAIN, WS_DOMAIN, ACME_EMAIL in .env
+# See config/traefik/ for static and dynamic Traefik configuration.
+
+services:
+  traefik:
+    image: traefik:v3.3
+    container_name: aurora-traefik
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
+      - traefik-certs:/letsencrypt
+      - traefik-logs:/var/log/traefik
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    depends_on:
+      aurora-server:
+        condition: service_started
+      chatbot:
+        condition: service_started
+      frontend:
+        condition: service_started
+    networks:
+      - proxy
+      - backend
+
+  aurora-server:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.api.loadbalancer.server.port=${FLASK_PORT}"
+    networks:
+      - proxy
+
+  chatbot:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ws.rule=Host(`${WS_DOMAIN}`)"
+      - "traefik.http.routers.ws.entrypoints=websecure"
+      - "traefik.http.routers.ws.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ws.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.ws.loadbalancer.server.port=5006"
+    networks:
+      - proxy
+
+  frontend:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.frontend.entrypoints=websecure"
+      - "traefik.http.routers.frontend.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.frontend.middlewares=security-headers@file,rate-limit@file"
+      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
+    networks:
+      - proxy
+
+volumes:
+  traefik-certs:
+  traefik-logs:
+
+networks:
+  proxy:
+    name: aurora-proxy

--- a/server/utils/web/cors_utils.py
+++ b/server/utils/web/cors_utils.py
@@ -1,17 +1,32 @@
 from flask import jsonify, request
 import os
+from urllib.parse import urlparse
 
-FRONTEND_URL = os.getenv("FRONTEND_URL")
+FRONTEND_URL = os.getenv("FRONTEND_URL", "")
+
+# Build allowed origins set from FRONTEND_URL
+_allowed_origins = set()
+if FRONTEND_URL:
+    _allowed_origins.add(FRONTEND_URL.rstrip("/"))
+    # Also allow localhost variants for development
+    parsed = urlparse(FRONTEND_URL)
+    if parsed.hostname in ("localhost", "127.0.0.1"):
+        for host in ("localhost", "127.0.0.1"):
+            _allowed_origins.add(f"{parsed.scheme}://{host}:{parsed.port}" if parsed.port else f"{parsed.scheme}://{host}")
+
 
 def create_cors_response(success=True):
     """Create a Flask response with proper CORS headers for preflight requests"""
     resp = jsonify(success=success)
-    # Dynamically reflect the origin for development/local usage while keeping a default
-    origin = request.headers.get('Origin', FRONTEND_URL)
-    resp.headers.add('Access-Control-Allow-Origin', origin)
-    # If you need to restrict in production, consider checking against a whitelist here.
+    origin = request.headers.get('Origin', '')
+    # Only allow the origin if it matches the configured FRONTEND_URL
+    if origin.rstrip("/") in _allowed_origins:
+        allowed_origin = origin
+    else:
+        allowed_origin = FRONTEND_URL
+    resp.headers.add('Access-Control-Allow-Origin', allowed_origin)
     resp.headers.add('Access-Control-Allow-Headers', 'Content-Type, X-Provider, X-Requested-With, X-User-ID, Authorization')
     resp.headers.add('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
     resp.headers.add('Access-Control-Allow-Credentials', 'true')
     resp.headers.add('Content-Type', 'application/json')
-    return resp 
+    return resp

--- a/server/utils/web/cors_utils.py
+++ b/server/utils/web/cors_utils.py
@@ -1,8 +1,13 @@
+import logging
 from flask import jsonify, request
 import os
 from urllib.parse import urlparse
 
+logger = logging.getLogger(__name__)
+
 FRONTEND_URL = os.getenv("FRONTEND_URL", "")
+if not FRONTEND_URL:
+    logger.warning("FRONTEND_URL not set - CORS will reject all cross-origin requests")
 
 # Build allowed origins set from FRONTEND_URL
 _allowed_origins = set()


### PR DESCRIPTION
## Summary
- Adds Traefik v3.3 as a TLS-terminating reverse proxy for `docker-compose.prod-local.yml`
- Routes frontend, API, and WebSocket through Traefik with automatic Let's Encrypt certificates
- Hardens the Docker Compose stack with network segmentation, 127.0.0.1 port bindings, and container security settings
- Fixes CORS origin reflection vulnerability in `cors_utils.py`

## Changes
- **`config/traefik/traefik.yml`** — Static config: HTTP→HTTPS redirect, ACME cert resolver, ping healthcheck, access logging
- **`config/traefik/dynamic/tls.yml`** — TLS 1.2+ minimum with strong cipher suites
- **`config/traefik/dynamic/middlewares.yml`** — Security headers (HSTS, frame deny, nosniff, permissions policy) + rate limiting
- **`docker-compose.prod-local.yml`** — Traefik service (hardened: read-only, no-new-privileges, cap_drop ALL), Docker labels on public services, proxy/backend network segmentation, internal services bound to 127.0.0.1
- **`server/utils/web/cors_utils.py`** — Validates Origin against FRONTEND_URL whitelist instead of reflecting arbitrary origins
- **`.env.example`** — Added DOMAIN/API_DOMAIN/WS_DOMAIN/ACME_EMAIL vars and URL configuration guidance

## Test plan
- [ ] `docker compose -f docker-compose.prod-local.yml config` validates without errors
- [ ] Traefik boots cleanly with `read_only` filesystem and healthcheck passes
- [ ] Frontend, API, and WebSocket accessible via Traefik-routed domains
- [ ] Internal services (postgres, redis, vault, etc.) not reachable from outside 127.0.0.1
- [ ] CORS preflight only reflects allowed origins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Traefik reverse proxy with automatic HTTPS (Let’s Encrypt), domain-based routing for frontend, API and WebSocket, and TLS hardening.
  * Added security middleware: HSTS, XSS/frame/content-type protections, permissions policy, custom headers, and rate limiting.
  * Improved CORS handling to whitelist frontend and localhost variants.

* **Chores**
  * New compose/make targets and network defaults to support local and Traefik-backed production runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->