### PR TITLE
fix(docker): resolve Sonar S6504 on kubectl-agent Dockerfile

### DIFF
--- a/kubectl-agent/src/Dockerfile
+++ b/kubectl-agent/src/Dockerfile
@@ -11,9 +11,9 @@ FROM python:3.12-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN useradd -m -u 1000 -s /bin/bash kubectl-agent
-COPY --from=builder --chown=kubectl-agent:kubectl-agent --chmod=0555 /root/.local /home/kubectl-agent/.local
+COPY --from=builder --chmod=0555 /root/.local /home/kubectl-agent/.local
 COPY --from=builder /build/kubectl /usr/local/bin/kubectl
-COPY --chown=kubectl-agent:kubectl-agent --chmod=0444 agent.py .
+COPY --chmod=0444 agent.py .
 USER kubectl-agent
 ENV PATH=/home/kubectl-agent/.local/bin:$PATH \
     PYTHONPATH=/home/kubectl-agent/.local/lib/python3.12/site-packages:$PYTHONPATH \


### PR DESCRIPTION
## Summary

Follow-up to #306. Sonar's post-merge scan still flagged `kubectl-agent/src/Dockerfile` lines 14 and 16 — S6504 treats non-root `--chown` as a risk even with `--chmod` present (owner can chmod-back). Same fix that resolved `server/Dockerfile` in #306: drop `--chown=kubectl-agent:kubectl-agent`, keep `--chmod=0555/0444`. Files become root-owned but world-read/executable, so the kubectl-agent runtime user still reads and imports them fine.

## Test plan

- [ ] kubectl-agent container boots; Python imports from `/home/kubectl-agent/.local` succeed under `USER kubectl-agent`
- [ ] `agent.py` runs end-to-end
- [ ] Sonar S6504 hotspots on lines 14, 16 auto-resolve on next main scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->