### PR TITLE
fix: don't persist rail-blocked user messages

### DIFF
--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -982,6 +982,14 @@ class Workflow:
                 yield ("token", "Your message was blocked by our safety system. Please rephrase your request.")
                 return
 
+            # Rail passed: NOW it's safe to persist the user message.
+            # Kept inside the rail gate so blocked messages never touch
+            # chat_sessions.messages (which legacy migration rehydrates into
+            # llm_context_history on the next turn).
+            if input_state.session_id and input_state.user_id:
+                from chat.backend.agent.utils.immediate_save_handler import handle_immediate_save
+                handle_immediate_save(input_state.session_id, input_state.user_id, msg_text)
+
         # Log initial state
         logger.info(f"Starting workflow with session_id={input_state.session_id}, user_id={input_state.user_id}")
         

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -44,7 +44,6 @@ from chat.backend.agent.workflow import Workflow
 from chat.backend.agent.weaviate_client import WeaviateClient
 from chat.backend.agent.utils.llm_context_manager import LLMContextManager
 from chat.backend.agent.utils.chat_context_manager import ChatContextManager
-from chat.backend.agent.utils.immediate_save_handler import handle_immediate_save
 from utils.db.connection_pool import db_pool
 from utils.billing.billing_cache import update_api_cost_cache_async, get_cached_api_cost
 from utils.billing.billing_utils import get_api_cost
@@ -1540,10 +1539,6 @@ async def handle_connection(websocket) -> None:
 
             logger.info(f"Created state with {len(attachments) if attachments else 0} attachments for regular query")
             logger.info(f"WebSocket sender initialized: {websocket_sender is not None}")
-
-            # IMMEDIATE SAVE: Save user message immediately when received
-            if session_id and user_id:
-                handle_immediate_save(session_id, user_id, question)
 
             # Launch workflow processing as async task without blocking
             # Set UI state in workflow before processing so it gets saved


### PR DESCRIPTION
## Summary
- Rail-blocked user prompts were leaking back into LLM memory on the next turn. `main_chatbot.py` called `handle_immediate_save` before the workflow ran, so the blocked text landed in `chat_sessions.messages`. On the next turn, the empty `llm_context_history` tripped `_handle_legacy_session_migration`, which rehydrated the blocked prompt from the UI messages column — and the model acted on it alongside the new (allowed) prompt.
- Moved `handle_immediate_save` into `workflow.stream()` immediately after the input rail passes. Blocked messages now short-circuit before any persistence happens. No rollback logic, no schema change.

## Invariant
A rail-blocked message must not touch any persistence. All user-turn writes now sit downstream of the rail gate.

## Test plan
- [ ] Send a rail-triggering prompt; confirm the block UI appears.
- [ ] Inspect the `chat_sessions` row: neither `messages` nor `llm_context_history` should contain the blocked text.
- [ ] Send a benign follow-up; confirm the response references only the follow-up, not the blocked prompt.
- [ ] Send a benign message on a fresh session; confirm the UI message still appears immediately (WebSocket-drop safety preserved for the happy path).