### PR TITLE
fix: add AWS default region selector and fix region label in chat UI

### DIFF
--- a/client/src/app/aws/onboarding/page.tsx
+++ b/client/src/app/aws/onboarding/page.tsx
@@ -29,12 +29,49 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { getEnv } from '@/lib/env';
 import ConnectorAuthGuard from "@/components/connectors/ConnectorAuthGuard";
 import { copyToClipboard } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
 
 const BACKEND_URL = getEnv('NEXT_PUBLIC_BACKEND_URL');
+
+const AWS_REGIONS = [
+  { value: 'us-east-1', label: 'US East (N. Virginia)' },
+  { value: 'us-east-2', label: 'US East (Ohio)' },
+  { value: 'us-west-1', label: 'US West (N. California)' },
+  { value: 'us-west-2', label: 'US West (Oregon)' },
+  { value: 'af-south-1', label: 'Africa (Cape Town)' },
+  { value: 'ap-east-1', label: 'Asia Pacific (Hong Kong)' },
+  { value: 'ap-south-1', label: 'Asia Pacific (Mumbai)' },
+  { value: 'ap-south-2', label: 'Asia Pacific (Hyderabad)' },
+  { value: 'ap-southeast-1', label: 'Asia Pacific (Singapore)' },
+  { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' },
+  { value: 'ap-southeast-3', label: 'Asia Pacific (Jakarta)' },
+  { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+  { value: 'ap-northeast-2', label: 'Asia Pacific (Seoul)' },
+  { value: 'ap-northeast-3', label: 'Asia Pacific (Osaka)' },
+  { value: 'ca-central-1', label: 'Canada (Central)' },
+  { value: 'eu-central-1', label: 'Europe (Frankfurt)' },
+  { value: 'eu-central-2', label: 'Europe (Zurich)' },
+  { value: 'eu-west-1', label: 'Europe (Ireland)' },
+  { value: 'eu-west-2', label: 'Europe (London)' },
+  { value: 'eu-west-3', label: 'Europe (Paris)' },
+  { value: 'eu-south-1', label: 'Europe (Milan)' },
+  { value: 'eu-south-2', label: 'Europe (Spain)' },
+  { value: 'eu-north-1', label: 'Europe (Stockholm)' },
+  { value: 'il-central-1', label: 'Israel (Tel Aviv)' },
+  { value: 'me-south-1', label: 'Middle East (Bahrain)' },
+  { value: 'me-central-1', label: 'Middle East (UAE)' },
+  { value: 'sa-east-1', label: 'South America (São Paulo)' },
+];
 
 interface OnboardingData {
   workspaceId: string;
@@ -149,6 +186,7 @@ export default function AWSOnboardingPage() {
   const [inactiveAccounts, setInactiveAccounts] = useState<ConnectedAccount[]>([]);
   const [reconnectingId, setReconnectingId] = useState<string | null>(null);
   const [setupMethod, setSetupMethod] = useState<'manual' | 'cloudformation'>('manual');
+  const [defaultRegion, setDefaultRegion] = useState('us-east-1');
 
   // Auto-set connected flag when configured
   useEffect(() => {
@@ -311,7 +349,7 @@ export default function AWSOnboardingPage() {
             'X-User-ID': userId,
           },
           credentials: 'include',
-          body: JSON.stringify({ roleArn }),
+          body: JSON.stringify({ roleArn, region: defaultRegion }),
         }
       );
 
@@ -402,7 +440,7 @@ export default function AWSOnboardingPage() {
   const fetchQuickCreateData = useCallback(async (rt: 'ReadOnly' | 'Admin' = 'ReadOnly') => {
     if (!workspaceId || !userId) return;
     try {
-      const res = await fetch(`${BACKEND_URL}/workspaces/${workspaceId}/aws/cfn-quickcreate?roleType=${rt}&_t=${Date.now()}`, {
+      const res = await fetch(`${BACKEND_URL}/workspaces/${workspaceId}/aws/cfn-quickcreate?roleType=${rt}&region=${defaultRegion}&_t=${Date.now()}`, {
         credentials: 'include',
         headers: { 'X-User-ID': userId },
       });
@@ -419,7 +457,7 @@ export default function AWSOnboardingPage() {
     } catch (err) {
       console.error('Failed to fetch quick-create data:', err);
     }
-  }, [workspaceId, userId]);
+  }, [workspaceId, userId, defaultRegion]);
 
   const fetchInactiveAccounts = useCallback(async () => {
     if (!workspaceId || !userId) return;
@@ -547,7 +585,7 @@ export default function AWSOnboardingPage() {
       const accounts = lines.map(line => {
         const parts = line.split(',').map(p => p.trim());
         const accountId = parts[0];
-        const region = parts[1] || 'us-east-1';
+        const region = parts[1] || defaultRegion;
         const roleName = parts[2] || (roleType === 'Admin' ? 'AuroraAdminRole' : 'AuroraReadOnlyRole');
         return {
           accountId,
@@ -630,7 +668,7 @@ export default function AWSOnboardingPage() {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json', 'X-User-ID': userId },
-        body: JSON.stringify({ accounts: [{ accountId, roleArn: arn, region: 'us-east-1' }] }),
+        body: JSON.stringify({ accounts: [{ accountId, roleArn: arn, region: defaultRegion }] }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -733,7 +771,7 @@ export default function AWSOnboardingPage() {
                 <p className="text-white/90 font-medium mb-1">3. Add to <code className="bg-black/50 px-1 py-0.5 rounded text-xs">.env</code>:</p>
                 <pre className="bg-black/50 p-3 rounded border border-white/10 text-xs mt-2 overflow-x-auto whitespace-pre break-all">{`AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
-AWS_DEFAULT_REGION=us-east-1`}</pre>
+AWS_DEFAULT_REGION=${defaultRegion}`}</pre>
               </div>
 
               <div className="break-words">
@@ -1084,6 +1122,23 @@ make dev`}</pre>
 
                 <RoleTypeToggle value={roleType} onChange={setRoleType} />
 
+                {/* Default region for new accounts */}
+                <div className="space-y-1.5">
+                  <label className="text-xs text-white/50">Default region</label>
+                  <Select value={defaultRegion} onValueChange={setDefaultRegion}>
+                    <SelectTrigger className="w-full bg-black/50 text-white border-white/10 focus:ring-white/20 text-xs h-9">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="bg-black border-white/10 max-h-60">
+                      {AWS_REGIONS.map((r) => (
+                        <SelectItem key={r.value} value={r.value} className="text-white/80 focus:bg-white/10 focus:text-white text-xs">
+                          {r.value} — {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
                 {/* Method toggle */}
                 <div className="space-y-2">
                   <p className="text-xs text-white/50">1. Create the IAM role</p>
@@ -1192,7 +1247,7 @@ make dev`}</pre>
                     <p className="text-sm font-medium text-white/70">Bulk Register AWS Accounts</p>
                     <p className="text-xs text-white/40">
                       After deploying the CloudFormation template to your accounts, paste account IDs below.
-                      One per line: <code className="bg-black/50 px-1 py-0.5 rounded">ACCOUNT_ID,REGION,ROLE_NAME</code> (region defaults to us-east-1 if omitted; specify the region where you deployed the stack)
+                      One per line: <code className="bg-black/50 px-1 py-0.5 rounded">ACCOUNT_ID,REGION,ROLE_NAME</code> (region defaults to your selected default region if omitted)
                     </p>
                   </div>
                   <textarea
@@ -1247,6 +1302,24 @@ make dev`}</pre>
               <div className="space-y-2">
                 <p className="text-sm text-white/70 font-medium">Access level</p>
                 <RoleTypeToggle value={roleType} onChange={setRoleType} />
+              </div>
+
+              {/* Default region selector */}
+              <div className="space-y-2">
+                <p className="text-sm text-white/70 font-medium">Default region</p>
+                <Select value={defaultRegion} onValueChange={setDefaultRegion}>
+                  <SelectTrigger className="w-full bg-white/5 text-white border-white/10 focus:ring-white/20 text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="bg-black border-white/10 max-h-60">
+                    {AWS_REGIONS.map((r) => (
+                      <SelectItem key={r.value} value={r.value} className="text-white/80 focus:bg-white/10 focus:text-white text-xs">
+                        {r.value} — {r.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-white/40">Your preferred region for CLI commands and API calls. Can be overridden per-request in chat.</p>
               </div>
 
               {/* Setup method toggle */}

--- a/server/chat/backend/agent/prompt/prompt_builder.py
+++ b/server/chat/backend/agent/prompt/prompt_builder.py
@@ -1159,10 +1159,32 @@ def build_system_invariant() -> str:
     )
 
 
-def build_regional_rules() -> str:
+def _get_user_aws_default_region(user_id: Optional[str]) -> Optional[str]:
+    """Look up the default region from the user's primary AWS connection."""
+    if not user_id:
+        return None
+    try:
+        from utils.db.connection_utils import get_user_aws_connection
+        conn = get_user_aws_connection(user_id)
+        if conn:
+            return conn.get("region")
+    except Exception:
+        pass
+    return None
+
+
+def build_regional_rules(user_id: Optional[str] = None) -> str:
+    aws_region = _get_user_aws_default_region(user_id)
+    aws_hint = ""
+    if aws_region:
+        aws_hint = (
+            f"- AWS default region preference: {aws_region}. Use this when the user doesn't specify a region. "
+            "If the user asks for a different region in their message, use that instead.\n"
+        )
     return (
-        "REGION AND ZONE SELECTION - CRITICAL:\n"
-        "When user specifies geographic requirements, honor them in terraform code:\n"
+        "REGION AND ZONE SELECTION:\n"
+        "When user specifies a region or geographic requirement, ALWAYS honor it.\n"
+        f"{aws_hint}"
         "- North America (non-US): northamerica-northeast1-a or northamerica-northeast2-a (Canada)\n"
         "- Europe: europe-west1-a (Belgium) or europe-west2-a (London)\n"
         "- Asia: asia-southeast1-a (Singapore) or asia-northeast1-a (Tokyo)\n"
@@ -1866,7 +1888,7 @@ def build_prompt_segments(provider_preference: Optional[Any], mode: Optional[str
     return PromptSegments(
         system_invariant=system_invariant,
         provider_constraints=provider_constraints,
-        regional_rules=build_regional_rules(),
+        regional_rules=build_regional_rules(getattr(state, 'user_id', None) if state else None),
         ephemeral_rules=build_ephemeral_rules(mode),
         long_documents_note=build_long_documents_note(has_zip_reference),
         provider_context=provider_context,

--- a/server/chat/backend/agent/prompt/prompt_builder.py
+++ b/server/chat/backend/agent/prompt/prompt_builder.py
@@ -1159,6 +1159,15 @@ def build_system_invariant() -> str:
     )
 
 
+import re as _re
+
+_AWS_REGION_RE = _re.compile(r'^[a-z]{2}(-[a-z]+-\d+)$')
+
+
+def _is_valid_aws_region(value: str) -> bool:
+    return bool(_AWS_REGION_RE.match(value))
+
+
 def _get_user_aws_default_region(user_id: Optional[str]) -> Optional[str]:
     """Look up the default region from the user's primary AWS connection."""
     if not user_id:
@@ -1167,10 +1176,12 @@ def _get_user_aws_default_region(user_id: Optional[str]) -> Optional[str]:
         from utils.db.connection_utils import get_user_aws_connection
         conn = get_user_aws_connection(user_id)
         if conn:
-            return conn.get("region")
+            region = conn.get("region")
+            if region and _is_valid_aws_region(region):
+                return region
     except (ImportError, AttributeError, TypeError, KeyError):
-        # Best-effort lookup: if connection utilities/data are unavailable, omit region hint.
-        return None
+        import logging
+        logging.warning("Failed to look up AWS default region for user %s", user_id)
     return None
 
 

--- a/server/chat/backend/agent/prompt/prompt_builder.py
+++ b/server/chat/backend/agent/prompt/prompt_builder.py
@@ -1190,18 +1190,18 @@ def build_regional_rules(user_id: Optional[str] = None) -> str:
     aws_hint = ""
     if aws_region:
         aws_hint = (
-            f"- AWS default region preference: {aws_region}. Use this when the user doesn't specify a region. "
-            "If the user asks for a different region in their message, use that instead.\n"
+            f"- AWS ONLY: The user's default AWS region is {aws_region}. Use this for AWS CLI commands and AWS Terraform resources "
+            "when the user doesn't specify a region. This does NOT apply to GCP, Azure, OVH, or any other provider.\n"
         )
     return (
         "REGION AND ZONE SELECTION:\n"
-        "When user specifies a region or geographic requirement, ALWAYS honor it.\n"
+        "When the user specifies a region or geographic requirement, ALWAYS honor it.\n"
+        "Each cloud provider has its own region naming — never use one provider's region for another:\n"
         f"{aws_hint}"
-        "- North America (non-US): northamerica-northeast1-a or northamerica-northeast2-a (Canada)\n"
-        "- Europe: europe-west1-a (Belgium) or europe-west2-a (London)\n"
-        "- Asia: asia-southeast1-a (Singapore) or asia-northeast1-a (Tokyo)\n"
-        "- US: Use US regions only if explicitly requested or if no geography specified\n"
-        "Do not just add comments; actually use the correct zone in code.\n"
+        "- GCP zones: northamerica-northeast1-a, europe-west1-a, asia-southeast1-a, us-central1-a, etc.\n"
+        "- AWS regions: us-east-1, eu-west-1, ap-southeast-1, etc.\n"
+        "- Azure locations: eastus, westeurope, southeastasia, etc.\n"
+        "Do not just add comments; actually use the correct region/zone in code.\n"
     )
 
 

--- a/server/chat/backend/agent/prompt/prompt_builder.py
+++ b/server/chat/backend/agent/prompt/prompt_builder.py
@@ -1168,8 +1168,9 @@ def _get_user_aws_default_region(user_id: Optional[str]) -> Optional[str]:
         conn = get_user_aws_connection(user_id)
         if conn:
             return conn.get("region")
-    except Exception:
-        pass
+    except (ImportError, AttributeError, TypeError, KeyError):
+        # Best-effort lookup: if connection utilities/data are unavailable, omit region hint.
+        return None
     return None
 
 

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1929,12 +1929,17 @@ Security & Compliance
                 command += f" --region {region_or_project}"
                 logger.info(f"Using explicit region: {region_or_project}")
             else:
-                # Extract the region from the command if specified
                 import re
                 region_match = re.search(r'--region[=\s]+([^\s]+)', command)
                 if region_match:
                     specified_region = region_match.group(1)
                     logger.info(f"Using user-specified region: {specified_region}")
+                    region_or_project = specified_region
+                    resource_id = specified_region
+                    label = (isolated_env.get("AURORA_AWS_ACCOUNT_ALIAS") or
+                             isolated_env.get("AURORA_AWS_ACCOUNT_ID") or "").strip()
+                    if label:
+                        resource_name = f"{label} - {specified_region}"
 
             # Add output json for better parsing if not already specified
             if '--output' not in command and ('list' in command or 'describe' in command or 'get' in command):

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1938,8 +1938,7 @@ Security & Compliance
                     resource_id = specified_region
                     label = (isolated_env.get("AURORA_AWS_ACCOUNT_ALIAS") or
                              isolated_env.get("AURORA_AWS_ACCOUNT_ID") or "").strip()
-                    if label:
-                        resource_name = f"{label} - {specified_region}"
+                    resource_name = f"{label} - {specified_region}" if label else specified_region
 
             # Add output json for better parsing if not already specified
             if '--output' not in command and ('list' in command or 'describe' in command or 'get' in command):

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -147,7 +147,11 @@ def set_aws_role(user_id, workspace_id):
             return jsonify({"error": "Invalid role ARN format"}), 400
 
         read_only_role_arn = data.get('readOnlyRoleArn') or data.get('read_only_role_arn')
-        region = (data.get('region') or 'us-east-1').strip()
+        raw_region = data.get('region')
+        if isinstance(raw_region, str) and raw_region.strip():
+            region = raw_region.strip()
+        else:
+            region = 'us-east-1'
 
         from utils.aws.aws_sts_client import assume_workspace_role, get_aurora_account_id
 
@@ -448,7 +452,8 @@ def bulk_register_aws_accounts(user_id, workspace_id):
                 continue
             role_arn = (entry.get("roleArn") or "").strip()
             account_id = (entry.get("accountId") or "").strip()
-            region = (entry.get("region") or "us-east-1").strip()
+            raw_region = entry.get("region")
+            region = raw_region.strip() if isinstance(raw_region, str) and raw_region.strip() else "us-east-1"
 
             if not role_arn or not account_id:
                 results.append({"accountId": account_id, "success": False, "error": "roleArn and accountId are required"})

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -147,6 +147,7 @@ def set_aws_role(user_id, workspace_id):
             return jsonify({"error": "Invalid role ARN format"}), 400
 
         read_only_role_arn = data.get('readOnlyRoleArn') or data.get('read_only_role_arn')
+        region = (data.get('region') or 'us-east-1').strip()
 
         from utils.aws.aws_sts_client import assume_workspace_role, get_aurora_account_id
 
@@ -214,6 +215,7 @@ def set_aws_role(user_id, workspace_id):
             workspace_id,
             role_arn,
             read_only_role_arn=read_only_role_arn,
+            region=region,
         )
 
         logger.info(

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -103,18 +103,20 @@ def update_workspace_aws_role(
     artifact_bucket: Optional[str] = None,
     artifact_key: Optional[str] = None,
     read_only_role_arn: Optional[str] = None,
+    region: Optional[str] = None,
 ) -> None:
     """
     Save AWS connection to user_connections (single source of truth).
     Workspace table is only used for aws_external_id (needed for STS).
-    
+
     Args:
         workspace_id: Workspace identifier
         role_arn: IAM role ARN for Aurora to assume
         artifact_bucket: Optional S3 bucket (legacy, not used in manual flow)
         artifact_key: Optional S3 key (legacy, not used in manual flow)
         read_only_role_arn: Optional read-only IAM role ARN
-        
+        region: Optional AWS region (e.g. us-west-2)
+
     Raises:
         Exception: Database errors
     """
@@ -145,6 +147,7 @@ def update_workspace_aws_role(
             role_arn=role_arn,
             read_only_role_arn=read_only_role_arn,
             connection_method="sts_assume_role",
+            region=region,
             workspace_id=workspace_id,
             status="active",
         )


### PR DESCRIPTION
## Summary

- **Frontend region selector**: Added a region dropdown (27 AWS regions) to the onboarding page using shadcn/ui Select component. Appears on both the initial setup form and the "Add More Accounts" section. Stored region is sent to the backend on all connection flows (single account, bulk, CloudFormation quick-create).
- **Backend region passthrough**: `set_aws_role` and `update_workspace_aws_role` now accept and persist the selected region to `user_connections`.
- **Agent prompt integration**: The agent's system prompt now includes the user's stored AWS default region as a soft preference ("use this when no region is specified"). Human messages can override it freely.
- **Chat UI label fix**: When the agent's command contains an explicit `--region`, the UI label (e.g. `damianloch - us-west-1`) now reflects the actual region being queried, not the stored default.

### Files changed
- `client/src/app/aws/onboarding/page.tsx` — region selector UI, wired into all flows
- `server/routes/aws/onboarding.py` — accept `region` in `set_aws_role`
- `server/utils/workspace/workspace_utils.py` — pass `region` to `save_connection_metadata`
- `server/chat/backend/agent/prompt/prompt_builder.py` — surface stored region as soft default in prompt
- `server/chat/backend/agent/tools/cloud_exec_tool.py` — update UI label to match actual `--region` in command

### Backward compatibility
- Existing connections with `NULL` or `us-east-1` region continue to work via existing `or "us-east-1"` fallbacks
- No DB migration needed — `region` column already exists in `user_connections`
- Multi-account fan-out and RCA background flows are unaffected

## Test plan
- [ ] Onboard a new AWS account and verify the region dropdown appears and the selected region is stored
- [ ] Change region and add another account — verify the new region is stored
- [ ] In chat, ask about resources in a specific region — verify the UI label shows the correct region
- [ ] Verify existing connections still work without re-onboarding


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable AWS region selection during onboarding (defaults to `us-east-1`) in account addition and manual connection flows.
  * System now respects and uses user-specified AWS regions in agent operations and AWS CLI command execution.
  * Updated environment configuration to reflect AWS default region preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->