### PR TITLE
fix: remove 10s timeout from SSE stream routes that crashes frontend

### DIFF
--- a/client/src/app/api/incidents/[id]/visualization/stream/route.ts
+++ b/client/src/app/api/incidents/[id]/visualization/stream/route.ts
@@ -15,16 +15,12 @@ export async function GET(
 
     const { id } = await params;
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
-
     const response = await fetch(`${API_BASE_URL}/api/incidents/${id}/visualization/stream`, {
       method: 'GET',
       headers: authResult.headers,
       credentials: 'include',
-      signal: controller.signal,
+      signal: request.signal,
     });
-    clearTimeout(timeoutId);
 
     if (!response.ok) return new Response('Failed to connect to visualization stream', { status: response.status });
 

--- a/client/src/app/api/incidents/stream/route.ts
+++ b/client/src/app/api/incidents/stream/route.ts
@@ -10,16 +10,12 @@ export async function GET(request: NextRequest) {
     const authResult = await getAuthenticatedUser();
     if (authResult instanceof NextResponse) return authResult;
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
-
     const response = await fetch(`${API_BASE_URL}/api/incidents/stream`, {
       method: 'GET',
       headers: authResult.headers,
       credentials: 'include',
-      signal: controller.signal,
+      signal: request.signal,
     });
-    clearTimeout(timeoutId);
 
     if (!response.ok) return new Response('Failed to connect to incident stream', { status: response.status });
 


### PR DESCRIPTION
## Summary
- Remove hardcoded 10s `AbortController` timeout from SSE stream routes (`/api/incidents/stream` and `/api/incidents/[id]/visualization/stream`)
- Use `request.signal` instead so the stream only aborts when the client disconnects
- Fixes frontend container crash on cold start when backend takes >10s to respond (Vault init, Turbopack compilation, DB pool warmup)

## Root cause
Added in `5b4dce71` (fix: resolve frontend freeze after idle) — the 10s timeout was appropriate for regular API calls but not for SSE endpoints that are long-lived by design. On cold start the backend can exceed 10s, triggering an `AbortError` that crashes the Next.js process.

## Test plan
- [x] `docker compose down && docker compose up -d` — frontend should stay up through cold start
- [ ] Navigate to incidents page — SSE stream should remain connected
- [ ] Open an incident with visualization — visualization stream should remain connected
- [ ] Verify no regression on idle freeze (heartbeats still active at 30s intervals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved incident stream cancellation handling for more responsive and reliable streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->