### PR TITLE
test: add unit tests for log_sanitizer and payload_timestamp utils

### DIFF
--- a/server/tests/test_log_sanitizer.py
+++ b/server/tests/test_log_sanitizer.py
@@ -1,0 +1,244 @@
+"""Tests for utils.log_sanitizer -- log injection prevention utilities."""
+
+import os
+import sys
+
+import pytest
+
+# Ensure server/ is on sys.path
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+from utils.log_sanitizer import sanitize, safe_provider, hash_for_log
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def secret_key(monkeypatch):
+    """Set FLASK_SECRET_KEY and reset the lru_cache around each test."""
+    from utils.log_sanitizer import _get_log_hash_salt
+
+    def _set(value="test-key"):  # noqa: S107
+        _get_log_hash_salt.cache_clear()
+        monkeypatch.setenv("FLASK_SECRET_KEY", value)
+        return value
+
+    yield _set
+    _get_log_hash_salt.cache_clear()
+
+
+@pytest.fixture()
+def no_secret_key(monkeypatch):
+    """Remove FLASK_SECRET_KEY and reset the lru_cache around each test."""
+    from utils.log_sanitizer import _get_log_hash_salt
+
+    _get_log_hash_salt.cache_clear()
+    monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+    yield
+    _get_log_hash_salt.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# sanitize()
+# ---------------------------------------------------------------------------
+
+
+class TestSanitize:
+    """Tests for the sanitize() function that strips control characters."""
+
+    def test_normal_string_unchanged(self):
+        """Ordinary ASCII text must pass through unmodified."""
+        assert sanitize("hello world") == "hello world"
+
+    def test_empty_string(self):
+        """Empty input must return an empty string."""
+        assert sanitize("") == ""
+
+    def test_strips_newline(self):
+        """Newlines can be used for log injection -- must be stripped."""
+        assert sanitize("line1\nline2") == "line1line2"
+
+    def test_strips_carriage_return(self):
+        """Carriage returns must be removed to prevent log line forgery."""
+        assert sanitize("line1\rline2") == "line1line2"
+
+    def test_strips_tab(self):
+        """Tab characters must be stripped from output."""
+        assert sanitize("col1\tcol2") == "col1col2"
+
+    def test_strips_null_byte(self):
+        """Null bytes must be removed to prevent truncation attacks."""
+        assert sanitize("before\x00after") == "beforeafter"
+
+    def test_strips_unicode_line_separator(self):
+        """U+2028 LINE SEPARATOR can forge new log lines in Unicode parsers."""
+        assert sanitize("before\u2028after") == "beforeafter"
+
+    def test_strips_unicode_paragraph_separator(self):
+        """U+2029 PARAGRAPH SEPARATOR -- same risk as line separator."""
+        assert sanitize("before\u2029after") == "beforeafter"
+
+    def test_strips_zero_width_space(self):
+        """U+200B ZERO WIDTH SPACE can hide content in logs."""
+        assert sanitize("be\u200bfore") == "before"
+
+    def test_strips_zero_width_no_break_space(self):
+        """U+FEFF BOM / ZERO WIDTH NO-BREAK SPACE must be removed."""
+        assert sanitize("\ufeffhello") == "hello"
+
+    def test_strips_zero_width_non_joiner(self):
+        """U+200C ZERO WIDTH NON-JOINER must be stripped."""
+        assert sanitize("be\u200cfore") == "before"
+
+    def test_strips_zero_width_joiner(self):
+        """U+200D ZERO WIDTH JOINER must be stripped."""
+        assert sanitize("be\u200dfore") == "before"
+
+    def test_strips_left_to_right_mark(self):
+        """U+200E LEFT-TO-RIGHT MARK must be stripped."""
+        assert sanitize("hello\u200eworld") == "helloworld"
+
+    def test_strips_right_to_left_mark(self):
+        """U+200F RIGHT-TO-LEFT MARK must be stripped."""
+        assert sanitize("hello\u200fworld") == "helloworld"
+
+    def test_strips_word_joiner(self):
+        """U+2060 WORD JOINER must be stripped."""
+        assert sanitize("be\u2060fore") == "before"
+
+    def test_strips_multiple_control_chars(self):
+        """Multiple different control characters in one string are all removed."""
+        malicious = "admin\n[INFO] Access granted\r\n"
+        result = sanitize(malicious)
+        assert "\n" not in result
+        assert "\r" not in result
+
+    def test_preserves_unicode_letters(self):
+        """Normal Unicode letters (accents, etc.) must pass through."""
+        assert sanitize("cafe resume") == "cafe resume"
+
+    def test_non_string_input_converted(self):
+        """Non-string values are converted via str() before sanitization."""
+        assert sanitize(42) == "42"
+        assert sanitize(None) == "None"
+
+    def test_log_injection_attack(self):
+        """Simulates a classic log injection attack via user_id field."""
+        attack = "user123\n[ADMIN] Token revoked for all users"
+        result = sanitize(attack)
+        assert "[ADMIN]" in result
+        assert "\n" not in result
+
+
+# ---------------------------------------------------------------------------
+# safe_provider()
+# ---------------------------------------------------------------------------
+
+
+class TestSafeProvider:
+    """Tests for the safe_provider() allowlist function."""
+
+    def test_known_provider_returned(self):
+        """Known provider names must be returned as-is."""
+        assert safe_provider("aws") == "aws"
+        assert safe_provider("gcp") == "gcp"
+        assert safe_provider("datadog") == "datadog"
+
+    def test_case_insensitive(self):
+        """Provider lookup must be case-insensitive."""
+        assert safe_provider("AWS") == "aws"
+        assert safe_provider("Datadog") == "datadog"
+
+    def test_unknown_provider_returns_sentinel(self):
+        """Unrecognized provider names must return the unknown sentinel."""
+        assert safe_provider("evil_provider") == "unknown"
+        assert safe_provider("anything_else") == "unknown"
+
+    def test_empty_string(self):
+        """Empty string input must return the unknown sentinel."""
+        assert safe_provider("") == "unknown"
+
+    def test_none_value(self):
+        """None input must return the unknown sentinel."""
+        assert safe_provider(None) == "unknown"
+
+    def test_strips_control_chars_before_lookup(self):
+        """Provider name with injected control chars should still match."""
+        assert safe_provider("aws\n") == "aws"
+        assert safe_provider("\tgcp") == "gcp"
+
+    def test_strips_whitespace(self):
+        """Leading and trailing whitespace must be stripped before lookup."""
+        assert safe_provider("  aws  ") == "aws"
+
+    def test_injection_in_provider_name(self):
+        """Attacker tries to inject via provider field -- always gets unknown."""
+        assert safe_provider("aws\n[CRITICAL] System compromised") == "unknown"
+
+    def test_coroot_provider(self):
+        """Coroot is a known connector directory in Aurora."""
+        assert safe_provider("coroot") == "coroot"
+
+    def test_kubernetes_auxiliary_provider(self):
+        """kubectl is an auxiliary provider in KNOWN_PROVIDERS."""
+        assert safe_provider("kubectl") == "kubectl"
+
+
+# ---------------------------------------------------------------------------
+# hash_for_log()
+# ---------------------------------------------------------------------------
+
+
+class TestHashForLog:
+    """Tests for the HMAC-based log fingerprinting function."""
+
+    def test_none_returns_dash(self):
+        """None input must return the dash sentinel."""
+        assert hash_for_log(None) == "-"
+
+    def test_empty_string_returns_dash(self):
+        """Empty string input must return the dash sentinel."""
+        assert hash_for_log("") == "-"
+
+    def test_without_secret_key_returns_sentinel(self, no_secret_key):
+        """Without FLASK_SECRET_KEY, must degrade to '?' -- never crash."""
+        assert hash_for_log("user123") == "?"
+
+    def test_with_secret_key_returns_hex(self, secret_key):
+        """With FLASK_SECRET_KEY set, returns a 12-char hex fingerprint."""
+        secret_key("test-secret-key")
+        result = hash_for_log("user123")
+        assert result not in {"?", "-"}
+        assert len(result) == 12
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_same_input_same_hash(self, secret_key):
+        """Deterministic: same input always produces the same hash."""
+        secret_key()
+        h1 = hash_for_log("user-abc")
+        h2 = hash_for_log("user-abc")
+        assert h1 == h2
+
+    def test_different_inputs_different_hashes(self, secret_key):
+        """Different inputs must produce different fingerprints."""
+        secret_key()
+        h1 = hash_for_log("user-A")
+        h2 = hash_for_log("user-B")
+        assert h1 != h2
+
+    def test_custom_length(self, secret_key):
+        """Custom length parameter must control output hex string length."""
+        secret_key()
+        result = hash_for_log("user123", length=8)
+        assert len(result) == 8
+
+    def test_non_string_input(self, secret_key):
+        """Numeric user IDs should be handled without error."""
+        secret_key()
+        result = hash_for_log(12345)
+        assert result not in {"?", "-"}

--- a/server/tests/test_payload_timestamp.py
+++ b/server/tests/test_payload_timestamp.py
@@ -1,0 +1,246 @@
+"""Tests for utils.payload_timestamp -- alert timestamp extraction utilities."""
+
+import os
+import sys
+import pytest
+from datetime import datetime, timezone
+
+# Ensure server/ is on sys.path
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+from utils.payload_timestamp import parse_timestamp, extract_alert_fired_at, _walk
+
+
+class TestParseTimestamp:
+    """Tests for coercing various formats into UTC datetime."""
+
+    def test_none_returns_none(self):
+        """None input must return None."""
+        assert parse_timestamp(None) is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string input must return None."""
+        assert parse_timestamp("") is None
+
+    def test_bool_returns_none(self):
+        """bool is a subclass of int -- must not be treated as a timestamp."""
+        assert parse_timestamp(True) is None
+        assert parse_timestamp(False) is None
+
+    def test_random_string_returns_none(self):
+        """Unparseable string must return None."""
+        assert parse_timestamp("not-a-date") is None
+
+    def test_list_returns_none(self):
+        """Non-scalar types like list must return None."""
+        assert parse_timestamp([1, 2, 3]) is None
+
+    def test_iso_with_z_suffix(self):
+        """ISO 8601 string with Z suffix must parse correctly."""
+        result = parse_timestamp("2024-06-15T10:30:00Z")
+        assert result == datetime(2024, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_iso_with_offset(self):
+        """ISO 8601 string with explicit UTC offset must parse correctly."""
+        result = parse_timestamp("2024-06-15T10:30:00+00:00")
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_iso_without_timezone(self):
+        """ISO string without tz info returns a naive datetime (no UTC tag)."""
+        result = parse_timestamp("2024-06-15T10:30:00")
+        assert result is not None
+        assert result.tzinfo is None
+
+    def test_iso_with_microseconds(self):
+        """ISO 8601 string with microseconds must preserve them."""
+        result = parse_timestamp("2024-06-15T10:30:00.123456Z")
+        assert result is not None
+        assert result.microsecond == 123456
+
+    def test_unix_seconds(self):
+        """Standard Unix timestamp in seconds must parse correctly."""
+        result = parse_timestamp(1718451000)
+        assert result is not None
+        assert result.year == 2024
+
+    def test_unix_milliseconds(self):
+        """Timestamps > 1e12 are treated as milliseconds."""
+        result = parse_timestamp(1718451000000)
+        assert result is not None
+        assert result.year == 2024
+
+    def test_unix_float(self):
+        """Floating-point Unix timestamps must be accepted."""
+        result = parse_timestamp(1718451000.5)
+        assert result is not None
+
+    def test_unix_zero(self):
+        """Epoch 0 is a valid Unix timestamp."""
+        result = parse_timestamp(0)
+        assert result is not None
+        assert result == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    def test_overflow_returns_none(self):
+        """Extremely large values must not crash -- return None instead."""
+        assert parse_timestamp(99999999999999999) is None
+
+    def test_aware_datetime_passthrough(self):
+        """Already timezone-aware datetime must be returned as-is."""
+        dt = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        assert parse_timestamp(dt) is dt
+
+    def test_naive_datetime_tagged_utc(self):
+        """Naive datetime objects must be tagged with UTC."""
+        dt = datetime(2024, 1, 1)
+        result = parse_timestamp(dt)
+        assert result.tzinfo == timezone.utc
+
+    def test_tz_aware_inputs_return_aware_datetime(self):
+        """Inputs that carry tz info must return timezone-aware datetimes."""
+        test_values = [
+            "2024-06-15T10:30:00Z",
+            "2024-06-15T10:30:00+00:00",
+            1718451000,
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ]
+        for val in test_values:
+            result = parse_timestamp(val)
+            assert result is not None, f"Failed for {val}"
+            assert result.tzinfo is not None, f"Missing tzinfo for {val}"
+
+
+class TestWalk:
+    """Tests for the dot-separated path walker."""
+
+    def test_simple_key(self):
+        """Single-level dict key lookup must work."""
+        assert _walk({"name": "Aurora"}, "name") == "Aurora"
+
+    def test_nested_key(self):
+        """Two-level nested dict lookup must work."""
+        data = {"alert": {"status": "firing"}}
+        assert _walk(data, "alert.status") == "firing"
+
+    def test_deeply_nested(self):
+        """Four-level nested dict lookup must work."""
+        data = {"a": {"b": {"c": {"d": "deep"}}}}
+        assert _walk(data, "a.b.c.d") == "deep"
+
+    def test_list_index(self):
+        """Numeric path components must index into lists."""
+        data = {"alerts": [{"name": "first"}, {"name": "second"}]}
+        assert _walk(data, "alerts.0.name") == "first"
+        assert _walk(data, "alerts.1.name") == "second"
+
+    def test_missing_key_returns_none(self):
+        """Missing top-level key must return None."""
+        assert _walk({"a": 1}, "b") is None
+
+    def test_missing_nested_key_returns_none(self):
+        """Missing nested key must return None."""
+        assert _walk({"a": {"b": 1}}, "a.c") is None
+
+    def test_list_index_out_of_range(self):
+        """Out-of-range list index must return None."""
+        assert _walk({"items": [1, 2]}, "items.5") is None
+
+    def test_none_input(self):
+        """None as root object must return None."""
+        assert _walk(None, "any.path") is None
+
+    def test_non_dict_input(self):
+        """Non-dict root object must return None."""
+        assert _walk("string", "key") is None
+
+    def test_empty_dict(self):
+        """Empty dict must return None for any key."""
+        assert _walk({}, "key") is None
+
+    def test_walk_through_mixed_types(self):
+        """Dict containing list containing dict must be navigable."""
+        data = {
+            "incidents": [
+                {"alerts": [{"startsAt": "2024-01-01T00:00:00Z"}]}
+            ]
+        }
+        assert _walk(data, "incidents.0.alerts.0.startsAt") == "2024-01-01T00:00:00Z"
+
+
+class TestExtractAlertFiredAt:
+    """Tests for the multi-path timestamp extraction."""
+
+    def test_first_valid_path_wins(self):
+        """When multiple paths match, the first one must be returned."""
+        payload = {
+            "startsAt": "2024-06-15T10:30:00Z",
+            "created_at": "2024-06-15T09:00:00Z",
+        }
+        result = extract_alert_fired_at(payload, ["startsAt", "created_at"])
+        assert result == datetime(2024, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_skips_invalid_paths(self):
+        """Invalid paths must be skipped until a valid one is found."""
+        payload = {"created_at": "2024-06-15T10:30:00Z"}
+        result = extract_alert_fired_at(payload, [
+            "nonexistent",
+            "also.missing",
+            "created_at",
+        ])
+        assert result is not None
+        assert result.year == 2024
+
+    def test_nested_path(self):
+        """Dot-separated nested paths must be resolved correctly."""
+        payload = {
+            "incident": {
+                "created_at": "2024-06-15T10:30:00Z"
+            }
+        }
+        result = extract_alert_fired_at(payload, ["incident.created_at"])
+        assert result is not None
+
+    def test_no_valid_paths_returns_none(self):
+        """When no paths match, must return None."""
+        payload = {"unrelated": "data"}
+        result = extract_alert_fired_at(payload, ["startsAt", "created_at"])
+        assert result is None
+
+    def test_empty_paths_returns_none(self):
+        """Empty paths iterable must return None."""
+        payload = {"startsAt": "2024-06-15T10:30:00Z"}
+        result = extract_alert_fired_at(payload, [])
+        assert result is None
+
+    def test_pagerduty_style_payload(self):
+        """Simulates a PagerDuty webhook payload structure."""
+        payload = {
+            "event": {
+                "occurred_at": "2024-06-15T10:30:00Z",
+                "data": {"id": "P123"}
+            }
+        }
+        result = extract_alert_fired_at(payload, ["event.occurred_at"])
+        assert result is not None
+
+    def test_datadog_style_payload(self):
+        """Simulates a Datadog webhook with Unix millisecond timestamp."""
+        payload = {
+            "last_updated": 1718451000000,
+            "title": "CPU High",
+        }
+        result = extract_alert_fired_at(payload, ["last_updated"])
+        assert result is not None
+        assert result.year == 2024
+
+    def test_grafana_style_payload(self):
+        """Simulates a Grafana alert with nested alerts array."""
+        payload = {
+            "alerts": [
+                {"startsAt": "2024-06-15T10:30:00Z", "status": "firing"}
+            ]
+        }
+        result = extract_alert_fired_at(payload, ["alerts.0.startsAt"])
+        assert result is not None


### PR DESCRIPTION
Adds 68 unit tests for two previously untested utility modules:
utils/log_sanitizer.py (32 tests), covers sanitize(), safe_provider(), and hash_for_log() including log injection prevention, allowlist validation, HMAC fingerprinting, and graceful degradation when FLASK_SECRET_KEY is unset.
utils/payload_timestamp.py (36 tests), covers parse_timestamp(), _walk(), and extract_alert_fired_at() including ISO 8601 parsing, Unix timestamp handling (seconds and milliseconds), dot-path walking through nested dicts/lists, and simulated webhook payloads from PagerDuty, Datadog, and Grafana.
All tests run with pytest and require no external dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for log sanitization and provider name handling, including control-character removal, safe provider lookups, and deterministic log hashing behavior.
  * Added a dedicated test suite for timestamp parsing and payload timestamp extraction, covering ISO/unix formats, timezone handling, large inputs, and traversal of nested payload structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->