### PR TITLE
fix: restore Chart.yaml metadata and add OCI source annotation

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -10,3 +10,5 @@ sources:
 maintainers:
   - name: Arvo AI
     url: https://github.com/Arvo-AI
+annotations:
+  org.opencontainers.image.source: https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
The squash merge lost maintainers/home/sources fields and version. Adds org.opencontainers.image.source annotation so GHCR auto-links the package to the aurora repo, granting GITHUB_TOKEN write access.