### PR TITLE
fix(bitbucket): migrate to /2.0/user/workspaces (CHANGE-2770)

### DIFF
--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -205,8 +205,16 @@ class BitbucketAPIClient:
     # ------------------------------------------------------------------
 
     def get_workspaces(self):
-        """List all workspaces the authenticated user has access to."""
-        return self._paginated_get(f"{BITBUCKET_API_BASE}/workspaces")
+        """List all workspaces the authenticated user has access to.
+
+        Uses ``/2.0/user/workspaces``. The legacy ``/2.0/workspaces`` and
+        ``/2.0/user/permissions/workspaces`` endpoints were removed in
+        CHANGE-2770 on 2026-04-14 (both return HTTP 410).
+        """
+        result = self._paginated_get(f"{BITBUCKET_API_BASE}/user/workspaces")
+        if isinstance(result, dict) and result.get("error"):
+            return result
+        return [entry["workspace"] for entry in result if isinstance(entry, dict) and entry.get("workspace")]
 
     def get_workspace(self, workspace):
         """Get a single workspace by slug."""

--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -205,12 +205,7 @@ class BitbucketAPIClient:
     # ------------------------------------------------------------------
 
     def get_workspaces(self):
-        """List all workspaces the authenticated user has access to.
-
-        Uses ``/2.0/user/workspaces``. The legacy ``/2.0/workspaces`` and
-        ``/2.0/user/permissions/workspaces`` endpoints were removed in
-        CHANGE-2770 on 2026-04-14 (both return HTTP 410).
-        """
+        """List all workspaces the authenticated user has access to."""
         result = self._paginated_get(f"{BITBUCKET_API_BASE}/user/workspaces")
         if isinstance(result, dict) and result.get("error"):
             return result

--- a/server/routes/bitbucket/bitbucket_browsing.py
+++ b/server/routes/bitbucket/bitbucket_browsing.py
@@ -63,6 +63,8 @@ def list_workspaces(user_id):
             return jsonify({"error": "Bitbucket not connected"}), 401
 
         workspaces = client.get_workspaces()
+        if isinstance(workspaces, dict) and workspaces.get("error"):
+            return jsonify(workspaces), 502
         return jsonify({"workspaces": workspaces})
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Bitbucket removed `/2.0/workspaces` on 2026-04-14 (CHANGE-2770, returns HTTP 410), which broke the workspace dropdown in the connectors UI with `workspaces.map is not a function`.
- Switched `BitbucketAPIClient.get_workspaces()` to the CHANGE-3022 replacement `/2.0/user/workspaces` and unwrapped `values[].workspace` so the existing list-of-workspaces contract is preserved.
- `/2.0/user/permissions/workspaces` was also killed by the same change, so it's explicitly ruled out in the docstring.

## Test plan
- [x] Verified live against Bitbucket: `/2.0/user/workspaces` returns 200 with the expected shape
- [x] Reloaded `/connectors` — workspace dropdown populates, repo + branch selection saves end-to-end (`Saved Bitbucket workspace selection … arvoai / test / main`)
- [x] Probed all other workspace- and user-scoped endpoints the client uses (`/workspaces/{ws}`, `/repositories/{ws}/...`, `/workspaces/{ws}/search/code`, etc.) — all 200, none affected by CHANGE-2770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bitbucket workspace retrieval updated to use the correct integration endpoint.
  * Improved handling of paginated responses and error payloads for more reliable syncs.
  * Workspace results are now flattened and cleaned of invalid entries, yielding a more consistent list for display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->