### PR TITLE
fix: make Weaviate work without OpenAI API key

### DIFF
--- a/server/chat/backend/agent/tools/rag_indexer_tool.py
+++ b/server/chat/backend/agent/tools/rag_indexer_tool.py
@@ -155,7 +155,7 @@ def rag_index_zip(attachment_index: int = 0, max_files: int = 200, max_file_byte
                     from weaviate.classes.config import Configure, Property, DataType
                     client.collections.create(
                         name="RAGDoc",
-                        vectorizer_config=Configure.Vectorizer.text2vec_openai(),
+                        vectorizer_config=Configure.Vectorizer.text2vec_transformers(),
                         properties=[
                             Property(name="text", data_type=DataType.TEXT),
                             Property(name="filename", data_type=DataType.TEXT),

--- a/server/chat/backend/agent/weaviate_client.py
+++ b/server/chat/backend/agent/weaviate_client.py
@@ -1,8 +1,6 @@
 import json
 from typing import Dict, List, Tuple
-import openai
 import re
-from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
 import weaviate
 from weaviate.classes.query import Filter
 from weaviate.util import generate_uuid5
@@ -27,8 +25,6 @@ class WeaviateClient:
         headers = {}
         if openai_api_key:
             headers["X-OpenAI-Api-Key"] = openai_api_key
-        else:
-            logger.warning("OPENAI_API_KEY not set - Weaviate text2vec-openai vectorizer will not work")
 
         WEAVIATE_HOST = os.getenv("WEAVIATE_HOST", "weaviate.default.svc.cluster.local")
         weaviate_secure = os.getenv("WEAVIATE_SECURE", "false").lower() in ("1", "true", "yes")

--- a/server/chat/backend/agent/weaviate_client.py
+++ b/server/chat/backend/agent/weaviate_client.py
@@ -22,10 +22,13 @@ class WeaviateClient:
     def __init__(self, postgres_client: PostgreSQLClient):
         self.postgres_client = postgres_client
 
-        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-        assert OPENAI_API_KEY is not None, "OPENAI_API_KEY environment variable not set"
-        os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
-        
+        openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
+
+        headers = {}
+        if openai_api_key:
+            headers["X-OpenAI-Api-Key"] = openai_api_key
+        else:
+            logger.warning("OPENAI_API_KEY not set - Weaviate text2vec-openai vectorizer will not work")
 
         WEAVIATE_HOST = os.getenv("WEAVIATE_HOST", "weaviate.default.svc.cluster.local")
         weaviate_secure = os.getenv("WEAVIATE_SECURE", "false").lower() in ("1", "true", "yes")
@@ -37,7 +40,7 @@ class WeaviateClient:
             grpc_host=WEAVIATE_HOST,
             grpc_port=int(os.getenv("WEAVIATE_GRPC_PORT", "50051")),
             grpc_secure=weaviate_secure,
-            headers={"X-OpenAI-Api-Key": OPENAI_API_KEY}
+            headers=headers,
         )
 
         assert self.client.is_ready(), "Weaviate client is not ready. Check the connection."


### PR DESCRIPTION
## Summary

- Removed the hard `assert OPENAI_API_KEY` in the chatbot Weaviate client that crashed the pod on startup when the key was missing or whitespace (the "spamming" errors PSL hit during deployment).
- Made the `X-OpenAI-Api-Key` header conditional -- only sent when the key is actually present, matching the pattern already used by the knowledge base and incident feedback Weaviate clients.
- Switched the `RAGDoc` collection vectorizer from `text2vec_openai()` to `text2vec_transformers()`. The `text2vec-openai` module was never loaded in any Weaviate deployment (`ENABLE_MODULES` only includes `text2vec-transformers`), so RAGDoc creation would always fail. Now it uses the same local t2v-transformers sidecar as the other two collections (`KnowledgeBaseChunk`, `IncidentKnowledge`).
- Removed unused `import openai` and `from openai.types.chat import ...` dead imports from `weaviate_client.py`.

## Files changed

- `server/chat/backend/agent/weaviate_client.py` -- Remove assert, conditional header, remove dead imports
- `server/chat/backend/agent/tools/rag_indexer_tool.py` -- Switch RAGDoc vectorizer to text2vec_transformers

## What is NOT changed

- Knowledge base and incident feedback Weaviate clients (already correct)
- Docker Compose / Helm Weaviate config (`ENABLE_MODULES: "text2vec-transformers"` stays as-is)
- `OPENAI_API_KEY` env var itself (still needed for LLM calls, just not for Weaviate)