### PR TITLE
feat(prediscovery): add auto-discovery toggle with cancel

### DIFF
--- a/client/src/app/api/prediscovery/cancel/route.ts
+++ b/client/src/app/api/prediscovery/cancel/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function POST(request: NextRequest) {
+  return forwardRequest(request, 'POST', '/api/prediscovery/cancel', 'prediscovery-cancel');
+}

--- a/client/src/components/DiscoverySettings.tsx
+++ b/client/src/components/DiscoverySettings.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { Radar, Check } from "lucide-react";
 import { useAuth } from "@/hooks/useAuthHooks";
@@ -15,6 +16,8 @@ export function DiscoverySettings() {
   const [discovering, setDiscovering] = useState(false);
   const [intervalHours, setIntervalHours] = useState<number>(24);
   const [savingInterval, setSavingInterval] = useState(false);
+  const [autoEnabled, setAutoEnabled] = useState<boolean>(true);
+  const [savingEnabled, setSavingEnabled] = useState(false);
   const { toast } = useToast();
   const { userId } = useAuth();
 
@@ -36,7 +39,62 @@ export function DiscoverySettings() {
         if (data.value != null) setIntervalHours(data.value);
       })
       .catch(() => {});
+    fetch(`/api/proxy/user-preferences?key=prediscovery_enabled`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.value != null) setAutoEnabled(Boolean(data.value));
+      })
+      .catch(() => {});
   }, [userId]);
+
+  const cancelAndRefreshStatus = async () => {
+    try {
+      const cancelRes = await fetch("/api/prediscovery/cancel", { method: "POST", credentials: "include" });
+      if (!cancelRes.ok) {
+        console.error("Failed to cancel prediscovery:", cancelRes.status);
+        return;
+      }
+      const statusRes = await fetch("/api/prediscovery/status", { credentials: "include" });
+      if (!statusRes.ok) return;
+      const data = await statusRes.json();
+      setStatus(data.status || "never_run");
+      setLastRun(data.updated_at || data.started_at || null);
+    } catch (err) {
+      console.error("Failed to cancel prediscovery:", err);
+    }
+  };
+
+  const toggleAutoDiscovery = async (next: boolean) => {
+    if (!userId) return;
+    const revert = () => {
+      setAutoEnabled(!next);
+      toast({ title: "Failed to save", variant: "destructive" });
+    };
+    setAutoEnabled(next);
+    setSavingEnabled(true);
+    try {
+      const res = await fetch(`/api/proxy/user-preferences`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "prediscovery_enabled", value: next }),
+      });
+      if (!res.ok) {
+        revert();
+        return;
+      }
+      if (!next) await cancelAndRefreshStatus();
+      toast({
+        title: next ? "Auto-discovery enabled" : "Auto-discovery disabled",
+        description: next
+          ? "Aurora will scan your infrastructure on the configured interval."
+          : "Scheduled scans paused and any running scan was cancelled.",
+      });
+    } catch {
+      revert();
+    } finally {
+      setSavingEnabled(false);
+    }
+  };
 
   const runDiscovery = async () => {
     setDiscovering(true);
@@ -89,6 +147,7 @@ export function DiscoverySettings() {
       return `Last synced ${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", timeZoneName: "short" })}`;
     }
     if (status === "failed") return "Last run failed";
+    if (status === "cancelled") return "Last run cancelled";
     if (status === "never_run") return "Never run";
     return status;
   };
@@ -105,6 +164,23 @@ export function DiscoverySettings() {
       <CardContent className="space-y-4">
         <div className="flex items-center justify-between p-4 border rounded-lg">
           <div className="space-y-1">
+            <Label htmlFor="auto-discovery-toggle" className="font-medium">Automatic Discovery</Label>
+            <p className="text-sm text-muted-foreground">
+              {autoEnabled
+                ? "Aurora scans on the interval below. Toggle off to stop scheduled runs."
+                : "Scheduled scans are paused. Manual runs still work."}
+            </p>
+          </div>
+          <Switch
+            id="auto-discovery-toggle"
+            checked={autoEnabled}
+            onCheckedChange={toggleAutoDiscovery}
+            disabled={savingEnabled}
+          />
+        </div>
+
+        <div className="flex items-center justify-between p-4 border rounded-lg">
+          <div className="space-y-1">
             <h4 className="font-medium">Run Discovery</h4>
             <p className="text-sm text-muted-foreground">{formatStatus()}</p>
           </div>
@@ -118,7 +194,7 @@ export function DiscoverySettings() {
           </Button>
         </div>
 
-        <div className="flex items-center justify-between p-4 border rounded-lg">
+        <div className={`flex items-center justify-between p-4 border rounded-lg ${autoEnabled ? "" : "opacity-50"}`}>
           <div className="space-y-1">
             <Label htmlFor="discovery-interval" className="font-medium">Auto-Discovery Interval</Label>
             <p className="text-sm text-muted-foreground">
@@ -133,9 +209,10 @@ export function DiscoverySettings() {
               value={intervalHours}
               onChange={(e) => setIntervalHours(Number(e.target.value))}
               className="w-20"
+              disabled={!autoEnabled}
             />
             <span className="text-sm text-muted-foreground">hours</span>
-            <Button variant="outline" size="sm" onClick={saveInterval} disabled={savingInterval}>
+            <Button variant="outline" size="sm" onClick={saveInterval} disabled={savingInterval || !autoEnabled}>
               <Check className="h-4 w-4" />
             </Button>
           </div>

--- a/client/src/components/DiscoverySettings.tsx
+++ b/client/src/components/DiscoverySettings.tsx
@@ -48,23 +48,26 @@ export function DiscoverySettings() {
       .catch(() => {});
   }, [userId]);
 
-  const cancelAndRefreshStatus = async (): Promise<boolean> => {
+  type CancelOutcome = "cancelled" | "no_active" | "error";
+
+  const cancelAndRefreshStatus = async (): Promise<CancelOutcome> => {
     try {
       const cancelRes = await fetch("/api/prediscovery/cancel", { method: "POST", credentials: "include" });
       if (!cancelRes.ok) {
         console.error("Failed to cancel prediscovery:", cancelRes.status);
-        return false;
+        return "error";
       }
+      const cancelData = await cancelRes.json().catch(() => ({}));
       const statusRes = await fetch("/api/prediscovery/status", { credentials: "include" });
       if (statusRes.ok) {
         const data = await statusRes.json();
         setStatus(data.status || "never_run");
         setLastRun(data.updated_at || data.started_at || null);
       }
-      return true;
+      return cancelData.status === "cancelled" ? "cancelled" : "no_active";
     } catch (err) {
       console.error("Failed to cancel prediscovery:", err);
-      return false;
+      return "error";
     }
   };
 
@@ -86,23 +89,25 @@ export function DiscoverySettings() {
         revert();
         return;
       }
-      let cancelOk = true;
-      if (!next) cancelOk = await cancelAndRefreshStatus();
+      const cancelOutcome = next ? "cancelled" : await cancelAndRefreshStatus();
       if (next) {
         toast({
           title: "Auto-discovery enabled",
           description: "Aurora will scan your infrastructure on the configured interval.",
         });
-      } else if (cancelOk) {
-        toast({
-          title: "Auto-discovery disabled",
-          description: "Scheduled scans paused and any running scan was cancelled.",
-        });
-      } else {
+      } else if (cancelOutcome === "error") {
         toast({
           title: "Auto-discovery disabled",
           description: "Scheduled scans paused, but cancelling the running scan failed.",
           variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Auto-discovery disabled",
+          description:
+            cancelOutcome === "cancelled"
+              ? "Scheduled scans paused and the running scan was cancelled."
+              : "Scheduled scans paused.",
         });
       }
     } catch {
@@ -115,12 +120,14 @@ export function DiscoverySettings() {
   const cancelRun = async () => {
     setCancelling(true);
     try {
-      const ok = await cancelAndRefreshStatus();
-      toast(
-        ok
-          ? { title: "Discovery cancelled", description: "The running scan has been stopped." }
-          : { title: "Failed to cancel", variant: "destructive" },
-      );
+      const outcome = await cancelAndRefreshStatus();
+      if (outcome === "cancelled") {
+        toast({ title: "Discovery cancelled", description: "The running scan has been stopped." });
+      } else if (outcome === "no_active") {
+        toast({ title: "No active scan to cancel" });
+      } else {
+        toast({ title: "Failed to cancel", variant: "destructive" });
+      }
     } finally {
       setCancelling(false);
     }
@@ -205,7 +212,7 @@ export function DiscoverySettings() {
             id="auto-discovery-toggle"
             checked={autoEnabled}
             onCheckedChange={toggleAutoDiscovery}
-            disabled={savingEnabled}
+            disabled={savingEnabled || cancelling}
           />
         </div>
 

--- a/client/src/components/DiscoverySettings.tsx
+++ b/client/src/components/DiscoverySettings.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
-import { Radar, Check } from "lucide-react";
+import { Radar, Check, X } from "lucide-react";
 import { useAuth } from "@/hooks/useAuthHooks";
 
 export function DiscoverySettings() {
@@ -18,6 +18,7 @@ export function DiscoverySettings() {
   const [savingInterval, setSavingInterval] = useState(false);
   const [autoEnabled, setAutoEnabled] = useState<boolean>(true);
   const [savingEnabled, setSavingEnabled] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
   const { toast } = useToast();
   const { userId } = useAuth();
 
@@ -47,20 +48,23 @@ export function DiscoverySettings() {
       .catch(() => {});
   }, [userId]);
 
-  const cancelAndRefreshStatus = async () => {
+  const cancelAndRefreshStatus = async (): Promise<boolean> => {
     try {
       const cancelRes = await fetch("/api/prediscovery/cancel", { method: "POST", credentials: "include" });
       if (!cancelRes.ok) {
         console.error("Failed to cancel prediscovery:", cancelRes.status);
-        return;
+        return false;
       }
       const statusRes = await fetch("/api/prediscovery/status", { credentials: "include" });
-      if (!statusRes.ok) return;
-      const data = await statusRes.json();
-      setStatus(data.status || "never_run");
-      setLastRun(data.updated_at || data.started_at || null);
+      if (statusRes.ok) {
+        const data = await statusRes.json();
+        setStatus(data.status || "never_run");
+        setLastRun(data.updated_at || data.started_at || null);
+      }
+      return true;
     } catch (err) {
       console.error("Failed to cancel prediscovery:", err);
+      return false;
     }
   };
 
@@ -82,17 +86,43 @@ export function DiscoverySettings() {
         revert();
         return;
       }
-      if (!next) await cancelAndRefreshStatus();
-      toast({
-        title: next ? "Auto-discovery enabled" : "Auto-discovery disabled",
-        description: next
-          ? "Aurora will scan your infrastructure on the configured interval."
-          : "Scheduled scans paused and any running scan was cancelled.",
-      });
+      let cancelOk = true;
+      if (!next) cancelOk = await cancelAndRefreshStatus();
+      if (next) {
+        toast({
+          title: "Auto-discovery enabled",
+          description: "Aurora will scan your infrastructure on the configured interval.",
+        });
+      } else if (cancelOk) {
+        toast({
+          title: "Auto-discovery disabled",
+          description: "Scheduled scans paused and any running scan was cancelled.",
+        });
+      } else {
+        toast({
+          title: "Auto-discovery disabled",
+          description: "Scheduled scans paused, but cancelling the running scan failed.",
+          variant: "destructive",
+        });
+      }
     } catch {
       revert();
     } finally {
       setSavingEnabled(false);
+    }
+  };
+
+  const cancelRun = async () => {
+    setCancelling(true);
+    try {
+      const ok = await cancelAndRefreshStatus();
+      toast(
+        ok
+          ? { title: "Discovery cancelled", description: "The running scan has been stopped." }
+          : { title: "Failed to cancel", variant: "destructive" },
+      );
+    } finally {
+      setCancelling(false);
     }
   };
 
@@ -184,14 +214,17 @@ export function DiscoverySettings() {
             <h4 className="font-medium">Run Discovery</h4>
             <p className="text-sm text-muted-foreground">{formatStatus()}</p>
           </div>
-          <Button
-            variant="outline"
-            onClick={runDiscovery}
-            disabled={discovering || status === "in_progress"}
-          >
-            <Radar className={`h-4 w-4 mr-2 ${discovering || status === "in_progress" ? "animate-spin" : ""}`} />
-            {discovering || status === "in_progress" ? "Discovering..." : "Run Now"}
-          </Button>
+          {status === "in_progress" ? (
+            <Button variant="outline" onClick={cancelRun} disabled={cancelling}>
+              <X className="h-4 w-4 mr-2" />
+              {cancelling ? "Cancelling..." : "Cancel"}
+            </Button>
+          ) : (
+            <Button variant="outline" onClick={runDiscovery} disabled={discovering}>
+              <Radar className={`h-4 w-4 mr-2 ${discovering ? "animate-spin" : ""}`} />
+              {discovering ? "Starting..." : "Run Now"}
+            </Button>
+          )}
         </div>
 
         <div className={`flex items-center justify-between p-4 border rounded-lg ${autoEnabled ? "" : "opacity-50"}`}>

--- a/server/chat/background/context_updates.py
+++ b/server/chat/background/context_updates.py
@@ -11,6 +11,7 @@ from utils.cloud.cloud_utils import get_workflow_context
 from utils.cache.redis_client import get_redis_client
 from utils.db.connection_pool import db_pool
 from utils.auth.stateless_auth import set_rls_context
+from chat.background.task import TERMINAL_SESSION_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +171,7 @@ def enqueue_rca_context_update(
 
     # Check if session is already completed
     session_status = _get_session_status(user_id, session_id)
-    if session_status in ("completed", "failed"):
+    if session_status in TERMINAL_SESSION_STATUSES:
         logger.info(
             "[RCA-UPDATE] Session %s is %s, appending context update directly to database",
             session_id, session_status
@@ -369,7 +370,7 @@ def apply_rca_context_updates(state: Any) -> Optional[HumanMessage]:
 
     # Check if session is completed - if so, write directly to database instead of injecting into state
     session_status = _get_session_status(user_id, session_id)
-    if session_status in ("completed", "failed"):
+    if session_status in TERMINAL_SESSION_STATUSES:
         logger.info(
             "[RCA-UPDATE] Session %s is %s, writing %d drained update(s) directly to database",
             session_id,

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -196,10 +196,11 @@ def run_prediscovery(
 
         prompt = build_prediscovery_prompt(user_id, providers, integrations)
 
+        task_id = self.request.id
         session_id = create_background_chat_session(
             user_id=user_id,
             title=f"Infrastructure Pre-Discovery ({trigger})",
-            trigger_metadata={"source": "prediscovery", "trigger": trigger},
+            trigger_metadata={"source": "prediscovery", "trigger": trigger, "task_id": task_id},
         )
 
         asyncio.run(_execute_background_chat(
@@ -237,6 +238,9 @@ def _should_run_for_user(user_id: str) -> bool:
     from utils.auth.stateless_auth import get_user_preference
     from utils.db.connection_pool import db_pool
     from datetime import datetime, timedelta
+
+    if not get_user_preference(user_id, "prediscovery_enabled", True):
+        return False
 
     interval = get_user_preference(user_id, "prediscovery_interval_hours", DEFAULT_INTERVAL_HOURS)
     interval = max(MIN_INTERVAL_HOURS, int(interval or DEFAULT_INTERVAL_HOURS))

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -15,35 +15,38 @@ logger = logging.getLogger(__name__)
 
 
 def _get_users_with_integrations() -> List[Dict[str, Any]]:
-    """Get all users who have at least one connected integration.
+    """Get one enabled user per org who has at least one connected integration.
 
-    Iterates per-org to satisfy RLS on user_tokens / user_connections.
+    Iterates per-user to satisfy RLS on user_tokens / user_connections, skips
+    users with prediscovery_enabled=false, then dedups to one user per org.
     """
     from utils.db.connection_pool import db_pool
-    from utils.auth.stateless_auth import set_rls_context
+    from utils.auth.stateless_auth import set_rls_context, get_user_preference
 
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
-                # No RLS needed — cross-org loop sets RLS per user
-                cur.execute("SELECT DISTINCT ON (org_id) id, org_id FROM users WHERE org_id IS NOT NULL ORDER BY org_id, id")
+                cur.execute("SELECT id, org_id FROM users WHERE org_id IS NOT NULL ORDER BY org_id, id")
                 all_users = cur.fetchall()
 
+                seen_orgs = set()
                 results = []
                 for user_id, org_id in all_users:
+                    if org_id in seen_orgs:
+                        continue
+                    if not get_user_preference(user_id, "prediscovery_enabled", True):
+                        continue
                     set_rls_context(cur, conn, user_id, log_prefix="[Prediscovery]")
-
                     cur.execute("""
                         SELECT EXISTS (
-                            SELECT 1 FROM user_tokens ut
-                            WHERE ut.is_active = true
+                            SELECT 1 FROM user_tokens ut WHERE ut.is_active = true
                             UNION
-                            SELECT 1 FROM user_connections uc
-                            WHERE uc.status = 'active'
+                            SELECT 1 FROM user_connections uc WHERE uc.status = 'active'
                         )
                     """)
                     row = cur.fetchone()
                     if row and row[0]:
+                        seen_orgs.add(org_id)
                         results.append({"user_id": user_id, "org_id": org_id})
                 return results
     except Exception as e:
@@ -239,9 +242,6 @@ def _should_run_for_user(user_id: str) -> bool:
     from utils.auth.stateless_auth import get_user_preference
     from utils.db.connection_pool import db_pool
     from datetime import datetime, timedelta
-
-    if not get_user_preference(user_id, "prediscovery_enabled", True):
-        return False
 
     interval = get_user_preference(user_id, "prediscovery_interval_hours", DEFAULT_INTERVAL_HOURS)
     interval = max(MIN_INTERVAL_HOURS, int(interval or DEFAULT_INTERVAL_HOURS))

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -197,17 +197,18 @@ def run_prediscovery(
         prompt = build_prediscovery_prompt(user_id, providers, integrations)
 
         task_id = self.request.id
+        trigger_metadata = {"source": "prediscovery", "trigger": trigger, "task_id": task_id}
         session_id = create_background_chat_session(
             user_id=user_id,
             title=f"Infrastructure Pre-Discovery ({trigger})",
-            trigger_metadata={"source": "prediscovery", "trigger": trigger, "task_id": task_id},
+            trigger_metadata=trigger_metadata,
         )
 
         asyncio.run(_execute_background_chat(
             user_id=user_id,
             session_id=session_id,
             initial_message=prompt,
-            trigger_metadata={"source": "prediscovery", "trigger": trigger},
+            trigger_metadata=trigger_metadata,
             provider_preference=providers,
             mode="prediscovery",
         ))

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1194,8 +1194,9 @@ def _update_session_status(session_id: str, status: str, user_id: str) -> None:
                 if not set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat]"):
                     return
                 cursor.execute(
-                    "UPDATE chat_sessions SET status = %s, updated_at = %s WHERE id = %s",
-                    (status, datetime.now(), session_id)
+                    "UPDATE chat_sessions SET status = %s, updated_at = %s "
+                    "WHERE id = %s AND status != ALL(%s)",
+                    (status, datetime.now(), session_id, list(TERMINAL_SESSION_STATUSES))
                 )
                 rows_updated = cursor.rowcount
             conn.commit()

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1199,8 +1199,24 @@ def _update_session_status(session_id: str, status: str, user_id: str) -> None:
                     (status, datetime.now(), session_id, list(TERMINAL_SESSION_STATUSES))
                 )
                 rows_updated = cursor.rowcount
+                if rows_updated == 0:
+                    cursor.execute("SELECT status FROM chat_sessions WHERE id = %s", (session_id,))
+                    existing = cursor.fetchone()
+                    if existing is None:
+                        logger.info(f"[BackgroundChat] No session found with id {session_id}")
+                    elif existing[0] in TERMINAL_SESSION_STATUSES:
+                        logger.info(
+                            f"[BackgroundChat] Skipped update for session {session_id}: "
+                            f"already in terminal status '{existing[0]}'"
+                        )
+                    else:
+                        logger.info(
+                            f"[BackgroundChat] Update for session {session_id} to '{status}' "
+                            f"affected 0 rows (current status='{existing[0]}')"
+                        )
+                else:
+                    logger.info(f"[BackgroundChat] Updated session {session_id} status to '{status}' (rows={rows_updated})")
             conn.commit()
-            logger.info(f"[BackgroundChat] Updated session {session_id} status to '{status}' (rows={rows_updated})")
     except Exception as e:
         logger.error(f"[BackgroundChat] Failed to update session {session_id} status to '{status}': {e}")
         return

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1176,12 +1176,15 @@ async def _execute_background_chat(
                 logger.error(f"[BackgroundChat] Failed to close weaviate client - potential connection leak: {e}")
 
 
+TERMINAL_SESSION_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+
 def _update_session_status(session_id: str, status: str, user_id: str) -> None:
     """Update the status of a chat session.
     
     Args:
         session_id: The chat session ID
-        status: New status ('in_progress', 'completed', 'failed', 'active')
+        status: New status ('in_progress', 'completed', 'failed', 'cancelled', 'active')
         user_id: User ID for RLS context (required from Celery workers)
     """
     rows_updated = 0
@@ -1201,7 +1204,7 @@ def _update_session_status(session_id: str, status: str, user_id: str) -> None:
         logger.error(f"[BackgroundChat] Failed to update session {session_id} status to '{status}': {e}")
         return
 
-    if rows_updated > 0 and status in ("completed", "failed"):
+    if rows_updated > 0 and status in TERMINAL_SESSION_STATUSES:
         _propagate_suggestion_status(session_id, status)
 
 

--- a/server/routes/prediscovery/routes.py
+++ b/server/routes/prediscovery/routes.py
@@ -65,10 +65,16 @@ def cancel_prediscovery(user_id):
                         celery_app.control.revoke(task_id, terminate=True, signal="SIGTERM")
                     except Exception as e:
                         logger.warning(f"[Prediscovery API] Failed to revoke {task_id}: {e}")
+                else:
+                    logger.warning(
+                        f"[Prediscovery API] in_progress session {session_id} has no task_id; "
+                        "any running Celery worker will not be revoked"
+                    )
                 _update_session_status(str(session_id), "cancelled", user_id=user_id)
                 cancelled.append(str(session_id))
 
-        return jsonify({"status": "cancelled", "sessions": cancelled})
+        status = "cancelled" if cancelled else "no_active_sessions"
+        return jsonify({"status": status, "sessions": cancelled})
     except Exception as e:
         logger.exception(f"[Prediscovery API] Failed to cancel: {e}")
         return jsonify({"error": "Failed to cancel discovery"}), 500

--- a/server/routes/prediscovery/routes.py
+++ b/server/routes/prediscovery/routes.py
@@ -36,6 +36,44 @@ def trigger_prediscovery(user_id):
         return jsonify({"error": "Failed to start discovery"}), 500
 
 
+@prediscovery_bp.route("/cancel", methods=["POST"])
+@require_permission("connectors", "write")
+def cancel_prediscovery(user_id):
+    """Cancel any in-progress prediscovery runs for this user."""
+    try:
+        org_id = get_org_id_from_request()
+        cancelled = []
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Prediscovery]")
+                cur.execute("""
+                    SELECT id, ui_state->'triggerMetadata'->>'task_id'
+                    FROM chat_sessions
+                    WHERE org_id = %s
+                      AND user_id = %s
+                      AND status = 'in_progress'
+                      AND ui_state->'triggerMetadata'->>'source' = 'prediscovery'
+                """, (org_id, user_id))
+                rows = cur.fetchall()
+
+        if rows:
+            from celery_config import celery_app
+            from chat.background.task import _update_session_status
+            for session_id, task_id in rows:
+                if task_id:
+                    try:
+                        celery_app.control.revoke(task_id, terminate=True, signal="SIGTERM")
+                    except Exception as e:
+                        logger.warning(f"[Prediscovery API] Failed to revoke {task_id}: {e}")
+                _update_session_status(str(session_id), "cancelled", user_id=user_id)
+                cancelled.append(str(session_id))
+
+        return jsonify({"status": "cancelled", "sessions": cancelled})
+    except Exception as e:
+        logger.exception(f"[Prediscovery API] Failed to cancel: {e}")
+        return jsonify({"error": "Failed to cancel discovery"}), 500
+
+
 @prediscovery_bp.route("/status", methods=["GET"])
 @require_permission("connectors", "read")
 def get_prediscovery_status(user_id):

--- a/server/routes/prediscovery/routes.py
+++ b/server/routes/prediscovery/routes.py
@@ -42,6 +42,8 @@ def cancel_prediscovery(user_id):
     """Cancel any in-progress prediscovery runs for this user."""
     try:
         org_id = get_org_id_from_request()
+        if not org_id:
+            return jsonify({"error": "Missing org context"}), 400
         cancelled = []
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
@@ -62,7 +64,7 @@ def cancel_prediscovery(user_id):
             for session_id, task_id in rows:
                 if task_id:
                     try:
-                        celery_app.control.revoke(task_id, terminate=True, signal="SIGTERM")
+                        celery_app.control.revoke(task_id, terminate=True, signal="SIGKILL")
                     except Exception as e:
                         logger.warning(f"[Prediscovery API] Failed to revoke {task_id}: {e}")
                 else:


### PR DESCRIPTION
## Summary
- Adds an Automatic Discovery switch in Knowledge Base settings. When off, the hourly scheduler skips the user via a new `prediscovery_enabled` preference.
- Toggling off also cancels any in-flight run: new `POST /api/prediscovery/cancel` revokes the Celery task (`task_id` now stored in session metadata at dispatch) and marks the session `cancelled`.
- Promotes `cancelled` to a first-class terminal session status — `TERMINAL_SESSION_STATUSES` covers it in `_update_session_status` suggestion propagation and in the RCA context-update gates. UI renders "Last run cancelled".
- Cancel scope is per-user (SELECT filters by `user_id`), so users can't cancel sessions owned by other editors in the same org.

## Test plan
- [x] Toggle off with no in-flight run: preference saves, no session changes, scheduler skips user
- [x] Toggle off during in-flight run: Celery task revoked, session flips to `cancelled`, UI shows "Last run cancelled"
- [x] Toggle on: preference saves, scheduler resumes on next hourly tick
- [x] Manual "Run Now" still works when toggle is off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Automatic Discovery" toggle in settings with persisted preference.
  * Added ability to cancel in-progress discovery runs from the UI.
  * Status display now shows "Last run cancelled" when a run is cancelled.

* **Improvements**
  * Cancellation and run status handling made more reliable and reflect cancellations promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->