### PR TITLE
chore: bump Helm chart to 1.2.14

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.13
-appVersion: "1.2.13"
+version: 1.2.14
+appVersion: "1.2.14"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps Helm chart version and appVersion from 1.2.13 to 1.2.14


Made with [Cursor](https://cursor.com)