### PR TITLE
feat(helm): support additional ingress resources

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.14
-appVersion: "1.2.14"
+version: 1.2.15
+appVersion: "1.2.15"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora

--- a/deploy/helm/aurora/templates/additional-ingress.yaml
+++ b/deploy/helm/aurora/templates/additional-ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "aurora.fullname" $ }}-{{ .name }}
+  name: {{ include "aurora.fullname" $ }}-{{ required ".ingress.additional[].name is required" .name }}
   labels:
     {{- include "aurora.labels" $ | nindent 4 }}
   {{- with .annotations }}

--- a/deploy/helm/aurora/templates/additional-ingress.yaml
+++ b/deploy/helm/aurora/templates/additional-ingress.yaml
@@ -1,0 +1,36 @@
+{{- range .Values.ingress.additional }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "aurora.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "aurora.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .rules }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .http.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "aurora.fullname" $ }}-{{ .backend.service }}
+                port:
+                  number: {{ .backend.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/aurora/templates/additional-ingress.yaml
+++ b/deploy/helm/aurora/templates/additional-ingress.yaml
@@ -28,7 +28,7 @@ spec:
             pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "aurora.fullname" $ }}-{{ .backend.service }}
+                name: {{ .backend.service }}
                 port:
                   number: {{ .backend.port }}
           {{- end }}

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -643,6 +643,24 @@ ingress:
     api: "api.aurora.example.com"
     ws: "ws.aurora.example.com"
 
+  # Additional Ingress resources (e.g., external ingress for webhooks).
+  # Each entry creates a separate Kubernetes Ingress object.
+  # Service names (server, frontend, chatbot) auto-resolve to full release names.
+  additional: []
+    # - name: external-webhooks
+    #   className: "nginx"
+    #   annotations: {}
+    #   tls: []
+    #   rules:
+    #     - host: "api-external.example.com"
+    #       http:
+    #         paths:
+    #           - path: /
+    #             pathType: Prefix
+    #             backend:
+    #               service: server
+    #               port: 5080
+
 # ------------------------------------------------------------------------------
 # Vault Configuration
 # ------------------------------------------------------------------------------

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -645,7 +645,9 @@ ingress:
 
   # Additional Ingress resources (e.g., external ingress for webhooks).
   # Each entry creates a separate Kubernetes Ingress object.
-  # Service names (server, frontend, chatbot) auto-resolve to full release names.
+  # Service names are NOT auto-resolved. Use the full Kubernetes service name.
+  # Aurora services follow the pattern: <release-name>-<component>
+  # e.g., aurora-oss-server, aurora-oss-frontend, aurora-oss-chatbot
   additional: []
     # - name: external-webhooks
     #   className: "nginx"
@@ -658,7 +660,7 @@ ingress:
     #           - path: /
     #             pathType: Prefix
     #             backend:
-    #               service: server
+    #               service: aurora-oss-server
     #               port: 5080
 
 # ------------------------------------------------------------------------------

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -645,6 +645,8 @@ ingress:
 
   # Additional Ingress resources (e.g., external ingress for webhooks).
   # Each entry creates a separate Kubernetes Ingress object.
+  # IMPORTANT: 'name' is required, must be unique across entries, and must not
+  # be 'ingress' (reserved for the primary ingress object).
   # Service names are NOT auto-resolved. Use the full Kubernetes service name.
   # Aurora services follow the pattern: <release-name>-<component>
   # e.g., aurora-oss-server, aurora-oss-frontend, aurora-oss-chatbot


### PR DESCRIPTION
## Summary

- Adds `ingress.additional` list to `values.yaml` enabling users to define extra Kubernetes Ingress objects without modifying the primary ingress
- New `additional-ingress.yaml` template iterates over the list and creates one Ingress per entry with full control over className, annotations, TLS, and routing rules
- Service names are passed through as-is (no auto-resolve) -- users write the full Kubernetes service name, which is simpler and supports both Aurora services and external services without magic
- Bumps Helm chart to 1.2.15

## Use Case

Deployments that need a second ingress -- for example, a public-facing ingress for webhook endpoints (OpsGenie/JSM, New Relic) while keeping the primary ingress internal behind a Cloudflare tunnel or VPN. Users can add it declaratively:

```yaml
ingress:
  additional:
    - name: external-webhooks
      className: "nginx"
      annotations:
        nginx.ingress.kubernetes.io/proxy-body-size: "10m"
      rules:
        - host: webhooks.example.com
          http:
            paths:
              - path: /
                pathType: Prefix
                backend:
                  service: aurora-oss-server
                  port: 5080
```
