### PR TITLE
add audit on auth failure

### DIFF
--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -267,13 +267,16 @@ def verify_internal_api_secret():
 _TENANT_OPEN_PREFIXES = ("/api/auth/login", "/api/auth/register", _HEALTH_PATH)
 
 
-def _audit_tenant_failure(user_id, org_id, action, reason):
+def _audit_tenant_failure(user_id, org_id, action, reason, detail=None) -> None:
     """Best-effort audit log for tenant isolation failures."""
     try:
         from routes.audit_routes import record_audit_event
-        record_audit_event(org_id or "", user_id or "", action, "auth", None, {"reason": reason}, request)
+        payload = detail if detail is not None else {"reason": reason}
+        record_audit_event(org_id or "", user_id or "", action, "auth", None, payload, request)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "Could not record tenant audit event", exc_info=True
+        )
 
 @app.before_request
 def enforce_user_org_binding():
@@ -304,7 +307,8 @@ def enforce_user_org_binding():
             "Tenant mismatch: user=%s claimed_org=%s actual_org=%s",
             sanitize(user_id), sanitize(claimed_org), sanitize(actual_org),
         )
-        _audit_tenant_failure(user_id, actual_org, "tenant_mismatch", "org_id_mismatch")
+        _audit_tenant_failure(user_id, actual_org, "tenant_mismatch", "org_id_mismatch",
+                              {"reason": "org_id_mismatch", "claimed_org": claimed_org, "actual_org": actual_org})
         return jsonify({"error": "Forbidden - organization mismatch"}), 403
 
     return None

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -271,7 +271,7 @@ def _audit_tenant_failure(user_id, org_id, action, reason, detail=None) -> None:
     """Best-effort audit log for tenant isolation failures."""
     try:
         from routes.audit_routes import record_audit_event
-        payload = detail if detail is not None else {"reason": reason}
+        payload = {"reason": reason, **(detail or {})}
         record_audit_event(org_id or "", user_id or "", action, "auth", None, payload, request)
     except Exception:
         logging.getLogger(__name__).debug(
@@ -308,7 +308,7 @@ def enforce_user_org_binding():
             sanitize(user_id), sanitize(claimed_org), sanitize(actual_org),
         )
         _audit_tenant_failure(user_id, actual_org, "tenant_mismatch", "org_id_mismatch",
-                              {"reason": "org_id_mismatch", "claimed_org": claimed_org, "actual_org": actual_org})
+                              {"claimed_org": claimed_org, "actual_org": actual_org})
         return jsonify({"error": "Forbidden - organization mismatch"}), 403
 
     return None

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -299,7 +299,8 @@ def enforce_user_org_binding():
     actual_org = resolve_org_id(user_id)
 
     if not actual_org:
-        _audit_tenant_failure(user_id, claimed_org, "auth_failed", "unknown_user")
+        _audit_tenant_failure(user_id, None, "auth_failed", "unknown_user",
+                              {"claimed_org": claimed_org})
         return jsonify({"error": "Unauthorized - unknown user"}), 401
 
     if actual_org != claimed_org:

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -266,6 +266,15 @@ def verify_internal_api_secret():
 # Separate from _OPEN_PREFIXES: this only skips routes that carry identity headers before auth completes (login/register); webhook routes don't need listing here because they lack X-User-ID/X-Org-ID and the check below short-circuits on missing headers.
 _TENANT_OPEN_PREFIXES = ("/api/auth/login", "/api/auth/register", _HEALTH_PATH)
 
+
+def _audit_tenant_failure(user_id, org_id, action, reason):
+    """Best-effort audit log for tenant isolation failures."""
+    try:
+        from routes.audit_routes import record_audit_event
+        record_audit_event(org_id or "", user_id or "", action, "auth", None, {"reason": reason}, request)
+    except Exception:
+        pass
+
 @app.before_request
 def enforce_user_org_binding():
     """Reject requests where X-Org-ID doesn't match the user's actual org."""
@@ -287,6 +296,7 @@ def enforce_user_org_binding():
     actual_org = resolve_org_id(user_id)
 
     if not actual_org:
+        _audit_tenant_failure(user_id, claimed_org, "auth_failed", "unknown_user")
         return jsonify({"error": "Unauthorized - unknown user"}), 401
 
     if actual_org != claimed_org:
@@ -294,6 +304,7 @@ def enforce_user_org_binding():
             "Tenant mismatch: user=%s claimed_org=%s actual_org=%s",
             sanitize(user_id), sanitize(claimed_org), sanitize(actual_org),
         )
+        _audit_tenant_failure(user_id, actual_org, "tenant_mismatch", "org_id_mismatch")
         return jsonify({"error": "Forbidden - organization mismatch"}), 403
 
     return None

--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -306,18 +306,25 @@ def login():
                 # Verify password (runs regardless of whether user exists)
                 password_valid = bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8'))
                 
-                if not user or not password_valid:
+                # Resolve audit identifiers before branching so the variable
+                # lookups don't create a measurable timing difference.
+                _audit_org = (user_org_id or "") if user else ""
+                _audit_uid = user_id if user else ""
+                _login_failed = not user or not password_valid
+
+                # Always perform one DB round-trip (audit INSERT) regardless of
+                # success/failure to preserve the timing-attack protection from
+                # _DUMMY_BCRYPT_HASH.
+                if _login_failed:
                     record_audit_event(
-                        user_org_id if user else "", user_id if user else "",
+                        _audit_org, _audit_uid,
                         "login_failed", "session", None,
                         {"email": email, "reason": "invalid_password" if user else "unknown_email"},
                         request,
                     )
                     return jsonify({"error": "Invalid credentials"}), 401
                 
-                logging.info(f"User logged in: {email}")
-
-                record_audit_event(user_org_id or "", user_id, "login", "session", user_id, {"email": email}, request)
+                record_audit_event(_audit_org, _audit_uid, "login", "session", _audit_uid, {"email": email}, request)
 
                 return jsonify({
                     "id": user_id,

--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -4,6 +4,7 @@ Replaces the previous authentication system.
 """
 import logging
 from routes.audit_routes import record_audit_event
+import hashlib
 import re
 import bcrypt
 from flask import Blueprint, request, jsonify
@@ -316,10 +317,14 @@ def login():
                 # success/failure to preserve the timing-attack protection from
                 # _DUMMY_BCRYPT_HASH.
                 if _login_failed:
+                    _detail = {"reason": "invalid_password", "email": email} if user else {
+                        "reason": "unknown_email",
+                        "email_sha256": hashlib.sha256(email[:254].lower().encode()).hexdigest(),
+                    }
                     record_audit_event(
                         _audit_org, _audit_uid,
                         "login_failed", "session", None,
-                        {"email": email, "reason": "invalid_password" if user else "unknown_email"},
+                        _detail,
                         request,
                     )
                     return jsonify({"error": "Invalid credentials"}), 401
@@ -377,13 +382,13 @@ def change_password(user_id):
                 
                 password_hash = result[0]
                 
-                from utils.auth.stateless_auth import get_org_id_from_request
-                _org = get_org_id_from_request() or ""
+                from utils.auth.stateless_auth import resolve_org_id
+                org_id = resolve_org_id(user_id) or ""
 
                 # Verify current password
                 if not bcrypt.checkpw(current_password.encode('utf-8'), password_hash.encode('utf-8')):
                     record_audit_event(
-                        _org, user_id, "change_password_failed",
+                        org_id, user_id, "change_password_failed",
                         "user", user_id, {"reason": "wrong_current_password"}, request,
                     )
                     return jsonify({"error": "Current password is incorrect"}), 401
@@ -398,7 +403,7 @@ def change_password(user_id):
                 
                 logging.info(f"Password changed for user: {user_id}")
 
-                record_audit_event(_org, user_id, "change_password", "user", user_id, {}, request)
+                record_audit_event(org_id, user_id, "change_password", "user", user_id, {}, request)
 
                 return jsonify({"message": "Password changed successfully"}), 200
         finally:

--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -370,11 +370,13 @@ def change_password(user_id):
                 
                 password_hash = result[0]
                 
+                from utils.auth.stateless_auth import get_org_id_from_request
+                _org = get_org_id_from_request() or ""
+
                 # Verify current password
                 if not bcrypt.checkpw(current_password.encode('utf-8'), password_hash.encode('utf-8')):
-                    from utils.auth.stateless_auth import get_org_id_from_request as _get_org_fail
                     record_audit_event(
-                        _get_org_fail() or "", user_id, "change_password_failed",
+                        _org, user_id, "change_password_failed",
                         "user", user_id, {"reason": "wrong_current_password"}, request,
                     )
                     return jsonify({"error": "Current password is incorrect"}), 401
@@ -389,8 +391,6 @@ def change_password(user_id):
                 
                 logging.info(f"Password changed for user: {user_id}")
 
-                from utils.auth.stateless_auth import get_org_id_from_request as _get_org
-                _org = _get_org() or ""
                 record_audit_event(_org, user_id, "change_password", "user", user_id, {}, request)
 
                 return jsonify({"message": "Password changed successfully"}), 200

--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -307,6 +307,12 @@ def login():
                 password_valid = bcrypt.checkpw(password.encode('utf-8'), password_hash.encode('utf-8'))
                 
                 if not user or not password_valid:
+                    record_audit_event(
+                        user_org_id if user else "", user_id if user else "",
+                        "login_failed", "session", None,
+                        {"email": email, "reason": "invalid_password" if user else "unknown_email"},
+                        request,
+                    )
                     return jsonify({"error": "Invalid credentials"}), 401
                 
                 logging.info(f"User logged in: {email}")
@@ -366,6 +372,11 @@ def change_password(user_id):
                 
                 # Verify current password
                 if not bcrypt.checkpw(current_password.encode('utf-8'), password_hash.encode('utf-8')):
+                    from utils.auth.stateless_auth import get_org_id_from_request as _get_org_fail
+                    record_audit_event(
+                        _get_org_fail() or "", user_id, "change_password_failed",
+                        "user", user_id, {"reason": "wrong_current_password"}, request,
+                    )
                     return jsonify({"error": "Current password is incorrect"}), 401
                 
                 # Hash and update new password

--- a/server/utils/auth/rbac_decorators.py
+++ b/server/utils/auth/rbac_decorators.py
@@ -25,12 +25,11 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 
-def _audit_auth_failure(user_id, org_id, action, detail):
+def _audit_auth_failure(user_id, org_id, action, detail) -> None:
     """Best-effort audit log for auth/RBAC failures."""
     try:
         from routes.audit_routes import record_audit_event
-        from flask import request as _req
-        record_audit_event(org_id or "", user_id or "", action, "auth", None, detail, _req)
+        record_audit_event(org_id or "", user_id or "", action, "auth", None, detail, request)
     except Exception:
         logger.debug("Could not record auth audit event", exc_info=True)
 

--- a/server/utils/auth/rbac_decorators.py
+++ b/server/utils/auth/rbac_decorators.py
@@ -25,6 +25,16 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 
+def _audit_auth_failure(user_id, org_id, action, detail):
+    """Best-effort audit log for auth/RBAC failures."""
+    try:
+        from routes.audit_routes import record_audit_event
+        from flask import request as _req
+        record_audit_event(org_id or "", user_id or "", action, "auth", None, detail, _req)
+    except Exception:
+        logger.debug("Could not record auth audit event", exc_info=True)
+
+
 def require_permission(resource: str, action: str):
     """Decorator that enforces Casbin domain-based RBAC on a Flask route.
 
@@ -47,6 +57,7 @@ def require_permission(resource: str, action: str):
 
             user_id = get_user_id_from_request()
             if not user_id:
+                _audit_auth_failure(None, None, "auth_failed", {"endpoint": fn.__name__, "reason": "no_user_id"})
                 return jsonify({"error": "Unauthorized"}), 401
 
             org_id = get_org_id_from_request()
@@ -55,6 +66,7 @@ def require_permission(resource: str, action: str):
                     "RBAC denied: no org context for user=%s endpoint=%s",
                     sanitize(user_id), fn.__name__,
                 )
+                _audit_auth_failure(user_id, None, "rbac_denied", {"endpoint": fn.__name__, "reason": "no_org_context"})
                 return jsonify({"error": "Forbidden - no organization context"}), 403
 
             enforcer = get_enforcer()
@@ -65,6 +77,9 @@ def require_permission(resource: str, action: str):
                         "RBAC denied: user=%s org=%s resource=%s action=%s endpoint=%s",
                         sanitize(user_id), sanitize(org_id), resource, action, fn.__name__,
                     )
+                    _audit_auth_failure(user_id, org_id, "rbac_denied", {
+                        "endpoint": fn.__name__, "resource": resource, "action": action,
+                    })
                     return jsonify({"error": "Forbidden"}), 403
 
             try:
@@ -98,6 +113,7 @@ def require_auth_only(fn):
 
         user_id = get_user_id_from_request()
         if not user_id:
+            _audit_auth_failure(None, None, "auth_failed", {"endpoint": fn.__name__, "reason": "no_user_id"})
             return jsonify({"error": "Unauthorized"}), 401
         try:
             return fn(user_id, *args, **kwargs)


### PR DESCRIPTION
Add light logging 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced audit logging for auth and RBAC events: failed logins (unknown email vs wrong password), password-change failures, permission denials, and tenant/org mismatches. Events include contextual details (session/org identifiers, claimed vs actual org, and failure reasons) to improve tracing. Audit attempts are best-effort and won't affect existing user-facing responses (401/403 remain unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->