### PR TITLE
fix(command-policies): persist allowlist/denylist toggle

### DIFF
--- a/server/routes/command_policies.py
+++ b/server/routes/command_policies.py
@@ -4,7 +4,6 @@ Blueprint: command_policies_bp
 Prefix: /api/org
 """
 
-import json
 import logging
 from datetime import datetime, timezone
 
@@ -13,9 +12,9 @@ from flask import Blueprint, jsonify, request
 from utils.auth.rbac_decorators import require_permission, require_auth_only
 from utils.auth.stateless_auth import (
     get_org_id_from_request,
-    get_user_preference,
-    store_user_preference,
+    get_org_preference,
     set_rls_context,
+    store_org_preference,
 )
 from utils.auth.command_policy import (
     evaluate_compound_command,
@@ -32,10 +31,9 @@ command_policies_bp = Blueprint("command_policies", __name__, url_prefix="/api/o
 
 def _list_states(org_id: str) -> dict:
     """Read allowlist/denylist toggle states from user_preferences."""
-    org_key = f"__org__{org_id}"
-    al = get_user_preference(org_key, "command_policy_allowlist") or "off"
-    dl = get_user_preference(org_key, "command_policy_denylist") or "off"
-    at = get_user_preference(org_key, "command_policy_active_template")
+    al = get_org_preference(org_id, "command_policy_allowlist") or "off"
+    dl = get_org_preference(org_id, "command_policy_denylist") or "off"
+    at = get_org_preference(org_id, "command_policy_active_template")
     return {
         "allowlist_enabled": str(al).lower() == "on",
         "denylist_enabled": str(dl).lower() == "on",
@@ -175,10 +173,10 @@ def update_policy(user_id, rule_id):
             )
             if cur.rowcount == 0:
                 return jsonify({"error": "Rule not found"}), 404
+            store_org_preference(org_id, "command_policy_active_template", None, cursor=cur)
         conn.commit()
 
     invalidate_cache(org_id)
-    store_user_preference(f"__org__{org_id}", "command_policy_active_template", None)
     return jsonify({"status": "updated"})
 
 
@@ -199,10 +197,10 @@ def delete_policy(user_id, rule_id):
             )
             if cur.rowcount == 0:
                 return jsonify({"error": "Rule not found"}), 404
+            store_org_preference(org_id, "command_policy_active_template", None, cursor=cur)
         conn.commit()
 
     invalidate_cache(org_id)
-    store_user_preference(f"__org__{org_id}", "command_policy_active_template", None)
     return jsonify({"status": "deleted"})
 
 
@@ -243,16 +241,15 @@ def toggle_list(user_id):
         return jsonify({"error": "enabled must be a boolean"}), 400
 
     pref_key = f"command_policy_{list_name}"
-    org_key = f"__org__{org_id}"
-    store_user_preference(org_key, pref_key, "on" if enabled else "off")
+    from utils.db.connection_pool import db_pool
+    with db_pool.get_admin_connection() as conn:
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CommandPolicies:toggle]")
+            store_org_preference(org_id, pref_key, "on" if enabled else "off", cursor=cur)
 
-    # Auto-seed rules on first enable if list is empty
-    if enabled:
-        mode = "allow" if list_name == "allowlist" else "deny"
-        from utils.db.connection_pool import db_pool
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cur:
-                set_rls_context(cur, conn, user_id, log_prefix="[CommandPolicies:toggle]")
+            # Auto-seed rules on first enable if list is empty
+            if enabled:
+                mode = "allow" if list_name == "allowlist" else "deny"
                 cur.execute(
                     "SELECT COUNT(*) FROM org_command_policies "
                     "WHERE org_id = %s AND mode = %s",
@@ -270,7 +267,7 @@ def toggle_list(user_id):
                             (org_id, mode, seed["pattern"],
                              seed["description"], seed["priority"], user_id),
                         )
-            conn.commit()
+        conn.commit()
 
     invalidate_cache(org_id)
     return jsonify({"status": "updated", **_list_states(org_id)})
@@ -315,13 +312,6 @@ def apply_template(user_id):
     if not tpl:
         return jsonify({"error": f"Unknown template: {template_id}"}), 400
 
-    org_key = f"__org__{org_id}"
-    pref_upsert = (
-        "INSERT INTO user_preferences (user_id, org_id, preference_key, preference_value) "
-        "VALUES (%s, %s, %s, %s) "
-        "ON CONFLICT (user_id, org_id, preference_key) WHERE org_id IS NOT NULL DO UPDATE "
-        "SET preference_value = EXCLUDED.preference_value, updated_at = CURRENT_TIMESTAMP"
-    )
     from utils.db.connection_pool import db_pool
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
@@ -339,9 +329,9 @@ def apply_template(user_id):
                         (org_id, mode_key, rule["pattern"],
                          rule["description"], rule["priority"], user_id),
                     )
-            cur.execute(pref_upsert, (org_key, org_id, "command_policy_allowlist", json.dumps("on")))
-            cur.execute(pref_upsert, (org_key, org_id, "command_policy_denylist", json.dumps("on")))
-            cur.execute(pref_upsert, (org_key, org_id, "command_policy_active_template", json.dumps(template_id)))
+            store_org_preference(org_id, "command_policy_allowlist", "on", cursor=cur)
+            store_org_preference(org_id, "command_policy_denylist", "on", cursor=cur)
+            store_org_preference(org_id, "command_policy_active_template", template_id, cursor=cur)
         conn.commit()
 
     invalidate_cache(org_id)
@@ -355,19 +345,12 @@ def clear_active_template(user_id):
     if not org_id:
         return jsonify({"error": "No organization context"}), 403
 
-    org_key = f"__org__{org_id}"
-    pref_upsert = (
-        "INSERT INTO user_preferences (user_id, org_id, preference_key, preference_value) "
-        "VALUES (%s, %s, %s, %s) "
-        "ON CONFLICT (user_id, org_id, preference_key) WHERE org_id IS NOT NULL DO UPDATE "
-        "SET preference_value = EXCLUDED.preference_value, updated_at = CURRENT_TIMESTAMP"
-    )
     from utils.db.connection_pool import db_pool
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[CommandPolicies:clear_template]")
             cur.execute("DELETE FROM org_command_policies WHERE org_id = %s AND source = 'template'", (org_id,))
-            cur.execute(pref_upsert, (org_key, org_id, "command_policy_active_template", json.dumps(None)))
+            store_org_preference(org_id, "command_policy_active_template", None, cursor=cur)
         conn.commit()
 
     invalidate_cache(org_id)

--- a/server/utils/auth/stateless_auth.py
+++ b/server/utils/auth/stateless_auth.py
@@ -408,6 +408,9 @@ def store_org_preference(org_id: str, key: str, value: Any, *, cursor=None) -> N
     caller is responsible for RLS context and commit; otherwise an admin
     connection is opened here and RLS is configured from org_id directly.
     """
+    if not org_id:
+        raise ValueError("store_org_preference requires a non-empty org_id")
+
     params = (_org_pseudo_user_id(org_id), org_id, key, json.dumps(value))
 
     if cursor is not None:
@@ -432,6 +435,9 @@ def get_org_preference(org_id: str, key: str, default=None):
     works outside Flask request context (e.g. Celery) where connection-pool
     RLS vars aren't auto-populated.
     """
+    if not org_id:
+        raise ValueError("get_org_preference requires a non-empty org_id")
+
     from utils.db.connection_pool import db_pool
     try:
         with db_pool.get_admin_connection() as conn:

--- a/server/utils/auth/stateless_auth.py
+++ b/server/utils/auth/stateless_auth.py
@@ -340,12 +340,22 @@ def get_deployment_task(user_id: str, task_id: str = None) -> Optional[Dict]:
             conn.close()
 
 def store_user_preference(user_id: str, key: str, value: Any):
-    """Store user preference in database."""
+    """Store a user-scoped preference.
+
+    For org-scoped preferences (shared across an organization), use
+    store_org_preference() instead — passing an "__org__<uuid>" pseudo-user id
+    here will fail because that id does not exist in the users table.
+    """
     try:
         conn = connect_to_db_as_user()
         cursor = conn.cursor()
         org_id = set_rls_context(cursor, conn, user_id, log_prefix="[StoreUserPref]")
         if not org_id:
+            logger.error(
+                "store_user_preference: cannot resolve org for user %s; "
+                "preference %s not written. Use store_org_preference() for org-scoped keys.",
+                sanitize(user_id), key,
+            )
             return
 
         cursor.execute(
@@ -365,6 +375,48 @@ def store_user_preference(user_id: str, key: str, value: Any):
             cursor.close()
         if 'conn' in locals() and conn:
             conn.close()
+
+
+_ORG_PREF_UPSERT_SQL = (
+    "INSERT INTO user_preferences (user_id, org_id, preference_key, preference_value) "
+    "VALUES (%s, %s, %s, %s) "
+    "ON CONFLICT (user_id, org_id, preference_key) WHERE org_id IS NOT NULL DO UPDATE "
+    "SET preference_value = EXCLUDED.preference_value, updated_at = CURRENT_TIMESTAMP"
+)
+
+
+def _org_pseudo_user_id(org_id: str) -> str:
+    return f"__org__{org_id}"
+
+
+def store_org_preference(org_id: str, key: str, value: Any, *, cursor=None) -> None:
+    """Upsert an org-scoped preference row.
+
+    Org-scoped preferences are stored with a synthetic user_id of
+    "__org__<org_id>" so they share the user_preferences table without
+    colliding with real user-scoped keys. When `cursor` is provided, the
+    caller is responsible for RLS context and commit; otherwise an admin
+    connection is opened here.
+    """
+    params = (_org_pseudo_user_id(org_id), org_id, key, json.dumps(value))
+
+    if cursor is not None:
+        cursor.execute(_ORG_PREF_UPSERT_SQL, params)
+        return
+
+    from utils.db.connection_pool import db_pool
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(_ORG_PREF_UPSERT_SQL, params)
+            conn.commit()
+    except Exception:
+        logger.exception("Error storing org preference %s for org %s", key, sanitize(org_id))
+
+
+def get_org_preference(org_id: str, key: str, default=None):
+    """Read an org-scoped preference written via store_org_preference()."""
+    return get_user_preference(_org_pseudo_user_id(org_id), key, default)
 
 def _parse_preference_value(raw, default=None):
     """Decode a preference_value column, which may be JSON text or already decoded."""

--- a/server/utils/auth/stateless_auth.py
+++ b/server/utils/auth/stateless_auth.py
@@ -354,7 +354,7 @@ def store_user_preference(user_id: str, key: str, value: Any):
             logger.error(
                 "store_user_preference: cannot resolve org for user %s; "
                 "preference %s not written. Use store_org_preference() for org-scoped keys.",
-                sanitize(user_id), key,
+                sanitize(user_id), sanitize(key),
             )
             return
 
@@ -389,6 +389,16 @@ def _org_pseudo_user_id(org_id: str) -> str:
     return f"__org__{org_id}"
 
 
+def _set_org_rls(cursor, org_id: str) -> None:
+    """Set RLS session vars directly from an org_id (no users-table lookup).
+
+    Needed because org-scoped prefs use a synthetic "__org__<uuid>" user id
+    that set_rls_context() can't resolve via get_org_id_for_user().
+    """
+    cursor.execute("SET myapp.current_user_id = %s;", (_org_pseudo_user_id(org_id),))
+    cursor.execute("SET myapp.current_org_id = %s;", (org_id,))
+
+
 def store_org_preference(org_id: str, key: str, value: Any, *, cursor=None) -> None:
     """Upsert an org-scoped preference row.
 
@@ -396,7 +406,7 @@ def store_org_preference(org_id: str, key: str, value: Any, *, cursor=None) -> N
     "__org__<org_id>" so they share the user_preferences table without
     colliding with real user-scoped keys. When `cursor` is provided, the
     caller is responsible for RLS context and commit; otherwise an admin
-    connection is opened here.
+    connection is opened here and RLS is configured from org_id directly.
     """
     params = (_org_pseudo_user_id(org_id), org_id, key, json.dumps(value))
 
@@ -408,15 +418,37 @@ def store_org_preference(org_id: str, key: str, value: Any, *, cursor=None) -> N
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
+                _set_org_rls(cur, org_id)
                 cur.execute(_ORG_PREF_UPSERT_SQL, params)
             conn.commit()
     except Exception:
-        logger.exception("Error storing org preference %s for org %s", key, sanitize(org_id))
+        logger.exception("Error storing org preference %s for org %s", sanitize(key), sanitize(org_id))
 
 
 def get_org_preference(org_id: str, key: str, default=None):
-    """Read an org-scoped preference written via store_org_preference()."""
-    return get_user_preference(_org_pseudo_user_id(org_id), key, default)
+    """Read an org-scoped preference written via store_org_preference().
+
+    Uses an admin connection with RLS configured from org_id directly, so it
+    works outside Flask request context (e.g. Celery) where connection-pool
+    RLS vars aren't auto-populated.
+    """
+    from utils.db.connection_pool import db_pool
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                _set_org_rls(cur, org_id)
+                cur.execute(
+                    "SELECT preference_value FROM user_preferences "
+                    "WHERE org_id = %s AND user_id = %s AND preference_key = %s",
+                    (org_id, _org_pseudo_user_id(org_id), key),
+                )
+                row = cur.fetchone()
+                if not row:
+                    return default
+                return _parse_preference_value(row[0], default)
+    except Exception:
+        logger.exception("Error reading org preference %s for org %s", sanitize(key), sanitize(org_id))
+        return default
 
 def _parse_preference_value(raw, default=None):
     """Decode a preference_value column, which may be JSON text or already decoded."""


### PR DESCRIPTION
## Summary
Toggling the Denylist/Allowlist switch on the Command Policies page was a no-op (most noticeable while the Observability Only template was active). `store_user_preference` silently returned when it couldn't resolve an org for the synthetic `__org__<uuid>` pseudo-user, so the write never landed and the UI snapped back.

- Added `store_org_preference` / `get_org_preference` helpers for org-scoped prefs so routes don't have to fake a user id.
- `store_user_preference` now logs an error instead of silently dropping the write when RLS can't be set.
- Command policy routes use the new helpers; also clears the active template on rule edit/delete (previously intended but silently broken).

## Test plan
- [ ] Apply Observability Only template, toggle Denylist off -> persists after refresh
- [ ] Toggle Allowlist on/off with no template active -> persists
- [ ] Edit/delete a rule -> active template badge clears

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization-level command policy preference storage through streamlined implementation.
  * Enhanced preference persistence with consolidated database transactions for better consistency of organizational settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->