### PR TITLE
fix: fresh-install DB init + chatbot-WS health check regressions from PR #280

### DIFF
--- a/docker-compose.airtight.yml
+++ b/docker-compose.airtight.yml
@@ -474,6 +474,7 @@ services:
     logging: *default-logging
     environment:
       NODE_ENV: production
+      AURORA_ENV: ${AURORA_ENV}
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}
       NEXT_PUBLIC_WEBSOCKET_URL: ${NEXT_PUBLIC_WEBSOCKET_URL}
       NEXT_PUBLIC_ENABLE_OVH: ${NEXT_PUBLIC_ENABLE_OVH}

--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -547,6 +547,7 @@ services:
     environment:
       # Next.js production configuration
       NODE_ENV: production
+      AURORA_ENV: ${AURORA_ENV}
 
       # Runtime env injection (docker-entrypoint.sh writes these to /app/public/env-config.js)
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -510,6 +510,7 @@ services:
     environment:
       # Next.js development configuration
       NODE_ENV: development
+      AURORA_ENV: ${AURORA_ENV}
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"
       WATCHPACK_POLLING_INTERVAL: 1000

--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -168,7 +168,10 @@ async def send_chatbot_test_message():
                     return {"status": "healthy", "message": "Chatbot connection and initial response successful"}
                 return {
                     "status": "unhealthy",
-                    "error": f"Unexpected chatbot response: {response_data.get('type')}",
+                    "error": (
+                        f"Unexpected chatbot response: type={response_data.get('type')!r} "
+                        f"status={response_data.get('data', {}).get('status')!r}"
+                    ),
                 }
             except json.JSONDecodeError:
                 return {"status": "unhealthy", "error": "Invalid JSON response from chatbot"}

--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -6,9 +6,10 @@ This module provides comprehensive health checks for all Aurora services.
 import logging
 import time
 import os
+import uuid
 import requests
 import socket
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import Blueprint, jsonify
 import psycopg2
 import redis
@@ -16,6 +17,7 @@ from celery_config import celery_app
 import websockets
 import asyncio
 import json
+import jwt as pyjwt
 
 
 logger = logging.getLogger(__name__)
@@ -117,20 +119,41 @@ async def send_chatbot_test_message():
     else:
         host = os.getenv('CHATBOT_HOST', 'chatbot')
     port = 5006
-    uri = f"ws://{host}:{port}"
-    
+
+    # Mint a short-lived JWT matching the chatbot's expected format
+    # (see main_chatbot.py:_validate_ws_token). Skipped when INTERNAL_API_SECRET
+    # is unset (dev mode); the chatbot allows unauthenticated connections then.
+    internal_secret = os.getenv('INTERNAL_API_SECRET', '')
+    token_qs = ''
+    if internal_secret:
+        now = int(time.time())
+        token = pyjwt.encode(
+            {
+                "userId": "health-check",
+                "aud": "chatbot-ws",
+                "jti": str(uuid.uuid4()),
+                "iat": now,
+                "exp": now + 60,
+            },
+            internal_secret + "aurora:ws-token-signing",
+            algorithm="HS256",
+        )
+        token_qs = f"?token={token}"
+
+    uri = f"ws://{host}:{port}{token_qs}"
+
     try:
         async with websockets.connect(uri, ping_interval=None) as websocket:
             # Send init message
             await websocket.send(json.dumps({
                 "type": "init",
-                "user_id": "user_32760a7xMqdpxteAQgVbt1cKc6b"
+                "user_id": "health-check"
             }))
 
             # Send a test query
             await websocket.send(json.dumps({
                 "query": "Hello",
-                "user_id": "user_32760a7xMqdpxteAQgVbt1cKc6b",
+                "user_id": "health-check",
                 "session_id": "health_check_session"
             }))
 
@@ -143,6 +166,10 @@ async def send_chatbot_test_message():
                 response_data = json.loads(response)
                 if response_data.get("type") == "status" and response_data.get("data", {}).get("status") == "START":
                     return {"status": "healthy", "message": "Chatbot connection and initial response successful"}
+                return {
+                    "status": "unhealthy",
+                    "error": f"Unexpected chatbot response: {response_data.get('type')}",
+                }
             except json.JSONDecodeError:
                 return {"status": "unhealthy", "error": "Invalid JSON response from chatbot"}
 

--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -9,7 +9,7 @@ import os
 import uuid
 import requests
 import socket
-from datetime import datetime, timezone
+from datetime import datetime
 from flask import Blueprint, jsonify
 import psycopg2
 import redis

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -378,24 +378,6 @@ def initialize_tables():
                         UNIQUE(user_id, org_id, preference_key)
                     );
                 """,
-                "org_command_policies": """
-                    CREATE TABLE IF NOT EXISTS org_command_policies (
-                        id SERIAL PRIMARY KEY,
-                        org_id VARCHAR(255) NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-                        mode VARCHAR(20) NOT NULL CHECK (mode IN ('allow', 'deny')),
-                        pattern TEXT NOT NULL,
-                        description TEXT,
-                        priority INT DEFAULT 0,
-                        enabled BOOLEAN DEFAULT true,
-                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        updated_by VARCHAR(255),
-                        source VARCHAR(20) DEFAULT 'custom' NOT NULL,
-                        UNIQUE(org_id, mode, pattern, source)
-                    );
-                    CREATE INDEX IF NOT EXISTS idx_ocp_org
-                        ON org_command_policies(org_id);
-                """,
                 "workspaces": """
                     CREATE TABLE IF NOT EXISTS workspaces (
                         id VARCHAR(50) PRIMARY KEY,
@@ -1022,6 +1004,24 @@ def initialize_tables():
                     );
 
                     CREATE INDEX IF NOT EXISTS idx_organizations_slug ON organizations(slug);
+                """,
+                "org_command_policies": """
+                    CREATE TABLE IF NOT EXISTS org_command_policies (
+                        id SERIAL PRIMARY KEY,
+                        org_id VARCHAR(255) NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+                        mode VARCHAR(20) NOT NULL CHECK (mode IN ('allow', 'deny')),
+                        pattern TEXT NOT NULL,
+                        description TEXT,
+                        priority INT DEFAULT 0,
+                        enabled BOOLEAN DEFAULT true,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_by VARCHAR(255),
+                        source VARCHAR(20) DEFAULT 'custom' NOT NULL,
+                        UNIQUE(org_id, mode, pattern, source)
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_ocp_org
+                        ON org_command_policies(org_id);
                 """,
                 "org_invitations": """
                     CREATE TABLE IF NOT EXISTS org_invitations (


### PR DESCRIPTION
## Summary
- **DB init**: `org_command_policies` was defined before `organizations` in the `create_tables` dict, so its FK to `organizations(id)` fails on fresh postgres volumes. Moved it after `organizations`.
- **Compose**: `AURORA_ENV` wasn't passed to the `frontend` service, so `requiredInProduction()` in `server-env.ts` saw the default `"production"` and refused to start without `INTERNAL_API_SECRET`. Added `AURORA_ENV: \${AURORA_ENV}` to both compose files.
- **Health check**: `/health/` started returning 500 after PR #280 added WS auth to the chatbot. The probe didn't send a token (chatbot rejected with JSON error), and `send_chatbot_test_message()` had no fall-through return for unexpected replies — it returned `None`, then `s["status"]` crashed. Now mints a short-lived HS256 JWT matching `_validate_ws_token`'s format, and always returns a dict.

## Test plan
- [ ] `make down && docker volume rm aurora_postgres-data && make dev` — server comes up healthy on empty DB
- [ ] `curl localhost:5080/health/` returns 200 with all five sub-checks reporting `healthy`
- [ ] `docker logs aurora-chatbot-1` shows no "no valid token" warnings from the health probe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Frontend now accepts an AURORA_ENV runtime environment variable in Docker configs.
* **Security**
  * Health check WebSocket supports optional short-lived JWT authentication when configured.
* **Bug Fixes / Reliability**
  * Health check validation tightened to surface unexpected chatbot responses as unhealthy.
* **Refactor**
  * Database table declarations reorganized without behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->