### PR TITLE
feat(github): bulk repo selection with owner/visibility filters

### DIFF
--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from '@/hooks/use-toast';
@@ -9,6 +9,7 @@ import Image from 'next/image';
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useGitHubStatus } from '@/hooks/use-github-status';
 import { ToastAction } from "@/components/ui/toast";
 import { getEnv } from '@/lib/env';
@@ -160,6 +161,8 @@ export default function GitHubProviderIntegration() {
   const [hasLoadedRepos, setHasLoadedRepos] = useState(false);
   const [checkedRepos, setCheckedRepos] = useState<Set<string>>(new Set());
   const [searchFilter, setSearchFilter] = useState('');
+  const [ownerFilter, setOwnerFilter] = useState<string>("all");
+  const [visibilityFilter, setVisibilityFilter] = useState<"all" | "public" | "private">("all");
   const [expanded, setExpanded] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -322,6 +325,20 @@ export default function GitHubProviderIntegration() {
     } catch {}
   };
 
+  const owners = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of allRepos) counts.set(r.owner.login, (counts.get(r.owner.login) ?? 0) + 1);
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  }, [allRepos]);
+
+  const filteredRepos = useMemo(() => allRepos.filter(r => {
+    if (ownerFilter !== "all" && r.owner.login !== ownerFilter) return false;
+    if (visibilityFilter === "private" && !r.private) return false;
+    if (visibilityFilter === "public" && r.private) return false;
+    if (searchFilter && !r.full_name.toLowerCase().includes(searchFilter.toLowerCase())) return false;
+    return true;
+  }), [allRepos, ownerFilter, visibilityFilter, searchFilter]);
+
   if (!userId || githubStatus.hasReposConnected === null) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground p-3 border border-border rounded-lg">
@@ -330,9 +347,17 @@ export default function GitHubProviderIntegration() {
     );
   }
 
-  const filteredRepos = allRepos.filter(r =>
-    r.full_name.toLowerCase().includes(searchFilter.toLowerCase())
-  );
+  const allFilteredSelected = filteredRepos.length > 0 && filteredRepos.every(r => checkedRepos.has(r.full_name));
+  const someFilteredSelected = filteredRepos.some(r => checkedRepos.has(r.full_name));
+  const isFilterActive = ownerFilter !== "all" || visibilityFilter !== "all" || !!searchFilter;
+
+  const setFilteredSelection = (selected: boolean) =>
+    setCheckedRepos(prev => {
+      const next = new Set(prev);
+      for (const r of filteredRepos) selected ? next.add(r.full_name) : next.delete(r.full_name);
+      return next;
+    });
+  const handleClearAll = () => setCheckedRepos(new Set());
 
   const hasUnsavedChanges = (() => {
     const savedSet = new Set(savedRepos.map(r => r.repo_full_name));
@@ -475,15 +500,68 @@ export default function GitHubProviderIntegration() {
               </div>
             </div>
 
-            {allRepos.length > 10 && (
-              <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
-                <Input
-                  placeholder="Filter repositories..."
-                  value={searchFilter}
-                  onChange={(e) => setSearchFilter(e.target.value)}
-                  className="h-8 text-xs pl-7"
-                />
+            {allRepos.length > 0 && (
+              <>
+                <div className="flex items-center gap-2">
+                  <Select value={ownerFilter} onValueChange={setOwnerFilter}>
+                    <SelectTrigger className="h-8 text-xs flex-1">
+                      <SelectValue placeholder="All owners" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All owners</SelectItem>
+                      {owners.map(([login, count]) => (
+                        <SelectItem key={login} value={login}>{login} ({count})</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select value={visibilityFilter} onValueChange={(v) => setVisibilityFilter(v as "all" | "public" | "private")}>
+                    <SelectTrigger className="h-8 text-xs w-28">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      <SelectItem value="public">Public</SelectItem>
+                      <SelectItem value="private">Private</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                  <Input
+                    placeholder="Filter repositories..."
+                    value={searchFilter}
+                    onChange={(e) => setSearchFilter(e.target.value)}
+                    className="h-8 text-xs pl-7"
+                  />
+                </div>
+              </>
+            )}
+
+            {filteredRepos.length > 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  {checkedRepos.size} selected • {filteredRepos.length} shown
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => setFilteredSelection(true)}
+                    disabled={allFilteredSelected}
+                  >
+                    Select all
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={isFilterActive && someFilteredSelected ? () => setFilteredSelection(false) : handleClearAll}
+                    disabled={checkedRepos.size === 0}
+                  >
+                    {isFilterActive && someFilteredSelected ? "Clear filtered" : "Clear all"}
+                  </Button>
+                </div>
               </div>
             )}
 
@@ -518,7 +596,7 @@ export default function GitHubProviderIntegration() {
                 ))
               ) : (
                 <p className="text-xs text-muted-foreground text-center py-4">
-                  {searchFilter ? 'No repositories match your filter.' : 'No repositories available.'}
+                  {isFilterActive ? 'No repositories match your filter.' : 'No repositories available.'}
                 </p>
               )}
             </div>
@@ -526,12 +604,14 @@ export default function GitHubProviderIntegration() {
             {allRepos.length > 0 && (
               <Button
                 onClick={handleSaveSelections}
-                disabled={isSaving || checkedRepos.size === 0 || !hasUnsavedChanges}
+                disabled={isSaving || !hasUnsavedChanges}
                 size="sm"
                 className="w-full"
               >
                 {isSaving ? <Loader2 className="h-3 w-3 animate-spin mr-2" /> : null}
-                {hasUnsavedChanges ? `Save ${checkedRepos.size} Repositories` : `${checkedRepos.size} Repositories Saved`}
+                {hasUnsavedChanges
+                  ? (checkedRepos.size === 0 ? 'Remove All Repositories' : `Save ${checkedRepos.size} Repositories`)
+                  : `${checkedRepos.size} Repositories Saved`}
               </Button>
             )}
           </div>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -339,6 +339,15 @@ export default function GitHubProviderIntegration() {
     return true;
   }), [allRepos, ownerFilter, visibilityFilter, searchFilter]);
 
+  const allFilteredSelected = useMemo(
+    () => filteredRepos.length > 0 && filteredRepos.every(r => checkedRepos.has(r.full_name)),
+    [filteredRepos, checkedRepos],
+  );
+  const someFilteredSelected = useMemo(
+    () => filteredRepos.some(r => checkedRepos.has(r.full_name)),
+    [filteredRepos, checkedRepos],
+  );
+
   if (!userId || githubStatus.hasReposConnected === null) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground p-3 border border-border rounded-lg">
@@ -347,8 +356,6 @@ export default function GitHubProviderIntegration() {
     );
   }
 
-  const allFilteredSelected = filteredRepos.length > 0 && filteredRepos.every(r => checkedRepos.has(r.full_name));
-  const someFilteredSelected = filteredRepos.some(r => checkedRepos.has(r.full_name));
   const isFilterActive = ownerFilter !== "all" || visibilityFilter !== "all" || !!searchFilter;
 
   const setFilteredSelection = (selected: boolean) =>
@@ -357,7 +364,9 @@ export default function GitHubProviderIntegration() {
       for (const r of filteredRepos) selected ? next.add(r.full_name) : next.delete(r.full_name);
       return next;
     });
-  const handleClearAll = () => setCheckedRepos(new Set());
+  const isClearFilteredMode = isFilterActive && someFilteredSelected;
+  const handleClear = () =>
+    isClearFilteredMode ? setFilteredSelection(false) : setCheckedRepos(new Set());
 
   const hasUnsavedChanges = (() => {
     const savedSet = new Set(savedRepos.map(r => r.repo_full_name));
@@ -556,10 +565,10 @@ export default function GitHubProviderIntegration() {
                     variant="ghost"
                     size="sm"
                     className="h-6 px-2 text-xs"
-                    onClick={isFilterActive && someFilteredSelected ? () => setFilteredSelection(false) : handleClearAll}
+                    onClick={handleClear}
                     disabled={checkedRepos.size === 0}
                   >
-                    {isFilterActive && someFilteredSelected ? "Clear filtered" : "Clear all"}
+                    {isClearFilteredMode ? "Clear filtered" : "Clear all"}
                   </Button>
                 </div>
               </div>

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -77,8 +77,10 @@ def get_repo_selections(user_id):
 def save_repo_selections(user_id):
     """Sync the set of connected repos. Upserts new, removes deselected, triggers metadata gen."""
     try:
-        data = request.get_json()
-        repositories = data.get("repositories") if data else None
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"error": "Request body must be a JSON object"}), 400
+        repositories = data.get("repositories")
         if not isinstance(repositories, list):
             return jsonify({"error": "repositories array is required"}), 400
 
@@ -96,6 +98,8 @@ def save_repo_selections(user_id):
                 newly_added = []
 
                 for repo in repositories:
+                    if not isinstance(repo, dict):
+                        return jsonify({"error": "Each repository must be an object"}), 400
                     full_name = repo.get("full_name")
                     if not full_name:
                         continue

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -79,7 +79,7 @@ def save_repo_selections(user_id):
     try:
         data = request.get_json()
         repositories = data.get("repositories") if data else None
-        if not isinstance(repositories, list) or not repositories:
+        if not isinstance(repositories, list):
             return jsonify({"error": "repositories array is required"}), 400
 
         org_id = _get_user_org_id(user_id)
@@ -124,7 +124,7 @@ def save_repo_selections(user_id):
                     if full_name not in existing:
                         newly_added.append(full_name)
 
-                if not incoming:
+                if repositories and not incoming:
                     return jsonify({"error": "No valid repositories in request (all missing full_name)"}), 400
 
                 removed = existing - incoming

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -128,6 +128,8 @@ def save_repo_selections(user_id):
                     if full_name not in existing:
                         newly_added.append(full_name)
 
+                # Empty `repositories` is valid (clears all); only reject if the caller sent
+                # items but none had a usable full_name.
                 if repositories and not incoming:
                     return jsonify({"error": "No valid repositories in request (all missing full_name)"}), 400
 


### PR DESCRIPTION
## Summary
- Adds owner + visibility dropdowns and bulk Select all / Clear controls to the GitHub repo picker so customers with 400+ repos can select subsets without per-row clicks.
- Allows saving an empty selection to remove all connected repos (previously blocked by a 400 on empty array).

## Test plan
- [ ] Open Connectors → GitHub → expand; verify owner dropdown lists owners with counts.
- [ ] Filter by owner / visibility / search — confirm filters compose.
- [ ] Select all / Clear filtered / Clear all behave per counter.
- [ ] Uncheck all and Save — button reads "Remove All Repositories" and clears DB selections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner and visibility filters for repositories alongside existing search
  * Introduced bulk selection controls to select/deselect filtered repositories at once
  * Added selection summary row with quick "Select All" and clear actions

* **Improvements**
  * Empty-state messaging now reflects which filters are active
  * Save button now supports removing all repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->