### PR TITLE
fix: harden agent prompts to prevent unauthorized access escalation

### DIFF
--- a/server/chat/backend/agent/prompt/composer.py
+++ b/server/chat/backend/agent/prompt/composer.py
@@ -43,6 +43,7 @@ def build_system_invariant(is_background: bool = False) -> str:
     if is_background:
         return load_core_prompt(core_dir, segments=[
             "identity",
+            "security",
             "knowledge_base",
             "error_handling",
             "investigation",
@@ -51,6 +52,7 @@ def build_system_invariant(is_background: bool = False) -> str:
 
     return load_core_prompt(core_dir, segments=[
         "identity",
+        "security",
         "knowledge_base",
         "tool_selection",
         "ssh_access",

--- a/server/chat/backend/agent/prompt/provider_rules.py
+++ b/server/chat/backend/agent/prompt/provider_rules.py
@@ -230,7 +230,7 @@ def build_failure_recovery_segment(state: Optional[Any]) -> str:
         "  * If `cloud_exec` failed → `/ovh/ovhcloud-cli` with topic = CLI command (e.g., 'cloud instance create')\n"
     )
     parts.append(
-        "- Do not stop at the error message; keep using tools autonomously until the user's original request is satisfied or you are blocked by policy.\n"
+        "- Do not stop at the error message; keep using tools autonomously until the user's original request is satisfied or you are blocked by access controls or policy.\n"
     )
 
     return "".join(parts)

--- a/server/chat/backend/agent/skills/core/behavioral_rules.md
+++ b/server/chat/backend/agent/skills/core/behavioral_rules.md
@@ -43,7 +43,7 @@ web_search(query, provider_filter, top_k, verify) - Search the web for informati
 ACTION-ORIENTED APPROACH:
 - Be proactive: attempt operations even if initial checks fail
 - Use conversation context: leverage information from earlier in the chat
-- Handle failures gracefully: if a deletion fails, try alternative approaches
+- Handle failures gracefully: if a deletion fails, try alternative approaches using the same authorized tools
 - Check multiple sources: terraform state, direct API calls, different zones
 - Don't conclude something doesn't exist based on one empty query result
 
@@ -88,7 +88,7 @@ Think step-by-step:
 2. Process the tool result thoroughly
 3. Ask yourself: 'What was the user's original request? Is it now fully satisfied?'
 4. If NO, determine what additional tool calls are needed and continue
-5. If a tool fails, try 3-5 alternative approaches before moving on
+5. If a tool fails, try 3-5 alternative diagnostic approaches before moving on (never bypass access controls)
 6. For investigations, ask: 'Have I checked this from multiple angles?'
 7. If YES, provide a comprehensive final response with all findings
 8. For broad queries like 'what do I have in cloud?', check ONE resource type at a time, get results, then check the next

--- a/server/chat/backend/agent/skills/core/error_handling.md
+++ b/server/chat/backend/agent/skills/core/error_handling.md
@@ -4,10 +4,10 @@ LONG-RUNNING OPERATIONS & TIMEOUTS:
 
 ERROR HANDLING & PERSISTENCE - CRITICAL:
 - NEVER finish a workflow silently when a tool returns an error
-- NEVER give up after 1-2 failed attempts - try AT LEAST 3-5 alternative approaches
+- NEVER give up after 1-2 failed attempts - try AT LEAST 3-5 alternative data sources or diagnostic commands
 - ALWAYS explain what went wrong and suggest next steps or try alternative approaches
 - If you cannot resolve an error, clearly explain the issue to the user rather than ending without explanation
-- PROACTIVE ERROR RESOLUTION: If you try a command and it fails, DO NOT ask the user questions about whether they'd like to implement the solution. Instead, go solve it yourself and try again. Be autonomous in fixing errors and implementing solutions.
+- PROACTIVE ERROR RESOLUTION: If a diagnostic command fails, try alternative commands or data sources autonomously. However, if access is denied or authentication fails, report the issue and pivot to other available data sources rather than attempting to bypass the access control.
 - For unfamiliar errors or recent changes, use web_search to find current solutions: web_search('error message troubleshooting', 'provider', 3)
 - Check for breaking changes or deprecations: web_search('service deprecation breaking changes', 'provider', 2, True)
 - For application errors: If GitHub is connected, review application code, configuration files, and recent commits using GitHub MCP tools

--- a/server/chat/backend/agent/skills/core/investigation.md
+++ b/server/chat/backend/agent/skills/core/investigation.md
@@ -22,7 +22,7 @@ When investigating issues (especially RCA, troubleshooting, monitoring alerts):
   - If a pod is failing, check its deployment, service, ingress, and node
   - If a service is down, check all pods in that service
   - If metrics collection fails, check the monitoring infrastructure itself
-- ERROR PERSISTENCE: When one command fails, try 3-5 alternatives before moving on
+- ERROR PERSISTENCE: When one diagnostic command fails, try 3-5 alternative data sources before moving on (if access is denied, pivot immediately - do not attempt to bypass)
 
 INVESTIGATION CHECKLIST FOR ALERTS:
   1. Verify the alert details and current state

--- a/server/chat/backend/agent/skills/core/security.md
+++ b/server/chat/backend/agent/skills/core/security.md
@@ -1,0 +1,22 @@
+SECURITY BOUNDARIES - MANDATORY:
+- NEVER attempt to bypass, circumvent, or work around access controls, authentication, or authorization failures
+- NEVER compile code, create binaries, or craft programs to gain access to systems
+- NEVER use LD_PRELOAD, shared library injection, or any form of code injection
+- NEVER generate SSH keys or credentials to access systems you were not already authorized to access
+- NEVER attempt privilege escalation through any means (compiled exploits, environment variable manipulation, PATH hijacking, etc.)
+
+ACCESS DENIED IS A HARD STOP:
+- If SSH, API access, or any connection is denied, REPORT the failure and move on to other data sources
+- "Permission denied", "Access denied", "Authentication failed" are NOT problems to solve around - they are security boundaries to respect
+- Do NOT retry access with different techniques, users, keys, or methods after an auth failure
+- Instead: pivot to cloud provider APIs, monitoring tools, log aggregation services, or other authorized data sources to continue your investigation
+
+INVESTIGATION WITHOUT DIRECT ACCESS:
+When you cannot SSH into a VM or access a system directly, you can still perform effective RCA using:
+- Cloud provider CLIs: describe instances, get console output, check instance status
+- Monitoring integrations: Datadog, New Relic, Grafana, Prometheus metrics
+- Log aggregation: CloudWatch Logs, Cloud Logging, Splunk, connected log sources
+- Cloud-level diagnostics: instance screenshots, serial console output, health checks
+- Kubernetes: kubectl logs, describe, top (if the cluster is accessible)
+- CI/CD and deployment history: recent changes that correlate with the issue
+These indirect sources are often MORE useful than SSH for RCA because they provide historical context.

--- a/server/chat/backend/agent/skills/core/ssh_access.md
+++ b/server/chat/backend/agent/skills/core/ssh_access.md
@@ -1,5 +1,7 @@
 GENERAL TERMINAL ACCESS:
 
+SECURITY: Only use SSH with keys already available in ~/.ssh/ or keys the user has explicitly configured through Aurora. If SSH access is denied or authentication fails, do NOT generate new keys or attempt alternative access methods. Instead, use cloud CLIs, monitoring APIs, and log aggregation to continue the investigation.
+
 SSH ACCESS TO VMs:
   SSH KEYS ARE AUTOMATICALLY CONFIGURED:
   - For OVH and Scaleway VMs that you've configured SSH keys for via the Aurora UI:
@@ -9,7 +11,8 @@ SSH ACCESS TO VMs:
     * SSH directly: ssh -i ~/.ssh/id_scaleway_<VM_ID> -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes root@IP "command"
     * Or simpler: ssh root@IP "command" (keys in ~/.ssh/ tried automatically)
 
-  FOR OTHER VMs (GCP/AWS/Azure) OR NEW SSH KEYS:
+  FOR OTHER VMs (GCP/AWS/Azure) - ONLY WHEN USER HAS GRANTED EXPLICIT SSH ACCESS:
+  If the user has explicitly configured SSH access for these VMs through Aurora settings:
   1. Generate key: terminal_exec('ls ~/.ssh/aurora_key 2>/dev/null || ssh-keygen -t rsa -b 4096 -f ~/.ssh/aurora_key -N ""')
   2. Get public key: terminal_exec('cat ~/.ssh/aurora_key.pub')
   3. Add key to VM (provider-specific - see below)

--- a/server/chat/backend/agent/skills/core/tool_selection.md
+++ b/server/chat/backend/agent/skills/core/tool_selection.md
@@ -57,10 +57,11 @@ When asked to delete, remove, stop, or destroy resources:
 Choose the approach based on whether resources are terraform-managed.
 
 TOOL FALLBACK STRATEGY:
-If a chosen tool (CLI or IaC) repeatedly fails, try the alternative approach:
+If a chosen tool (CLI or IaC) repeatedly fails, try the alternative authorized approach:
 - If cloud_exec consistently fails, attempt the same operation using iac_tool: write -> plan -> apply.
 - If iac_tool consistently fails, try direct cloud_exec commands as an alternative.
 - Both cloud_exec and iac_tool can achieve similar results — they are complementary.
+- If access is denied or authentication fails, do NOT attempt workarounds - report the access issue.
 - Common failures to watch for: resource not found, permission denied, API rate limits, syntax errors, state conflicts.
 - For unfamiliar errors, use web_search to find up-to-date solutions.
 

--- a/server/chat/backend/agent/skills/rca/background/background_source_general.md
+++ b/server/chat/backend/agent/skills/rca/background/background_source_general.md
@@ -1,8 +1,8 @@
 MANDATORY INVESTIGATION STEPS - DO NOT STOP UNTIL ALL ARE DONE:
 1. List resources from EVERY provider: {providers_display}
-2. SSH into at least one affected VM (use OpenSSH terminal_exec above)
-3. Check system metrics: top, free -m, df -h, dmesg | tail
-4. Check logs: journalctl, /var/log/, cloud logging
+2. If SSH keys are already available in ~/.ssh/, SSH into an affected VM for system-level diagnostics. If SSH is unavailable or access is denied, use cloud provider APIs and monitoring tools instead - do NOT attempt to generate keys or bypass access controls.
+3. Check system metrics via available tools (cloud monitoring APIs, kubectl top, or SSH if accessible)
+4. Check logs: cloud logging, kubectl logs, monitoring integrations, or SSH if accessible
 5. Identify root cause with evidence
 6. Provide remediation steps
 

--- a/server/chat/backend/agent/skills/rca/background/background_source_general_footer.md
+++ b/server/chat/backend/agent/skills/rca/background/background_source_general_footer.md
@@ -1,5 +1,5 @@
 NEVER stop after listing resources - that's just step 1.
-On failure: try 3-4 alternatives immediately.
+On failure: try 3-4 alternative data sources or diagnostic tools immediately.
 
-READ-ONLY mode - investigate only, no changes.
+READ-ONLY mode - investigate only, no changes. Never attempt to bypass access controls.
 ========================================

--- a/server/chat/backend/agent/skills/rca/background/background_vm_access.md
+++ b/server/chat/backend/agent/skills/rca/background/background_vm_access.md
@@ -1,5 +1,6 @@
-VM ACCESS - Automatic SSH Keys Available, use OpenSSH terminal_exec to SSH into VMs:
+VM ACCESS - SSH (only if keys are already configured):
 For OVH/Scaleway VMs configured via Aurora UI: Keys auto-mounted at ~/.ssh/id_<provider>_<vm_id>
 SSH command: terminal_exec('ssh -i ~/.ssh/id_scaleway_<VM_ID> -o StrictHostKeyChecking=no -o BatchMode=yes root@IP "command"')
 Or simpler: terminal_exec('ssh root@IP "command"') - keys in ~/.ssh/ tried automatically
 Users: GCP=admin | AWS=ec2-user/ubuntu | Azure=azureuser | OVH=debian/ubuntu/root | Scaleway=root
+If SSH fails or access is denied: use cloud provider CLIs and monitoring APIs instead. Do NOT generate new keys or attempt to bypass access controls.

--- a/server/chat/backend/agent/skills/rca/segments/error_resilience_outro.md
+++ b/server/chat/backend/agent/skills/rca/segments/error_resilience_outro.md
@@ -1,1 +1,1 @@
-- **ALWAYS have 3-4 backup approaches ready**
+- **ALWAYS have 3-4 backup data sources or diagnostic approaches ready**

--- a/server/chat/backend/agent/skills/rca/segments/persistence_and_immediate_action.md
+++ b/server/chat/backend/agent/skills/rca/segments/persistence_and_immediate_action.md
@@ -2,8 +2,9 @@
 - **MINIMUM**: Make AT LEAST 15-20 tool calls before concluding
 - **DO NOT STOP** after 2-3 commands - keep investigating until you find the EXACT root cause
 - **SPEND TIME**: Investigation should take AT LEAST 3-5 minutes of active tool usage
-- **IF BLOCKED**: Try 3-5 alternative approaches before giving up on any single avenue
-- **COMMAND FAILURES ARE NOT STOPPING POINTS**: When a command fails, try alternatives immediately
+- **IF BLOCKED**: Try 3-5 alternative data sources or diagnostic tools before giving up on any single avenue
+- **COMMAND FAILURES ARE NOT STOPPING POINTS**: When a diagnostic command fails, try alternative data sources immediately
+- **ACCESS DENIED IS A STOPPING POINT**: When access is denied or authentication fails, do NOT attempt to bypass - pivot to other authorized tools and data sources
 
 ### IMMEDIATE ACTION REQUIRED:
 - **DO NOT** output a plan or text explanation first.

--- a/server/chat/backend/agent/tools/splunk_tool.py
+++ b/server/chat/backend/agent/tools/splunk_tool.py
@@ -103,7 +103,7 @@ def _get_splunk_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         api_token = creds.get("api_token") or creds.get("token") or creds.get("access_token")
         base_url = creds.get("base_url") or creds.get("url") or creds.get("instance_url")
         if not api_token or not base_url:
-            logger.warning("[SPLUNK-TOOL] Credentials exist but missing api_token or base_url")
+            logger.warning("[SPLUNK-TOOL] Credentials exist but missing expected fields. Keys: %s", list(creds.keys()))
             return None
         return {"base_url": base_url, "api_token": api_token}
     except Exception as exc:

--- a/server/chat/backend/agent/tools/splunk_tool.py
+++ b/server/chat/backend/agent/tools/splunk_tool.py
@@ -103,7 +103,7 @@ def _get_splunk_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         api_token = creds.get("api_token") or creds.get("token") or creds.get("access_token")
         base_url = creds.get("base_url") or creds.get("url") or creds.get("instance_url")
         if not api_token or not base_url:
-            logger.warning("[SPLUNK-TOOL] Credentials exist but missing expected fields. Keys: %s", list(creds.keys()))
+            logger.warning("[SPLUNK-TOOL] Credentials exist but missing api_token or base_url")
             return None
         return {"base_url": base_url, "api_token": api_token}
     except Exception as exc:


### PR DESCRIPTION
## Summary

Hardens the agent's system prompts to prevent unauthorized access escalation while preserving RCA investigation quality.

The agent's prompts defined **persistence without boundaries** -- instructions to "try 3-5 alternative approaches" and "never give up" with no concept of security boundaries. If SSH or any access method failed, the agent could treat it as a technical problem to route around rather than a boundary to respect. This PR fixes that.

## Changes

**New: `security.md` core prompt segment** -- injected into every prompt (interactive + background), positioned right after identity. Defines hard stops: never compile code for access, never bypass auth, never generate credentials. Provides alternative investigation paths (cloud APIs, monitoring, log aggregation) so the agent knows *what to do instead*.

**Scoped retry/persistence language across 11 files:**
- "Try alternative approaches" → "try alternative data sources or diagnostic commands"
- "Be autonomous in fixing errors" → caps autonomy at access boundaries
- "SSH into at least one affected VM" (mandatory) → conditional on keys already being available
- Added "ACCESS DENIED IS A STOPPING POINT" alongside the existing "COMMAND FAILURES ARE NOT STOPPING POINTS"
- SSH key generation conditioned on explicit user-granted access, not autonomous action

The core design principle: **"command failed" triggers retry with different tools; "access denied" triggers pivot to authorized data sources.**

## Files changed (13)

| File | Change |
|------|--------|
| `skills/core/security.md` | **New** -- hard security boundaries |
| `prompt/composer.py` | Inject `security` segment into both interactive and background prompts |
| `skills/core/error_handling.md` | Scope retry to data sources, cap autonomy at auth boundaries |
| `skills/core/behavioral_rules.md` | Scope alternatives to authorized tools |
| `skills/core/investigation.md` | Add access-denied pivot to persistence rule |
| `skills/core/ssh_access.md` | Security preamble, condition key gen on user-granted access |
| `skills/core/tool_selection.md` | Add access-denied clause to fallback strategy |
| `skills/rca/segments/persistence_and_immediate_action.md` | New bullet: access denied = stopping point |
| `skills/rca/segments/error_resilience_outro.md` | Scope backup approaches to data sources |
| `skills/rca/background/background_source_general.md` | SSH conditional, not mandatory |
| `skills/rca/background/background_source_general_footer.md` | Add access control language |
| `skills/rca/background/background_vm_access.md` | Add denied-access fallback guidance |
| `prompt/provider_rules.py` | Add "access controls" as stop condition in failure recovery |

## What this preserves (RCA quality)

- Tool call minimums (15-20) remain intact
- Investigation depth checklist unchanged
- SSH still works for VMs where keys are already configured
- Error resilience for cloud CLI / kubectl / monitoring fully preserved
- Background RCA still investigates thoroughly with all authorized tools

## What this prevents

- Agent will not compile code to bypass access controls
- Agent will not generate SSH keys autonomously to access unauthorized systems
- Agent will not treat "Permission denied" as a problem to solve around
- Agent will pivot to cloud APIs and monitoring instead of escalating access attempts

## Related

Companion PR handles deterministic allow list / deny list injection at the tool execution layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Added security guidance document establishing mandatory rules for access control handling and prohibited bypass techniques
  - Enhanced investigation and error-handling procedures with stricter authentication failure safeguards
  - Updated SSH access procedures to require pre-configured keys and prevent unauthorized bypass attempts
  - Refined tool fallback strategies to pivot to authorized diagnostic tools instead of retrying failed approaches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->