### PR TITLE
chore: bump Helm chart version to 1.2.10

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.9
-appVersion: "1.2.9"
+version: 1.2.10
+appVersion: "1.2.10"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps chart version to 1.2.10 to publish the SearXNG template fix from #249.

## Test plan
- Merge, tag `v1.2.10`, push tag. Verify Helm chart publishes and installs cleanly.