### PR TITLE
fix: RLS policy violations on user_tokens and user_connections

### DIFF
--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -37,7 +37,7 @@ HTTP_TIMEOUT = (3.5, 5)
 def _check_grafana(user_id: str, org_id: str) -> Dict[str, Any]:
     """Grafana is webhook-based — check is_active directly (no secret_ref needed)."""
     try:
-        with db_pool.get_admin_connection() as conn:
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(
                     """SELECT 1 FROM user_tokens
@@ -705,7 +705,7 @@ def get_connected_count(user_id: str, org_id: str) -> int:
 
 def _check_all_connectors(user_id: str, org_id: str) -> Dict[str, Dict[str, Any]]:
 
-    with db_pool.get_admin_connection() as conn:
+    with db_pool.get_admin_connection(org_id=org_id) as conn:
         with conn.cursor() as cursor:
             cursor.execute(
                 """
@@ -745,7 +745,7 @@ def _check_all_connectors(user_id: str, org_id: str) -> Dict[str, Dict[str, Any]
             return provider, _check_grafana(user_id, org_id)
         creds = get_token_data(token_owner_id, provider)
         if not creds:
-            with db_pool.get_admin_connection() as fallback_conn:
+            with db_pool.get_admin_connection(org_id=org_id) as fallback_conn:
                 with fallback_conn.cursor() as cur:
                     cur.execute(
                         "SELECT 1 FROM user_connections WHERE (user_id = %s OR org_id = %s) AND provider = %s AND status = 'active' LIMIT 1",
@@ -785,7 +785,7 @@ def _check_all_connectors(user_id: str, org_id: str) -> Dict[str, Dict[str, Any]
 
 def _check_onprem(user_id: str, org_id: str) -> Dict[str, Any]:
     try:
-        with db_pool.get_admin_connection() as conn:
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(
                     """SELECT COUNT(*) FROM user_manual_vms
@@ -802,7 +802,7 @@ def _check_onprem(user_id: str, org_id: str) -> Dict[str, Any]:
 
 def _check_kubectl(user_id: str, org_id: str) -> Dict[str, Any]:
     try:
-        with db_pool.get_admin_connection() as conn:
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(
                     """SELECT COUNT(*) FROM active_kubectl_connections ac

--- a/server/utils/auth/token_management.py
+++ b/server/utils/auth/token_management.py
@@ -76,10 +76,8 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 logger.error("[STORE-TOKENS] Please ensure VAULT_ADDR and VAULT_TOKEN environment variables are configured")
             raise
         
-        with db_pool.get_admin_connection() as conn:
+        with db_pool.get_admin_connection(org_id=request_org_id) as conn:
             cursor = conn.cursor()
-            
-            # Store only metadata and secret reference in database
             if provider == "azure":
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id, tenant_id, client_id, client_secret) "

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -1,5 +1,6 @@
 import psycopg2
 import psycopg2.pool
+import psycopg2.extensions
 import logging
 import os
 import threading
@@ -35,7 +36,11 @@ class DatabaseConnectionPool:
             'user': os.getenv('POSTGRES_USER'),
             'password': os.getenv('POSTGRES_PASSWORD'),
             'host': os.getenv('POSTGRES_HOST'),
-            'port': int(os.getenv('POSTGRES_PORT'))
+            'port': int(os.getenv('POSTGRES_PORT')),
+            'keepalives': 1,
+            'keepalives_idle': 30,
+            'keepalives_interval': 10,
+            'keepalives_count': 5,
         }
         pg_sslmode = os.getenv('POSTGRES_SSLMODE', 'prefer')
         if pg_sslmode:
@@ -73,31 +78,66 @@ class DatabaseConnectionPool:
                         logger.error(f"Failed to create connection pool: {e}")
                         raise
         return self._pool
+
+    def _validate_connection(self, connection) -> bool:
+        """Check if a pooled connection is still usable."""
+        try:
+            if connection.closed:
+                return False
+            status = connection.info.transaction_status
+            if status == psycopg2.extensions.TRANSACTION_STATUS_UNKNOWN:
+                return False
+            old_autocommit = connection.autocommit
+            connection.autocommit = True
+            with connection.cursor() as cur:
+                cur.execute("SELECT 1")
+            connection.autocommit = old_autocommit
+            return True
+        except Exception:
+            return False
     
     @contextmanager
-    def get_connection(self):
-        """Get a connection from the pool with automatic cleanup."""
+    def get_connection(self, org_id: Optional[str] = None):
+        """Get a connection from the pool with automatic cleanup.
+
+        Args:
+            org_id: If provided, ``SET myapp.current_org_id`` is executed on
+                    the connection so that RLS policies see the caller's org.
+        """
         pool = self._get_pool()
         connection = None
         try:
             connection = pool.getconn()
-            if connection:
-                connection.autocommit = False
-                logger.debug("Retrieved connection from pool")
-                yield connection
-            else:
-                raise Exception("Failed to get connection from pool")
+            if not connection or not self._validate_connection(connection):
+                if connection:
+                    try:
+                        pool.putconn(connection, close=True)
+                    except Exception:
+                        pass
+                connection = pool.getconn()
+                if not connection:
+                    raise Exception("Failed to get connection from pool")
+            connection.autocommit = False
+            if org_id:
+                with connection.cursor() as cur:
+                    cur.execute("SET myapp.current_org_id = %s", (org_id,))
+            logger.debug("Retrieved connection from pool")
+            yield connection
         except Exception as e:
             if connection:
                 try:
                     connection.rollback()
-                except:
+                except Exception:
                     pass
             logger.error(f"Error with connection: {e}")
             raise
         finally:
             if connection:
                 try:
+                    if org_id:
+                        with connection.cursor() as cur:
+                            cur.execute("RESET myapp.current_org_id")
+                        connection.commit()
                     pool.putconn(connection)
                     logger.debug("Returned connection to pool")
                 except Exception as e:
@@ -108,9 +148,9 @@ class DatabaseConnectionPool:
         """Alias for get_connection() - kept for backward compatibility."""
         return self.get_connection()
 
-    def get_admin_connection(self):
-        """Alias for get_connection() - kept for backward compatibility."""
-        return self.get_connection()
+    def get_admin_connection(self, org_id: Optional[str] = None):
+        """Get a connection with optional RLS org context."""
+        return self.get_connection(org_id=org_id)
     
     def get_pool_status(self) -> dict:
         """Get status information about the connection pool."""

--- a/server/utils/db/connection_utils.py
+++ b/server/utils/db/connection_utils.py
@@ -5,7 +5,8 @@ import logging
 from datetime import datetime
 from typing import Optional, List, Dict
 
-from utils.db.db_utils import connect_to_db_as_user, connect_to_db_as_admin
+from utils.db.connection_pool import db_pool
+from utils.db.db_utils import connect_to_db_as_user
 
 logger = logging.getLogger(__name__)
 
@@ -53,37 +54,31 @@ def save_connection_metadata(
             status = EXCLUDED.status,
             last_verified_at = EXCLUDED.last_verified_at;
     """
-    conn = None
     try:
-        conn = connect_to_db_as_admin()
-        with conn.cursor() as cur:
-            cur.execute(
-                sql,
-                (
-                    user_id,
-                    org_id,
-                    provider,
-                    account_id,
-                    role_arn,
-                    read_only_role_arn,
-                    connection_method,
-                    region,
-                    workspace_id,
-                    status,
-                    datetime.utcnow(),
-                ),
-            )
-        conn.commit()
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (
+                        user_id,
+                        org_id,
+                        provider,
+                        account_id,
+                        role_arn,
+                        read_only_role_arn,
+                        connection_method,
+                        region,
+                        workspace_id,
+                        status,
+                        datetime.utcnow(),
+                    ),
+                )
+            conn.commit()
         logger.info("[CONN-META] Upsert successful for %s/%s/%s", user_id, provider, account_id)
         return True
     except Exception as e:
         logger.error("Failed to save connection metadata: %s", e)
-        if conn:
-            conn.rollback()
         return False
-    finally:
-        if conn:
-            conn.close()
 
 
 def set_connection_status(
@@ -93,34 +88,29 @@ def set_connection_status(
     status: str,
 ) -> bool:
     """Update the status column for a connection (disconnect etc.)."""
+    org_id = _resolve_org_id(user_id)
     sql = """
         UPDATE user_connections
         SET status = %s, last_verified_at = %s
         WHERE user_id = %s AND provider = %s AND account_id = %s;
     """
-    conn = None
     try:
-        conn = connect_to_db_as_admin()
-        logger.info(
-            "[CONN-META] Updating status user=%s provider=%s account=%s → %s",
-            user_id,
-            provider,
-            account_id,
-            status,
-        )
-        with conn.cursor() as cur:
-            cur.execute(sql, (status, datetime.utcnow(), user_id, provider, account_id))
-        conn.commit()
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
+            logger.info(
+                "[CONN-META] Updating status user=%s provider=%s account=%s -> %s",
+                user_id,
+                provider,
+                account_id,
+                status,
+            )
+            with conn.cursor() as cur:
+                cur.execute(sql, (status, datetime.utcnow(), user_id, provider, account_id))
+            conn.commit()
         logger.info("[CONN-META] Status update success for %s/%s/%s", user_id, provider, account_id)
         return True
     except Exception as e:
         logger.error("Failed to set connection status: %s", e)
-        if conn:
-            conn.rollback()
         return False
-    finally:
-        if conn:
-            conn.close()
 
 
 def list_active_connections(user_id: str) -> List[Dict]:
@@ -291,6 +281,7 @@ def delete_connection_secret(
 
     Returns ``True`` when database update succeeds.
     """
+    org_id = _resolve_org_id(user_id)
 
     sql_select = (
         "SELECT role_arn "
@@ -304,47 +295,44 @@ def delete_connection_secret(
         "WHERE user_id = %s AND provider = %s AND account_id = %s;"
     )
 
-    conn = None
     try:
-        conn = connect_to_db_as_admin()
-        with conn.cursor() as cur:
-            cur.execute(sql_select, (user_id, provider, account_id))
-            row = cur.fetchone()
-            
-            if not row:
-                logger.warning("[CONN-META] No active connection found for %s/%s/%s", user_id, provider, account_id)
-                return False
+        with db_pool.get_admin_connection(org_id=org_id) as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql_select, (user_id, provider, account_id))
+                row = cur.fetchone()
+                
+                if not row:
+                    logger.warning("[CONN-META] No active connection found for %s/%s/%s", user_id, provider, account_id)
+                    return False
 
-            if provider in ['gcp', 'azure', 'github']:
-                try:
-                    from utils.secrets.secret_ref_utils import SecretRefManager
-                    # Try to get secret_ref if column exists (may not for all schemas)
+                if provider in ['gcp', 'azure', 'github']:
                     try:
-                        cur.execute(
-                            "SELECT secret_ref FROM user_connections WHERE user_id = %s AND provider = %s AND account_id = %s",
-                            (user_id, provider, account_id)
-                        )
-                        secret_row = cur.fetchone()
-                        if secret_row and secret_row[0]:
-                            srm = SecretRefManager()
-                            srm.delete_secret(secret_row[0])
-                    except Exception:
-                        # Column doesn't exist or no secret_ref - that's fine
-                        pass
-                except Exception as e:
-                    logger.warning("[CONN-META] Vault secret deletion skipped for %s/%s/%s: %s", user_id, provider, account_id, e)
+                        from utils.secrets.secret_ref_utils import SecretRefManager
+                        try:
+                            cur.execute(
+                                "SELECT secret_ref FROM user_connections WHERE user_id = %s AND provider = %s AND account_id = %s",
+                                (user_id, provider, account_id)
+                            )
+                            secret_row = cur.fetchone()
+                            if secret_row and secret_row[0]:
+                                srm = SecretRefManager()
+                                srm.delete_secret(secret_row[0])
+                        except Exception:
+                            pass
+                    except Exception as e:
+                        logger.warning("[CONN-META] Vault secret deletion skipped for %s/%s/%s: %s", user_id, provider, account_id, e)
 
-            cur.execute(
-                sql_update,
-                (
-                    datetime.utcnow(),
-                    user_id,
-                    provider,
-                    account_id,
-                ),
-            )
+                cur.execute(
+                    sql_update,
+                    (
+                        datetime.utcnow(),
+                        user_id,
+                        provider,
+                        account_id,
+                    ),
+                )
 
-        conn.commit()
+            conn.commit()
         logger.info(
             "[CONN-META] Connection %s/%s/%s marked as inactive",
             user_id,
@@ -354,12 +342,7 @@ def delete_connection_secret(
         return True
     except Exception as e:
         logger.error("[CONN-META] Failed to delete connection: %s", e)
-        if conn:
-            conn.rollback()
         return False
-    finally:
-        if conn:
-            conn.close()
 
 
 def get_inactive_aws_connections(user_id: str) -> List[Dict]:

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1916,6 +1916,7 @@ def initialize_tables():
                     "user_preferences",
                     "deployment_tasks",
                     "user_tokens",
+                    "user_connections",
                     "llm_usage_tracking",
                     "kubectl_agent_tokens",
                     "mcp_tokens",


### PR DESCRIPTION
## Summary

- **Root cause**: Admin code paths (`store_tokens_in_db`, `save_connection_metadata`, `connector_status`) used `get_admin_connection()` without setting the `myapp.current_org_id` PostgreSQL session variable. With `FORCE ROW LEVEL SECURITY` enabled, the org-scoped RLS policies rejected all writes since `current_setting('myapp.current_org_id', true)` returned NULL.
- **Missing CRUD policies**: `user_connections` had RLS enabled+forced but was missing from the CRUD policy list in `db_utils.py` — only a SELECT policy existed, so INSERT/UPDATE/DELETE were always denied.
- **Stale connections**: The connection pool lacked TCP keepalives and health checks, causing `SSL error: decryption failed` and `SSL SYSCALL error: EOF detected` when RDS killed idle connections.

## Changes

### `server/utils/db/connection_pool.py`
- `get_connection(org_id=)` / `get_admin_connection(org_id=)` now accept an optional `org_id` that auto-executes `SET myapp.current_org_id` on checkout and `RESET` on return — fully backward-compatible (existing callers pass nothing)
- Added `_validate_connection()` that checks `closed`, `transaction_status`, and runs `SELECT 1` before handing out a connection
- Added TCP keepalive params (`keepalives=1`, `keepalives_idle=30`, `keepalives_interval=10`, `keepalives_count=5`) to detect dead connections at the OS level

### `server/utils/db/db_utils.py`
- Added `user_connections` to the CRUD policy table list so INSERT/UPDATE/DELETE policies are created alongside the existing SELECT policy

### `server/utils/auth/token_management.py`
- `store_tokens_in_db()` now passes `org_id=request_org_id` to `get_admin_connection()`

### `server/utils/db/connection_utils.py`
- Migrated `save_connection_metadata`, `set_connection_status`, `delete_connection_secret` from legacy `connect_to_db_as_admin()` to `db_pool.get_admin_connection(org_id=...)` with proper org context
- Simplified error handling (context manager handles rollback/cleanup)

### `server/routes/connector_status.py`
- All 5 `get_admin_connection()` calls in status checkers now pass `org_id=org_id` so SELECT queries satisfy the `select_by_org` RLS policy

## Test plan
- [ ] Deploy to PSL's EKS cluster and verify connector onboarding (New Relic, AWS) stores tokens and connection metadata without RLS errors
- [ ] Verify `/api/connectors/status` returns connected status for all configured providers
- [ ] Confirm no SSL connection drops after idle periods (keepalive fix)
- [ ] Existing callers that don't pass `org_id` continue to work (backward compat)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection reliability with TCP keepalive parameters and connection validation to handle stale connections.

* **Security**
  * Enhanced organization-level data isolation by scoping admin database connections to individual organizations across all connection operations.
  * Applied row-level security policies to user connection data for improved data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->