### PR TITLE
Remove unused Testing Sandbox chat mode

### DIFF
--- a/client/src/components/ModeSelector.tsx
+++ b/client/src/components/ModeSelector.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Infinity, Bot, MessageSquare, ChevronDown } from "lucide-react";
+import { Infinity, MessageSquare, ChevronDown } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,11 +35,6 @@ const modeOptions: ModeOption[] = [
     id: "agent",
     displayName: "Agent",
     icon: <Infinity className="w-2 h-2 flex-shrink-0" />,
-  },
-  {
-    id: "sandbox",
-    displayName: "Testing Sandbox",
-    icon: <Bot className="w-2 h-2 flex-shrink-0" />,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Remove the "Testing Sandbox" option from the chat mode dropdown in `ModeSelector.tsx`
- Remove the unused `Bot` icon import that was only used by that entry
- The sandbox mode had no backend-specific logic — it fell through to agent mode behavior, making it dead code

## Test plan
- [ ] Verify the mode dropdown only shows "Ask (Read Mode)" and "Agent"
- [ ] Confirm existing chat sessions with mode set to "sandbox" in localStorage gracefully fall back to the default ("agent")

Made with [Cursor](https://cursor.com)