### PR TITLE
fix: gate confluence_runbook_parse behind credential check

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1163,7 +1163,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         (cloud_exec_wrapper, "cloud_exec"),
         (terminal_exec, "terminal_exec"),
         (tailscale_ssh, "tailscale_ssh"),
-        (confluence_runbook_parse, "confluence_runbook_parse"),
         (on_prem_kubectl, "on_prem_kubectl"),
         (analyze_zip_file, "analyze_zip_file"),
         # (web_search, "web_search"),  # Moved to dedicated registration below with explicit args_schema
@@ -1319,12 +1318,19 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                 ),
                 args_schema=GitHubApplyFixArgs
             )
-        elif name == "confluence_runbook_parse":
+        elif name == 'trigger_rca':
             tool = StructuredTool.from_function(
                 func=final_func,
                 name=name,
-                description="Fetch and parse a Confluence runbook into markdown and steps for LLM use. Parameter: page_url (string, required).",
-                args_schema=ConfluenceRunbookArgs,
+                description=(
+                    "Trigger a full automated Root Cause Analysis investigation. "
+                    "Use this when the user reports an operational incident or describes symptoms "
+                    "that warrant investigation (e.g. high CPU, errors, latency spikes, outages). "
+                    "Creates an incident and dispatches a background RCA using all connected integrations. "
+                    "Parameters: issue_description (required), title (optional), service (optional), "
+                    "severity (optional: critical/high/medium/low)."
+                ),
+                args_schema=TriggerRCAArgs,
             )
         elif name == 'trigger_rca':
             tool = StructuredTool.from_function(
@@ -1597,7 +1603,10 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     except Exception as e:
         logging.warning(f"Failed to add Bitbucket tools: {e}")
 
-    # Add Confluence search tools if enabled
+    # Add Confluence tools if the user has a Confluence connection.
+    # confluence_runbook_parse was previously in the unconditional tool list,
+    # which caused the agent to call Confluence tools even when the user had
+    # no Confluence credentials, breaking RCAs that mention runbook URLs.
     try:
         from utils.auth.token_management import get_token_data
         if user_id and get_token_data(user_id, "confluence"):
@@ -1622,7 +1631,18 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     description=_desc,
                     args_schema=_schema,
                 ))
-            logging.info(f"Added 3 Confluence search tools for user {user_id}")
+            # Also register the runbook parser inside the gate so the agent
+            # only sees it when Confluence credentials exist.
+            _rp_ctx = with_user_context(confluence_runbook_parse)
+            _rp_notif = with_completion_notification(_rp_ctx)
+            _rp_final = wrap_func_with_capture(_rp_notif, "confluence_runbook_parse") if tool_capture else _rp_notif
+            tools.append(StructuredTool.from_function(
+                func=_rp_final,
+                name="confluence_runbook_parse",
+                description="Fetch and parse a Confluence runbook into markdown and steps for LLM use. Parameter: page_url (string, required).",
+                args_schema=ConfluenceRunbookArgs,
+            ))
+            logging.info(f"Added 4 Confluence tools for user {user_id}")
     except Exception as e:
         logging.warning(f"Failed to add Confluence search tools: {e}")
 

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1332,20 +1332,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                 ),
                 args_schema=TriggerRCAArgs,
             )
-        elif name == 'trigger_rca':
-            tool = StructuredTool.from_function(
-                func=final_func,
-                name=name,
-                description=(
-                    "Trigger a full automated Root Cause Analysis investigation. "
-                    "Use this when the user reports an operational incident or describes symptoms "
-                    "that warrant investigation (e.g. high CPU, errors, latency spikes, outages). "
-                    "Creates an incident and dispatches a background RCA using all connected integrations. "
-                    "Parameters: issue_description (required), title (optional), service (optional), "
-                    "severity (optional: critical/high/medium/low)."
-                ),
-                args_schema=TriggerRCAArgs,
-            )
         else:
             tool = StructuredTool.from_function(final_func)
         tools.append(tool)


### PR DESCRIPTION
confluence_runbook_parse was registered in the unconditional tool_functions list, so the agent saw it for every user regardless of whether they had Confluence credentials. When an alert payload included a runbook_url, the agent would call this tool, fail because no Confluence token existed, and the entire RCA would error out.

Moved the tool registration into the existing credential-gated Confluence block (alongside confluence_search_similar, confluence_search_runbooks, and confluence_fetch_page) so it only appears when the user actually has a Confluence connection. Also removed the now-dead elif branch from the unconditional loop that handled ConfluenceRunbookArgs schema binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confluence tools no longer activate unless valid Confluence credentials are present.

* **Improvements**
  * Confluence integration now registers the full set of tools only when authenticated, with consistent user-context handling, completion notifications, and optional capture.
  * Logging updated to reflect the correct number of Confluence tools when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->