### PR TITLE
feat(agent): codify Datadog UI silences as Terraform PRs

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1170,10 +1170,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         (cloudbees_rca, "cloudbees_rca"),
         (spinnaker_rca, "spinnaker_rca"),
         (github_apply_fix, "github_apply_fix"),
-        (list_datadog_silence_drift, "list_datadog_silence_drift"),
-        (silence_datadog_monitor_via_terraform, "silence_datadog_monitor_via_terraform"),
-        (silence_all_drifted_monitors, "silence_all_drifted_monitors"),
-        (reindex_terraform_repo, "reindex_terraform_repo"),
         (cloud_exec_wrapper, "cloud_exec"),
         (terminal_exec, "terminal_exec"),
         (tailscale_ssh, "tailscale_ssh"),
@@ -1185,6 +1181,15 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     # Only include trigger_rca when the user explicitly requested it via the UI button
     if state_context and getattr(state_context, 'trigger_rca_requested', False):
         tool_functions.append((trigger_rca, "trigger_rca"))
+
+    # Datadog↔Terraform drift tools only surface when Datadog is connected.
+    if user_id and is_datadog_connected(user_id):
+        tool_functions.extend([
+            (list_datadog_silence_drift, "list_datadog_silence_drift"),
+            (silence_datadog_monitor_via_terraform, "silence_datadog_monitor_via_terraform"),
+            (silence_all_drifted_monitors, "silence_all_drifted_monitors"),
+            (reindex_terraform_repo, "reindex_terraform_repo"),
+        ])
     
     # Process Aurora native tools
     for func, name in tool_functions:

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -33,6 +33,16 @@ from .jenkins_rca_tool import jenkins_rca, JenkinsRCAArgs
 from .cloudbees_rca_tool import cloudbees_rca, CloudBeesRCAArgs
 from .spinnaker_rca_tool import spinnaker_rca, SpinnakerRCAArgs
 from .trigger_rca_tool import trigger_rca, TriggerRCAArgs
+from .datadog_terraform_tool import (
+    list_datadog_silence_drift,
+    silence_datadog_monitor_via_terraform,
+    silence_all_drifted_monitors,
+    reindex_terraform_repo,
+    ListDatadogSilenceDriftArgs,
+    SilenceDatadogMonitorViaTerraformArgs,
+    SilenceAllDriftedMonitorsArgs,
+    ReindexTerraformRepoArgs,
+)
 
 # Visualization trigger caching
 from cachetools import TTLCache
@@ -1160,6 +1170,10 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         (cloudbees_rca, "cloudbees_rca"),
         (spinnaker_rca, "spinnaker_rca"),
         (github_apply_fix, "github_apply_fix"),
+        (list_datadog_silence_drift, "list_datadog_silence_drift"),
+        (silence_datadog_monitor_via_terraform, "silence_datadog_monitor_via_terraform"),
+        (silence_all_drifted_monitors, "silence_all_drifted_monitors"),
+        (reindex_terraform_repo, "reindex_terraform_repo"),
         (cloud_exec_wrapper, "cloud_exec"),
         (terminal_exec, "terminal_exec"),
         (tailscale_ssh, "tailscale_ssh"),
@@ -1331,6 +1345,57 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "severity (optional: critical/high/medium/low)."
                 ),
                 args_schema=TriggerRCAArgs,
+            )
+        elif name == 'list_datadog_silence_drift':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "List Datadog UI mutes / active downtimes that are NOT codified in Terraform. "
+                    "Read-only: fetches downtimes and legacy monitor.silenced, cross-references the "
+                    "HCL index, and returns drift rows with matched_tf_file and tf_match_confidence. "
+                    "Optional filters: repo ('owner/repo'), monitor_name_pattern (substring), "
+                    "scope (e.g. 'env:prod')."
+                ),
+                args_schema=ListDatadogSilenceDriftArgs,
+            )
+        elif name == 'silence_datadog_monitor_via_terraform':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Open a GitHub PR that adds a `datadog_downtime_schedule` Terraform resource "
+                    "silencing a monitor indefinitely. NEVER calls Datadog write APIs. "
+                    "Parameters: monitor_name OR monitor_id (required), scope (e.g. 'env:prod', "
+                    "defaults to '*'), repo ('owner/repo', required when multiple repos connected), "
+                    "target_file (override the sibling downtimes.tf location), message (optional "
+                    "override). Returns the PR URL."
+                ),
+                args_schema=SilenceDatadogMonitorViaTerraformArgs,
+            )
+        elif name == 'silence_all_drifted_monitors':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Bundle every drifted Datadog silence into a single PR adding one "
+                    "`datadog_downtime_schedule` per monitor (one downtimes.tf per directory). "
+                    "Parameters: monitor_ids (optional subset), repo ('owner/repo'). Returns a "
+                    "single PR URL covering all selected silences."
+                ),
+                args_schema=SilenceAllDriftedMonitorsArgs,
+            )
+        elif name == 'reindex_terraform_repo':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Re-run the Terraform HCL indexer on the repo's default branch. Call this "
+                    "after the user merges new `datadog_monitor` / `datadog_downtime*` blocks. "
+                    "Parameters: repo ('owner/repo'). Returns files scanned, resources indexed, "
+                    "and delta vs previous index."
+                ),
+                args_schema=ReindexTerraformRepoArgs,
             )
         else:
             tool = StructuredTool.from_function(final_func)

--- a/server/chat/backend/agent/tools/datadog_terraform_tool.py
+++ b/server/chat/backend/agent/tools/datadog_terraform_tool.py
@@ -1,0 +1,676 @@
+"""
+Datadog <-> Terraform drift agent tools.
+
+Four chat-driven tools that let the agent:
+  1. List Datadog UI mutes that aren't codified in Terraform
+  2. Open a PR silencing a single monitor via `datadog_downtime_schedule`
+  3. Bundle every drifted silence into one PR
+  4. Re-index the repo after the user merges new monitor blocks
+
+Hard rule: these tools NEVER call Datadog write APIs. Every state change
+lands as a GitHub PR that a human reviews and merges.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from chat.backend.agent.tools.github_mcp_utils import (
+    build_error_response,
+    build_success_response,
+    call_github_mcp_sync,
+    parse_file_content_response,
+    parse_mcp_response,
+)
+from chat.backend.agent.tools.github_rca_tool import _resolve_repository
+from routes.datadog.datadog_routes import (
+    DatadogAPIError,
+    _build_client_from_creds,
+    _get_stored_datadog_credentials,
+)
+from services.terraform.datadog_drift_detector import compute_drift, drift_row_to_dict
+from services.terraform.datadog_hcl_indexer import (
+    IndexedResource,
+    count_indexed_resources,
+    get_repo_default_branch,
+    index_repo,
+    load_index,
+    match_resources_to_monitor,
+)
+
+MAX_RESOURCE_NAME_LEN = 80
+MAX_SLUG_LEN = 40
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic arg schemas
+# ---------------------------------------------------------------------------
+
+
+class ListDatadogSilenceDriftArgs(BaseModel):
+    """Arguments for list_datadog_silence_drift."""
+
+    repo: Optional[str] = Field(
+        default=None,
+        description="Optional 'owner/repo' to scope against. Defaults to the user's connected repo (if single) or all.",
+    )
+    monitor_name_pattern: Optional[str] = Field(
+        default=None,
+        description="Optional substring filter on monitor name.",
+    )
+    scope: Optional[str] = Field(
+        default=None,
+        description="Optional exact scope filter (e.g., 'env:prod').",
+    )
+
+
+class SilenceDatadogMonitorViaTerraformArgs(BaseModel):
+    """Arguments for silence_datadog_monitor_via_terraform."""
+
+    monitor_name: Optional[str] = Field(
+        default=None, description="Name of the Datadog monitor to silence (or pass monitor_id)."
+    )
+    monitor_id: Optional[int] = Field(
+        default=None, description="Datadog monitor ID. Preferred over monitor_name."
+    )
+    scope: Optional[str] = Field(
+        default=None,
+        description="Scope for the silence (e.g., 'env:prod'). Defaults to '*' (all groups).",
+    )
+    repo: Optional[str] = Field(
+        default=None,
+        description="'owner/repo'. Required when the user has multiple connected repos.",
+    )
+    target_file: Optional[str] = Field(
+        default=None,
+        description="Override the target .tf file. Defaults to a sibling `downtimes.tf` next to the matched monitor.",
+    )
+    message: Optional[str] = Field(
+        default=None,
+        description="Optional message override for the downtime block.",
+    )
+
+
+class SilenceAllDriftedMonitorsArgs(BaseModel):
+    """Arguments for silence_all_drifted_monitors."""
+
+    monitor_ids: Optional[List[int]] = Field(
+        default=None,
+        description="Optional subset of monitor IDs to include. Defaults to every drifted monitor.",
+    )
+    repo: Optional[str] = Field(
+        default=None, description="'owner/repo'. Required when multiple repos are connected."
+    )
+
+
+class ReindexTerraformRepoArgs(BaseModel):
+    """Arguments for reindex_terraform_repo."""
+
+    repo: Optional[str] = Field(
+        default=None, description="'owner/repo' to re-index. Defaults to single connected repo."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: list drift
+# ---------------------------------------------------------------------------
+
+
+def list_datadog_silence_drift(
+    repo: Optional[str] = None,
+    monitor_name_pattern: Optional[str] = None,
+    scope: Optional[str] = None,
+    user_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    if not user_id:
+        return build_error_response("User ID is required")
+
+    target_repo = _resolve_target_repo(user_id, repo)
+    try:
+        report = compute_drift(
+            user_id=user_id,
+            repo_full_name=target_repo,
+            monitor_filter=monitor_name_pattern,
+            scope_filter=scope,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[DD_TF] drift compute failed: %s", exc, exc_info=True)
+        return build_error_response(f"Failed to compute drift: {exc}")
+
+    return build_success_response(
+        repo=target_repo,
+        silences_total=report.silences_total,
+        drift_count=len(report.drifted),
+        codified_count=len(report.codified),
+        drifted=[drift_row_to_dict(r) for r in report.drifted],
+        codified=[drift_row_to_dict(r) for r in report.codified],
+        errors=report.errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: silence single monitor via PR
+# ---------------------------------------------------------------------------
+
+
+def silence_datadog_monitor_via_terraform(
+    monitor_name: Optional[str] = None,
+    monitor_id: Optional[int] = None,
+    scope: Optional[str] = None,
+    repo: Optional[str] = None,
+    target_file: Optional[str] = None,
+    message: Optional[str] = None,
+    user_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    if not user_id:
+        return build_error_response("User ID is required")
+    if not monitor_name and not monitor_id:
+        return build_error_response("Provide either monitor_name or monitor_id")
+
+    target_repo = _resolve_target_repo(user_id, repo)
+    if not target_repo:
+        return build_error_response(
+            "Multiple repos are connected. Please pass repo='owner/repo'."
+        )
+
+    try:
+        monitor = _resolve_datadog_monitor(user_id, monitor_name, monitor_id)
+    except DatadogAPIError as exc:
+        return build_error_response(f"Datadog lookup failed: {exc}")
+    if not monitor:
+        return build_error_response(
+            f"Could not find Datadog monitor (name={monitor_name}, id={monitor_id})"
+        )
+
+    index = load_index(user_id, target_repo)
+    if not index:
+        return build_error_response(
+            f"No Terraform index for {target_repo}. Run reindex_terraform_repo first."
+        )
+
+    matched, confidence = match_resources_to_monitor(
+        index, monitor.get("name") or "", monitor.get("query")
+    )
+
+    if not matched and not target_file:
+        return build_error_response(
+            f"No matching Terraform resource for monitor '{monitor.get('name')}'. "
+            "Pass target_file to write a sibling downtimes.tf in that directory.",
+            match_confidence=confidence,
+        )
+
+    effective_scope = scope or "*"
+    resource_name = _sanitize_resource_name(
+        f"mute_{monitor.get('name') or monitor.get('id') or 'monitor'}"
+    )
+    block = _build_downtime_schedule_block(
+        resource_name=resource_name,
+        monitor_resource_address=matched.resource_address if matched else None,
+        monitor_id=monitor.get("id"),
+        scope=effective_scope,
+        original_message=message,
+        source_label="Silenced via Aurora chat" if not message else "Codified from UI mute",
+    )
+
+    write_path = target_file or _default_downtimes_path(matched)
+    if not write_path:
+        return build_error_response("Could not determine target file. Pass target_file.")
+
+    owner, repo_name = target_repo.split("/", 1)
+    branch_name = f"aurora/silence-{_slugify(monitor.get('name') or str(monitor.get('id')))}-{int(time.time())}"
+
+    pr_url, err = _open_silence_pr(
+        user_id=user_id,
+        owner=owner,
+        repo=repo_name,
+        branch_name=branch_name,
+        file_changes=[(write_path, block)],
+        pr_title=f"Silence {monitor.get('name') or monitor.get('id')} via Terraform",
+        pr_body=_single_pr_body(
+            monitor_name=monitor.get("name") or str(monitor.get("id")),
+            scope=effective_scope,
+            codified_from_ui=message is None,
+        ),
+    )
+    if err:
+        return build_error_response(err)
+
+    return build_success_response(
+        prUrl=pr_url,
+        repo=target_repo,
+        branch=branch_name,
+        filePath=write_path,
+        monitorName=monitor.get("name"),
+        monitorId=monitor.get("id"),
+        scope=effective_scope,
+        tfMatchConfidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: bulk silence via one PR
+# ---------------------------------------------------------------------------
+
+
+def silence_all_drifted_monitors(
+    monitor_ids: Optional[List[int]] = None,
+    repo: Optional[str] = None,
+    user_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    if not user_id:
+        return build_error_response("User ID is required")
+
+    target_repo = _resolve_target_repo(user_id, repo)
+    if not target_repo:
+        return build_error_response(
+            "Multiple repos are connected. Please pass repo='owner/repo'."
+        )
+
+    try:
+        report = compute_drift(user_id=user_id, repo_full_name=target_repo)
+    except Exception as exc:  # noqa: BLE001
+        return build_error_response(f"Failed to compute drift: {exc}")
+
+    drifted = report.drifted
+    if monitor_ids:
+        wanted = {int(m) for m in monitor_ids}
+        drifted = [r for r in drifted if r.silence.monitor_id in wanted]
+
+    if not drifted:
+        return build_error_response("No drifted silences to codify.")
+
+    index = report.indexed_resources
+
+    grouped: Dict[str, List[str]] = {}
+    summary_rows: List[Dict[str, Any]] = []
+    for drift_row in drifted:
+        monitor_name = drift_row.silence.monitor_name or str(drift_row.silence.monitor_id)
+        matched = drift_row.matched_tf_resource
+        if matched is None:
+            matched, _ = match_resources_to_monitor(
+                index, monitor_name, drift_row.silence.monitor_query
+            )
+        write_path = _default_downtimes_path(matched)
+        if not write_path:
+            summary_rows.append(
+                {"monitor": monitor_name, "status": "skipped", "reason": "no TF match"}
+            )
+            continue
+        resource_name = _sanitize_resource_name(f"mute_{monitor_name}")
+        block = _build_downtime_schedule_block(
+            resource_name=resource_name,
+            monitor_resource_address=matched.resource_address if matched else None,
+            monitor_id=drift_row.silence.monitor_id,
+            scope=drift_row.silence.scope or "*",
+            original_message=drift_row.silence.message,
+            source_label="Codified from UI mute",
+        )
+        grouped.setdefault(write_path, []).append(block)
+        summary_rows.append(
+            {
+                "monitor": monitor_name,
+                "file": write_path,
+                "scope": drift_row.silence.scope or "*",
+                "status": "queued",
+            }
+        )
+
+    if not grouped:
+        return build_error_response(
+            "No silences could be codified (no matching Terraform files).",
+            summary=summary_rows,
+        )
+
+    owner, repo_name = target_repo.split("/", 1)
+    branch_name = f"aurora/silence-drift-{int(time.time())}"
+    file_changes = [
+        (path, "\n\n".join(blocks)) for path, blocks in grouped.items()
+    ]
+
+    pr_url, err = _open_silence_pr(
+        user_id=user_id,
+        owner=owner,
+        repo=repo_name,
+        branch_name=branch_name,
+        file_changes=file_changes,
+        pr_title=f"Silence {len(drifted)} Datadog monitor(s) via Terraform",
+        pr_body=_bulk_pr_body(summary_rows),
+    )
+    if err:
+        return build_error_response(err)
+
+    return build_success_response(
+        prUrl=pr_url,
+        repo=target_repo,
+        branch=branch_name,
+        filesTouched=list(grouped.keys()),
+        resourcesAdded=sum(len(v) for v in grouped.values()),
+        summary=summary_rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: reindex repo
+# ---------------------------------------------------------------------------
+
+
+def reindex_terraform_repo(
+    repo: Optional[str] = None,
+    user_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    if not user_id:
+        return build_error_response("User ID is required")
+    target_repo = _resolve_target_repo(user_id, repo)
+    if not target_repo:
+        return build_error_response(
+            "Multiple repos are connected. Please pass repo='owner/repo'."
+        )
+
+    previous_count = count_indexed_resources(user_id, target_repo)
+
+    try:
+        summary = index_repo(user_id, target_repo)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[DD_TF] reindex failed: %s", exc, exc_info=True)
+        return build_error_response(f"Re-index failed: {exc}")
+
+    delta = summary.resources_indexed - previous_count
+    return build_success_response(
+        repo=target_repo,
+        commitSha=summary.commit_sha,
+        filesScanned=summary.files_scanned,
+        filesSkipped=summary.files_skipped,
+        resourcesIndexed=summary.resources_indexed,
+        previousResources=previous_count,
+        delta=delta,
+        errors=summary.errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target_repo(user_id: str, explicit_repo: Optional[str]) -> Optional[str]:
+    """Return 'owner/repo' for the chosen repo, or None if ambiguous/missing."""
+    owner, repo_name, _ = _resolve_repository(user_id, explicit_repo)
+    if owner and repo_name:
+        return f"{owner}/{repo_name}"
+    return None
+
+
+def _resolve_datadog_monitor(
+    user_id: str, monitor_name: Optional[str], monitor_id: Optional[int]
+) -> Optional[Dict[str, Any]]:
+    creds = _get_stored_datadog_credentials(user_id)
+    if not creds:
+        raise DatadogAPIError("Datadog not connected")
+    client = _build_client_from_creds(creds)
+    if not client:
+        raise DatadogAPIError("Failed to build Datadog client")
+
+    if monitor_id is not None:
+        try:
+            resp = client.get_monitor(int(monitor_id))
+            if isinstance(resp, dict) and resp.get("id"):
+                return resp
+        except DatadogAPIError as exc:
+            logger.warning("[DD_TF] monitor lookup by id failed: %s", exc)
+
+    if monitor_name:
+        payload = client.list_monitors({"name": monitor_name, "page_size": 50})
+        if isinstance(payload, list):
+            target = monitor_name.strip().lower()
+            for m in payload:
+                if isinstance(m, dict) and (m.get("name") or "").strip().lower() == target:
+                    return m
+            if payload:
+                return payload[0] if isinstance(payload[0], dict) else None
+    return None
+
+
+def _default_downtimes_path(matched: Optional[IndexedResource]) -> Optional[str]:
+    if not matched or not matched.file_path:
+        return None
+    directory = matched.file_path.rsplit("/", 1)[0] if "/" in matched.file_path else ""
+    return f"{directory}/downtimes.tf" if directory else "downtimes.tf"
+
+
+def _sanitize_resource_name(raw: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_]", "_", raw)
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    if not cleaned:
+        cleaned = f"mute_{int(time.time())}"
+    if not cleaned[0].isalpha() and cleaned[0] != "_":
+        cleaned = f"mute_{cleaned}"
+    return cleaned.lower()[:MAX_RESOURCE_NAME_LEN]
+
+
+def _slugify(raw: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", raw).strip("-").lower()
+    return slug[:MAX_SLUG_LEN] or "monitor"
+
+
+def _build_downtime_schedule_block(
+    resource_name: str,
+    monitor_resource_address: Optional[str],
+    monitor_id: Optional[int],
+    scope: str,
+    original_message: Optional[str],
+    source_label: str,
+) -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    start = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    if original_message:
+        message = f"{original_message} — codified from UI mute on {today}"
+    else:
+        message = f"{source_label} on {today}. Silenced until this block is removed."
+
+    if monitor_resource_address:
+        monitor_ref = f"    monitor_id = {monitor_resource_address}.id"
+    elif monitor_id is not None:
+        monitor_ref = f"    monitor_id = {int(monitor_id)}"
+    else:
+        monitor_ref = "    # monitor_id = <REPLACE_ME>"
+
+    escaped_message = message.replace("\\", "\\\\").replace('"', '\\"')
+
+    return (
+        f'resource "datadog_downtime_schedule" "{resource_name}" {{\n'
+        f"  monitor_identifier {{\n"
+        f"{monitor_ref}\n"
+        f"  }}\n"
+        f'  scope = "{scope}"\n'
+        f"  schedule {{\n"
+        f"    one_time_schedule {{\n"
+        f'      start = "{start}"\n'
+        f"      # no end → indefinite; remove this resource to lift the silence\n"
+        f"    }}\n"
+        f"  }}\n"
+        f'  message          = "{escaped_message}"\n'
+        f'  display_timezone = "UTC"\n'
+        f"}}\n"
+    )
+
+
+def _single_pr_body(monitor_name: str, scope: str, codified_from_ui: bool) -> str:
+    source_line = (
+        "codified from UI mute" if codified_from_ui else "silenced via Aurora chat"
+    )
+    return (
+        "## Why\n"
+        "Aurora codifying a Datadog silence so it survives `terraform apply`.\n\n"
+        "## What this PR does\n"
+        f"- Adds a `datadog_downtime_schedule` resource mirroring the current silence ({source_line})\n"
+        f"- Monitor: `{monitor_name}`\n"
+        f"- Scope: `{scope}`\n\n"
+        "## How to revert\n"
+        "Delete the block and run `terraform apply`.\n"
+    )
+
+
+def _bulk_pr_body(summary_rows: List[Dict[str, Any]]) -> str:
+    bullets = []
+    for row in summary_rows:
+        if row.get("status") != "queued":
+            continue
+        bullets.append(
+            f"- `{row['monitor']}` (scope `{row.get('scope', '*')}`) → `{row['file']}`"
+        )
+    skipped = [r for r in summary_rows if r.get("status") == "skipped"]
+
+    body = (
+        "## Why\n"
+        "Aurora codifying Datadog UI silences so they survive `terraform apply`.\n\n"
+        "## What this PR does\n"
+        "- Adds `datadog_downtime_schedule` resources mirroring current silences:\n"
+        + ("\n".join(bullets) if bullets else "  (none)")
+    )
+    if skipped:
+        body += "\n\n## Skipped\n" + "\n".join(
+            f"- `{r['monitor']}` — {r.get('reason', 'no match')}" for r in skipped
+        )
+    body += "\n\n## How to revert\nDelete the block(s) and run `terraform apply`.\n"
+    return body
+
+
+def _open_silence_pr(
+    user_id: str,
+    owner: str,
+    repo: str,
+    branch_name: str,
+    file_changes: List[Tuple[str, str]],
+    pr_title: str,
+    pr_body: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    base_branch = get_repo_default_branch(user_id, f"{owner}/{repo}") or "main"
+
+    branch_err = _create_branch(user_id, owner, repo, branch_name, base_branch)
+    if branch_err:
+        return None, f"Failed to create branch: {branch_err}"
+
+    combined_files: List[Dict[str, str]] = []
+    for path, new_content in file_changes:
+        existing = _get_existing_file(user_id, owner, repo, path, base_branch)
+        if existing:
+            if not existing.endswith("\n"):
+                existing += "\n"
+            content = existing + "\n" + new_content
+        else:
+            content = new_content
+        combined_files.append({"path": path, "content": content})
+
+    push_err = _push_files(
+        user_id=user_id,
+        owner=owner,
+        repo=repo,
+        branch=branch_name,
+        files=combined_files,
+        message=pr_title,
+    )
+    if push_err:
+        return None, f"Failed to push files: {push_err}"
+
+    pr_url, pr_err = _create_pull_request(
+        user_id=user_id,
+        owner=owner,
+        repo=repo,
+        title=pr_title,
+        body=pr_body,
+        head=branch_name,
+        base=base_branch,
+    )
+    if pr_err:
+        return None, f"Failed to open PR: {pr_err}"
+    return pr_url, None
+
+
+def _create_branch(user_id: str, owner: str, repo: str, branch: str, base: str) -> Optional[str]:
+    result = call_github_mcp_sync(
+        "create_branch",
+        {"owner": owner, "repo": repo, "branch": branch, "from_branch": base},
+        user_id,
+    )
+    parsed = parse_mcp_response(result)
+    if isinstance(parsed, dict) and "error" in parsed:
+        return parsed["error"]
+    return None
+
+
+def _get_existing_file(
+    user_id: str, owner: str, repo: str, path: str, branch: str
+) -> Optional[str]:
+    args = {"owner": owner, "repo": repo, "path": path, "ref": f"refs/heads/{branch}"}
+    result = call_github_mcp_sync("get_file_contents", args, user_id)
+    return parse_file_content_response(result)
+
+
+def _push_files(
+    user_id: str,
+    owner: str,
+    repo: str,
+    branch: str,
+    files: List[Dict[str, str]],
+    message: str,
+) -> Optional[str]:
+    result = call_github_mcp_sync(
+        "push_files",
+        {
+            "owner": owner,
+            "repo": repo,
+            "branch": branch,
+            "files": files,
+            "message": message,
+        },
+        user_id,
+    )
+    parsed = parse_mcp_response(result)
+    if isinstance(parsed, dict) and "error" in parsed:
+        return parsed["error"]
+    return None
+
+
+def _create_pull_request(
+    user_id: str,
+    owner: str,
+    repo: str,
+    title: str,
+    body: str,
+    head: str,
+    base: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    result = call_github_mcp_sync(
+        "create_pull_request",
+        {"owner": owner, "repo": repo, "title": title, "body": body, "head": head, "base": base},
+        user_id,
+    )
+    parsed = parse_mcp_response(result)
+    if isinstance(parsed, dict) and "error" in parsed:
+        return None, parsed["error"]
+    pr_url = (
+        parsed.get("html_url")
+        or parsed.get("url")
+        or parsed.get("pullRequestUrl")
+        if isinstance(parsed, dict)
+        else None
+    )
+    pr_number = parsed.get("number") if isinstance(parsed, dict) else None
+    if not pr_url and pr_number:
+        pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
+    if not pr_url:
+        return None, "PR created but no URL returned"
+    return pr_url, None

--- a/server/chat/backend/agent/tools/datadog_terraform_tool.py
+++ b/server/chat/backend/agent/tools/datadog_terraform_tool.py
@@ -210,9 +210,7 @@ def silence_datadog_monitor_via_terraform(
         )
 
     effective_scope = scope or "*"
-    resource_name = _sanitize_resource_name(
-        f"mute_{monitor.get('name') or monitor.get('id') or 'monitor'}"
-    )
+    resource_name = _unique_silence_label(monitor, effective_scope, message)
     block = _build_downtime_schedule_block(
         resource_name=resource_name,
         monitor_resource_address=matched.resource_address if matched else None,
@@ -280,6 +278,7 @@ def silence_all_drifted_monitors(
     try:
         report = compute_drift(user_id=user_id, repo_full_name=target_repo)
     except Exception as exc:  # noqa: BLE001
+        logger.exception("[DD_TF] compute_drift failed for user=%s repo=%s", user_id, target_repo)
         return build_error_response(f"Failed to compute drift: {exc}")
 
     drifted = report.drifted
@@ -307,12 +306,17 @@ def silence_all_drifted_monitors(
                 {"monitor": monitor_name, "status": "skipped", "reason": "no TF match"}
             )
             continue
-        resource_name = _sanitize_resource_name(f"mute_{monitor_name}")
+        silence_scope = drift_row.silence.scope or "*"
+        resource_name = _unique_silence_label(
+            {"name": drift_row.silence.monitor_name, "id": drift_row.silence.monitor_id},
+            silence_scope,
+            drift_row.silence.message,
+        )
         block = _build_downtime_schedule_block(
             resource_name=resource_name,
             monitor_resource_address=matched.resource_address if matched else None,
             monitor_id=drift_row.silence.monitor_id,
-            scope=drift_row.silence.scope or "*",
+            scope=silence_scope,
             original_message=drift_row.silence.message,
             source_label="Codified from UI mute",
         )
@@ -437,8 +441,6 @@ def _resolve_datadog_monitor(
             for m in payload:
                 if isinstance(m, dict) and (m.get("name") or "").strip().lower() == target:
                     return m
-            if payload:
-                return payload[0] if isinstance(payload[0], dict) else None
     return None
 
 
@@ -457,6 +459,21 @@ def _sanitize_resource_name(raw: str) -> str:
     if not cleaned[0].isalpha() and cleaned[0] != "_":
         cleaned = f"mute_{cleaned}"
     return cleaned.lower()[:MAX_RESOURCE_NAME_LEN]
+
+
+def _unique_silence_label(monitor: Dict[str, Any], scope: str, message: Optional[str]) -> str:
+    """Build a Terraform-safe `datadog_downtime_schedule` label unique per silence.
+
+    Two PRs silencing the same monitor at different scopes would otherwise
+    collide on the resource label and break `terraform apply`.
+    """
+    import hashlib
+
+    base = f"mute_{monitor.get('name') or monitor.get('id') or 'monitor'}"
+    digest = hashlib.sha1(
+        f"{monitor.get('id')}|{scope}|{message or ''}".encode("utf-8")
+    ).hexdigest()[:6]
+    return _sanitize_resource_name(f"{base}_{digest}")
 
 
 def _slugify(raw: str) -> str:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -54,6 +54,7 @@ pydantic>=2.9.0  # Flexible for langchain compatibility
 pypdf>=4.0.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
+python-hcl2>=4.3.2
 requests==2.32.5
 rsa==4.9
 six==1.17.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -54,7 +54,7 @@ pydantic>=2.9.0  # Flexible for langchain compatibility
 pypdf>=4.0.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-hcl2>=4.3.2
+python-hcl2>=8.0.0,<9.0.0
 requests==2.32.5
 rsa==4.9
 six==1.17.0

--- a/server/routes/datadog/datadog_routes.py
+++ b/server/routes/datadog/datadog_routes.py
@@ -239,6 +239,23 @@ class DatadogClient:
         }
         return self._request("GET", "/api/v2/incidents", params=params).json()
 
+    def list_downtimes(self, current_only: bool = True, include_monitor: bool = True) -> Dict[str, Any]:
+        """List active downtimes via GET /api/v2/downtime. Read-only."""
+        params: Dict[str, Any] = {
+            "current_only": "true" if current_only else "false",
+        }
+        if include_monitor:
+            params["include"] = "monitor"
+        return self._request("GET", "/api/v2/downtime", params=params).json()
+
+    def list_monitor_downtime_matches(self, monitor_id: int) -> Dict[str, Any]:
+        """Fast per-monitor downtime lookup via GET /api/v2/monitor/{id}/downtime_matches."""
+        return self._request("GET", f"/api/v2/monitor/{monitor_id}/downtime_matches").json()
+
+    def get_monitor(self, monitor_id: int) -> Dict[str, Any]:
+        """Fetch a single monitor via GET /api/v1/monitor/{id}."""
+        return self._request("GET", f"/api/v1/monitor/{monitor_id}").json()
+
 
 def _get_stored_datadog_credentials(user_id: str) -> Optional[Dict[str, Any]]:
     try:

--- a/server/services/terraform/__init__.py
+++ b/server/services/terraform/__init__.py
@@ -1,0 +1,1 @@
+"""Terraform-aware services for Aurora (read-only HCL parsing + drift detection)."""

--- a/server/services/terraform/datadog_drift_detector.py
+++ b/server/services/terraform/datadog_drift_detector.py
@@ -1,0 +1,390 @@
+"""
+Datadog silence drift detection.
+
+Combines three read-only Datadog sources (v2 downtimes, per-monitor downtime
+matches, v1 monitor.silenced legacy field) with the HCL index to produce the
+set of silences that exist in Datadog but have no Terraform counterpart.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Literal, Optional
+
+from routes.datadog.datadog_routes import (
+    DatadogAPIError,
+    DatadogClient,
+    _build_client_from_creds,
+    _get_stored_datadog_credentials,
+)
+from services.terraform.datadog_hcl_indexer import (
+    IndexedResource,
+    MatchConfidence,
+    load_index,
+    match_resources_to_monitor,
+)
+
+logger = logging.getLogger(__name__)
+
+SilenceSource = Literal["downtime_v2", "monitor_silenced_legacy"]
+
+
+@dataclass
+class Silence:
+    source: SilenceSource
+    monitor_id: Optional[int]
+    monitor_name: Optional[str]
+    monitor_query: Optional[str]
+    scope: Optional[str]
+    downtime_id: Optional[str]
+    muted_since: Optional[str]
+    muted_until: Optional[str]
+    message: Optional[str] = None
+
+
+@dataclass
+class DriftRow:
+    silence: Silence
+    matched_tf_resource: Optional[IndexedResource]
+    tf_match_confidence: MatchConfidence
+    is_already_codified: bool
+    reason_if_codified: str = ""
+
+
+@dataclass
+class DriftReport:
+    drifted: List[DriftRow] = field(default_factory=list)
+    codified: List[DriftRow] = field(default_factory=list)
+    monitors_total: int = 0
+    silences_total: int = 0
+    errors: List[str] = field(default_factory=list)
+    indexed_resources: List[IndexedResource] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_silence_inventory(user_id: str) -> List[Silence]:
+    """Fetch the current set of silences from Datadog (read-only)."""
+    creds = _get_stored_datadog_credentials(user_id)
+    if not creds:
+        raise DatadogAPIError("Datadog is not connected for this user")
+    client = _build_client_from_creds(creds)
+    if client is None:
+        raise DatadogAPIError("Failed to construct Datadog client")
+
+    silences: List[Silence] = []
+    silences.extend(_list_active_downtimes(client))
+    silences.extend(_list_legacy_silenced_monitors(client))
+    # Dedupe on (monitor_id, scope, source) to avoid duplicates when the legacy
+    # field and a v2 downtime cover the same scope.
+    seen = set()
+    deduped: List[Silence] = []
+    for s in silences:
+        key = (s.source, s.monitor_id, s.scope or "", s.downtime_id or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(s)
+    return deduped
+
+
+def compute_drift(
+    user_id: str,
+    repo_full_name: Optional[str] = None,
+    monitor_filter: Optional[str] = None,
+    scope_filter: Optional[str] = None,
+) -> DriftReport:
+    """Build the drift report against the current HCL index.
+
+    Drift = a silence in Datadog with no corresponding Terraform block.
+    """
+    report = DriftReport()
+    try:
+        inventory = build_silence_inventory(user_id)
+    except DatadogAPIError as exc:
+        report.errors.append(str(exc))
+        return report
+
+    report.silences_total = len(inventory)
+
+    index = load_index(user_id, repo_full_name)
+    report.indexed_resources = index
+    monitor_index = [r for r in index if r.resource_type == "datadog_monitor"]
+    schedule_index = [r for r in index if r.resource_type == "datadog_downtime_schedule"]
+    legacy_downtime_index = [r for r in index if r.resource_type == "datadog_downtime"]
+
+    monitor_ids_seen = set()
+    for silence in inventory:
+        if scope_filter and (silence.scope or "") != scope_filter:
+            continue
+        if monitor_filter and monitor_filter.lower() not in (silence.monitor_name or "").lower():
+            continue
+        monitor_ids_seen.add(silence.monitor_id)
+
+        matched, confidence = match_resources_to_monitor(
+            monitor_index, silence.monitor_name or "", silence.monitor_query
+        )
+
+        # Is this silence already codified?
+        codified, reason = _is_silence_codified(
+            silence, matched, schedule_index, legacy_downtime_index
+        )
+        row = DriftRow(
+            silence=silence,
+            matched_tf_resource=matched,
+            tf_match_confidence=confidence,
+            is_already_codified=codified,
+            reason_if_codified=reason,
+        )
+        if codified:
+            report.codified.append(row)
+        else:
+            report.drifted.append(row)
+
+    report.monitors_total = len(monitor_ids_seen)
+    _persist_drift_snapshot(user_id, report)
+    return report
+
+
+def drift_row_to_dict(row: DriftRow) -> Dict[str, Any]:
+    tf = row.matched_tf_resource
+    return {
+        "monitor_id": row.silence.monitor_id,
+        "monitor_name": row.silence.monitor_name,
+        "scope": row.silence.scope,
+        "muted_since": row.silence.muted_since,
+        "muted_until": row.silence.muted_until,
+        "source": row.silence.source,
+        "downtime_id": row.silence.downtime_id,
+        "original_message": row.silence.message,
+        "matched_tf_file": tf.file_path if tf else None,
+        "matched_tf_address": tf.resource_address if tf else None,
+        "tf_match_confidence": row.tf_match_confidence,
+        "is_already_codified": row.is_already_codified,
+        "reason_if_codified": row.reason_if_codified,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Datadog fetchers (read-only)
+# ---------------------------------------------------------------------------
+
+
+def _list_active_downtimes(client: DatadogClient) -> List[Silence]:
+    try:
+        payload = client.list_downtimes(current_only=True, include_monitor=True)
+    except DatadogAPIError as exc:
+        logger.warning("[DRIFT] list_downtimes failed: %s", exc)
+        return []
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    included = payload.get("included") if isinstance(payload, dict) else None
+    monitor_by_id: Dict[str, Dict[str, Any]] = {}
+    if isinstance(included, list):
+        for item in included:
+            if isinstance(item, dict) and item.get("type") == "monitor":
+                monitor_by_id[str(item.get("id"))] = item.get("attributes") or {}
+
+    silences: List[Silence] = []
+    if not isinstance(data, list):
+        return silences
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        attributes = item.get("attributes") or {}
+        relationships = item.get("relationships") or {}
+        monitor_rel = (relationships.get("monitor") or {}).get("data") or {}
+        monitor_ref_id = monitor_rel.get("id")
+        monitor_attr = monitor_by_id.get(str(monitor_ref_id), {}) if monitor_ref_id else {}
+
+        monitor_identifier = attributes.get("monitor_identifier") or {}
+        monitor_id = None
+        if isinstance(monitor_identifier, dict):
+            monitor_id = monitor_identifier.get("monitor_id")
+        if monitor_id is None and monitor_ref_id:
+            try:
+                monitor_id = int(monitor_ref_id)
+            except (TypeError, ValueError):
+                monitor_id = None
+
+        schedule = attributes.get("schedule") or {}
+        start = schedule.get("start") if isinstance(schedule, dict) else None
+        end = schedule.get("end") if isinstance(schedule, dict) else None
+
+        silences.append(
+            Silence(
+                source="downtime_v2",
+                monitor_id=monitor_id,
+                monitor_name=monitor_attr.get("name"),
+                monitor_query=monitor_attr.get("query"),
+                scope=_stringify_scope(attributes.get("scope")),
+                downtime_id=item.get("id"),
+                muted_since=start,
+                muted_until=end,
+                message=attributes.get("message"),
+            )
+        )
+    return silences
+
+
+def _list_legacy_silenced_monitors(client: DatadogClient) -> List[Silence]:
+    """Catch customers still using the deprecated monitor.silenced attribute."""
+    silences: List[Silence] = []
+    page = 0
+    while True:
+        try:
+            payload = client.list_monitors(
+                {"page": page, "page_size": 100, "group_states": "all", "with_downtimes": "false"}
+            )
+        except DatadogAPIError as exc:
+            logger.warning("[DRIFT] list_monitors failed: %s", exc)
+            break
+        if not isinstance(payload, list) or not payload:
+            break
+        for monitor in payload:
+            if not isinstance(monitor, dict):
+                continue
+            options = monitor.get("options") or {}
+            silenced_map = options.get("silenced") if isinstance(options, dict) else None
+            if not isinstance(silenced_map, dict) or not silenced_map:
+                continue
+            for scope_key, _end_ts in silenced_map.items():
+                silences.append(
+                    Silence(
+                        source="monitor_silenced_legacy",
+                        monitor_id=monitor.get("id"),
+                        monitor_name=monitor.get("name"),
+                        monitor_query=monitor.get("query"),
+                        scope=scope_key or "*",
+                        downtime_id=None,
+                        muted_since=None,
+                        muted_until=None,
+                        message=None,
+                    )
+                )
+        if len(payload) < 100:
+            break
+        page += 1
+    return silences
+
+
+# ---------------------------------------------------------------------------
+# Matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_silence_codified(
+    silence: Silence,
+    matched_monitor: Optional[IndexedResource],
+    schedule_index: Iterable[IndexedResource],
+    legacy_downtime_index: Iterable[IndexedResource],
+) -> tuple[bool, str]:
+    """Does the repo already contain a block that covers this silence?"""
+    scope = (silence.scope or "").strip()
+
+    if matched_monitor and matched_monitor.silenced_inline:
+        inline = matched_monitor.silenced_inline
+        if isinstance(inline, dict):
+            if "*" in inline or (scope and scope in inline):
+                return True, f"already in {matched_monitor.file_path} options.silenced"
+
+    def _targets_match(block: IndexedResource) -> bool:
+        if not matched_monitor:
+            return False
+        ref = block.downtime_monitor_ref or ""
+        if not isinstance(ref, str):
+            ref = str(ref)
+        return (
+            matched_monitor.resource_address in ref
+            or matched_monitor.resource_address.split(".")[-1] in ref
+        )
+
+    for block in schedule_index:
+        block_scope = (block.scope or "").strip()
+        if _targets_match(block) and (not scope or not block_scope or block_scope == scope):
+            return True, f"already in {block.file_path} ({block.resource_address})"
+
+    for block in legacy_downtime_index:
+        block_scope = (block.scope or "").strip()
+        if _targets_match(block) and (not scope or not block_scope or block_scope == scope):
+            return True, f"already in {block.file_path} ({block.resource_address})"
+
+    return False, ""
+
+
+def _stringify_scope(scope: Any) -> Optional[str]:
+    if scope is None:
+        return None
+    if isinstance(scope, list):
+        return ",".join(str(s) for s in scope)
+    return str(scope)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _persist_drift_snapshot(user_id: str, report: DriftReport) -> None:
+    from psycopg2.extras import execute_values
+    from utils.db.connection_pool import db_pool
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM datadog_silence_drift WHERE user_id = %s", (user_id,))
+            if report.drifted:
+                rows = [
+                    (
+                        user_id,
+                        row.silence.monitor_id,
+                        row.silence.monitor_name,
+                        row.silence.scope,
+                        row.silence.downtime_id,
+                        _parse_iso(row.silence.muted_since),
+                        row.silence.source,
+                        row.matched_tf_resource.file_path if row.matched_tf_resource else None,
+                        row.tf_match_confidence,
+                        row.silence.message,
+                    )
+                    for row in report.drifted
+                ]
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO datadog_silence_drift
+                    (user_id, monitor_id, monitor_name, scope, downtime_id, muted_since,
+                     source, matched_tf_file, tf_match_confidence, original_message)
+                    VALUES %s
+                    ON CONFLICT (user_id, monitor_id, scope, source) DO UPDATE
+                    SET monitor_name = EXCLUDED.monitor_name,
+                        downtime_id = EXCLUDED.downtime_id,
+                        muted_since = EXCLUDED.muted_since,
+                        matched_tf_file = EXCLUDED.matched_tf_file,
+                        tf_match_confidence = EXCLUDED.tf_match_confidence,
+                        original_message = EXCLUDED.original_message,
+                        computed_at = CURRENT_TIMESTAMP
+                    """,
+                    rows,
+                )
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[DRIFT] snapshot persist failed: %s", exc)
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:  # noqa: BLE001
+        return None

--- a/server/services/terraform/datadog_drift_detector.py
+++ b/server/services/terraform/datadog_drift_detector.py
@@ -80,17 +80,19 @@ def build_silence_inventory(user_id: str) -> List[Silence]:
     silences: List[Silence] = []
     silences.extend(_list_active_downtimes(client))
     silences.extend(_list_legacy_silenced_monitors(client))
-    # Dedupe on (monitor_id, scope, source) to avoid duplicates when the legacy
-    # field and a v2 downtime cover the same scope.
-    seen = set()
-    deduped: List[Silence] = []
+    # When the same monitor+scope shows up in both the v2 downtime API and the
+    # legacy `silenced` map, prefer the v2 row — it carries muted_since/message
+    # and is the path Datadog itself recommends.
+    deduped: Dict[tuple, Silence] = {}
     for s in silences:
-        key = (s.source, s.monitor_id, s.scope or "", s.downtime_id or "")
-        if key in seen:
+        key = (s.monitor_id, s.scope or "")
+        existing = deduped.get(key)
+        if existing is None:
+            deduped[key] = s
             continue
-        seen.add(key)
-        deduped.append(s)
-    return deduped
+        if existing.source != "downtime_v2" and s.source == "downtime_v2":
+            deduped[key] = s
+    return list(deduped.values())
 
 
 def compute_drift(
@@ -147,7 +149,11 @@ def compute_drift(
             report.drifted.append(row)
 
     report.monitors_total = len(monitor_ids_seen)
-    _persist_drift_snapshot(user_id, report)
+    # Only persist when the run covers the full canonical inventory; a
+    # monitor_name / scope filter would otherwise overwrite the snapshot with a
+    # subset. (repo_full_name is allowed — the snapshot table is user-level.)
+    if not (monitor_filter or scope_filter):
+        _persist_drift_snapshot(user_id, report)
     return report
 
 
@@ -362,9 +368,8 @@ def _persist_drift_snapshot(user_id: str, report: DriftReport) -> None:
                     (user_id, monitor_id, monitor_name, scope, downtime_id, muted_since,
                      source, matched_tf_file, tf_match_confidence, original_message)
                     VALUES %s
-                    ON CONFLICT (user_id, monitor_id, scope, source) DO UPDATE
+                    ON CONFLICT (user_id, monitor_id, scope, source, downtime_id) DO UPDATE
                     SET monitor_name = EXCLUDED.monitor_name,
-                        downtime_id = EXCLUDED.downtime_id,
                         muted_since = EXCLUDED.muted_since,
                         matched_tf_file = EXCLUDED.matched_tf_file,
                         tf_match_confidence = EXCLUDED.tf_match_confidence,

--- a/server/services/terraform/datadog_hcl_indexer.py
+++ b/server/services/terraform/datadog_hcl_indexer.py
@@ -1,0 +1,538 @@
+"""
+Terraform HCL indexer for Datadog resources.
+
+Walks .tf files in a connected GitHub repo via MCP, parses with python-hcl2,
+and extracts every `datadog_monitor`, `datadog_downtime`, and
+`datadog_downtime_schedule` block into `terraform_datadog_resources`.
+
+Read-only: never mutates the repo.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+TF_DATADOG_RESOURCE_TYPES = (
+    "datadog_monitor",
+    "datadog_downtime",
+    "datadog_downtime_schedule",
+)
+
+FUZZY_MATCH_MIN_SCORE = 0.6
+
+MatchConfidence = Literal["exact_query", "exact_name", "fuzzy_name", "none"]
+
+_RESOURCE_HEADER_RE = re.compile(
+    r'^\s*resource\s+"(?P<type>datadog_(?:monitor|downtime|downtime_schedule))"\s+"(?P<name>[A-Za-z0-9_\-]+)"\s*\{',
+    re.MULTILINE,
+)
+
+
+@dataclass
+class IndexedResource:
+    resource_type: str
+    resource_address: str  # e.g. datadog_monitor.api_error_rate
+    file_path: str
+    line_start: int
+    line_end: int
+    monitor_name: Optional[str] = None
+    query_hash: Optional[str] = None
+    scope: Optional[str] = None
+    silenced_inline: Optional[Dict[str, Any]] = None
+    raw_block: str = ""
+    commit_sha: Optional[str] = None
+    # downtime-specific
+    downtime_monitor_ref: Optional[str] = None  # e.g. datadog_monitor.foo.id or raw id
+
+
+@dataclass
+class IndexSummary:
+    repo_full_name: str
+    commit_sha: Optional[str]
+    files_scanned: int = 0
+    files_skipped: int = 0
+    resources_indexed: int = 0
+    resources: List[IndexedResource] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def index_repo(user_id: str, repo_full_name: str, branch: Optional[str] = None) -> IndexSummary:
+    """Walk the repo's default (or specified) branch and build a fresh index.
+
+    Persists rows to `terraform_datadog_resources` for `user_id` + `repo_full_name`
+    (replaces prior rows for that pair in a single transaction).
+    """
+    owner, repo = _split_repo(repo_full_name)
+    summary = IndexSummary(repo_full_name=repo_full_name, commit_sha=None)
+
+    if not owner or not repo:
+        summary.errors.append(f"Invalid repo format: {repo_full_name}")
+        return summary
+
+    effective_branch = branch or get_repo_default_branch(user_id, repo_full_name) or "main"
+    summary.commit_sha = _get_branch_head_sha(user_id, owner, repo, effective_branch)
+
+    tf_paths = _walk_tf_files(user_id, owner, repo, effective_branch)
+    for path in tf_paths:
+        content = _fetch_file(user_id, owner, repo, path, effective_branch)
+        if content is None:
+            summary.files_skipped += 1
+            continue
+        summary.files_scanned += 1
+        try:
+            extracted = extract_resources_from_hcl(content, path)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[HCL_INDEXER] Parse error in %s: %s", path, exc)
+            summary.errors.append(f"{path}: {exc}")
+            continue
+        for res in extracted:
+            res.commit_sha = summary.commit_sha
+            summary.resources.append(res)
+
+    summary.resources_indexed = len(summary.resources)
+    _persist_index(user_id, repo_full_name, summary.resources)
+    return summary
+
+
+def extract_resources_from_hcl(content: str, file_path: str) -> List[IndexedResource]:
+    """Parse a single .tf file's content and return IndexedResource rows.
+
+    python-hcl2 gives us the semantic block tree; we use a regex over the raw
+    text to recover approximate line ranges, which are good enough for user-
+    facing tool output.
+    """
+    import hcl2  # deferred import so module import doesn't require the dep
+
+    try:
+        parsed = hcl2.load(io.StringIO(content))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"HCL parse failed: {exc}") from exc
+
+    line_map = _build_line_map(content)
+    resources = parsed.get("resource", []) or []
+
+    results: List[IndexedResource] = []
+    for resource_block in resources:
+        if not isinstance(resource_block, dict):
+            continue
+        for rtype, named_blocks in resource_block.items():
+            if rtype not in TF_DATADOG_RESOURCE_TYPES:
+                continue
+            if not isinstance(named_blocks, dict):
+                continue
+            for name, body in named_blocks.items():
+                if not isinstance(body, dict):
+                    continue
+                address = f"{rtype}.{name}"
+                line_start, line_end, raw = _lookup_line_range(line_map, rtype, name, content)
+                row = IndexedResource(
+                    resource_type=rtype,
+                    resource_address=address,
+                    file_path=file_path,
+                    line_start=line_start,
+                    line_end=line_end,
+                    raw_block=raw,
+                )
+                if rtype == "datadog_monitor":
+                    row.monitor_name = _first(body.get("name"))
+                    row.query_hash = _query_hash(body.get("query"))
+                    options = _first(body.get("options"))
+                    if isinstance(options, dict):
+                        silenced = _first(options.get("silenced"))
+                        if silenced is not None:
+                            row.silenced_inline = silenced if isinstance(silenced, dict) else {"_raw": silenced}
+                elif rtype == "datadog_downtime":
+                    row.scope = _stringify_scope(body.get("scope"))
+                    row.downtime_monitor_ref = _first(body.get("monitor_id"))
+                    tags = _first(body.get("monitor_tags"))
+                    if tags and not row.scope:
+                        row.scope = _stringify_scope(tags)
+                elif rtype == "datadog_downtime_schedule":
+                    row.scope = _stringify_scope(body.get("scope"))
+                    mid = _first(body.get("monitor_identifier"))
+                    if isinstance(mid, dict):
+                        row.downtime_monitor_ref = _first(mid.get("monitor_id"))
+                results.append(row)
+    return results
+
+
+def match_resources_to_monitor(
+    resources: Iterable[IndexedResource],
+    monitor_name: str,
+    monitor_query: Optional[str],
+) -> Tuple[Optional[IndexedResource], MatchConfidence]:
+    """Find best-matching datadog_monitor resource for a live monitor."""
+    monitors = [r for r in resources if r.resource_type == "datadog_monitor"]
+    query_hash = _query_hash(monitor_query) if monitor_query else None
+    if query_hash:
+        for r in monitors:
+            if r.query_hash and r.query_hash == query_hash:
+                return r, "exact_query"
+    if monitor_name:
+        target = monitor_name.strip().lower()
+        for r in monitors:
+            if (r.monitor_name or "").strip().lower() == target:
+                return r, "exact_name"
+        best = None
+        best_score = 0.0
+        for r in monitors:
+            candidate = (r.monitor_name or "").strip().lower()
+            if not candidate:
+                continue
+            score = _similarity(candidate, target)
+            if score > best_score:
+                best, best_score = r, score
+        if best is not None and best_score >= FUZZY_MATCH_MIN_SCORE:
+            return best, "fuzzy_name"
+    return None, "none"
+
+
+def load_index(
+    user_id: str,
+    repo_full_name: Optional[str] = None,
+    include_raw_block: bool = False,
+) -> List[IndexedResource]:
+    """Load all indexed resources for a user, optionally filtered by repo.
+
+    `raw_block` can inflate rows significantly for large monitors; callers that
+    only need match metadata should leave `include_raw_block=False`.
+    """
+    from utils.db.connection_pool import db_pool
+
+    raw_column = "raw_block" if include_raw_block else "''"
+    sql = f"""
+        SELECT resource_type, resource_address, file_path, line_start, line_end,
+               monitor_name, query_hash, scope, silenced_inline, {raw_column}, commit_sha
+        FROM terraform_datadog_resources
+        WHERE user_id = %s
+    """
+    params: Tuple[Any, ...] = (user_id,)
+    if repo_full_name:
+        sql += " AND repo_full_name = %s"
+        params = (user_id, repo_full_name)
+
+    rows: List[IndexedResource] = []
+    try:
+        with db_pool.get_admin_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(sql, params)
+            for row in cur.fetchall():
+                silenced = row[8]
+                if isinstance(silenced, str):
+                    try:
+                        silenced = json.loads(silenced)
+                    except json.JSONDecodeError:
+                        silenced = None
+                rows.append(
+                    IndexedResource(
+                        resource_type=row[0],
+                        resource_address=row[1],
+                        file_path=row[2],
+                        line_start=row[3] or 0,
+                        line_end=row[4] or 0,
+                        monitor_name=row[5],
+                        query_hash=row[6],
+                        scope=row[7],
+                        silenced_inline=silenced,
+                        raw_block=row[9] or "",
+                        commit_sha=row[10],
+                    )
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[HCL_INDEXER] load_index failed: %s", exc)
+    return rows
+
+
+def count_indexed_resources(user_id: str, repo_full_name: str) -> int:
+    """Cheap row-count without hydrating every resource."""
+    from utils.db.connection_pool import db_pool
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM terraform_datadog_resources WHERE user_id = %s AND repo_full_name = %s",
+                (user_id, repo_full_name),
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[HCL_INDEXER] count failed: %s", exc)
+        return 0
+
+
+def get_repo_default_branch(user_id: str, repo_full_name: str) -> Optional[str]:
+    """Lookup of `github_connected_repos.default_branch` shared with callers."""
+    from utils.db.connection_pool import db_pool
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT default_branch FROM github_connected_repos WHERE user_id = %s AND repo_full_name = %s",
+                (user_id, repo_full_name),
+            )
+            row = cur.fetchone()
+            return row[0] if row and row[0] else None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[HCL_INDEXER] Default branch lookup failed: %s", exc)
+        return None
+
+
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (MCP reads only)
+# ---------------------------------------------------------------------------
+
+
+def _split_repo(repo_full_name: str) -> Tuple[Optional[str], Optional[str]]:
+    if not repo_full_name or "/" not in repo_full_name:
+        return None, None
+    owner, _, repo = repo_full_name.partition("/")
+    owner = owner.strip()
+    repo = repo.strip()
+    if not owner or not repo:
+        return None, None
+    return owner, repo
+
+
+def _get_branch_head_sha(user_id: str, owner: str, repo: str, branch: str) -> Optional[str]:
+    from chat.backend.agent.tools.github_mcp_utils import call_github_mcp_sync, parse_mcp_response
+
+    result = call_github_mcp_sync(
+        "get_branch",
+        {"owner": owner, "repo": repo, "branch": branch},
+        user_id,
+    )
+    parsed = parse_mcp_response(result)
+    commit = parsed.get("commit") if isinstance(parsed, dict) else None
+    if isinstance(commit, dict):
+        return commit.get("sha") or (commit.get("commit") or {}).get("sha")
+    return parsed.get("sha") if isinstance(parsed, dict) else None
+
+
+def _walk_tf_files(user_id: str, owner: str, repo: str, branch: str) -> List[str]:
+    """Recursive walk via GitHub MCP `get_file_contents`. Returns .tf paths."""
+    from chat.backend.agent.tools.github_mcp_utils import call_github_mcp_sync, parse_mcp_response
+
+    out: List[str] = []
+    stack: List[str] = [""]
+    visited: set = set()
+    while stack:
+        path = stack.pop()
+        if path in visited:
+            continue
+        visited.add(path)
+
+        args = {"owner": owner, "repo": repo, "path": path, "ref": f"refs/heads/{branch}"}
+        result = call_github_mcp_sync("get_file_contents", args, user_id)
+        parsed = parse_mcp_response(result)
+        entries = _extract_directory_entries(parsed)
+        if entries is None:
+            continue
+        for entry in entries:
+            etype = entry.get("type")
+            epath = entry.get("path") or entry.get("name")
+            if not epath:
+                continue
+            if etype == "dir":
+                stack.append(epath)
+            elif etype == "file" and epath.endswith(".tf"):
+                out.append(epath)
+    return out
+
+
+def _extract_directory_entries(parsed: Any) -> Optional[List[Dict[str, Any]]]:
+    if isinstance(parsed, list):
+        return [e for e in parsed if isinstance(e, dict)]
+    if isinstance(parsed, dict):
+        for key in ("entries", "content", "items"):
+            value = parsed.get(key)
+            if isinstance(value, list):
+                return [e for e in value if isinstance(e, dict)]
+    return None
+
+
+def _fetch_file(user_id: str, owner: str, repo: str, path: str, branch: str) -> Optional[str]:
+    from chat.backend.agent.tools.github_mcp_utils import call_github_mcp_sync, parse_file_content_response
+
+    args = {"owner": owner, "repo": repo, "path": path, "ref": f"refs/heads/{branch}"}
+    result = call_github_mcp_sync("get_file_contents", args, user_id)
+    return parse_file_content_response(result)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _persist_index(user_id: str, repo_full_name: str, resources: List[IndexedResource]) -> None:
+    from psycopg2.extras import execute_values
+    from utils.db.connection_pool import db_pool
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM terraform_datadog_resources WHERE user_id = %s AND repo_full_name = %s",
+                (user_id, repo_full_name),
+            )
+            if resources:
+                rows = [
+                    (
+                        user_id,
+                        repo_full_name,
+                        r.commit_sha,
+                        r.resource_type,
+                        r.resource_address,
+                        r.file_path,
+                        r.line_start,
+                        r.line_end,
+                        r.monitor_name,
+                        r.query_hash,
+                        r.scope,
+                        json.dumps(r.silenced_inline) if r.silenced_inline is not None else None,
+                        r.raw_block,
+                    )
+                    for r in resources
+                ]
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO terraform_datadog_resources
+                    (user_id, repo_full_name, commit_sha, resource_type, resource_address,
+                     file_path, line_start, line_end, monitor_name, query_hash, scope,
+                     silenced_inline, raw_block)
+                    VALUES %s
+                    ON CONFLICT (user_id, repo_full_name, resource_address, file_path) DO UPDATE
+                    SET commit_sha = EXCLUDED.commit_sha,
+                        resource_type = EXCLUDED.resource_type,
+                        line_start = EXCLUDED.line_start,
+                        line_end = EXCLUDED.line_end,
+                        monitor_name = EXCLUDED.monitor_name,
+                        query_hash = EXCLUDED.query_hash,
+                        scope = EXCLUDED.scope,
+                        silenced_inline = EXCLUDED.silenced_inline,
+                        raw_block = EXCLUDED.raw_block,
+                        indexed_at = CURRENT_TIMESTAMP
+                    """,
+                    rows,
+                )
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[HCL_INDEXER] Persist failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _first(value: Any) -> Any:
+    """python-hcl2 returns most fields as single-element lists. Unwrap."""
+    if isinstance(value, list):
+        return value[0] if value else None
+    return value
+
+
+def _query_hash(query: Any) -> Optional[str]:
+    q = _first(query)
+    if not isinstance(q, str) or not q.strip():
+        return None
+    return hashlib.sha1(q.strip().encode("utf-8")).hexdigest()
+
+
+def _stringify_scope(scope: Any) -> Optional[str]:
+    s = _first(scope)
+    if s is None:
+        return None
+    if isinstance(s, list):
+        return ",".join(str(x) for x in s)
+    return str(s)
+
+
+def _similarity(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    from difflib import SequenceMatcher
+
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _build_line_map(content: str) -> List[Tuple[int, int, str, str]]:
+    """Return list of (start_line, end_line, type, name) by scanning headers.
+
+    End line is inferred by brace matching from the header onward. This is a
+    lightweight approximation; good enough for user-facing line ranges.
+    """
+    entries: List[Tuple[int, int, str, str]] = []
+    for match in _RESOURCE_HEADER_RE.finditer(content):
+        rtype = match.group("type")
+        name = match.group("name")
+        start_offset = match.start()
+        header_line = content.count("\n", 0, start_offset) + 1
+        end_line = _find_block_end_line(content, match.end())
+        entries.append((header_line, end_line, rtype, name))
+    return entries
+
+
+def _lookup_line_range(
+    line_map: List[Tuple[int, int, str, str]],
+    rtype: str,
+    name: str,
+    content: str,
+) -> Tuple[int, int, str]:
+    for start, end, t, n in line_map:
+        if t == rtype and n == name:
+            lines = content.splitlines()
+            raw = "\n".join(lines[start - 1 : end])
+            return start, end, raw
+    return 0, 0, ""
+
+
+def _find_block_end_line(content: str, header_end_offset: int) -> int:
+    """Brace-balance forward from the opening `{` to locate the closing `}`."""
+    depth = 1  # header already consumed the opening `{`
+    i = header_end_offset
+    n = len(content)
+    in_str = False
+    str_char = ""
+    while i < n and depth > 0:
+        ch = content[i]
+        if in_str:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == str_char:
+                in_str = False
+        else:
+            if ch in ('"', "'"):
+                in_str = True
+                str_char = ch
+            elif ch == "#":
+                nl = content.find("\n", i)
+                if nl == -1:
+                    break
+                i = nl
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return content.count("\n", 0, i) + 1
+        i += 1
+    return content.count("\n", 0, min(i, n - 1)) + 1

--- a/server/services/terraform/datadog_hcl_indexer.py
+++ b/server/services/terraform/datadog_hcl_indexer.py
@@ -128,12 +128,14 @@ def extract_resources_from_hcl(content: str, file_path: str) -> List[IndexedReso
     for resource_block in resources:
         if not isinstance(resource_block, dict):
             continue
-        for rtype, named_blocks in resource_block.items():
+        for rtype_raw, named_blocks in resource_block.items():
+            rtype = _unquote(rtype_raw)
             if rtype not in TF_DATADOG_RESOURCE_TYPES:
                 continue
             if not isinstance(named_blocks, dict):
                 continue
-            for name, body in named_blocks.items():
+            for name_raw, body in named_blocks.items():
+                name = _unquote(name_raw)
                 if not isinstance(body, dict):
                     continue
                 address = f"{rtype}.{name}"
@@ -147,8 +149,8 @@ def extract_resources_from_hcl(content: str, file_path: str) -> List[IndexedReso
                     raw_block=raw,
                 )
                 if rtype == "datadog_monitor":
-                    row.monitor_name = _first(body.get("name"))
-                    row.query_hash = _query_hash(body.get("query"))
+                    row.monitor_name = _clean_scalar(body.get("name"))
+                    row.query_hash = _query_hash(_clean_scalar(body.get("query")))
                     options = _first(body.get("options"))
                     if isinstance(options, dict):
                         silenced = _first(options.get("silenced"))
@@ -156,7 +158,7 @@ def extract_resources_from_hcl(content: str, file_path: str) -> List[IndexedReso
                             row.silenced_inline = silenced if isinstance(silenced, dict) else {"_raw": silenced}
                 elif rtype == "datadog_downtime":
                     row.scope = _stringify_scope(body.get("scope"))
-                    row.downtime_monitor_ref = _first(body.get("monitor_id"))
+                    row.downtime_monitor_ref = _clean_scalar(body.get("monitor_id"))
                     tags = _first(body.get("monitor_tags"))
                     if tags and not row.scope:
                         row.scope = _stringify_scope(tags)
@@ -164,7 +166,7 @@ def extract_resources_from_hcl(content: str, file_path: str) -> List[IndexedReso
                     row.scope = _stringify_scope(body.get("scope"))
                     mid = _first(body.get("monitor_identifier"))
                     if isinstance(mid, dict):
-                        row.downtime_monitor_ref = _first(mid.get("monitor_id"))
+                        row.downtime_monitor_ref = _clean_scalar(mid.get("monitor_id"))
                 results.append(row)
     return results
 
@@ -449,8 +451,19 @@ def _first(value: Any) -> Any:
     return value
 
 
+def _unquote(s: Any) -> Any:
+    """python-hcl2 ≥5 returns identifiers and string literals with surrounding quotes."""
+    if isinstance(s, str) and len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def _clean_scalar(value: Any) -> Any:
+    return _unquote(_first(value))
+
+
 def _query_hash(query: Any) -> Optional[str]:
-    q = _first(query)
+    q = _unquote(_first(query))
     if not isinstance(q, str) or not q.strip():
         return None
     return hashlib.sha1(q.strip().encode("utf-8")).hexdigest()
@@ -461,8 +474,8 @@ def _stringify_scope(scope: Any) -> Optional[str]:
     if s is None:
         return None
     if isinstance(s, list):
-        return ",".join(str(x) for x in s)
-    return str(s)
+        return ",".join(_unquote(str(x)) for x in s)
+    return _unquote(str(s))
 
 
 def _similarity(a: str, b: str) -> float:

--- a/server/services/terraform/datadog_hcl_indexer.py
+++ b/server/services/terraform/datadog_hcl_indexer.py
@@ -27,6 +27,7 @@ TF_DATADOG_RESOURCE_TYPES = (
 )
 
 FUZZY_MATCH_MIN_SCORE = 0.6
+_FUZZY_AMBIGUITY_DELTA = 0.05
 
 MatchConfidence = Literal["exact_query", "exact_name", "fuzzy_name", "none"]
 
@@ -103,6 +104,16 @@ def index_repo(user_id: str, repo_full_name: str, branch: Optional[str] = None) 
             summary.resources.append(res)
 
     summary.resources_indexed = len(summary.resources)
+    # An incomplete scan would shrink or blank out a previously-good index —
+    # keep the old index in place and surface the errors to the caller.
+    if summary.errors or summary.files_skipped:
+        logger.warning(
+            "[HCL_INDEXER] Skipping persist for %s: errors=%d skipped=%d",
+            repo_full_name,
+            len(summary.errors),
+            summary.files_skipped,
+        )
+        return summary
     _persist_index(user_id, repo_full_name, summary.resources)
     return summary
 
@@ -176,30 +187,44 @@ def match_resources_to_monitor(
     monitor_name: str,
     monitor_query: Optional[str],
 ) -> Tuple[Optional[IndexedResource], MatchConfidence]:
-    """Find best-matching datadog_monitor resource for a live monitor."""
+    """Find best-matching datadog_monitor resource for a live monitor.
+
+    Query-hash matches short-circuit since they're canonical. Name-based matches
+    fail closed on ambiguity (multiple exact hits, or fuzzy near-ties) to avoid
+    silently writing a downtime against the wrong monitor.
+    """
     monitors = [r for r in resources if r.resource_type == "datadog_monitor"]
     query_hash = _query_hash(monitor_query) if monitor_query else None
     if query_hash:
         for r in monitors:
             if r.query_hash and r.query_hash == query_hash:
                 return r, "exact_query"
-    if monitor_name:
-        target = monitor_name.strip().lower()
-        for r in monitors:
-            if (r.monitor_name or "").strip().lower() == target:
-                return r, "exact_name"
-        best = None
-        best_score = 0.0
-        for r in monitors:
-            candidate = (r.monitor_name or "").strip().lower()
-            if not candidate:
-                continue
-            score = _similarity(candidate, target)
-            if score > best_score:
-                best, best_score = r, score
-        if best is not None and best_score >= FUZZY_MATCH_MIN_SCORE:
-            return best, "fuzzy_name"
-    return None, "none"
+    if not monitor_name:
+        return None, "none"
+
+    target = monitor_name.strip().lower()
+    exact = [r for r in monitors if (r.monitor_name or "").strip().lower() == target]
+    if len(exact) == 1:
+        return exact[0], "exact_name"
+    if len(exact) > 1:
+        return None, "none"
+
+    scored: List[Tuple[float, IndexedResource]] = []
+    for r in monitors:
+        candidate = (r.monitor_name or "").strip().lower()
+        if not candidate:
+            continue
+        score = _similarity(candidate, target)
+        if score >= FUZZY_MATCH_MIN_SCORE:
+            scored.append((score, r))
+    if not scored:
+        return None, "none"
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    top_score, top_resource = scored[0]
+    # Fail closed when the runner-up is within a near-tie of the leader.
+    if len(scored) > 1 and (top_score - scored[1][0]) < _FUZZY_AMBIGUITY_DELTA:
+        return None, "none"
+    return top_resource, "fuzzy_name"
 
 
 def load_index(
@@ -435,8 +460,9 @@ def _persist_index(user_id: str, repo_full_name: str, resources: List[IndexedRes
                     rows,
                 )
             conn.commit()
-    except Exception as exc:  # noqa: BLE001
-        logger.error("[HCL_INDEXER] Persist failed: %s", exc)
+    except Exception:
+        logger.exception("[HCL_INDEXER] Persist failed for %s", repo_full_name)
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1164,7 +1164,7 @@ def initialize_tables():
                         tf_match_confidence VARCHAR(16),
                         original_message TEXT,
                         computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        UNIQUE(user_id, monitor_id, scope, source)
+                        UNIQUE(user_id, monitor_id, scope, source, downtime_id)
                     );
 
                     CREATE INDEX IF NOT EXISTS idx_dd_drift_user ON datadog_silence_drift(user_id, computed_at DESC);

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1123,6 +1123,53 @@ def initialize_tables():
                     CREATE INDEX IF NOT EXISTS idx_audit_log_org_created ON audit_log(org_id, created_at DESC);
                     CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(org_id, action);
                 """,
+                "terraform_datadog_resources": """
+                    CREATE TABLE IF NOT EXISTS terraform_datadog_resources (
+                        id SERIAL PRIMARY KEY,
+                        user_id VARCHAR(255) NOT NULL,
+                        org_id VARCHAR(255),
+                        repo_full_name VARCHAR(512) NOT NULL,
+                        commit_sha VARCHAR(64),
+                        resource_type VARCHAR(64) NOT NULL,
+                        resource_address VARCHAR(512) NOT NULL,
+                        file_path VARCHAR(1024) NOT NULL,
+                        line_start INTEGER,
+                        line_end INTEGER,
+                        monitor_name TEXT,
+                        query_hash VARCHAR(64),
+                        scope TEXT,
+                        silenced_inline JSONB,
+                        raw_block TEXT,
+                        indexed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        UNIQUE(user_id, repo_full_name, resource_address, file_path)
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_tf_dd_user_repo ON terraform_datadog_resources(user_id, repo_full_name);
+                    CREATE INDEX IF NOT EXISTS idx_tf_dd_query_hash ON terraform_datadog_resources(user_id, query_hash);
+                    CREATE INDEX IF NOT EXISTS idx_tf_dd_monitor_name ON terraform_datadog_resources(user_id, monitor_name);
+                    CREATE INDEX IF NOT EXISTS idx_tf_dd_type ON terraform_datadog_resources(user_id, resource_type);
+                """,
+                "datadog_silence_drift": """
+                    CREATE TABLE IF NOT EXISTS datadog_silence_drift (
+                        id SERIAL PRIMARY KEY,
+                        user_id VARCHAR(255) NOT NULL,
+                        org_id VARCHAR(255),
+                        monitor_id BIGINT,
+                        monitor_name TEXT,
+                        scope TEXT,
+                        downtime_id VARCHAR(128),
+                        muted_since TIMESTAMP,
+                        source VARCHAR(32),
+                        matched_tf_file VARCHAR(1024),
+                        tf_match_confidence VARCHAR(16),
+                        original_message TEXT,
+                        computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        UNIQUE(user_id, monitor_id, scope, source)
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_dd_drift_user ON datadog_silence_drift(user_id, computed_at DESC);
+                    CREATE INDEX IF NOT EXISTS idx_dd_drift_monitor ON datadog_silence_drift(user_id, monitor_id);
+                """,
             }
 
             # List of tables that should have RLS enabled and a policy applied.
@@ -1172,6 +1219,8 @@ def initialize_tables():
             rls_tables.append("incident_lifecycle_events")
             rls_tables.append("github_connected_repos")
             rls_tables.append("execution_steps")
+            rls_tables.append("terraform_datadog_resources")
+            rls_tables.append("datadog_silence_drift")
 
 
             # Migration: Add rca_celery_task_id column to incidents table if it doesn't exist


### PR DESCRIPTION
## Summary
- Four new chat tools that turn Datadog UI mutes into `datadog_downtime_schedule` PRs so silences survive `terraform apply`: `list_datadog_silence_drift`, `silence_datadog_monitor_via_terraform`, `silence_all_drifted_monitors`, `reindex_terraform_repo`
- New `services/terraform/` module: HCL indexer (walks `*.tf` via GitHub MCP, parses with `python-hcl2`, stores resources + inline `options.silenced`) + drift detector (combines `/api/v2/downtime` + legacy `monitor.silenced` and cross-references the index)
- Hard invariant: zero Datadog write calls — every silence lands as a reviewable GitHub PR via `create_branch → get_file_contents → push_files → create_pull_request`

## Reviewer test steps

### 1. Bring up Aurora on this branch
```bash
git checkout sms10221/dev-datadog-terraform-drift
make down && make dev
```

Wait for containers to come up, then confirm the new tables exist:
```bash
docker exec aurora-postgres psql -U aurora -d aurora_db -c "\d terraform_datadog_resources"
docker exec aurora-postgres psql -U aurora -d aurora_db -c "\d datadog_silence_drift"
```

### 2. Create a demo repo
Make any GitHub repo you own (e.g. `your-handle/datadog-tf-demo`) with these three files:

**`monitors/api.tf`**
```hcl
resource "datadog_monitor" "api_error_rate" {
  name    = "API Error Rate High"
  type    = "metric alert"
  message = "API errors @slack-test"
  query   = "avg(last_5m):avg:system.cpu.user{*} > 90"
  monitor_thresholds { critical = 90 }
  tags    = ["env:prod", "service:api"]
}

resource "datadog_monitor" "api_latency_high" {
  name    = "API Latency p95 High"
  type    = "metric alert"
  message = "API latency high @slack-test"
  query   = "avg(last_5m):avg:system.cpu.user{*} > 500"
  monitor_thresholds { critical = 500 }
  tags    = ["env:prod", "service:api"]
}
```

**`monitors/db.tf`**
```hcl
resource "datadog_monitor" "db_connection_pool_exhausted" {
  name    = "DB Connection Pool Exhausted"
  type    = "metric alert"
  message = "DB pool high @slack-test"
  query   = "avg(last_5m):avg:system.cpu.user{*} > 80"
  monitor_thresholds { critical = 80 }
  tags    = ["env:prod", "service:postgres"]
}
```

**`monitors/downtimes.tf`** (pre-codified silence — tests the "already codified" path)
```hcl
resource "datadog_downtime_schedule" "mute_db_connection_pool_exhausted" {
  monitor_identifier {
    monitor_id = datadog_monitor.db_connection_pool_exhausted.id
  }
  scope = "*"
  schedule {
    one_time_schedule {
      start = "2026-01-01T00:00:00Z"
    }
  }
  message          = "Known issue tracked in DEMO-1"
  display_timezone = "UTC"
}
```

Push all three to `main`. No `terraform apply` needed — the monitors will be created manually in step 3.

### 3. Create 3 monitors in Datadog UI
**Monitors → New Monitor → Metric** → repeat 3 times with the names below exactly matching the `.tf` files:
- `API Error Rate High`
- `API Latency p95 High`
- `DB Connection Pool Exhausted`

Any metric/threshold works (the demo doesn't care about the query itself, only the name).

### 4. Connect Datadog + GitHub in Aurora
- Open http://localhost:3000 → log in
- **Settings → Connectors → Datadog** → paste API key + App key + site → Connect
- **Settings → Connectors → GitHub** → OAuth flow
- **Settings → GitHub → Select Repositories** → pick your demo repo → Save

### 5. Run the four tools from chat

| Prompt | Expected result |
|---|---|
| `re-index my terraform repo` | `filesScanned: 3`, `resourcesIndexed: 4`, `delta: 4` |
| In Datadog UI, **Mute** `API Error Rate High` and `API Latency p95 High` indefinitely (do NOT mute the DB one) | — |
| `which Datadog mutes aren't in Terraform?` | `drift_count: 2`, both with `tf_match_confidence: "exact_query"`; `DB Connection Pool Exhausted` appears under `codified` |
| `silence api-error-rate-high via terraform` | Returns a PR URL. PR appends a `datadog_downtime_schedule` block to `monitors/downtimes.tf` |
| Close that PR without merging | — |
| `codify all UI mutes into Terraform in one PR` | Returns a single PR URL touching `monitors/downtimes.tf` with 2 new resources |
| Merge that PR → `re-index` → `which Datadog mutes aren't in Terraform?` | `drift_count: 0`; the two merged silences now show up under `codified` |

### 6. DB verification
```bash
# After step 5's re-index:
docker exec aurora-postgres psql -U aurora -d aurora_db -c \
  "SELECT resource_type, resource_address, monitor_name, scope FROM terraform_datadog_resources;"

# After the drift query:
docker exec aurora-postgres psql -U aurora -d aurora_db -c \
  "SELECT monitor_name, scope, source, matched_tf_file, tf_match_confidence FROM datadog_silence_drift;"
```

### 7. Check the hard invariant
Grep the diff for any Datadog write call — there should be zero:
```bash
git diff main..HEAD -- server/ | grep -E "mute_monitor|create_downtime|cancel_downtime|POST.*downtime|PUT.*downtime|DELETE.*downtime"
```

## Test plan
- [x] `re-index` against a demo repo (3 monitors + 1 pre-codified downtime_schedule) → 4 resources indexed
- [x] UI-mute 2 monitors in Datadog → `list_datadog_silence_drift` returns 2 drifted rows with `exact_name` / `exact_query` confidence
- [x] Pre-codified downtime shows up under `codified`, not `drifted`
- [x] `silence_datadog_monitor_via_terraform` on a single monitor opens a PR appending the block to sibling `monitors/downtimes.tf`
- [x] `silence_all_drifted_monitors` bundles N drifted silences into one PR (one `downtimes.tf` per directory)
- [x] Merge the bulk PR → `re-index` → new silences show up as `codified`
- [x] `python-hcl2` 8.x quote-wrapping on identifiers and scalars handled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Datadog-Terraform drift detection to identify silences in the UI not yet codified in infrastructure as code.
  * Introduced tools to convert Datadog monitor silences into Terraform code via automated GitHub pull requests.
  * Added bulk silence operations to codify all drifted monitors in a single pull request.
  * Added Terraform repository reindexing capability for Datadog monitor mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
