### PR TITLE
fix: repair broken SearXNG Helm deployment template

### DIFF
--- a/deploy/helm/aurora/templates/searxng-deployment.yaml
+++ b/deploy/helm/aurora/templates/searxng-deployment.yaml
@@ -39,10 +39,8 @@ spec:
             - configMapRef:
                 name: {{ include "aurora.fullname" . }}-config
             - secretRef:
-                name: {{ include "aurora.fullname" . }}-secrets-app
-          startupProbe:
                 name: {{ include "aurora.secretName.app" . }}
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /healthz
               port: 8080


### PR DESCRIPTION
## Summary
- Fixed `secretRef` using wrong helper (`aurora.fullname` instead of `aurora.secretName.app`)
- Replaced malformed `startupProbe` (had a stray `name:` field from a merge artifact) with a proper HTTP probe
- Removed duplicate `readinessProbe` block

Without this fix, `helm install` fails with:
```
failed to create typed patch object: .spec.template.spec.containers[name="searxng"].startupProbe.name: field not declared in schema
```

## Test plan
- Deployed full stack on GKE (`aurora-oss-demo` cluster) with this fix -- all 12 pods running successfully.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Kubernetes deployment health probe configuration with adjusted sequencing of startup and readiness checks to enhance application initialization reliability and deployment stability.
  * Refined probe and secret management associations for better deployment configuration clarity and consistency.
  * Enhanced container initialization behavior for more predictable system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->