### PR TITLE
fix: add OCI source annotation and bump chart to 1.2.9

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.8
-appVersion: "1.2.8"
+version: 1.2.9
+appVersion: "1.2.9"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora

--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -10,3 +10,5 @@ sources:
 maintainers:
   - name: Arvo AI
     url: https://github.com/Arvo-AI
+annotations:
+  org.opencontainers.image.source: https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Adds `org.opencontainers.image.source` annotation to `Chart.yaml` so GHCR auto-links the package to the repo, allowing `GITHUB_TOKEN` write access in CI.
- Bumps chart version/appVersion to 1.2.9.

## Test plan
- Merge, tag `v1.2.9`, verify Publish Helm Chart workflow passes.


Made with [Cursor](https://cursor.com)