### PR TITLE
fix(frontend): strip Next.js fingerprint headers

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -24,6 +24,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   cacheMaxMemorySize: 0,
+  poweredByHeader: false,
   webpack: (config, { isServer, dev }) => {
     // Aggressive tree shaking configuration
     if (!isServer && !dev) {

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -23,6 +23,20 @@ const publicRoutes = [
 // Routes that should redirect authenticated users away
 const authRoutes = ["/sign-in", "/sign-up"]
 
+// Strips framework/runtime fingerprint headers from every outgoing response.
+// Note: x-nextjs-* headers on cached responses are injected by Next.js after
+// middleware runs, so the authoritative strip belongs at the CDN/proxy layer
+// (Cloudflare Transform Rules, Nginx, etc.). These deletes remain as defense
+// in depth for dynamic responses where middleware headers propagate.
+function sanitizeResponse(response: NextResponse): NextResponse {
+  response.headers.delete('x-powered-by')
+  response.headers.delete('x-nextjs-cache')
+  response.headers.delete('x-nextjs-prerender')
+  response.headers.delete('x-nextjs-stale-time')
+  response.headers.delete('server-timing')
+  return response
+}
+
 export default auth((req) => {
   const { nextUrl } = req
   const isLoggedIn = !!req.auth?.user?.id
@@ -41,36 +55,36 @@ export default auth((req) => {
 
   // If user is logged in and tries to access auth pages, redirect to home
   if (isAuthRoute && isLoggedIn) {
-    return NextResponse.redirect(new URL("/", nextUrl))
+    return sanitizeResponse(NextResponse.redirect(new URL("/", nextUrl)))
   }
 
   // Force password change: redirect to /change-password if flag is set
   if (isLoggedIn && req.auth?.user?.mustChangePassword && !isChangePasswordRoute && !isApiRoute) {
-    return NextResponse.redirect(new URL("/change-password", nextUrl))
+    return sanitizeResponse(NextResponse.redirect(new URL("/change-password", nextUrl)))
   }
 
   // Force org setup: redirect users without an org (or in Default Org) to create one
   const orgName = req.auth?.user?.orgName
   const needsOrg = !req.auth?.user?.orgId || (orgName && orgName.toLowerCase() === "default organization")
   if (isLoggedIn && needsOrg && !isSetupOrgRoute && !isOrgSwitching && !isChangePasswordRoute && !isApiRoute) {
-    return NextResponse.redirect(new URL("/setup-org", nextUrl))
+    return sanitizeResponse(NextResponse.redirect(new URL("/setup-org", nextUrl)))
   }
 
   // If user is not logged in and tries to access protected route
   if (!isPublicRoute && !isLoggedIn) {
     // For API routes, return 401 JSON response instead of redirecting
     if (isApiRoute) {
-      return NextResponse.json(
+      return sanitizeResponse(NextResponse.json(
         { error: "Unauthorized" },
         { status: 401 }
-      )
+      ))
     }
-    
+
     // For page routes, redirect to sign-in
     const callbackUrl = nextUrl.pathname + nextUrl.search
     const signInUrl = new URL("/sign-in", nextUrl)
     signInUrl.searchParams.set("callbackUrl", callbackUrl)
-    return NextResponse.redirect(signInUrl)
+    return sanitizeResponse(NextResponse.redirect(signInUrl))
   }
 
   // Gate admin routes to admin role only
@@ -78,9 +92,9 @@ export default auth((req) => {
     const role = req.auth?.user?.role
     if (role !== ROLE_ADMIN) {
       if (isApiRoute) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+        return sanitizeResponse(NextResponse.json({ error: "Forbidden" }, { status: 403 }))
       }
-      return NextResponse.redirect(new URL("/", nextUrl))
+      return sanitizeResponse(NextResponse.redirect(new URL("/", nextUrl)))
     }
   }
 
@@ -108,14 +122,7 @@ export default auth((req) => {
     "form-action 'self'",
   ].join('; '))
 
-  // Strip framework fingerprint headers so ZAP/StackHawk can't fingerprint Next.js
-  response.headers.delete('x-powered-by')
-  response.headers.delete('x-nextjs-cache')
-  response.headers.delete('x-nextjs-prerender')
-  response.headers.delete('x-nextjs-stale-time')
-  response.headers.delete('server-timing')
-
-  return response
+  return sanitizeResponse(response)
 })
 
 export const config = {

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -108,6 +108,13 @@ export default auth((req) => {
     "form-action 'self'",
   ].join('; '))
 
+  // Strip framework fingerprint headers so ZAP/StackHawk can't fingerprint Next.js
+  response.headers.delete('x-powered-by')
+  response.headers.delete('x-nextjs-cache')
+  response.headers.delete('x-nextjs-prerender')
+  response.headers.delete('x-nextjs-stale-time')
+  response.headers.delete('server-timing')
+
   return response
 })
 


### PR DESCRIPTION
## Summary
- Set `poweredByHeader: false` in `next.config.ts` to stop emitting `x-powered-by: Next.js`.
- In `middleware.ts`, delete `x-powered-by`, `x-nextjs-cache`, `x-nextjs-prerender`, `x-nextjs-stale-time`, and `server-timing` from outgoing responses.

Addresses 10 StackHawk "Proxy Disclosure" findings (CWE-200) where authenticated responses were leaking framework/runtime fingerprint headers. Cloudflare-inherent headers (`server: cloudflare`, `cf-ray`) remain; those cannot be hidden from the origin.

## Test plan
- [x] `npm run lint` clean on changed files
- [x] Local `curl -sI` against `/sign-in`, `/api/auth/providers`, `/api/connectors` — no fingerprint headers present
- [ ] After deploy, rescan in StackHawk; if `Server-Timing` persists it is CF-emitted and needs a dashboard toggle (Speed → Optimization → Server-Timing Headers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic framework identification headers from server responses across all routes.
  * Removed internal framework and performance tracking headers from HTTP responses to reduce technology stack visibility.

These updates strengthen the application's security and privacy profile without impacting user-visible functionality or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->