### PR TITLE
feat: enable RLS on knowledge_base tables

### DIFF
--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -82,14 +82,11 @@ def build_knowledge_base_memory_segment(user_id: Optional[str]) -> str:
     kb_logger = logging.getLogger(__name__)
 
     try:
+        from utils.auth.stateless_auth import set_rls_context
+
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-            # No RLS needed — users, knowledge_base_memory not RLS-protected
-            cursor.execute(
-                "SELECT org_id FROM users WHERE id = %s", (user_id,)
-            )
-            user_row = cursor.fetchone()
-            org_id = user_row[0] if user_row else None
+            org_id = set_rls_context(cursor, conn, user_id, log_prefix="[KB Memory]")
 
             if org_id:
                 cursor.execute(

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -326,7 +326,6 @@ def workspace_cleanup(user_id, workspace_id):
             from utils.db.connection_pool import db_pool
             with db_pool.get_admin_connection() as conn:
                 cur = conn.cursor()
-                # No RLS needed — workspaces not RLS-protected
                 cur.execute(
                     """UPDATE workspaces SET aws_discovery_summary = NULL,
                        aws_discovery_artifact_bucket = NULL,

--- a/server/routes/knowledge_base/tasks.py
+++ b/server/routes/knowledge_base/tasks.py
@@ -12,7 +12,7 @@ import logging
 
 from celery_config import celery_app
 from utils.db.connection_pool import db_pool
-from utils.auth.stateless_auth import get_org_id_for_user
+from utils.auth.stateless_auth import get_org_id_for_user, set_rls_context
 
 logger = logging.getLogger(__name__)
 
@@ -122,8 +122,7 @@ def _update_document_status(
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-
-            # No RLS needed — knowledge_base_documents not RLS-protected
+            set_rls_context(cursor, conn, user_id, log_prefix="[KB Task]")
             cursor.execute(
                 """
                 UPDATE knowledge_base_documents
@@ -140,7 +139,7 @@ def _update_document_status(
 
     except Exception as e:
         logger.error(f"[KB Task] Error updating document status: {e}")
-        raise  # Propagate to allow retry or alerting
+        raise
 
 
 def _get_document_info(document_id: str, user_id: str) -> dict | None:
@@ -155,7 +154,7 @@ def _get_document_info(document_id: str, user_id: str) -> dict | None:
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-            # No RLS needed — knowledge_base_documents not RLS-protected
+            set_rls_context(cursor, conn, user_id, log_prefix="[KB Task]")
             cursor.execute(
                 """
                 SELECT original_filename, file_type, storage_path
@@ -176,7 +175,7 @@ def _get_document_info(document_id: str, user_id: str) -> dict | None:
 
     except Exception as e:
         logger.error(f"[KB Task] Error getting document info: {e}")
-        raise  # Re-raise to distinguish DB errors from "not found"
+        raise
 
 
 def _download_file(storage_path: str) -> bytes | None:
@@ -222,6 +221,9 @@ def cleanup_stale_documents() -> dict:
     """
     Mark documents stuck in 'processing' or 'uploading' for >3 minutes as failed.
 
+    Uses the cleanup_stale_kb_documents() SECURITY DEFINER function so this
+    cross-org sweep works even though knowledge_base_documents is RLS-protected.
+
     This handles edge cases where:
     - Celery worker crashed mid-processing
     - DB update failed after max retries
@@ -230,19 +232,7 @@ def cleanup_stale_documents() -> dict:
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-
-            # No RLS needed — knowledge_base_documents not RLS-protected
-            cursor.execute(
-                """
-                UPDATE knowledge_base_documents
-                SET status = 'failed',
-                    error_message = 'Processing timed out. Please try uploading again.',
-                    updated_at = CURRENT_TIMESTAMP
-                WHERE status IN ('processing', 'uploading')
-                  AND updated_at < CURRENT_TIMESTAMP - INTERVAL '3 minutes'
-                RETURNING id, user_id, original_filename
-                """
-            )
+            cursor.execute("SELECT * FROM cleanup_stale_kb_documents()")
             stale_docs = cursor.fetchall()
             conn.commit()
 

--- a/server/tests/test_rls_coverage.py
+++ b/server/tests/test_rls_coverage.py
@@ -17,8 +17,6 @@ RLS_EXCLUSIONS: Set[str] = {
     "users",                      # queried during login before org context is set
     "audit_log",                  # written with explicit org_id outside RLS session scope
     "org_invitations",            # queried during invite/join flows before org context
-    "knowledge_base_documents",   # Celery cleanup_stale_documents runs cross-org sweeps
-    "knowledge_base_memory",      # same Celery task dependency as knowledge_base_documents
 }
 
 

--- a/server/tests/test_rls_coverage.py
+++ b/server/tests/test_rls_coverage.py
@@ -1,0 +1,87 @@
+"""Verify every table with an org_id column is either RLS-protected or explicitly excluded.
+
+Parses db_utils.py statically to find CREATE TABLE statements with org_id
+columns and compares them against the rls_tables list. If a new table with
+org_id is added without being in either list, this test fails.
+"""
+
+import re
+from pathlib import Path
+from typing import Set
+
+import pytest
+
+_DB_UTILS = Path(__file__).resolve().parent.parent / "utils" / "db" / "db_utils.py"
+
+# Tables with org_id that are intentionally excluded from RLS.
+# Each entry MUST have a comment explaining why.
+RLS_EXCLUSIONS: Set[str] = {
+    "users",                      # queried during login before org context is set
+    "audit_log",                  # written with explicit org_id outside RLS session scope
+    "org_invitations",            # queried during invite/join flows before org context
+    "knowledge_base_documents",   # Celery cleanup_stale_documents runs cross-org sweeps
+    "knowledge_base_memory",      # same Celery task dependency as knowledge_base_documents
+}
+
+
+def _parse_tables_with_orgid(source: str) -> Set[str]:
+    tables: Set[str] = set()
+    for m in re.finditer(
+        r"CREATE TABLE IF NOT EXISTS (\w+)\s*\((.*?)\);", source, re.DOTALL
+    ):
+        if "org_id" in m.group(2):
+            tables.add(m.group(1))
+    return tables
+
+
+def _parse_rls_tables(source: str) -> Set[str]:
+    block = source[source.index("rls_tables = ["):]
+    block = block[:block.index("# Commit table creation and RLS")]
+    tables: Set[str] = set()
+    for m in re.finditer(r'rls_tables\s*=\s*\[(.*?)\]', block, re.DOTALL):
+        for name in re.findall(r'"(\w+)"', m.group(1)):
+            tables.add(name)
+    for m in re.finditer(r'rls_tables\.append\("(\w+)"\)', block):
+        tables.add(m.group(1))
+    return tables
+
+
+def test_all_orgid_tables_covered():
+    """Every table with org_id must be in rls_tables or RLS_EXCLUSIONS."""
+    source = _DB_UTILS.read_text()
+    orgid_tables = _parse_tables_with_orgid(source)
+    rls_tables = _parse_rls_tables(source)
+
+    covered = rls_tables | RLS_EXCLUSIONS
+    uncovered = orgid_tables - covered
+
+    assert not uncovered, (
+        f"Tables with org_id missing from both rls_tables and RLS_EXCLUSIONS: "
+        f"{sorted(uncovered)}. Add them to rls_tables in db_utils.py or to "
+        f"RLS_EXCLUSIONS in this test with a comment explaining why."
+    )
+
+
+def test_no_rls_on_tables_without_orgid():
+    """Tables in rls_tables must actually have an org_id column."""
+    source = _DB_UTILS.read_text()
+    orgid_tables = _parse_tables_with_orgid(source)
+    rls_tables = _parse_rls_tables(source)
+
+    bogus = rls_tables - orgid_tables
+    assert not bogus, (
+        f"Tables in rls_tables that have no org_id column: {sorted(bogus)}. "
+        f"Remove them from rls_tables — RLS policies referencing org_id will fail."
+    )
+
+
+def test_exclusions_still_needed():
+    """RLS_EXCLUSIONS entries must still exist as tables with org_id."""
+    source = _DB_UTILS.read_text()
+    orgid_tables = _parse_tables_with_orgid(source)
+
+    stale = RLS_EXCLUSIONS - orgid_tables
+    assert not stale, (
+        f"RLS_EXCLUSIONS entries that no longer exist as tables with org_id: "
+        f"{sorted(stale)}. Remove stale entries from RLS_EXCLUSIONS."
+    )

--- a/server/tests/test_rls_coverage.py
+++ b/server/tests/test_rls_coverage.py
@@ -9,8 +9,6 @@ import re
 from pathlib import Path
 from typing import Set
 
-import pytest
-
 _DB_UTILS = Path(__file__).resolve().parent.parent / "utils" / "db" / "db_utils.py"
 
 # Tables with org_id that are intentionally excluded from RLS.

--- a/server/tests/test_rls_kb_integration.py
+++ b/server/tests/test_rls_kb_integration.py
@@ -21,10 +21,7 @@ import pytest
 _ADMIN_PARAMS = {
     "dbname": os.getenv("POSTGRES_DB", "aurora_db"),
     "user": os.getenv("POSTGRES_USER", "aurora"),
-    "password": os.getenv(
-        "POSTGRES_PASSWORD",
-        "07017d104f177cd0b8e093f82d102338f455e70f7f22327d497eb999241e7197",
-    ),
+    "password": os.getenv("POSTGRES_PASSWORD", ""),
     "host": os.getenv("POSTGRES_HOST", "localhost"),
     "port": int(os.getenv("POSTGRES_PORT", "5432")),
 }

--- a/server/tests/test_rls_kb_integration.py
+++ b/server/tests/test_rls_kb_integration.py
@@ -1,0 +1,466 @@
+"""Integration tests for RLS on knowledge_base_documents and knowledge_base_memory.
+
+Requires a running PostgreSQL instance (the aurora-postgres Docker container).
+Creates a non-superuser test role to validate RLS enforcement, inserts test
+data across two orgs, and verifies that:
+1. RLS blocks cross-org reads/writes when org context is set
+2. The SECURITY DEFINER cleanup function works across orgs
+3. Celery-style set_rls_context flows work correctly
+4. Default-deny: no rows visible when session org_id is unset
+
+Run with:
+    cd server && python3 -m pytest tests/test_rls_kb_integration.py -v
+"""
+
+import os
+import uuid
+
+import psycopg2
+import pytest
+
+_ADMIN_PARAMS = {
+    "dbname": os.getenv("POSTGRES_DB", "aurora_db"),
+    "user": os.getenv("POSTGRES_USER", "aurora"),
+    "password": os.getenv(
+        "POSTGRES_PASSWORD",
+        "07017d104f177cd0b8e093f82d102338f455e70f7f22327d497eb999241e7197",
+    ),
+    "host": os.getenv("POSTGRES_HOST", "localhost"),
+    "port": int(os.getenv("POSTGRES_PORT", "5432")),
+}
+
+_TEST_ROLE = "aurora_rls_test"
+_TEST_ROLE_PW = "rls_test_pw_ephemeral"
+
+ORG_A = f"test-org-a-{uuid.uuid4().hex[:8]}"
+ORG_B = f"test-org-b-{uuid.uuid4().hex[:8]}"
+USER_A = f"user-a-{uuid.uuid4().hex[:8]}"
+USER_B = f"user-b-{uuid.uuid4().hex[:8]}"
+
+
+def _admin_connect():
+    return psycopg2.connect(**_ADMIN_PARAMS)
+
+
+def _app_connect():
+    """Connect as the non-superuser test role (RLS is enforced)."""
+    params = {**_ADMIN_PARAMS, "user": _TEST_ROLE, "password": _TEST_ROLE_PW}
+    return psycopg2.connect(**params)
+
+
+def _set_org(cursor, conn, org_id):
+    cursor.execute("SET myapp.current_org_id = %s;", (org_id,))
+    cursor.execute("SET myapp.current_user_id = %s;", ("test",))
+    conn.commit()
+
+
+def _reset_org(cursor, conn):
+    cursor.execute("RESET myapp.current_org_id;")
+    cursor.execute("RESET myapp.current_user_id;")
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def admin_conn():
+    """Superuser connection for setup/teardown."""
+    try:
+        conn = _admin_connect()
+    except psycopg2.OperationalError:
+        pytest.skip("PostgreSQL not reachable — skipping integration tests")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="module")
+def ensure_test_role(admin_conn):
+    """Create a non-superuser role that mirrors the app connection.
+
+    Superusers bypass RLS entirely, so we need a regular role to test policies.
+    """
+    admin_conn.autocommit = True
+    cur = admin_conn.cursor()
+
+    cur.execute(
+        "SELECT 1 FROM pg_roles WHERE rolname = %s", (_TEST_ROLE,)
+    )
+    if not cur.fetchone():
+        cur.execute(
+            f"CREATE ROLE {_TEST_ROLE} LOGIN PASSWORD %s", (_TEST_ROLE_PW,)
+        )
+    else:
+        cur.execute(
+            f"ALTER ROLE {_TEST_ROLE} LOGIN PASSWORD %s", (_TEST_ROLE_PW,)
+        )
+
+    cur.execute(
+        f"GRANT ALL ON ALL TABLES IN SCHEMA public TO {_TEST_ROLE}"
+    )
+    cur.execute(
+        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {_TEST_ROLE}"
+    )
+    cur.execute(
+        f"GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {_TEST_ROLE}"
+    )
+    admin_conn.autocommit = False
+    yield
+
+
+@pytest.fixture(scope="module")
+def ensure_rls(admin_conn, ensure_test_role):
+    """Ensure RLS + policies exist on KB tables (idempotent)."""
+    cur = admin_conn.cursor()
+
+    rls_using = """
+        org_id IS NOT NULL
+        AND COALESCE(current_setting('myapp.current_org_id', true), '') != ''
+        AND org_id = current_setting('myapp.current_org_id', true)::text
+    """
+
+    for table in ("knowledge_base_documents", "knowledge_base_memory"):
+        cur.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;")
+        cur.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY;")
+        for policy, cmd, clause in [
+            ("select_by_org", "SELECT", f"USING ({rls_using})"),
+            ("insert_by_org", "INSERT", f"WITH CHECK ({rls_using})"),
+            ("update_by_org", "UPDATE", f"USING ({rls_using})"),
+            ("delete_by_org", "DELETE", f"USING ({rls_using})"),
+        ]:
+            cur.execute(f"DROP POLICY IF EXISTS {policy} ON {table};")
+            cur.execute(
+                f"CREATE POLICY {policy} ON {table} FOR {cmd} {clause};"
+            )
+
+    cur.execute("""
+        CREATE OR REPLACE FUNCTION cleanup_stale_kb_documents()
+        RETURNS TABLE(doc_id UUID, doc_user_id VARCHAR, doc_filename VARCHAR)
+        LANGUAGE sql
+        SECURITY DEFINER
+        AS $$
+            UPDATE knowledge_base_documents
+            SET status = 'failed',
+                error_message = 'Processing timed out. Please try uploading again.',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE status IN ('processing', 'uploading')
+              AND updated_at < CURRENT_TIMESTAMP - INTERVAL '3 minutes'
+            RETURNING id, user_id, original_filename;
+        $$;
+    """)
+
+    admin_conn.commit()
+
+
+@pytest.fixture(scope="module")
+def app_conn(ensure_rls):
+    """Non-superuser connection where RLS is enforced."""
+    conn = _app_connect()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(autouse=True)
+def seed_and_cleanup(admin_conn, app_conn, ensure_rls):
+    """Insert test rows as superuser, run tests as app role, clean up after."""
+    cur = admin_conn.cursor()
+
+    # Seed as superuser (bypasses RLS)
+    cur.execute(
+        """
+        INSERT INTO knowledge_base_documents
+            (id, user_id, org_id, filename, original_filename, file_type,
+             file_size_bytes, status)
+        VALUES
+            (gen_random_uuid(), %s, %s, 'a.pdf', 'a.pdf', 'pdf', 100, 'ready')
+        """,
+        (USER_A, ORG_A),
+    )
+    cur.execute(
+        """
+        INSERT INTO knowledge_base_documents
+            (id, user_id, org_id, filename, original_filename, file_type,
+             file_size_bytes, status)
+        VALUES
+            (gen_random_uuid(), %s, %s, 'b.pdf', 'b.pdf', 'pdf', 200, 'ready')
+        """,
+        (USER_B, ORG_B),
+    )
+    cur.execute(
+        """
+        INSERT INTO knowledge_base_memory (user_id, org_id, content)
+        VALUES (%s, %s, 'memory for org A')
+        ON CONFLICT (user_id, org_id) DO UPDATE SET content = EXCLUDED.content
+        """,
+        (USER_A, ORG_A),
+    )
+    cur.execute(
+        """
+        INSERT INTO knowledge_base_memory (user_id, org_id, content)
+        VALUES (%s, %s, 'memory for org B')
+        ON CONFLICT (user_id, org_id) DO UPDATE SET content = EXCLUDED.content
+        """,
+        (USER_B, ORG_B),
+    )
+    admin_conn.commit()
+
+    yield
+
+    # Cleanup as superuser
+    cur = admin_conn.cursor()
+    cur.execute(
+        "DELETE FROM knowledge_base_documents WHERE org_id IN (%s, %s)",
+        (ORG_A, ORG_B),
+    )
+    cur.execute(
+        "DELETE FROM knowledge_base_memory WHERE org_id IN (%s, %s)",
+        (ORG_A, ORG_B),
+    )
+    admin_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestRLSIsolation:
+    """Verify org A cannot see org B's data and vice versa."""
+
+    def test_org_a_sees_only_own_documents(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_A)
+        cur.execute("SELECT org_id, original_filename FROM knowledge_base_documents")
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == ORG_A
+        assert rows[0][1] == "a.pdf"
+
+    def test_org_b_sees_only_own_documents(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_B)
+        cur.execute("SELECT org_id, original_filename FROM knowledge_base_documents")
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == ORG_B
+        assert rows[0][1] == "b.pdf"
+
+    def test_org_a_sees_only_own_memory(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_A)
+        cur.execute("SELECT org_id, content FROM knowledge_base_memory")
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == ORG_A
+        assert "org A" in rows[0][1]
+
+    def test_org_b_sees_only_own_memory(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_B)
+        cur.execute("SELECT org_id, content FROM knowledge_base_memory")
+        rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == ORG_B
+        assert "org B" in rows[0][1]
+
+    def test_org_a_cannot_update_org_b_documents(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_A)
+        cur.execute(
+            "UPDATE knowledge_base_documents SET status = 'hacked' WHERE org_id = %s",
+            (ORG_B,),
+        )
+        assert cur.rowcount == 0
+        app_conn.commit()
+
+    def test_org_a_cannot_delete_org_b_documents(self, app_conn):
+        cur = app_conn.cursor()
+        _set_org(cur, app_conn, ORG_A)
+        cur.execute(
+            "DELETE FROM knowledge_base_documents WHERE org_id = %s", (ORG_B,)
+        )
+        assert cur.rowcount == 0
+        app_conn.commit()
+
+
+class TestDefaultDeny:
+    """With no org context set, no rows should be visible (default-deny)."""
+
+    def test_no_context_returns_no_documents(self, app_conn):
+        cur = app_conn.cursor()
+        _reset_org(cur, app_conn)
+        cur.execute("SELECT * FROM knowledge_base_documents")
+        assert cur.fetchall() == []
+
+    def test_no_context_returns_no_memory(self, app_conn):
+        cur = app_conn.cursor()
+        _reset_org(cur, app_conn)
+        cur.execute("SELECT * FROM knowledge_base_memory")
+        assert cur.fetchall() == []
+
+    def test_empty_org_returns_no_documents(self, app_conn):
+        cur = app_conn.cursor()
+        cur.execute("SET myapp.current_org_id = '';")
+        app_conn.commit()
+        cur.execute("SELECT * FROM knowledge_base_documents")
+        assert cur.fetchall() == []
+
+
+class TestSecurityDefinerCleanup:
+    """The SECURITY DEFINER function should bypass RLS for the stale sweep."""
+
+    def test_cleanup_finds_stale_docs_across_orgs(self, admin_conn, app_conn):
+        cur = admin_conn.cursor()
+
+        # Insert stale docs as superuser (bypasses RLS)
+        cur.execute(
+            """
+            INSERT INTO knowledge_base_documents
+                (id, user_id, org_id, filename, original_filename, file_type,
+                 file_size_bytes, status, updated_at)
+            VALUES
+                (gen_random_uuid(), %s, %s, 'stale_a.pdf', 'stale_a.pdf', 'pdf',
+                 50, 'processing', CURRENT_TIMESTAMP - INTERVAL '10 minutes')
+            """,
+            (USER_A, ORG_A),
+        )
+        cur.execute(
+            """
+            INSERT INTO knowledge_base_documents
+                (id, user_id, org_id, filename, original_filename, file_type,
+                 file_size_bytes, status, updated_at)
+            VALUES
+                (gen_random_uuid(), %s, %s, 'stale_b.pdf', 'stale_b.pdf', 'pdf',
+                 50, 'uploading', CURRENT_TIMESTAMP - INTERVAL '10 minutes')
+            """,
+            (USER_B, ORG_B),
+        )
+        admin_conn.commit()
+
+        # Call the SECURITY DEFINER function as non-superuser with NO org context
+        app_cur = app_conn.cursor()
+        _reset_org(app_cur, app_conn)
+        app_cur.execute("SELECT * FROM cleanup_stale_kb_documents()")
+        cleaned = app_cur.fetchall()
+        app_conn.commit()
+
+        cleaned_filenames = {row[2] for row in cleaned}
+        assert "stale_a.pdf" in cleaned_filenames, "Cleanup missed stale doc from org A"
+        assert "stale_b.pdf" in cleaned_filenames, "Cleanup missed stale doc from org B"
+
+    def test_cleanup_does_not_touch_recent_processing_docs(self, admin_conn, app_conn):
+        cur = admin_conn.cursor()
+
+        cur.execute(
+            """
+            INSERT INTO knowledge_base_documents
+                (id, user_id, org_id, filename, original_filename, file_type,
+                 file_size_bytes, status, updated_at)
+            VALUES
+                (gen_random_uuid(), %s, %s, 'fresh.pdf', 'fresh.pdf', 'pdf',
+                 50, 'processing', CURRENT_TIMESTAMP)
+            """,
+            (USER_A, ORG_A),
+        )
+        admin_conn.commit()
+
+        app_cur = app_conn.cursor()
+        _reset_org(app_cur, app_conn)
+        app_cur.execute("SELECT * FROM cleanup_stale_kb_documents()")
+        cleaned = app_cur.fetchall()
+        app_conn.commit()
+
+        cleaned_filenames = {row[2] for row in cleaned}
+        assert "fresh.pdf" not in cleaned_filenames
+
+    def test_cleanup_does_not_expose_data_via_return(self, admin_conn, app_conn):
+        """The function only returns id, user_id, filename — no document content."""
+        cur = admin_conn.cursor()
+
+        cur.execute(
+            """
+            INSERT INTO knowledge_base_documents
+                (id, user_id, org_id, filename, original_filename, file_type,
+                 file_size_bytes, status, updated_at)
+            VALUES
+                (gen_random_uuid(), %s, %s, 'leak_test.pdf', 'leak_test.pdf', 'pdf',
+                 50, 'processing', CURRENT_TIMESTAMP - INTERVAL '10 minutes')
+            """,
+            (USER_A, ORG_A),
+        )
+        admin_conn.commit()
+
+        app_cur = app_conn.cursor()
+        _reset_org(app_cur, app_conn)
+        app_cur.execute("SELECT * FROM cleanup_stale_kb_documents()")
+        cleaned = app_cur.fetchall()
+        app_conn.commit()
+
+        for row in cleaned:
+            if row[2] == "leak_test.pdf":
+                assert len(row) == 3
+
+
+class TestCeleryStyleAccess:
+    """Simulate Celery task access patterns with explicit set_rls_context."""
+
+    def test_set_rls_context_allows_own_org_access(self, app_conn):
+        cur = app_conn.cursor()
+        cur.execute("SET myapp.current_user_id = %s;", (USER_A,))
+        cur.execute("SET myapp.current_org_id = %s;", (ORG_A,))
+        app_conn.commit()
+
+        cur.execute(
+            "SELECT original_filename FROM knowledge_base_documents WHERE user_id = %s",
+            (USER_A,),
+        )
+        rows = cur.fetchall()
+        assert len(rows) >= 1
+        filenames = {r[0] for r in rows}
+        assert "a.pdf" in filenames
+
+    def test_set_rls_context_blocks_cross_org(self, app_conn):
+        cur = app_conn.cursor()
+        cur.execute("SET myapp.current_user_id = %s;", (USER_A,))
+        cur.execute("SET myapp.current_org_id = %s;", (ORG_A,))
+        app_conn.commit()
+
+        cur.execute(
+            "SELECT original_filename FROM knowledge_base_documents WHERE user_id = %s",
+            (USER_B,),
+        )
+        assert cur.fetchall() == []
+
+    def test_update_with_rls_context_works(self, app_conn):
+        cur = app_conn.cursor()
+        cur.execute("SET myapp.current_user_id = %s;", (USER_A,))
+        cur.execute("SET myapp.current_org_id = %s;", (ORG_A,))
+        app_conn.commit()
+
+        cur.execute(
+            """
+            UPDATE knowledge_base_documents
+            SET status = 'processing'
+            WHERE user_id = %s AND original_filename = 'a.pdf'
+            """,
+            (USER_A,),
+        )
+        assert cur.rowcount == 1
+        app_conn.rollback()
+
+    def test_update_cross_org_blocked(self, app_conn):
+        cur = app_conn.cursor()
+        cur.execute("SET myapp.current_user_id = %s;", (USER_A,))
+        cur.execute("SET myapp.current_org_id = %s;", (ORG_A,))
+        app_conn.commit()
+
+        cur.execute(
+            """
+            UPDATE knowledge_base_documents
+            SET status = 'hacked'
+            WHERE user_id = %s AND original_filename = 'b.pdf'
+            """,
+            (USER_B,),
+        )
+        assert cur.rowcount == 0
+        app_conn.rollback()

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1201,14 +1201,15 @@ def initialize_tables():
             # - users: queried during login before org context is set; RLS would break auth
             # - audit_log: written via record_audit_event() which passes org_id explicitly;
             #   RLS would silently drop inserts when session org_id doesn't match or isn't set
+            # - org_invitations: queried during invite/join flows before org context is set
+            # - knowledge_base_documents, knowledge_base_memory: written by Celery tasks
+            #   (process_document) that don't call set_rls_context; needs task fix first
             rls_tables.append("workspaces")
             rls_tables.append("aurora_deployments")
             rls_tables.append("cloud_feed_metadata")
             rls_tables.append("cloud_ingestion_state")
             rls_tables.append("newrelic_events")
             rls_tables.append("pagerduty_events")
-            rls_tables.append("knowledge_base_documents")
-            rls_tables.append("knowledge_base_memory")
 
             # Add monitoring tables
             rls_tables.append("grafana_alerts")

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1202,9 +1202,8 @@ def initialize_tables():
             # - audit_log: written via record_audit_event() which passes org_id explicitly;
             #   RLS would silently drop inserts when session org_id doesn't match or isn't set
             # - org_invitations: queried during invite/join flows before org context is set
-            # - knowledge_base_documents, knowledge_base_memory: cleanup_stale_documents
-            #   Celery task runs cross-org sweeps with no user context; needs SECURITY
-            #   DEFINER function or BYPASSRLS role before RLS can be added
+            rls_tables.append("knowledge_base_documents")
+            rls_tables.append("knowledge_base_memory")
             rls_tables.append("workspaces")
             rls_tables.append("aurora_deployments")
             rls_tables.append("cloud_feed_metadata")
@@ -2105,6 +2104,28 @@ def initialize_tables():
             """)
             logging.info("Added MCP token resolve RLS policies on mcp_tokens.")
 
+            conn.commit()
+
+            # SECURITY DEFINER function: allows the Celery cleanup task to
+            # update stale KB documents across all orgs without needing a
+            # BYPASSRLS role.  The function body is a fixed UPDATE — callers
+            # cannot inject arbitrary queries.
+            cursor.execute("""
+                CREATE OR REPLACE FUNCTION cleanup_stale_kb_documents()
+                RETURNS TABLE(doc_id UUID, doc_user_id VARCHAR, doc_filename VARCHAR)
+                LANGUAGE sql
+                SECURITY DEFINER
+                AS $$
+                    UPDATE knowledge_base_documents
+                    SET status = 'failed',
+                        error_message = 'Processing timed out. Please try uploading again.',
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE status IN ('processing', 'uploading')
+                      AND updated_at < CURRENT_TIMESTAMP - INTERVAL '3 minutes'
+                    RETURNING id, user_id, original_filename;
+                $$;
+            """)
+            logging.info("Created SECURITY DEFINER function cleanup_stale_kb_documents().")
             conn.commit()
 
             # Migration: Add role column to users table for RBAC

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1197,6 +1197,19 @@ def initialize_tables():
                 "user_manual_vms",
             ]
 
+            # Tables with org_id NOT in this list (intentional):
+            # - users: queried during login before org context is set; RLS would break auth
+            # - audit_log: written via record_audit_event() which passes org_id explicitly;
+            #   RLS would silently drop inserts when session org_id doesn't match or isn't set
+            rls_tables.append("workspaces")
+            rls_tables.append("aurora_deployments")
+            rls_tables.append("cloud_feed_metadata")
+            rls_tables.append("cloud_ingestion_state")
+            rls_tables.append("newrelic_events")
+            rls_tables.append("pagerduty_events")
+            rls_tables.append("knowledge_base_documents")
+            rls_tables.append("knowledge_base_memory")
+
             # Add monitoring tables
             rls_tables.append("grafana_alerts")
             rls_tables.append("datadog_events")

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1202,8 +1202,9 @@ def initialize_tables():
             # - audit_log: written via record_audit_event() which passes org_id explicitly;
             #   RLS would silently drop inserts when session org_id doesn't match or isn't set
             # - org_invitations: queried during invite/join flows before org context is set
-            # - knowledge_base_documents, knowledge_base_memory: written by Celery tasks
-            #   (process_document) that don't call set_rls_context; needs task fix first
+            # - knowledge_base_documents, knowledge_base_memory: cleanup_stale_documents
+            #   Celery task runs cross-org sweeps with no user context; needs SECURITY
+            #   DEFINER function or BYPASSRLS role before RLS can be added
             rls_tables.append("workspaces")
             rls_tables.append("aurora_deployments")
             rls_tables.append("cloud_feed_metadata")
@@ -1215,7 +1216,6 @@ def initialize_tables():
             rls_tables.append("grafana_alerts")
             rls_tables.append("datadog_events")
             rls_tables.append("netdata_alerts")
-            rls_tables.append("netdata_verification_tokens")
             rls_tables.append("splunk_alerts")
             rls_tables.append("incidentio_alerts")
             rls_tables.append("bigpanda_events")

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -33,7 +33,6 @@ def get_or_create_workspace(user_id: str, workspace_name: str = "default") -> Di
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
             
-            # No RLS needed — workspaces not RLS-protected
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "
                 "aws_discovery_artifact_key, aws_discovery_summary, created_at, updated_at "
@@ -173,7 +172,6 @@ def get_workspace_by_id(workspace_id: str) -> Optional[Dict[str, Any]]:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
             
-            # No RLS needed — workspaces not RLS-protected
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "
                 "aws_discovery_artifact_key, aws_discovery_summary, created_at, updated_at "
@@ -227,7 +225,6 @@ def get_user_workspaces(user_id: str) -> list:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
             
-            # No RLS needed — workspaces not RLS-protected
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "
                 "aws_discovery_artifact_key, aws_discovery_summary, created_at, updated_at "


### PR DESCRIPTION
## Summary

Enables RLS on `knowledge_base_documents` and `knowledge_base_memory` with a SECURITY DEFINER function for the cross-org cleanup task.

**Depends on:** PR #314 (RLS gap fixes) must merge first.

**Blocked on:** non-superuser DB role for the app connection (currently `aurora` is a superuser, which bypasses all RLS). Merging this without that change is safe (policies exist but are inert) but pointless.

### Changes
- Adds KB tables to `rls_tables` in `db_utils.py`
- Creates `cleanup_stale_kb_documents()` SECURITY DEFINER function (fixed UPDATE body, no data exfiltration possible)
- Updates Celery task helpers to call `set_rls_context()` before querying
- Updates `context_fetchers.py` to use `set_rls_context()`
- 16 integration tests against real Postgres (non-superuser role)

### Prerequisites before merging
- [ ] PR #314 merged
- [ ] Create non-superuser DB role for the app connection
- [ ] Verify production DB role is not a superuser
- [ ] Test full KB upload + document processing flow end-to-end
- [ ] Test cleanup_stale_documents Celery beat task

🤖 Generated with [Claude Code](https://claude.com/claude-code)