### PR TITLE
fix(security): resolve SonarQube hotspots (30 FIXED, 11 ACKNOWLEDGED)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Display build info
         run: |
@@ -62,12 +62,12 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: image=moby/buildkit:latest
 
       - name: Build ${{ matrix.service }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.file }}
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Display build info
         run: |
@@ -143,12 +143,12 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: image=moby/buildkit:latest
 
       - name: Build ${{ matrix.service }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.file }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: website/build
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ jobs:
     name: gitleaks
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # TODO: Install dependencies, run lint, type-check, unit tests, etc.
       - name: Placeholder – run static analysis suite

--- a/.github/workflows/publish-airtight.yml
+++ b/.github/workflows/publish-airtight.yml
@@ -57,18 +57,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
 
       - name: Compute version tag
         id: version
@@ -153,7 +153,7 @@ jobs:
 
       - name: Attest build provenance
         id: attest
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-path: ${{ steps.tarball.outputs.filename }}
 

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check tag matches Chart.yaml
         run: |
@@ -57,7 +57,7 @@ jobs:
       pages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -67,10 +67,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: ${{ env.CHART_DIR }}
         env:
@@ -94,13 +94,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.OCI_REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -55,13 +55,13 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -69,14 +69,14 @@ jobs:
 
       - name: Extract metadata (labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
 
       - name: Build and push by digest (server)
         if: matrix.image == 'server'
         id: build-server
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -90,7 +90,7 @@ jobs:
       - name: Build and push by digest (frontend)
         if: matrix.image == 'frontend'
         id: build-frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -126,7 +126,7 @@ jobs:
           printf '%s' "$DIGEST" > "/tmp/digests/${ARCH}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.image }}-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -147,17 +147,17 @@ jobs:
         image: [server, frontend]
     steps:
       - name: Download digest artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.image }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/arvo-ai/aurora-${{ matrix.image }}
           tags: |

--- a/.github/workflows/validate-env-vars.yml
+++ b/.github/workflows/validate-env-vars.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run environment variables validation
         env:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload validation report (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: env-validation-report
           path: |

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -74,6 +74,8 @@ COPY --from=builder /app/package.json ./package.json
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh && chown -R 1000:1000 /app
 
+USER bun
+
 # Expose port and run Next.js
 EXPOSE 3000
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/client/src/components/RCASettings.tsx
+++ b/client/src/components/RCASettings.tsx
@@ -182,9 +182,9 @@ export function RCASettings() {
       return;
     }
 
-    // Simple email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(newEmail)) {
+    // Simple email validation (length-capped per RFC 5321; `.` excluded from the middle class to avoid backtracking).
+    const emailRegex = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
+    if (newEmail.length > 320 || !emailRegex.test(newEmail)) {
       toast({
         title: "Error",
         description: "Please enter a valid email address",

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -279,7 +279,7 @@ export default function GitHubProviderIntegration() {
           variant: "destructive",
           action: (
             <ToastAction altText="View setup guide"
-              onClick={() => window.open("https://github.com/arvo-ai/aurora/blob/main/server/connectors/github_connector/README.md", "_blank")}>
+              onClick={() => window.open("https://github.com/arvo-ai/aurora/blob/main/server/connectors/github_connector/README.md", "_blank", "noopener,noreferrer")}>
               <ExternalLink className="h-3 w-3 mr-1" />Setup Guide
             </ToastAction>
           ),

--- a/client/src/components/ui/markdown-renderer.tsx
+++ b/client/src/components/ui/markdown-renderer.tsx
@@ -369,11 +369,12 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     if (!content) return content;
     
     // Filter out tool call delimiters with special Unicode characters
-    // Pattern matches: "Executing now:<｜tool▁calls▁begin｜><｜tool▁calls▁end｜>" and similar
-    const toolCallDelimiterRegex = /Executing now:[<｜▁]*tool[▁_\s]*calls?[▁_\s]*begin[｜>]*[<｜▁]*[｜>]*[<｜▁]*tool[▁_\s]*calls?[▁_\s]*end[｜>]*/gi;
-    
+    // Pattern matches: "Executing now:<｜tool▁calls▁begin｜><｜tool▁calls▁end｜>" and similar.
+    // Delimiter chars are merged into a single class and bounded to avoid super-linear backtracking.
+    const toolCallDelimiterRegex = /Executing now:[<｜▁>]{0,8}tool[▁_\s]{0,4}calls?[▁_\s]{0,4}begin[<｜▁>]{0,8}tool[▁_\s]{0,4}calls?[▁_\s]{0,4}end[<｜▁>]{0,8}/gi;
+
     // Also filter out standalone tool call delimiters
-    const standaloneDelimiterRegex = /[<｜▁]*tool[▁_\s]*calls?[▁_\s]*(begin|end)[｜>]*/gi;
+    const standaloneDelimiterRegex = /[<｜▁>]{0,8}tool[▁_\s]{0,4}calls?[▁_\s]{0,4}(begin|end)[<｜▁>]{0,8}/gi;
     
     let filtered = content.replace(toolCallDelimiterRegex, '');
     filtered = filtered.replace(standaloneDelimiterRegex, '');

--- a/kubectl-agent/src/Dockerfile
+++ b/kubectl-agent/src/Dockerfile
@@ -11,9 +11,9 @@ FROM python:3.12-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN useradd -m -u 1000 -s /bin/bash kubectl-agent
-COPY --from=builder --chown=kubectl-agent:kubectl-agent /root/.local /home/kubectl-agent/.local
+COPY --from=builder --chown=kubectl-agent:kubectl-agent --chmod=0555 /root/.local /home/kubectl-agent/.local
 COPY --from=builder /build/kubectl /usr/local/bin/kubectl
-COPY --chown=kubectl-agent:kubectl-agent agent.py .
+COPY --chown=kubectl-agent:kubectl-agent --chmod=0444 agent.py .
 USER kubectl-agent
 ENV PATH=/home/kubectl-agent/.local/bin:$PATH \
     PYTHONPATH=/home/kubectl-agent/.local/lib/python3.12/site-packages:$PYTHONPATH \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -179,19 +179,19 @@ RUN useradd -m -u 1000 -s /bin/bash app && \
     mkdir -p /tmp/.cache/uv && \
     chown -R app:app /app /tmp/.cache
 
-# Copy the project sources directly to /app (not /app/server).
-# --chmod=0555 makes source read+execute-only so the runtime can't self-modify.
-COPY --chown=app:app --chmod=0555 ./chat /app/chat/
-COPY --chown=app:app --chmod=0555 ./config /app/config/
-COPY --chown=app:app --chmod=0555 ./connectors /app/connectors/
-COPY --chown=app:app --chmod=0555 ./routes /app/routes/
-COPY --chown=app:app --chmod=0555 ./services /app/services/
-COPY --chown=app:app --chmod=0555 ./utils /app/utils/
-COPY --chown=app:app --chmod=0444 ./celery_config.py /app/celery_config.py
-COPY --chown=app:app --chmod=0444 ./main_chatbot.py /app/main_chatbot.py
-COPY --chown=app:app --chmod=0444 ./main_compute.py /app/main_compute.py
-COPY --chown=app:app --chmod=0444 ./mcp_server.py /app/mcp_server.py
-COPY --chown=app:app --chmod=0444 ./rbac_model.conf /app/rbac_model.conf
+# Copy project sources with root:root ownership + world-read so the `app`
+# user can read+execute but cannot self-modify the image contents.
+COPY --chmod=0555 ./chat /app/chat/
+COPY --chmod=0555 ./config /app/config/
+COPY --chmod=0555 ./connectors /app/connectors/
+COPY --chmod=0555 ./routes /app/routes/
+COPY --chmod=0555 ./services /app/services/
+COPY --chmod=0555 ./utils /app/utils/
+COPY --chmod=0444 ./celery_config.py /app/celery_config.py
+COPY --chmod=0444 ./main_chatbot.py /app/main_chatbot.py
+COPY --chmod=0444 ./main_compute.py /app/main_compute.py
+COPY --chmod=0444 ./mcp_server.py /app/mcp_server.py
+COPY --chmod=0444 ./rbac_model.conf /app/rbac_model.conf
 
 USER app
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -175,18 +175,24 @@ CMD ["python", "main_chatbot.py"]
 # ============================================
 FROM base AS prod
 
+RUN useradd -m -u 1000 -s /bin/bash app && \
+    mkdir -p /tmp/.cache/uv && \
+    chown -R app:app /app /tmp/.cache
+
 # Copy the project sources directly to /app (not /app/server)
-COPY ./chat /app/chat/
-COPY ./config /app/config/
-COPY ./connectors /app/connectors/
-COPY ./routes /app/routes/
-COPY ./services /app/services/
-COPY ./utils /app/utils/
-COPY ./celery_config.py /app/celery_config.py
-COPY ./main_chatbot.py /app/main_chatbot.py
-COPY ./main_compute.py /app/main_compute.py
-COPY ./mcp_server.py /app/mcp_server.py
-COPY ./rbac_model.conf /app/rbac_model.conf
+COPY --chown=app:app ./chat /app/chat/
+COPY --chown=app:app ./config /app/config/
+COPY --chown=app:app ./connectors /app/connectors/
+COPY --chown=app:app ./routes /app/routes/
+COPY --chown=app:app ./services /app/services/
+COPY --chown=app:app ./utils /app/utils/
+COPY --chown=app:app ./celery_config.py /app/celery_config.py
+COPY --chown=app:app ./main_chatbot.py /app/main_chatbot.py
+COPY --chown=app:app ./main_compute.py /app/main_compute.py
+COPY --chown=app:app ./mcp_server.py /app/mcp_server.py
+COPY --chown=app:app ./rbac_model.conf /app/rbac_model.conf
+
+USER app
 
 EXPOSE 5006
 # Entrypoint for chat container:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -179,18 +179,19 @@ RUN useradd -m -u 1000 -s /bin/bash app && \
     mkdir -p /tmp/.cache/uv && \
     chown -R app:app /app /tmp/.cache
 
-# Copy the project sources directly to /app (not /app/server)
-COPY --chown=app:app ./chat /app/chat/
-COPY --chown=app:app ./config /app/config/
-COPY --chown=app:app ./connectors /app/connectors/
-COPY --chown=app:app ./routes /app/routes/
-COPY --chown=app:app ./services /app/services/
-COPY --chown=app:app ./utils /app/utils/
-COPY --chown=app:app ./celery_config.py /app/celery_config.py
-COPY --chown=app:app ./main_chatbot.py /app/main_chatbot.py
-COPY --chown=app:app ./main_compute.py /app/main_compute.py
-COPY --chown=app:app ./mcp_server.py /app/mcp_server.py
-COPY --chown=app:app ./rbac_model.conf /app/rbac_model.conf
+# Copy the project sources directly to /app (not /app/server).
+# --chmod=0555 makes source read+execute-only so the runtime can't self-modify.
+COPY --chown=app:app --chmod=0555 ./chat /app/chat/
+COPY --chown=app:app --chmod=0555 ./config /app/config/
+COPY --chown=app:app --chmod=0555 ./connectors /app/connectors/
+COPY --chown=app:app --chmod=0555 ./routes /app/routes/
+COPY --chown=app:app --chmod=0555 ./services /app/services/
+COPY --chown=app:app --chmod=0555 ./utils /app/utils/
+COPY --chown=app:app --chmod=0444 ./celery_config.py /app/celery_config.py
+COPY --chown=app:app --chmod=0444 ./main_chatbot.py /app/main_chatbot.py
+COPY --chown=app:app --chmod=0444 ./main_compute.py /app/main_compute.py
+COPY --chown=app:app --chmod=0444 ./mcp_server.py /app/mcp_server.py
+COPY --chown=app:app --chmod=0444 ./rbac_model.conf /app/rbac_model.conf
 
 USER app
 

--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -266,9 +266,9 @@ class RealMCPServerManager:
                     env["AWS_DEFAULT_REGION"] = str(aws_creds.get("region", "us-east-1"))
                     env["AWS_REGION"] = str(aws_creds.get("region", "us-east-1")) 
                     
-                    # Create AWS config directory in /tmp to ensure it's writable
-                    aws_dir = "/tmp/.aws"
-                    os.makedirs(aws_dir, exist_ok=True)
+                    # Per-invocation AWS config dir (0o700) so concurrent users in the same
+                    # worker cannot overwrite each other's credentials via a shared path.
+                    aws_dir = tempfile.mkdtemp(prefix=".aws-")
                     
                     # Create credentials file
                     credentials_content = f"""[default]

--- a/server/chat/backend/agent/tools/notion/postmortem.py
+++ b/server/chat/backend/agent/tools/notion/postmortem.py
@@ -21,11 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s.]+\.[^@\s]+$")
 
 
 def _looks_like_email(value: Optional[str]) -> bool:
-    return bool(value and _EMAIL_RE.match(value.strip()))
+    if not value:
+        return False
+    stripped = value.strip()
+    return len(stripped) <= 320 and bool(_EMAIL_RE.match(stripped))
 
 
 def _looks_like_iso_date(value: Optional[str]) -> bool:


### PR DESCRIPTION
## Summary

Sweeps the SonarQube security hotspot backlog: triaged 102 TO_REVIEW items, marked 61 as SAFE, fixed 30 in code here, and leaves 11 for ACKNOWLEDGED marking (dev-only image + deployment-layer mTLS).

## What's fixed in this PR

- **Docker hardening** — added `USER` to `client/Dockerfile` prod stage and new `app` user in `server/Dockerfile` prod stage; `--chmod=0555/0444` on `kubectl-agent` COPYs so runtime can't self-modify
- **ReDoS fixes** — bounded the LLM tool-call delimiter regexes in `markdown-renderer.tsx` (were exponential / quadratic), and fixed the email regexes in `RCASettings.tsx` + `notion/postmortem.py` with a `[^\s@.]` middle class + 320-char cap
- **AWS credential isolation** — replaced shared `/tmp/.aws` path in `mcp_tools.py` with `tempfile.mkdtemp()` per invocation; two concurrent users in the same worker can no longer overwrite each other's credentials
- **Link hardening** — `rel="noopener,noreferrer"` on the one `window.open` toast link
- **CI SHA pinning** — pinned every `uses:` across all 9 workflows (20 Sonar-flagged + 10 sibling refs) to full commit SHAs with `# v<tag>` comments

## Why 11 are left for ACKNOWLEDGED

- `Dockerfile-chatbot-dev.dockerfile` (2) — local-dev-only image bundling cloud CLIs; prod uses a separate Dockerfile
- 7 intra-cluster cleartext HTTP (Vault/backend/chatbot/weaviate) — deployment-layer concern, fixed via service-mesh mTLS or Vault TLS, not in the Helm defaults
- 2 user-configured URLs (SearXNG, Spinnaker Gate) — self-hosted targets where users legitimately pick the scheme

## Test plan

- [ ] Frontend container boots; markdown renderer strips LLM tool-call delimiters as before
- [ ] Server + celery containers boot under the new `app` user; subprocess tools (kubectl/terraform/gcloud) still work
- [ ] AWS MCP tool (if enabled) still writes creds and subprocess picks them up
- [ ] kubectl-agent container runs; no permission errors on `/home/kubectl-agent/.local`
- [ ] CI workflows run green on this branch (SHA-pinned actions resolve correctly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation to reject invalid domain formats and addresses exceeding length limits
  * Enhanced security for external link opening

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs across all workflows
  * Hardened container images with non-root user execution and restrictive file permissions
  * Improved isolation for temporary credential handling
  * Refined content filtering patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->