### PR TITLE
fix: save RCA llm_context_history synchronously for citation extraction

### DIFF
--- a/server/chat/backend/agent/utils/persistence/context_manager.py
+++ b/server/chat/backend/agent/utils/persistence/context_manager.py
@@ -35,12 +35,11 @@ class ContextManager:
     def save_context_history(cls, session_id: str, user_id: str, 
                            messages: List[Dict[str, Any]], 
                            tool_capture: Optional[List[Any]] = None) -> bool:
-        """Optimized save with caching and async execution.
-        
-        This method replaces the original synchronous save with:
-        1. Deduplication checking
-        2. Cached serialization
-        3. Async non-blocking saves
+        """Save LLM context with Redis-based dedup + cached serialization.
+
+        Runs synchronously. The previous async-queue path was removed because
+        it raced with asyncio.run() teardown in Celery tasks and silently
+        dropped saves.
         """
         instance = cls._get_instance()
         
@@ -61,24 +60,6 @@ class ContextManager:
                     logger.debug(f"Skipping duplicate save for session {session_id}")
                     return True
             
-            # Try async save first
-            if hasattr(instance, 'async_queue'):
-                try:
-                    loop = asyncio.get_running_loop()
-                    # Schedule async save without blocking
-                    future = asyncio.create_task(
-                        instance.async_queue.enqueue_save(
-                            session_id, user_id, messages, tool_capture
-                        )
-                    )
-                    logger.debug(f"Scheduled async save for session {session_id}")
-                    return True  # Return immediately, save happens in background
-                    
-                except RuntimeError:
-                    # No event loop, fall back to sync save
-                    pass
-            
-            # Fallback to synchronous save if async not available
             return instance._execute_actual_save(
                 session_id, user_id, messages, tool_capture
             )

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -166,12 +166,24 @@ def _ensure_llm_context_history(
 
         llm_context, ui_messages = row[0], row[1]
         if isinstance(llm_context, str):
-            llm_context = json.loads(llm_context) if llm_context else []
+            try:
+                llm_context = json.loads(llm_context) if llm_context else []
+            except (ValueError, TypeError) as e:
+                logger.error(
+                    f"[BackgroundChat] Malformed llm_context_history JSON for session {session_id}: {e}; treating as empty"
+                )
+                llm_context = []
         if llm_context:
             return llm_context
 
         if isinstance(ui_messages, str):
-            ui_messages = json.loads(ui_messages) if ui_messages else []
+            try:
+                ui_messages = json.loads(ui_messages) if ui_messages else []
+            except (ValueError, TypeError) as e:
+                logger.error(
+                    f"[BackgroundChat] Malformed messages JSON for session {session_id}: {e}; cannot rebuild context"
+                )
+                return []
         if not ui_messages:
             return []
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -91,27 +91,36 @@ def cancel_rca_for_incident(incident_id: str) -> bool:
         return False
 
 
-def _extract_tool_calls_for_viz(session_id: str, user_id: str) -> List[Dict]:
-    """Extract infrastructure tool calls from database for final visualization."""
+def _extract_tool_calls_for_viz(
+    session_id: str,
+    user_id: str,
+    llm_context: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict]:
+    """Extract infrastructure tool calls for visualization.
+
+    Accepts a pre-loaded ``llm_context`` to avoid an extra SELECT on the happy
+    path (``_ensure_llm_context_history`` already fetches the column).
+    """
     try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                cursor.execute("""
-                    SELECT llm_context_history
-                    FROM chat_sessions
-                    WHERE id = %s AND user_id = %s
-                """, (session_id, user_id))
-                
-                row = cursor.fetchone()
-        
-        if not row or not row[0]:
-            logger.warning(f"[Visualization] No llm_context_history for session {session_id}")
-            return []
-        
-        llm_context = row[0]
-        if isinstance(llm_context, str):
-            llm_context = json.loads(llm_context)
-        
+        if llm_context is None:
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        SELECT llm_context_history
+                        FROM chat_sessions
+                        WHERE id = %s AND user_id = %s
+                        """,
+                        (session_id, user_id),
+                    )
+                    row = cursor.fetchone()
+            if not row or not row[0]:
+                logger.warning(f"[Visualization] No llm_context_history for session {session_id}")
+                return []
+            llm_context = row[0]
+            if isinstance(llm_context, str):
+                llm_context = json.loads(llm_context)
+
         tool_calls = []
         for msg in llm_context:
             if isinstance(msg, dict) and msg.get('name') in INFRASTRUCTURE_TOOLS:
@@ -119,12 +128,115 @@ def _extract_tool_calls_for_viz(session_id: str, user_id: str) -> List[Dict]:
                     'tool': msg.get('name'),
                     'output': str(msg.get('content', ''))[:MAX_TOOL_OUTPUT_CHARS]
                 })
-        
+
         return tool_calls
-    
-    except Exception as e:
-        logger.error(f"[Visualization] Failed to extract tool calls from database: {e}")
+
+    except Exception:
+        logger.exception(f"[Visualization] Failed to extract tool calls for session {session_id}")
         return []
+
+
+def _ensure_llm_context_history(
+    session_id: str, user_id: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Return the session's llm_context_history, rebuilding from UI messages if empty.
+
+    Returns the deserialized context list so the caller can skip a second DB
+    read. Returns ``None`` when the session row is missing or on error.
+    """
+    from langchain_core.messages import AIMessage, ToolMessage
+    from chat.backend.agent.utils.llm_context_manager import LLMContextManager
+    from chat.backend.agent.utils.persistence.context_manager import ContextManager
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT llm_context_history, messages
+                    FROM chat_sessions
+                    WHERE id = %s AND user_id = %s
+                    """,
+                    (session_id, user_id),
+                )
+                row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        llm_context, ui_messages = row[0], row[1]
+        if isinstance(llm_context, str):
+            llm_context = json.loads(llm_context) if llm_context else []
+        if llm_context:
+            return llm_context
+
+        if isinstance(ui_messages, str):
+            ui_messages = json.loads(ui_messages) if ui_messages else []
+        if not ui_messages:
+            return []
+
+        logger.warning(
+            f"[BackgroundChat] llm_context_history empty for session {session_id}; "
+            f"rebuilding from UI messages as fallback"
+        )
+
+        rebuilt_messages: List[Any] = []
+        for ui_msg in ui_messages:
+            tool_calls_ui = ui_msg.get("toolCalls") or []
+            if not tool_calls_ui:
+                continue
+
+            ai_tool_calls = []
+            tool_messages: List[ToolMessage] = []
+            for tc in tool_calls_ui:
+                tool_call_id = tc.get("id")
+                if not tool_call_id:
+                    continue
+                tool_name = tc.get("tool_name") or tc.get("name") or "unknown"
+                try:
+                    args = json.loads(tc["input"]) if isinstance(tc.get("input"), str) else (tc.get("input") or {})
+                except (ValueError, TypeError):
+                    args = {}
+                ai_tool_calls.append({
+                    "id": tool_call_id,
+                    "name": tool_name,
+                    "args": args,
+                    "type": "tool_call",
+                })
+                output = tc.get("output")
+                if output is None:
+                    continue
+                tool_messages.append(
+                    ToolMessage(
+                        content=str(output),
+                        tool_call_id=tool_call_id,
+                        name=tool_name,
+                    )
+                )
+
+            if not ai_tool_calls:
+                continue
+
+            ai_content = ui_msg.get("content", "") if ui_msg.get("sender") == "bot" else ""
+            rebuilt_messages.append(AIMessage(content=ai_content, tool_calls=ai_tool_calls))
+            rebuilt_messages.extend(tool_messages)
+
+        if not rebuilt_messages:
+            return []
+
+        ContextManager.save_context_history(session_id, user_id, rebuilt_messages)
+        logger.info(
+            f"[BackgroundChat] Rebuilt llm_context_history for session {session_id} "
+            f"with {len(rebuilt_messages)} synthetic messages"
+        )
+        return [LLMContextManager.serialize_message(m) for m in rebuilt_messages]
+
+    except Exception:
+        logger.exception(
+            f"[BackgroundChat] Failed to ensure llm_context_history for session {session_id}"
+        )
+        return None
+
 
 _RATE_LIMIT_WINDOW_SECONDS = 300  # 5 minute window
 _RATE_LIMIT_MAX_REQUESTS = 5  # Max 5 background chats per window
@@ -1069,9 +1181,10 @@ async def _execute_background_chat(
                         logger.error(f"[BackgroundChat] ⚠️ WARNING: Incident {incident_id} aurora_status is already 'complete' before we set it! This indicates a race condition.")
         
         logger.info(f"[BackgroundChat] Workflow execution completed - all streams and tool calls finished")
-        
-        # Extract tool calls from database llm_context_history
-        tool_calls = _extract_tool_calls_for_viz(session_id, user_id)
+
+        # Fallback: rebuild llm_context_history from UI messages if the save was lost.
+        llm_context = _ensure_llm_context_history(session_id, user_id)
+        tool_calls = _extract_tool_calls_for_viz(session_id, user_id, llm_context)
         logger.info(f"[BackgroundChat] Extracted {len(tool_calls)} tool calls for visualization")
         
         return {

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -217,14 +217,27 @@ def _ensure_llm_context_history(
             if not ai_tool_calls:
                 continue
 
-            ai_content = ui_msg.get("content", "") if ui_msg.get("sender") == "bot" else ""
+            if ui_msg.get("sender") == "bot":
+                ai_content = ui_msg.get("text") or ui_msg.get("content") or ""
+            else:
+                ai_content = ""
             rebuilt_messages.append(AIMessage(content=ai_content, tool_calls=ai_tool_calls))
             rebuilt_messages.extend(tool_messages)
 
         if not rebuilt_messages:
             return []
 
-        ContextManager.save_context_history(session_id, user_id, rebuilt_messages)
+        # Bypass ContextManager.save_context_history's Redis dedup — a stale
+        # hash from the lost async save would cause this forced rewrite to
+        # no-op. We already know the DB column is empty, so write directly.
+        saved = ContextManager._get_instance()._execute_actual_save(
+            session_id, user_id, rebuilt_messages
+        )
+        if not saved:
+            logger.error(
+                f"[BackgroundChat] Forced rewrite of llm_context_history failed for session {session_id}"
+            )
+            return None
         logger.info(
             f"[BackgroundChat] Rebuilt llm_context_history for session {session_id} "
             f"with {len(rebuilt_messages)} synthetic messages"


### PR DESCRIPTION
## Summary
- `ContextManager.save_context_history` used an async-queue fast path that raced with `asyncio.run()` teardown in the Celery background chat task — the save task was cancelled before `_execute_actual_save` ran, leaving `llm_context_history = []` and the citation extractor reading zero tool outputs. Every RCA triggered by any connector was affected: incident summaries rendered without `[n]` citation badges.
- Run `_execute_actual_save` synchronously. We're already off the request path in Celery, so the async queue bought no latency — only the race.
- Added `_ensure_llm_context_history` as defense in depth: if the column is still empty post-stream, rebuild synthetic `AIMessage`/`ToolMessage` pairs from `chat_sessions.messages[*].toolCalls` and persist via the same save path.
- Pass the loaded context through to `_extract_tool_calls_for_viz` so the happy path does one DB read instead of two.

## Test plan
- [x] Trigger a fresh RCA — confirmed `Saving context …` + `Saved complete LLM context history …` logs fire before `[CitationExtractor] Extracted N citations` with N > 0
- [x] DB check: `jsonb_array_length(llm_context_history) > 0` and `incident_citations` populated for the verification incident
- [x] Incident page renders `[n]` citation badges inline in the summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of chat context persistence to prevent silent data loss.
  * Enhanced recovery mechanism to rebuild chat history when persistence data is unavailable.
  * Fixed race conditions that could result in dropped context updates during background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->