### PR TITLE
fix: derive AUTH_URL from FRONTEND_URL in Helm configmap

### DIFF
--- a/deploy/helm/aurora/templates/configmap.yaml
+++ b/deploy/helm/aurora/templates/configmap.yaml
@@ -20,11 +20,14 @@ data:
   # Backend needs this for OAuth callbacks (derived from ingress if not set)
   NEXT_PUBLIC_BACKEND_URL: {{ default (printf "https://%s" .Values.ingress.hosts.api) .Values.config.NEXT_PUBLIC_BACKEND_URL | quote }}
 
+  # Auth.js requires AUTH_URL for redirects; derive from FRONTEND_URL (mirrors docker-compose behavior)
+  AUTH_URL: {{ default .Values.config.FRONTEND_URL .Values.config.AUTH_URL | quote }}
+
   # All other config values from .Values.config (excluding keys with computed defaults above)
   # NOTE: NEXT_PUBLIC_* vars are included because the backend reads feature flags like
   # NEXT_PUBLIC_ENABLE_OVH, NEXT_PUBLIC_ENABLE_SCALEWAY, etc. to conditionally register routes.
   {{- range $key, $value := .Values.config }}
-  {{- if not (has $key (list "POSTGRES_HOST" "REDIS_URL" "WEAVIATE_HOST" "BACKEND_URL" "CHATBOT_INTERNAL_URL" "VAULT_ADDR" "SEARXNG_URL" "NEXT_PUBLIC_BACKEND_URL" (ternary "STORAGE_ENDPOINT_URL" "" (and $.Values.services.minio.enabled (not $.Values.config.STORAGE_ENDPOINT_URL))))) }}
+  {{- if not (has $key (list "POSTGRES_HOST" "REDIS_URL" "WEAVIATE_HOST" "BACKEND_URL" "CHATBOT_INTERNAL_URL" "VAULT_ADDR" "SEARXNG_URL" "NEXT_PUBLIC_BACKEND_URL" "AUTH_URL" (ternary "STORAGE_ENDPOINT_URL" "" (and $.Values.services.minio.enabled (not $.Values.config.STORAGE_ENDPOINT_URL))))) }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Auth.js uses `AUTH_URL` for login/logout redirects. Without it set, Auth.js defaults to `http://localhost:3000`, breaking logout in K8s deployments.
- Adds a computed `AUTH_URL` entry in the Helm configmap template, derived from `FRONTEND_URL` (mirrors docker-compose behavior). Overridable via `config.AUTH_URL` if needed.
- Adds `AUTH_URL` to the exclusion list so it won't be duplicated by the config range loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment configuration handling to prevent duplicate entries and ensure proper configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->