### PR TITLE
Helm fixes

### DIFF
--- a/deploy/helm/aurora/templates/_helpers.tpl
+++ b/deploy/helm/aurora/templates/_helpers.tpl
@@ -21,3 +21,34 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: aurora
 {{- end }}
+
+{{/*
+Pod scheduling block (tolerations, nodeSelector, affinity).
+Pass a dict with "service" (key into .Values.scheduling) and "global" (top-level context).
+Per-service values in .Values.scheduling.<service> override the global defaults.
+*/}}
+{{- define "aurora.scheduling" -}}
+{{- $svc := .service -}}
+{{- $ctx := .global -}}
+{{- $tol := $ctx.Values.tolerations -}}
+{{- $ns  := $ctx.Values.nodeSelector -}}
+{{- $aff := $ctx.Values.affinity -}}
+{{- if and $ctx.Values.scheduling (index $ctx.Values.scheduling $svc) -}}
+  {{- $override := index $ctx.Values.scheduling $svc -}}
+  {{- if $override.tolerations -}}{{- $tol = $override.tolerations -}}{{- end -}}
+  {{- if $override.nodeSelector -}}{{- $ns = $override.nodeSelector -}}{{- end -}}
+  {{- if $override.affinity -}}{{- $aff = $override.affinity -}}{{- end -}}
+{{- end -}}
+{{- if $tol }}
+tolerations:
+  {{- toYaml $tol | nindent 2 }}
+{{- end }}
+{{- if $ns }}
+nodeSelector:
+  {{- toYaml $ns | nindent 2 }}
+{{- end }}
+{{- if $aff }}
+affinity:
+  {{- toYaml $aff | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/aurora/templates/_helpers.tpl
+++ b/deploy/helm/aurora/templates/_helpers.tpl
@@ -35,9 +35,9 @@ Per-service values in .Values.scheduling.<service> override the global defaults.
 {{- $aff := $ctx.Values.affinity -}}
 {{- if and $ctx.Values.scheduling (index $ctx.Values.scheduling $svc) -}}
   {{- $override := index $ctx.Values.scheduling $svc -}}
-  {{- if $override.tolerations -}}{{- $tol = $override.tolerations -}}{{- end -}}
-  {{- if $override.nodeSelector -}}{{- $ns = $override.nodeSelector -}}{{- end -}}
-  {{- if $override.affinity -}}{{- $aff = $override.affinity -}}{{- end -}}
+  {{- if hasKey $override "tolerations" -}}{{- $tol = $override.tolerations -}}{{- end -}}
+  {{- if hasKey $override "nodeSelector" -}}{{- $ns = $override.nodeSelector -}}{{- end -}}
+  {{- if hasKey $override "affinity" -}}{{- $aff = $override.affinity -}}{{- end -}}
 {{- end -}}
 {{- if $tol }}
 tolerations:
@@ -57,6 +57,9 @@ affinity:
 Pod-level securityContext.
 Merges global .Values.podSecurityContext with per-service UID/GID defaults.
 Per-service override in .Values.podSecurityContextOverrides replaces the entire block.
+Note: Unlike aurora.scheduling (field-level merge where [] clears a field),
+overrides here are full replacement. An empty map {} means "no override" and
+falls through to the merged defaults — this is intentional.
 Usage: include "aurora.podSecurityContext" (dict "service" "server" "global" $ "defaults" (dict "runAsUser" 1000 ...))
 */}}
 {{- define "aurora.podSecurityContext" -}}
@@ -75,6 +78,7 @@ Usage: include "aurora.podSecurityContext" (dict "service" "server" "global" $ "
 Container-level securityContext.
 Merges global .Values.containerSecurityContext with per-service defaults.
 Per-service override in .Values.containerSecurityContextOverrides replaces the entire block.
+Same full-replacement semantics as aurora.podSecurityContext (see note above).
 Usage: include "aurora.containerSecurityContext" (dict "service" "server" "global" $ "defaults" (dict))
 */}}
 {{- define "aurora.containerSecurityContext" -}}

--- a/deploy/helm/aurora/templates/_helpers.tpl
+++ b/deploy/helm/aurora/templates/_helpers.tpl
@@ -52,3 +52,39 @@ affinity:
   {{- toYaml $aff | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Pod-level securityContext.
+Merges global .Values.podSecurityContext with per-service UID/GID defaults.
+Per-service override in .Values.podSecurityContextOverrides replaces the entire block.
+Usage: include "aurora.podSecurityContext" (dict "service" "server" "global" $ "defaults" (dict "runAsUser" 1000 ...))
+*/}}
+{{- define "aurora.podSecurityContext" -}}
+{{- $svc := .service -}}
+{{- $ctx := .global -}}
+{{- $defaults := .defaults -}}
+{{- if and $ctx.Values.podSecurityContextOverrides (index $ctx.Values.podSecurityContextOverrides $svc) }}
+{{- toYaml (index $ctx.Values.podSecurityContextOverrides $svc) }}
+{{- else }}
+{{- $merged := merge (deepCopy $ctx.Values.podSecurityContext) $defaults }}
+{{- toYaml $merged }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container-level securityContext.
+Merges global .Values.containerSecurityContext with per-service defaults.
+Per-service override in .Values.containerSecurityContextOverrides replaces the entire block.
+Usage: include "aurora.containerSecurityContext" (dict "service" "server" "global" $ "defaults" (dict))
+*/}}
+{{- define "aurora.containerSecurityContext" -}}
+{{- $svc := .service -}}
+{{- $ctx := .global -}}
+{{- $defaults := .defaults -}}
+{{- if and $ctx.Values.containerSecurityContextOverrides (index $ctx.Values.containerSecurityContextOverrides $svc) }}
+{{- toYaml (index $ctx.Values.containerSecurityContextOverrides $svc) }}
+{{- else }}
+{{- $merged := merge (deepCopy $ctx.Values.containerSecurityContext) $defaults }}
+{{- toYaml $merged }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/aurora/templates/_helpers.tpl
+++ b/deploy/helm/aurora/templates/_helpers.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/part-of: aurora
 {{/*
 Pod scheduling block (tolerations, nodeSelector, affinity).
 Pass a dict with "service" (key into .Values.scheduling) and "global" (top-level context).
-Per-service values in .Values.scheduling.<service> override the global defaults.
+When scheduling.<service> is set, it fully replaces the global defaults for that service.
 */}}
 {{- define "aurora.scheduling" -}}
 {{- $svc := .service -}}
@@ -35,9 +35,9 @@ Per-service values in .Values.scheduling.<service> override the global defaults.
 {{- $aff := $ctx.Values.affinity -}}
 {{- if and $ctx.Values.scheduling (index $ctx.Values.scheduling $svc) -}}
   {{- $override := index $ctx.Values.scheduling $svc -}}
-  {{- if hasKey $override "tolerations" -}}{{- $tol = $override.tolerations -}}{{- end -}}
-  {{- if hasKey $override "nodeSelector" -}}{{- $ns = $override.nodeSelector -}}{{- end -}}
-  {{- if hasKey $override "affinity" -}}{{- $aff = $override.affinity -}}{{- end -}}
+  {{- $tol = $override.tolerations -}}
+  {{- $ns = $override.nodeSelector -}}
+  {{- $aff = $override.affinity -}}
 {{- end -}}
 {{- if $tol }}
 tolerations:
@@ -57,9 +57,6 @@ affinity:
 Pod-level securityContext.
 Merges global .Values.podSecurityContext with per-service UID/GID defaults.
 Per-service override in .Values.podSecurityContextOverrides replaces the entire block.
-Note: Unlike aurora.scheduling (field-level merge where [] clears a field),
-overrides here are full replacement. An empty map {} means "no override" and
-falls through to the merged defaults — this is intentional.
 Usage: include "aurora.podSecurityContext" (dict "service" "server" "global" $ "defaults" (dict "runAsUser" 1000 ...))
 */}}
 {{- define "aurora.podSecurityContext" -}}
@@ -78,7 +75,6 @@ Usage: include "aurora.podSecurityContext" (dict "service" "server" "global" $ "
 Container-level securityContext.
 Merges global .Values.containerSecurityContext with per-service defaults.
 Per-service override in .Values.containerSecurityContextOverrides replaces the entire block.
-Same full-replacement semantics as aurora.podSecurityContext (see note above).
 Usage: include "aurora.containerSecurityContext" (dict "service" "server" "global" $ "defaults" (dict))
 */}}
 {{- define "aurora.containerSecurityContext" -}}

--- a/deploy/helm/aurora/templates/celery-beat-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-beat-deployment.yaml
@@ -25,10 +25,7 @@ spec:
       serviceAccountName: {{ include "aurora.fullname" . }}-celery-beat
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "celeryBeat" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -40,9 +37,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["celery", "-A", "celery_config", "beat", "--loglevel=info", "--pidfile=/tmp/celerybeat.pid", "--schedule=/tmp/celerybeat-schedule"]
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "celeryBeat" "global" $ "defaults" (dict)) | nindent 12 }}
           # Beat doesn't serve HTTP; use pidfile-based liveness check
           livenessProbe:
             exec:

--- a/deploy/helm/aurora/templates/celery-beat-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-beat-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      {{- include "aurora.scheduling" (dict "service" "celeryBeat" "global" $) | nindent 6 }}
       containers:
         - name: celery-beat
           image: "{{ .Values.image.registry }}/aurora-server:{{ .Values.image.tag }}"

--- a/deploy/helm/aurora/templates/celery-worker-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-worker-deployment.yaml
@@ -26,10 +26,7 @@ spec:
       serviceAccountName: {{ include "aurora.fullname" . }}-celery-worker
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "celeryWorker" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -41,9 +38,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["celery", "-A", "celery_config", "worker", "--loglevel=info", "--pidfile=/tmp/celery-worker.pid"]
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "celeryWorker" "global" $ "defaults" (dict)) | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "aurora.fullname" . }}-config

--- a/deploy/helm/aurora/templates/celery-worker-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-worker-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      {{- include "aurora.scheduling" (dict "service" "celeryWorker" "global" $) | nindent 6 }}
       containers:
         - name: celery-worker
           image: "{{ .Values.image.registry }}/aurora-server:{{ .Values.image.tag }}"

--- a/deploy/helm/aurora/templates/chatbot-deployment.yaml
+++ b/deploy/helm/aurora/templates/chatbot-deployment.yaml
@@ -35,6 +35,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      {{- include "aurora.scheduling" (dict "service" "chatbot" "global" $) | nindent 6 }}
       containers:
         - name: aurora-chatbot
           image: "{{ .Values.image.registry }}/aurora-server:{{ .Values.image.tag }}"

--- a/deploy/helm/aurora/templates/chatbot-deployment.yaml
+++ b/deploy/helm/aurora/templates/chatbot-deployment.yaml
@@ -27,10 +27,7 @@ spec:
       # Pod isolation requires K8s API access to create terminal pods
       automountServiceAccountToken: {{ eq .Values.config.ENABLE_POD_ISOLATION "true" }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "chatbot" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -42,9 +39,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["python", "main_chatbot.py"]
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "chatbot" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: ws
               containerPort: 5006

--- a/deploy/helm/aurora/templates/frontend-deployment.yaml
+++ b/deploy/helm/aurora/templates/frontend-deployment.yaml
@@ -23,10 +23,7 @@ spec:
       serviceAccountName: {{ include "aurora.fullname" . }}-frontend
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "frontend" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -37,9 +34,7 @@ spec:
           image: "{{ .Values.image.registry }}/aurora-frontend:{{ .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "frontend" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 3000

--- a/deploy/helm/aurora/templates/frontend-deployment.yaml
+++ b/deploy/helm/aurora/templates/frontend-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      {{- include "aurora.scheduling" (dict "service" "frontend" "global" $) | nindent 6 }}
       containers:
         - name: aurora-frontend
           image: "{{ .Values.image.registry }}/aurora-frontend:{{ .Values.image.tag }}"

--- a/deploy/helm/aurora/templates/minio-statefulset.yaml
+++ b/deploy/helm/aurora/templates/minio-statefulset.yaml
@@ -21,10 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "minio" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "minio" "global" $) | nindent 6 }}
       containers:
         - name: minio
@@ -43,9 +40,7 @@ spec:
                   name: {{ include "aurora.fullname" . }}-secrets-backend
                   key: STORAGE_SECRET_KEY
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "minio" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: api
               containerPort: 9000

--- a/deploy/helm/aurora/templates/minio-statefulset.yaml
+++ b/deploy/helm/aurora/templates/minio-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      {{- include "aurora.scheduling" (dict "service" "minio" "global" $) | nindent 6 }}
       containers:
         - name: minio
           image: minio/minio:RELEASE.2025-04-22T22-12-26Z

--- a/deploy/helm/aurora/templates/postgres-statefulset.yaml
+++ b/deploy/helm/aurora/templates/postgres-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         runAsUser: 70
         runAsGroup: 70
         fsGroup: 70
+      {{- include "aurora.scheduling" (dict "service" "postgres" "global" $) | nindent 6 }}
       containers:
         - name: postgres
           image: postgres:15-alpine

--- a/deploy/helm/aurora/templates/postgres-statefulset.yaml
+++ b/deploy/helm/aurora/templates/postgres-statefulset.yaml
@@ -24,19 +24,14 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 70
-        runAsGroup: 70
-        fsGroup: 70
+        {{- include "aurora.podSecurityContext" (dict "service" "postgres" "global" $ "defaults" (dict "runAsUser" 70 "runAsGroup" 70 "fsGroup" 70)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "postgres" "global" $) | nindent 6 }}
       containers:
         - name: postgres
           image: postgres:15-alpine
           imagePullPolicy: IfNotPresent
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "postgres" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: postgres
               containerPort: 5432

--- a/deploy/helm/aurora/templates/redis-statefulset.yaml
+++ b/deploy/helm/aurora/templates/redis-statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         runAsUser: 999
         runAsGroup: 1000
         fsGroup: 1000
+      {{- include "aurora.scheduling" (dict "service" "redis" "global" $) | nindent 6 }}
       containers:
         - name: redis
           image: redis:7-alpine

--- a/deploy/helm/aurora/templates/redis-statefulset.yaml
+++ b/deploy/helm/aurora/templates/redis-statefulset.yaml
@@ -21,10 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "redis" "global" $ "defaults" (dict "runAsUser" 999 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "redis" "global" $) | nindent 6 }}
       containers:
         - name: redis
@@ -32,10 +29,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["redis-server", "--appendonly", "yes", "--dir", "/data", "--maxmemory", {{ .Values.config.REDIS_MAXMEMORY | default "256mb" | quote }}, "--maxmemory-policy", "allkeys-lru"]
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "redis" "global" $ "defaults" (dict "readOnlyRootFilesystem" true)) | nindent 12 }}
           ports:
             - name: redis
               containerPort: 6379

--- a/deploy/helm/aurora/templates/searxng-deployment.yaml
+++ b/deploy/helm/aurora/templates/searxng-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         runAsUser: 977
         runAsGroup: 977
         fsGroup: 977
+      {{- include "aurora.scheduling" (dict "service" "searxng" "global" $) | nindent 6 }}
       containers:
         - name: searxng
           image: searxng/searxng:2025.5.8-7ca24eee4

--- a/deploy/helm/aurora/templates/searxng-deployment.yaml
+++ b/deploy/helm/aurora/templates/searxng-deployment.yaml
@@ -22,21 +22,14 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 977
-        runAsGroup: 977
-        fsGroup: 977
+        {{- include "aurora.podSecurityContext" (dict "service" "searxng" "global" $ "defaults" (dict "runAsUser" 977 "runAsGroup" 977 "fsGroup" 977)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "searxng" "global" $) | nindent 6 }}
       containers:
         - name: searxng
           image: searxng/searxng:2025.5.8-7ca24eee4
           imagePullPolicy: IfNotPresent
           securityContext:
-            runAsUser: 977
-            runAsGroup: 977
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "searxng" "global" $ "defaults" (dict "runAsUser" 977 "runAsGroup" 977)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/helm/aurora/templates/server-deployment.yaml
+++ b/deploy/helm/aurora/templates/server-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      {{- include "aurora.scheduling" (dict "service" "server" "global" $) | nindent 6 }}
       containers:
         - name: aurora-server
           image: "{{ .Values.image.registry }}/aurora-server:{{ .Values.image.tag }}"

--- a/deploy/helm/aurora/templates/server-deployment.yaml
+++ b/deploy/helm/aurora/templates/server-deployment.yaml
@@ -26,10 +26,7 @@ spec:
       # Pod isolation requires K8s API access to create terminal pods
       automountServiceAccountToken: {{ eq .Values.config.ENABLE_POD_ISOLATION "true" }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "server" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -43,9 +40,7 @@ spec:
           args:
             - gunicorn main_compute:app --bind 0.0.0.0:5080 -k gthread --threads 16 --workers 2 --timeout 120 --preload
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "server" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 5080

--- a/deploy/helm/aurora/templates/t2v-transformers-deployment.yaml
+++ b/deploy/helm/aurora/templates/t2v-transformers-deployment.yaml
@@ -18,15 +18,15 @@ spec:
         app.kubernetes.io/part-of: aurora
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        {{- include "aurora.podSecurityContext" (dict "service" "transformers" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "transformers" "global" $) | nindent 6 }}
       containers:
         - name: transformers
           image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
           imagePullPolicy: IfNotPresent
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "transformers" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/helm/aurora/templates/t2v-transformers-deployment.yaml
+++ b/deploy/helm/aurora/templates/t2v-transformers-deployment.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/part-of: aurora
     spec:
       automountServiceAccountToken: false
+      {{- include "aurora.scheduling" (dict "service" "transformers" "global" $) | nindent 6 }}
       containers:
         - name: transformers
           image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2

--- a/deploy/helm/aurora/templates/vault-statefulset.yaml
+++ b/deploy/helm/aurora/templates/vault-statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         runAsUser: 100
         runAsGroup: 1000
         fsGroup: 1000
+      {{- include "aurora.scheduling" (dict "service" "vault" "global" $) | nindent 6 }}
       containers:
         - name: vault
           image: hashicorp/vault:1.15

--- a/deploy/helm/aurora/templates/vault-statefulset.yaml
+++ b/deploy/helm/aurora/templates/vault-statefulset.yaml
@@ -24,10 +24,7 @@ spec:
       serviceAccountName: {{ include "aurora.fullname" . }}-vault
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 100
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- include "aurora.podSecurityContext" (dict "service" "vault" "global" $ "defaults" (dict "runAsUser" 100 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "vault" "global" $) | nindent 6 }}
       containers:
         - name: vault
@@ -39,11 +36,9 @@ spec:
               vault server -config=/vault/config/vault.hcl
           # Note: Vault typically needs IPC_LOCK capability for mlock (prevents secrets
           # from being swapped to disk). Since disable_mlock=true in vault.hcl, we can
-          # drop all capabilities. If you enable mlock, add: capabilities.add: ["IPC_LOCK"]
+          # drop all capabilities. If you enable mlock, override via containerSecurityContextOverrides.
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "vault" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8200

--- a/deploy/helm/aurora/templates/weaviate-statefulset.yaml
+++ b/deploy/helm/aurora/templates/weaviate-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/part-of: aurora
     spec:
       automountServiceAccountToken: false
+      {{- include "aurora.scheduling" (dict "service" "weaviate" "global" $) | nindent 6 }}
       containers:
         - name: weaviate
           image: cr.weaviate.io/semitechnologies/weaviate:1.27.6

--- a/deploy/helm/aurora/templates/weaviate-statefulset.yaml
+++ b/deploy/helm/aurora/templates/weaviate-statefulset.yaml
@@ -20,15 +20,15 @@ spec:
         app.kubernetes.io/part-of: aurora
     spec:
       automountServiceAccountToken: false
+      securityContext:
+        {{- include "aurora.podSecurityContext" (dict "service" "weaviate" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
       {{- include "aurora.scheduling" (dict "service" "weaviate" "global" $) | nindent 6 }}
       containers:
         - name: weaviate
           image: cr.weaviate.io/semitechnologies/weaviate:1.27.6
           imagePullPolicy: IfNotPresent
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            {{- include "aurora.containerSecurityContext" (dict "service" "weaviate" "global" $ "defaults" (dict)) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -273,6 +273,44 @@ secrets:
     GOOGLE_AI_API_KEY: ""        # Get from: https://makersuite.google.com/app/apikey
 
 # ------------------------------------------------------------------------------
+# Security contexts
+# ------------------------------------------------------------------------------
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+#
+# Global pod-level security context — merged into every pod.
+# Each service also has hardcoded UID/GID defaults (e.g. postgres=70, vault=100).
+# The global values here are merged with those defaults, so you only need to set
+# shared fields once (like seccompProfile) rather than repeating per-service.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Global container-level security context — merged into every container.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+# Per-service overrides (replaces the ENTIRE merged context for that service).
+# Use when a specific service needs a completely different security posture.
+# podSecurityContextOverrides:
+#   postgres:
+#     runAsNonRoot: true
+#     runAsUser: 70
+#     runAsGroup: 70
+#     fsGroup: 70
+#     seccompProfile:
+#       type: Localhost
+#       localhostProfile: profiles/custom.json
+# containerSecurityContextOverrides:
+#   vault:
+#     allowPrivilegeEscalation: false
+#     capabilities:
+#       drop: ["ALL"]
+#       add: ["IPC_LOCK"]
+
+# ------------------------------------------------------------------------------
 # Resource requests and limits
 # ------------------------------------------------------------------------------
 resources:

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -362,6 +362,89 @@ resources:
       memory: "512Mi"
 
 # ------------------------------------------------------------------------------
+# Pod scheduling: tolerations, nodeSelector, affinity
+# ------------------------------------------------------------------------------
+# Global values applied to ALL pods. Override per-service below.
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+#
+# Example - schedule on nodes tainted for your team:
+#   tolerations:
+#     - key: "team"
+#       operator: "Equal"
+#       value: "platform"
+#       effect: "NoSchedule"
+#
+# Example - restrict to specific node labels:
+#   nodeSelector:
+#     node-pool: "aurora"
+#
+# Example - prefer spreading across zones:
+#   affinity:
+#     podAntiAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#         - weight: 100
+#           podAffinityTerm:
+#             labelSelector:
+#               matchLabels:
+#                 app.kubernetes.io/part-of: aurora
+#             topologyKey: topology.kubernetes.io/zone
+
+tolerations: []
+nodeSelector: {}
+affinity: {}
+
+# Per-service overrides (only the fields you set are overridden; the rest inherit from global)
+# scheduling:
+#   server:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   celeryWorker:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   celeryBeat:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   chatbot:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   frontend:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   searxng:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   transformers:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   postgres:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   redis:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   weaviate:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   vault:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+#   minio:
+#     tolerations: []
+#     nodeSelector: {}
+#     affinity: {}
+
+# ------------------------------------------------------------------------------
 # Persistent storage
 # ------------------------------------------------------------------------------
 persistence:

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -292,10 +292,8 @@ containerSecurityContext:
   capabilities:
     drop: ["ALL"]
 
-# Per-service overrides (replaces the ENTIRE merged context for that service).
+# Per-service overrides (full replacement — provide all fields you need).
 # Use when a specific service needs a completely different security posture.
-# Note: {} means "no override" (use merged defaults). This differs from scheduling
-# overrides below, where [] / {} actively clears the inherited value.
 # podSecurityContextOverrides:
 #   postgres:
 #     runAsNonRoot: true
@@ -433,9 +431,7 @@ tolerations: []
 nodeSelector: {}
 affinity: {}
 
-# Per-service scheduling overrides (field-level merge, not full replacement).
-# Only the fields you set are overridden; the rest inherit from global.
-# Setting a field to [] or {} actively clears it for that service.
+# Per-service scheduling overrides (full replacement — provide all three fields).
 # scheduling:
 #   server:
 #     tolerations: []

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -294,6 +294,8 @@ containerSecurityContext:
 
 # Per-service overrides (replaces the ENTIRE merged context for that service).
 # Use when a specific service needs a completely different security posture.
+# Note: {} means "no override" (use merged defaults). This differs from scheduling
+# overrides below, where [] / {} actively clears the inherited value.
 # podSecurityContextOverrides:
 #   postgres:
 #     runAsNonRoot: true
@@ -431,7 +433,9 @@ tolerations: []
 nodeSelector: {}
 affinity: {}
 
-# Per-service overrides (only the fields you set are overridden; the rest inherit from global)
+# Per-service scheduling overrides (field-level merge, not full replacement).
+# Only the fields you set are overridden; the rest inherit from global.
+# Setting a field to [] or {} actively clears it for that service.
 # scheduling:
 #   server:
 #     tolerations: []


### PR DESCRIPTION
- Added SecurityContext to all pods
- Added modifiable secCompProfile 
- Added tolerations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized pod and container security settings into shared Helm helper templates
  * Replaced per-manifest hardcoded security and scheduling with parameterized, defaultable template includes
  * Added global scheduling controls (tolerations, nodeSelector, affinity) and per-service scheduling overrides
  * Introduced top-level pod/container security context values and documented per-service override options to replace or merge settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->