### PR TITLE
ci: publish multi-arch (amd64 + arm64) images natively

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Export digest
         env:
           DIGEST: ${{ steps.build-server.outputs.digest || steps.build-frontend.outputs.digest }}
+          ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
           if [ -z "${DIGEST:-}" ]; then
@@ -119,8 +120,11 @@ jobs:
             exit 1
           fi
           mkdir -p /tmp/digests
-          # Strip the "sha256:" prefix so the filename is just the hex digest.
-          touch "/tmp/digests/${DIGEST#sha256:}"
+          # File name = arch, content = sha256:<hex>. Per-arch filenames let the
+          # merge job validate that every expected arch is present *before*
+          # calling `imagetools create`, so we never publish a half-populated
+          # manifest list to the registry.
+          printf '%s' "$DIGEST" > "/tmp/digests/${ARCH}"
 
       - name: Upload digest artifact
         uses: actions/upload-artifact@v4
@@ -175,16 +179,31 @@ jobs:
           IMAGE_NAME: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
         run: |
           set -euo pipefail
-          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=""
-          for digest_file in *; do
-            [ -f "$digest_file" ] || continue
-            sources="$sources ${IMAGE_NAME}@sha256:${digest_file}"
+
+          # Fail fast if any expected arch's digest is missing, *before* we
+          # touch the registry. Keep this list in sync with the build matrix
+          # (currently amd64 + arm64).
+          expected_arches="amd64 arm64"
+          missing=""
+          for arch in $expected_arches; do
+            if [ ! -s "$arch" ]; then
+              missing="${missing} $arch"
+            fi
           done
-          if [ -z "$sources" ]; then
-            echo "No digest files found to merge" >&2
+          if [ -n "$missing" ]; then
+            echo "Missing digest file(s) for arch(es):$missing" >&2
+            echo "Contents of /tmp/digests:" >&2
+            ls -la >&2
             exit 1
           fi
+
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          sources=""
+          for arch in $expected_arches; do
+            digest=$(cat "$arch")
+            sources="${sources} ${IMAGE_NAME}@${digest}"
+          done
+
           # shellcheck disable=SC2086
           docker buildx imagetools create $tags $sources
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -24,18 +24,41 @@ permissions:
   packages: write
 
 jobs:
-  publish-server:
-    name: Publish aurora-server
-    runs-on: ubuntu-24.04
-    # Only run on the main repository, not on forks
+  build:
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
     if: github.repository == 'Arvo-AI/aurora'
-
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: server
+            context: ./server
+            dockerfile: ./server/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - image: server
+            context: ./server
+            dockerfile: ./server/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - image: frontend
+            context: ./client
+            dockerfile: ./client/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - image: frontend
+            context: ./client
+            dockerfile: ./client/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-
-      - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -47,74 +70,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.SERVER_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
-            type=edge,branch=main
-            type=sha,prefix=sha-,format=short
+          images: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
 
-      - name: Build and push aurora-server
+      - name: Build and push by digest (server)
+        if: matrix.image == 'server'
+        id: build-server
         uses: docker/build-push-action@v6
         with:
-          context: ./server
-          file: ./server/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           target: prod
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=server-publish
-          cache-to: type=gha,mode=max,scope=server-publish
+          outputs: type=image,name=ghcr.io/arvo-ai/aurora-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
 
-  publish-frontend:
-    name: Publish aurora-frontend
-    runs-on: ubuntu-24.04
-    if: github.repository == 'Arvo-AI/aurora'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.FRONTEND_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
-            type=edge,branch=main
-            type=sha,prefix=sha-,format=short
-
-      - name: Build and push aurora-frontend
+      - name: Build and push by digest (frontend)
+        if: matrix.image == 'frontend'
+        id: build-frontend
         uses: docker/build-push-action@v6
         with:
-          context: ./client
-          file: ./client/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           target: prod
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_BACKEND_URL=http://localhost:5080
@@ -123,13 +107,104 @@ jobs:
             NEXT_PUBLIC_ENABLE_PAGERDUTY_OAUTH=true
             NEXT_PUBLIC_ENABLE_SCALEWAY=true
             NEXT_PUBLIC_ENABLE_SHAREPOINT=true
-          cache-from: type=gha,scope=frontend-publish
-          cache-to: type=gha,mode=max,scope=frontend-publish
+          outputs: type=image,name=ghcr.io/arvo-ai/aurora-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build-server.outputs.digest || steps.build-frontend.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DIGEST:-}" ]; then
+            echo "No digest produced by build step" >&2
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          # Strip the "sha256:" prefix so the filename is just the hex digest.
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.image }} manifest
+    needs: build
+    if: github.repository == 'Arvo-AI/aurora'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [server, frontend]
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+            type=edge,branch=main
+            type=sha,prefix=sha-,format=short
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE_NAME: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          sources=""
+          for digest_file in *; do
+            [ -f "$digest_file" ] || continue
+            sources="$sources ${IMAGE_NAME}@sha256:${digest_file}"
+          done
+          if [ -z "$sources" ]; then
+            echo "No digest files found to merge" >&2
+            exit 1
+          fi
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $tags $sources
+
+      - name: Inspect and verify multi-arch manifest
+        run: |
+          set -euo pipefail
+          REF=$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          echo "Inspecting $REF"
+          docker buildx imagetools inspect "$REF"
+          PLATFORMS=$(docker buildx imagetools inspect "$REF" --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}')
+          echo "Platforms: $PLATFORMS"
+          echo "$PLATFORMS" | grep -q 'linux/amd64' || { echo "Missing linux/amd64 in manifest list"; exit 1; }
+          echo "$PLATFORMS" | grep -q 'linux/arm64' || { echo "Missing linux/arm64 in manifest list"; exit 1; }
 
   publish-summary:
     name: Publish Summary
     runs-on: ubuntu-24.04
-    needs: [publish-server, publish-frontend]
+    needs: [build, merge]
     if: always()
     steps:
       - name: Summary
@@ -138,11 +213,11 @@ jobs:
           echo "Image Publish Summary"
           echo "================================================"
           echo ""
-          echo "Server:   ${{ needs.publish-server.result }}"
-          echo "Frontend: ${{ needs.publish-frontend.result }}"
+          echo "Build:  ${{ needs.build.result }}"
+          echo "Merge:  ${{ needs.merge.result }}"
           echo ""
-          if [ "${{ needs.publish-server.result }}" != "success" ] || [ "${{ needs.publish-frontend.result }}" != "success" ]; then
-            echo "One or more publishes failed!"
+          if [ "${{ needs.build.result }}" != "success" ] || [ "${{ needs.merge.result }}" != "success" ]; then
+            echo "One or more publish stages failed!"
             exit 1
           fi
-          echo "All images published successfully"
+          echo "All multi-arch images published successfully"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,8 +16,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  SERVER_IMAGE: ghcr.io/arvo-ai/aurora-server
-  FRONTEND_IMAGE: ghcr.io/arvo-ai/aurora-frontend
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -264,12 +264,29 @@ prod-airtight:
 	@echo "View logs with: docker compose -f docker-compose.airtight.yml logs --tail 50 -f"
 
 # Kubernetes deployment commands
+# deploy-build produces a multi-arch (linux/amd64 + linux/arm64) manifest list
+# for each pushed image so the same tag works on both Graviton/Apple Silicon
+# (arm64) and x86_64 Kubernetes nodes. Override the platform list with e.g.
+# `make deploy-build PLATFORMS=linux/arm64` if you only need a single arch.
+#
+# NOTE: multi-arch buildx requires a docker-container builder (the default
+# `docker` driver is single-arch only). This target creates one named
+# `aurora-multiarch` on first use. Building the non-native arch locally uses
+# QEMU emulation and is significantly slower than native — CI publishes
+# (`.github/workflows/publish-images.yml`) use native matrix runners instead.
+PLATFORMS ?= linux/amd64,linux/arm64
+
 deploy-build:
-	@echo "Building and pushing images for Kubernetes deployment..."
+	@echo "Building and pushing multi-arch images for Kubernetes deployment..."
+	@echo "Target platforms: $(PLATFORMS)"
 	@if [ ! -f deploy/helm/aurora/values.generated.yaml ]; then \
 		echo "Error: values.generated.yaml not found. Copy values.yaml to values.generated.yaml and configure it."; \
 		exit 1; \
 	fi
+	@echo "Ensuring multi-arch buildx builder exists..."
+	@docker buildx inspect aurora-multiarch >/dev/null 2>&1 || \
+		docker buildx create --name aurora-multiarch --driver docker-container --use >/dev/null
+	@docker buildx use aurora-multiarch
 	@echo "Extracting image registry and build args from values.generated.yaml..."
 	@set -e; \
 	IMAGE_REGISTRY=$$(yq '.image.registry' deploy/helm/aurora/values.generated.yaml); \
@@ -287,17 +304,21 @@ deploy-build:
 		fi; \
 	done; \
 	echo "Using git SHA tag: $$GIT_SHA"; \
-	echo "Building backend image: $$IMAGE_REGISTRY/aurora-server:$$GIT_SHA"; \
-	docker buildx build --platform linux/amd64 -t $$IMAGE_REGISTRY/aurora-server:$$GIT_SHA -f server/Dockerfile --target prod ./server --push; \
-	echo "Building frontend image: $$IMAGE_REGISTRY/aurora-frontend:$$GIT_SHA"; \
-	docker buildx build --platform linux/amd64 -t $$IMAGE_REGISTRY/aurora-frontend:$$GIT_SHA \
+	echo "Building backend image: $$IMAGE_REGISTRY/aurora-server:$$GIT_SHA ($(PLATFORMS))"; \
+	docker buildx build --platform $(PLATFORMS) \
+		-t $$IMAGE_REGISTRY/aurora-server:$$GIT_SHA \
+		-f server/Dockerfile --target prod ./server --push; \
+	echo "Building frontend image: $$IMAGE_REGISTRY/aurora-frontend:$$GIT_SHA ($(PLATFORMS))"; \
+	docker buildx build --platform $(PLATFORMS) \
+		-t $$IMAGE_REGISTRY/aurora-frontend:$$GIT_SHA \
 		-f client/Dockerfile --target prod \
 		$$BUILD_ARGS \
 		./client --push; \
 	ENABLE_POD_ISOLATION=$$(yq '.config.ENABLE_POD_ISOLATION' deploy/helm/aurora/values.generated.yaml); \
 	if [ "$$ENABLE_POD_ISOLATION" = "true" ]; then \
-		echo "Pod isolation enabled, building terminal image: $$IMAGE_REGISTRY/aurora-terminal:$$GIT_SHA"; \
-		docker buildx build --platform linux/amd64 -t $$IMAGE_REGISTRY/aurora-terminal:$$GIT_SHA \
+		echo "Pod isolation enabled, building terminal image: $$IMAGE_REGISTRY/aurora-terminal:$$GIT_SHA ($(PLATFORMS))"; \
+		docker buildx build --platform $(PLATFORMS) \
+			-t $$IMAGE_REGISTRY/aurora-terminal:$$GIT_SHA \
 			-f server/Dockerfile-user-terminal \
 			./server --push; \
 		echo "Updating TERMINAL_IMAGE in values.generated.yaml..."; \
@@ -306,6 +327,12 @@ deploy-build:
 		echo "Pod isolation disabled, skipping terminal image build"; \
 	fi; \
 	echo "Images built and pushed successfully with tag: $$GIT_SHA"; \
+	echo "Verifying multi-arch manifests..."; \
+	docker buildx imagetools inspect $$IMAGE_REGISTRY/aurora-server:$$GIT_SHA; \
+	docker buildx imagetools inspect $$IMAGE_REGISTRY/aurora-frontend:$$GIT_SHA; \
+	if [ "$$ENABLE_POD_ISOLATION" = "true" ]; then \
+		docker buildx imagetools inspect $$IMAGE_REGISTRY/aurora-terminal:$$GIT_SHA; \
+	fi; \
 	echo "Updating values.generated.yaml with new tag..."; \
 	yq -i ".image.tag = \"$$GIT_SHA\"" deploy/helm/aurora/values.generated.yaml
 

--- a/website/docs/multi-arch-images.md
+++ b/website/docs/multi-arch-images.md
@@ -81,7 +81,9 @@ Manifests:
 
 ## Make commands
 
-Every `make` target that builds or pulls images auto-detects the host architecture. There are no arch flags to set.
+Most `make` targets that build or pull images auto-detect the host architecture — on Apple Silicon you get arm64 everywhere by default; on an x86_64 CI runner you get amd64. No flags, no branching.
+
+The one exception is **`make deploy-build`**, which is intentionally *not* host-scoped: it defaults to building both `linux/amd64` and `linux/arm64` regardless of where it runs, so a single push produces a multi-arch manifest list suitable for any target cluster. Override this with the `PLATFORMS` variable (e.g. `make deploy-build PLATFORMS=linux/arm64`) if you only need one arch for a quick demo.
 
 | Command | Arch behavior |
 |---|---|
@@ -89,9 +91,7 @@ Every `make` target that builds or pulls images auto-detects the host architectu
 | `make prod` / `make prod-prebuilt` | Pulls the matching arch from GHCR (Docker auto-resolves the manifest list). |
 | `make prod-build` / `make prod-local` | Builds for host arch from local source. |
 | `make prod-airtight` | Loads whichever per-arch tarball you provide (see the airtight section below). |
-| `make deploy-build` | Builds **both** `linux/amd64` and `linux/arm64` and pushes a multi-arch manifest list to your configured registry. Override with `make deploy-build PLATFORMS=linux/arm64` to build a single arch. |
-
-On Apple Silicon you get arm64 everywhere by default; on an x86_64 CI runner you get amd64. Same commands, no flags, no branching.
+| `make deploy-build` | Defaults to building **both** `linux/amd64` and `linux/arm64` and pushes a multi-arch manifest list to your configured registry. Override with `PLATFORMS=linux/arm64` (or any subset) to build a single arch. |
 
 ### Note on `make deploy-build`
 

--- a/website/docs/multi-arch-images.md
+++ b/website/docs/multi-arch-images.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 5
+---
+
+# Multi-architecture Images (ARM64 + AMD64)
+
+Aurora's published container images work transparently on both `linux/amd64` (Intel/AMD x86_64) and `linux/arm64` (Apple Silicon, AWS Graviton, Ampere) hosts. The same image tag serves both architectures — Docker automatically picks the right one based on your host, so there is no "choose your arch" step during install.
+
+## TL;DR
+
+```bash
+docker pull ghcr.io/arvo-ai/aurora-server:edge
+# On an Apple Silicon Mac       → pulls linux/arm64
+# On an EC2 x86_64 instance     → pulls linux/amd64
+# On an EKS Graviton node       → pulls linux/arm64
+# No flags, no configuration.
+```
+
+## Which images are multi-arch?
+
+- `ghcr.io/arvo-ai/aurora-server` — Flask API, Celery worker, Celery beat, and chatbot are all built from `server/Dockerfile`.
+- `ghcr.io/arvo-ai/aurora-frontend` — Next.js app built from `client/Dockerfile`.
+
+Both are published as **OCI image indexes** (a.k.a. manifest lists) containing `linux/amd64` and `linux/arm64` variants under the same tag.
+
+## How it works (OCI manifest lists)
+
+When you run `docker pull` against a multi-arch image, the registry returns a manifest list describing every available architecture. The Docker client reads your host's `GOARCH` and pulls only the matching variant. This is the same mechanism used by official images like `python:3.12-slim`, `node:20-alpine`, and `postgres:15-alpine`.
+
+You don't need to pick or configure anything — the registry serves the correct image automatically based on where you're running `docker pull`.
+
+## Forcing a specific architecture
+
+If you need to pull or run a non-native arch (for example, debugging an amd64-only issue on an Apple Silicon Mac via Rosetta), use `--platform`:
+
+```bash
+# Force amd64 pull on any host
+docker pull --platform linux/amd64 ghcr.io/arvo-ai/aurora-server:edge
+
+# Force amd64 at run time
+docker run --platform linux/amd64 ghcr.io/arvo-ai/aurora-server:edge
+
+# In docker-compose.yaml, pin a service to a specific arch:
+services:
+  aurora-server:
+    image: ghcr.io/arvo-ai/aurora-server:edge
+    platform: linux/amd64
+```
+
+## Kubernetes behavior
+
+No Helm chart changes are required. When the kubelet on each node pulls an image, it automatically requests the variant matching that node's architecture. On mixed amd64/arm64 clusters (e.g. EKS with both `m5` and `m7g` node groups), the same Helm release runs seamlessly on every node.
+
+If you want to pin a workload to a specific architecture, use a standard `nodeSelector`:
+
+```yaml
+spec:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+```
+
+## Verifying a multi-arch image
+
+```bash
+docker buildx imagetools inspect ghcr.io/arvo-ai/aurora-server:edge
+```
+
+The output should list both platforms under `Manifests`:
+
+```
+Name:      ghcr.io/arvo-ai/aurora-server:edge
+MediaType: application/vnd.oci.image.index.v1+json
+...
+Manifests:
+  Name:      ghcr.io/arvo-ai/aurora-server:edge@sha256:...
+  Platform:  linux/amd64
+  ...
+  Name:      ghcr.io/arvo-ai/aurora-server:edge@sha256:...
+  Platform:  linux/arm64
+```
+
+## Make commands
+
+Every `make` target that builds or pulls images auto-detects the host architecture. There are no arch flags to set.
+
+| Command | Arch behavior |
+|---|---|
+| `make dev` / `make dev-build` | Builds for host arch from local source. |
+| `make prod` / `make prod-prebuilt` | Pulls the matching arch from GHCR (Docker auto-resolves the manifest list). |
+| `make prod-build` / `make prod-local` | Builds for host arch from local source. |
+| `make prod-airtight` | Loads whichever per-arch tarball you provide (see the airtight section below). |
+| `make deploy-build` | Builds **both** `linux/amd64` and `linux/arm64` and pushes a multi-arch manifest list to your configured registry. Override with `make deploy-build PLATFORMS=linux/arm64` to build a single arch. |
+
+On Apple Silicon you get arm64 everywhere by default; on an x86_64 CI runner you get amd64. Same commands, no flags, no branching.
+
+### Note on `make deploy-build`
+
+`deploy-build` produces a multi-arch manifest list by default so the same tag deploys cleanly to mixed-arch Kubernetes clusters. Because it runs on a single host, the non-native architecture is built via QEMU emulation and is noticeably slower than a native build — especially for the Python server image, which compiles wheels for `grpcio`, `psycopg2`, and `cryptography`. For routine publishes, prefer the CI workflow (`.github/workflows/publish-images.yml`), which builds each arch natively on GitHub-hosted runners in parallel.
+
+If you only need a single arch for a quick demo push, override the platform list:
+
+```bash
+make deploy-build PLATFORMS=linux/arm64
+```
+
+## Publishing workflow
+
+`.github/workflows/publish-images.yml` builds `aurora-server` and `aurora-frontend` natively on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) GitHub-hosted runners in parallel, pushes each arch as a digest-only image to GHCR, and then merges the per-arch digests into a single manifest list under each published tag (`:edge`, `:v1.2.3`, `:sha-abc123`, `:latest`). Native builds avoid QEMU emulation overhead and keep publish times reasonable even as the Python layer grows.
+
+Every merge also runs `docker buildx imagetools inspect` and fails the job if both `linux/amd64` and `linux/arm64` aren't present in the published manifest list, so a broken multi-arch publish is caught in CI rather than at pull time.
+
+## Air-gapped deployments
+
+For air-gapped environments, `.github/workflows/publish-airtight.yml` produces per-arch tarballs via a native matrix:
+
+- `aurora-airtight-bucket` — `linux/amd64`
+- `aurora-airtight-bucket-arm64` — `linux/arm64`
+
+Download the bundle that matches your target host, transfer it across the air gap, and `make prod-airtight` will load and run it with `docker load`.

--- a/website/docs/multi-arch-images.md
+++ b/website/docs/multi-arch-images.md
@@ -111,7 +111,13 @@ Every merge also runs `docker buildx imagetools inspect` and fails the job if bo
 
 ## Air-gapped deployments
 
-For air-gapped environments, `.github/workflows/publish-airtight.yml` produces per-arch tarballs via a native matrix:
+For air-gapped environments, `.github/workflows/publish-airtight.yml` builds `scripts/package-airtight.sh` natively for each arch and publishes a single gzipped tarball per build:
+
+```text
+aurora-airtight-<version>-<arch>.tar.gz
+```
+
+The bundles are uploaded to per-arch GCS buckets:
 
 - `aurora-airtight-bucket` — `linux/amd64`
 - `aurora-airtight-bucket-arm64` — `linux/arm64`
@@ -119,7 +125,7 @@ For air-gapped environments, `.github/workflows/publish-airtight.yml` produces p
 Download the bundle that matches your target host, transfer it across the air gap, and point `make prod-airtight` at it with the `AIRTIGHT_BUNDLE` variable:
 
 ```bash
-make prod-airtight AIRTIGHT_BUNDLE=/path/to/aurora-airtight-<arch>.tar
+make prod-airtight AIRTIGHT_BUNDLE=/path/to/aurora-airtight-<version>-<arch>.tar.gz
 ```
 
-`prod-airtight` runs `docker load < $AIRTIGHT_BUNDLE` to import the images before starting Aurora. If `AIRTIGHT_BUNDLE` is not set, the target skips the load step and assumes the images are already present in the local Docker daemon — so first-time installs must always set it.
+`prod-airtight` runs `docker load < $AIRTIGHT_BUNDLE` to import the gzipped tarball before starting Aurora (`docker load` auto-detects gzip). If `AIRTIGHT_BUNDLE` is not set, the target skips the load step and assumes the images are already present in the local Docker daemon — so first-time installs must always set it.

--- a/website/docs/multi-arch-images.md
+++ b/website/docs/multi-arch-images.md
@@ -67,7 +67,7 @@ docker buildx imagetools inspect ghcr.io/arvo-ai/aurora-server:edge
 
 The output should list both platforms under `Manifests`:
 
-```
+```text
 Name:      ghcr.io/arvo-ai/aurora-server:edge
 MediaType: application/vnd.oci.image.index.v1+json
 ...
@@ -105,7 +105,7 @@ make deploy-build PLATFORMS=linux/arm64
 
 ## Publishing workflow
 
-`.github/workflows/publish-images.yml` builds `aurora-server` and `aurora-frontend` natively on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) GitHub-hosted runners in parallel, pushes each arch as a digest-only image to GHCR, and then merges the per-arch digests into a single manifest list under each published tag (`:edge`, `:v1.2.3`, `:sha-abc123`, `:latest`). Native builds avoid QEMU emulation overhead and keep publish times reasonable even as the Python layer grows.
+`.github/workflows/publish-images.yml` builds `aurora-server` and `aurora-frontend` natively on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) GitHub-hosted runners in parallel, pushes each arch as a digest-only image to GHCR, and then merges the per-arch digests into a single manifest list under each published tag (`:edge`, `:1.2.3`, `:1.2`, `:sha-abc123`, `:latest`). Native builds avoid QEMU emulation overhead and keep publish times reasonable even as the Python layer grows.
 
 Every merge also runs `docker buildx imagetools inspect` and fails the job if both `linux/amd64` and `linux/arm64` aren't present in the published manifest list, so a broken multi-arch publish is caught in CI rather than at pull time.
 

--- a/website/docs/multi-arch-images.md
+++ b/website/docs/multi-arch-images.md
@@ -105,7 +105,7 @@ make deploy-build PLATFORMS=linux/arm64
 
 ## Publishing workflow
 
-`.github/workflows/publish-images.yml` builds `aurora-server` and `aurora-frontend` natively on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) GitHub-hosted runners in parallel, pushes each arch as a digest-only image to GHCR, and then merges the per-arch digests into a single manifest list under each published tag (`:edge`, `:1.2.3`, `:1.2`, `:sha-abc123`, `:latest`). Native builds avoid QEMU emulation overhead and keep publish times reasonable even as the Python layer grows.
+`.github/workflows/publish-images.yml` builds `aurora-server` and `aurora-frontend` natively on both `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) GitHub-hosted runners in parallel, pushes each arch as a digest-only image to GHCR, and then merges the per-arch digests into a single manifest list under each published tag (`:edge`, `:1.2.3`, `:1.2`, `:sha-abc123`, `:latest`). `:latest` is only pushed for stable release-tag events (`refs/tags/v*.*.*`, excluding prereleases); pushes to `main` publish `:edge` and `:sha-<short>` but not `:latest`. Native builds avoid QEMU emulation overhead and keep publish times reasonable even as the Python layer grows.
 
 Every merge also runs `docker buildx imagetools inspect` and fails the job if both `linux/amd64` and `linux/arm64` aren't present in the published manifest list, so a broken multi-arch publish is caught in CI rather than at pull time.
 
@@ -116,4 +116,10 @@ For air-gapped environments, `.github/workflows/publish-airtight.yml` produces p
 - `aurora-airtight-bucket` — `linux/amd64`
 - `aurora-airtight-bucket-arm64` — `linux/arm64`
 
-Download the bundle that matches your target host, transfer it across the air gap, and `make prod-airtight` will load and run it with `docker load`.
+Download the bundle that matches your target host, transfer it across the air gap, and point `make prod-airtight` at it with the `AIRTIGHT_BUNDLE` variable:
+
+```bash
+make prod-airtight AIRTIGHT_BUNDLE=/path/to/aurora-airtight-<arch>.tar
+```
+
+`prod-airtight` runs `docker load < $AIRTIGHT_BUNDLE` to import the images before starting Aurora. If `AIRTIGHT_BUNDLE` is not set, the target skips the load step and assumes the images are already present in the local Docker daemon — so first-time installs must always set it.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -39,6 +39,11 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
+      type: 'doc',
+      id: 'multi-arch-images',
+      label: 'Multi-arch Images',
+    },
+    {
       type: 'category',
       label: 'Architecture',
       items: [


### PR DESCRIPTION
## Summary

- Rewrite `.github/workflows/publish-images.yml` to a native matrix: four parallel `build` jobs (server/frontend × amd64/arm64) run on `ubuntu-24.04` and `ubuntu-24.04-arm`, push per-arch digests, then two `merge` jobs stitch them into a single manifest list per tag and verify both platforms are present. Replaces the previous QEMU cross-build.
- Make `make deploy-build` multi-arch by default (`linux/amd64,linux/arm64`, overridable with `PLATFORMS=...`) via a `docker-container` buildx builder, and inspect each image's manifest list after push.
- Add `website/docs/multi-arch-images.md` explaining host auto-resolve, `--platform` overrides, Kubernetes behavior, and per-`make`-target arch behavior; link it in the Docusaurus sidebar.

Result: a single image tag (`:edge`, `:v1.2.3`, `:sha-abc123`) transparently serves both `linux/amd64` (x86_64 dev / CI / EC2) and `linux/arm64` (Apple Silicon / Graviton / Ampere) via an OCI manifest list. No Dockerfile, compose, or Helm changes are required — `server/Dockerfile` was already arch-safe and `client/Dockerfile` uses a multi-arch Bun base.

### Build time

Native matrix wall-clock on this branch: **10m 20s** total (4 builds in parallel; slowest was frontend arm64 at ~9:44).
Previous QEMU runs on `main`: ~19m (#233 python upgrade) and ~20m (#229 cache fixes).
Roughly **2× faster**, even on a cold GHA cache — subsequent runs will be faster still.

## Test plan

- [x] YAML / Makefile lint: `python3 -c 'import yaml; yaml.safe_load(...)'`, `make -n deploy-build`
- [x] CI workflow on this branch (run `24259339854`) — 4 native builds + 2 merges + summary all green
- [x] Manifest inspection — both `aurora-server:sha-0869ee9` and `aurora-frontend:sha-0869ee9` list `linux/amd64` and `linux/arm64` with distinct digests
- [x] Native pull on Apple Silicon → `aarch64` inside the container
- [x] Forced `docker pull --platform linux/amd64 ...` → `x86_64` inside the container (same tag)
- [x] `make prod-prebuilt VERSION=sha-0869ee9` smoke test on Apple Silicon: all 4 Aurora services (`aurora-server`, `aurora-frontend`, `aurora-celery_worker`, `aurora-chatbot`) run `aarch64`; backend `/health` and frontend `/` both return 200
- [x] `make deploy-build` end-to-end against a test registry + multi-arch manifest verification — see comment below
- [x] Mixed-arch EKS smoke — added a t4g.medium arm64 nodegroup to the test cluster; same image reference resolved to x86_64 on the amd64 node and aarch64 on the arm64 node. See comment below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-architecture container images for Linux AMD64 and ARM64 are published for server and frontend; Docker/Kubernetes will select the appropriate variant on pull.

* **Chores**
  * CI now builds per-architecture images, uploads per-arch digests, merges them into unified multi-arch manifests, and verifies manifest contents.
  * Build tooling updated to support configurable target platforms and post-publish inspections; logs now reflect multi-arch behavior.

* **Documentation**
  * New “Multi-arch Images” guide covering usage, verification, Kubernetes behavior, and air-gapped workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
