### PR TITLE
fix: show OpsGenie as connected on Incidents page

### DIFF
--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -22,10 +22,12 @@ import { useToast } from '@/hooks/use-toast';
 
 const ALERT_CATEGORIES = new Set(['Monitoring', 'Incident Management']);
 
-const ALERT_PROVIDERS = new Set([
-  'grafana', 'datadog', 'netdata', 'splunk', 'dynatrace',
-  'coroot', 'newrelic', 'thousandeyes', 'pagerduty', 'bigpanda',
-]);
+const ALERT_PROVIDERS = new Set(
+  connectorRegistry
+    .getAll()
+    .filter(c => c.category && ALERT_CATEGORIES.has(c.category))
+    .map(c => c.id),
+);
 
 interface IncidentsResponse { incidents: any[] }
 


### PR DESCRIPTION
## Summary
- Derive `ALERT_PROVIDERS` on the Incidents page from the connector registry (filtered by `ALERT_CATEGORIES`) instead of a hardcoded allowlist.
- Fixes the banner incorrectly showing "No alerting platform connected" when OpsGenie/JSM is connected — `opsgenie` was missing from the hardcoded list.
- Future alert connectors are now picked up automatically.

## Test plan
- [ ] Connect OpsGenie and confirm the "No alerting platform connected" banner is gone on `/incidents`
- [ ] Disconnect all alert connectors and confirm the banner reappears