### PR TITLE
chore: bump Helm chart version to 1.2.8

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.7
-appVersion: "1.2.7"
+version: 1.2.8
+appVersion: "1.2.8"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps `version` and `appVersion` in `Chart.yaml` to `1.2.8` so the next tag triggers a matching Helm chart publish.

## Test plan
- Merge, tag `v1.2.8`, and verify the Publish Helm Chart workflow passes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.2.8 with updated Helm chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->