### PR TITLE
chore: upgrade Python 3.11 to 3.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Aurora is a natural-language interface for managing cloud infrastructure. Before
 
 - Docker and Docker Compose >= 28.x
 - Node.js >= 18.x (for frontend development)
-- Python >= 3.11 (for backend development)
+- Python >= 3.12 (for backend development)
 - Make (for using Makefile commands)
 
 ### Initial Setup

--- a/kubectl-agent/src/Dockerfile
+++ b/kubectl-agent/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS builder
+FROM python:3.12-slim AS builder
 WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
@@ -7,7 +7,7 @@ ARG KUBECTL_VERSION=v1.31.0
 ARG TARGETARCH=amd64
 RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && chmod +x kubectl
 
-FROM python:3.11-slim
+FROM python:3.12-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN useradd -m -u 1000 -s /bin/bash kubectl-agent
@@ -16,7 +16,7 @@ COPY --from=builder /build/kubectl /usr/local/bin/kubectl
 COPY --chown=kubectl-agent:kubectl-agent agent.py .
 USER kubectl-agent
 ENV PATH=/home/kubectl-agent/.local/bin:$PATH \
-    PYTHONPATH=/home/kubectl-agent/.local/lib/python3.11/site-packages:$PYTHONPATH \
+    PYTHONPATH=/home/kubectl-agent/.local/lib/python3.12/site-packages:$PYTHONPATH \
     PYTHONUNBUFFERED=1
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD python -c "import sys; sys.exit(0)" || exit 1
 CMD ["python", "-u", "agent.py"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================
 # Base Stage - Common dependencies
 # ============================================
-FROM python:3.11-slim AS base
+FROM python:3.12-slim AS base
 
 ENV PYTHONPATH="/app"
 # Set uv cache directory to a writable location for non-root users

--- a/server/Dockerfile-chatbot-dev.dockerfile
+++ b/server/Dockerfile-chatbot-dev.dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image as the base
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Development Dockerfile for Chatbot
 # This includes cloud CLI tools (gcloud, aws, az, terraform, helm) for local development


### PR DESCRIPTION
## Summary
- Upgrades Python base image from 3.11-slim to 3.12-slim across all Dockerfiles
- Updates CONTRIBUTING.md prerequisite to match

## Why this is safe
- All pinned dependencies have verified cp312 wheels on PyPI (grpcio, gevent, psycopg2-binary, bcrypt, PyYAML 6.0.1, etc.)
- No usage of any stdlib modules removed in 3.12 (distutils, imp, asyncore, asynchat, smtpd)
- No TypeVar/ParamSpec or typing changes that affect this codebase
- The google-genai==1.58.0 pin is about a Python 3.13 issue, not 3.12
- CI workflows pull Python version from the Dockerfile, no separate pins to update

## Files changed
- `server/Dockerfile` (base stage)
- `server/Dockerfile-chatbot-dev.dockerfile`
- `kubectl-agent/src/Dockerfile` (builder + runtime stages + PYTHONPATH)
- `CONTRIBUTING.md`

## Test plan
- [ ] `make dev` builds and starts all containers
- [ ] Celery worker starts and processes tasks
- [ ] Chatbot WebSocket connects and responds
- [ ] kubectl-agent container starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend Python version requirement to 3.12 in setup documentation.

* **Chores**
  * Updated Docker base images to Python 3.12 across all deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->