### PR TITLE
chore: bump Helm chart version to 1.2.11

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.10
-appVersion: "1.2.10"
+version: 1.2.11
+appVersion: "1.2.11"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps Helm chart version and appVersion from 1.2.10 to 1.2.11 to include the session fix from #251.

## Test plan
- [ ] CI passes
- [ ] After merge, push tag v1.2.11 to trigger Helm chart publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata to 1.2.11

<!-- end of auto-generated comment: release notes by coderabbit.ai -->