### PR TITLE
fix(guardrails): skip input rail on background RCA turns

### DIFF
--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -971,9 +971,17 @@ class Workflow:
         self._history_prefix_len = history_prefix_len
 
         # --- Input rail: check user message for prompt injection ---
+        # Background (webhook-triggered) RCA turns build their HumanMessage
+        # from an internally-constructed prompt based on an authenticated
+        # alert payload, not user input. Running prompt-injection detection
+        # on that synthetic text produces false positives and prevents the
+        # investigation from ever starting. Skip the rail for background
+        # turns; subsequent interactive follow-ups on the same session still
+        # run through the rail because they reset is_background=False.
         from guardrails.input_rail import check_input
         last_msg = input_state.messages[-1] if input_state.messages else None
-        if last_msg and hasattr(last_msg, "type") and last_msg.type == "human":
+        is_background = bool(getattr(input_state, "is_background", False))
+        if last_msg and hasattr(last_msg, "type") and last_msg.type == "human" and not is_background:
             # RCA chat turns may prepend internal routing instructions to the
             # HumanMessage so the agent calls trigger_rca. Guardrails and chat
             # persistence should evaluate the user's original text only.


### PR DESCRIPTION
## Summary

Follow-up to #329, which narrowed the input rail's evaluation surface for *interactive* RCA-routing turns (evaluating \`input_state.question\` instead of the augmented \`HumanMessage\`). This PR extends the same "only evaluate real user input" principle to **webhook-triggered background RCA** turns.

## Problem

Webhook alert handlers (PagerDuty, Datadog, Jenkins, Jira, Spinnaker, Netdata, BigPanda, Incidentio, Grafana, etc.) call \`run_background_chat\` with a synthetic \`initial_message\` built by functions like \`build_pagerduty_rca_prompt\`. That prompt stitches alert metadata together with several kilobytes of investigation instructions so the agent knows which providers to query and in what order. The same text is passed as both \`HumanMessage.content\` and \`input_state.question\`, so PR #329's fix does not help here --- there is no "original user text" to fall back to.

When the input rail runs a prompt-injection judge over that synthetic payload, safety-calibrated models (especially the mini-class ones commonly used as cheap judges: \`gpt-4o-mini\`, \`gpt-5.4-mini\`, \`gemini-2.5-flash-lite\`) frequently flag it as adversarial. Because the rail fails closed, the webhook RCA is aborted before a single tool call is made. The incident is marked \`complete\` with a single thought: *"Your message was blocked by our safety system."*

## Fix

One-line guard on the input-rail block: when \`input_state.is_background\` is true, skip the rail.

\`\`\`python
is_background = bool(getattr(input_state, "is_background", False))
if last_msg and hasattr(last_msg, "type") and last_msg.type == "human" and not is_background:
    # existing rail check
\`\`\`

## Why this is safe

- \`is_background=True\` is only set by trusted internal call sites in \`run_background_chat\` / \`run_jira_action\` (see \`server/chat/background/task.py:984,1084\` and \`server/routes/jira/tasks.py\`). All of those call sites originate from authenticated webhook handlers that have already validated the alert payload.
- Interactive follow-up messages sent into an RCA chat session construct a new \`State\` from the WebSocket path, which defaults to \`is_background=False\`. Those still run through the rail unchanged --- this PR does not widen the attack surface for user input.
- The other guardrail layers still apply to anything the agent actually *does*:
  - **Command-safety judge** (\`utils/security/command_safety.py\`) gates every shell / kubectl / curl invocation and fails closed.
  - **SigmaHQ signature matcher** runs on every tool argument.
  - **Output rail** still runs on agent responses.
  - **\`trigger_rca_tool\`** already refuses to run from within a background session (\`is_background\` short-circuit), so background sessions cannot chain into another RCA to bypass policy.
- Background prompts are synthesized from an authenticated webhook payload by our own code, not user-submitted, so prompt-injection detection on them is a category mismatch.

## Verification

Reproduced the failure and confirmed the fix locally:

| | Before (main) | After (this PR) |
|---|---|---|
| \`GUARDRAILS_LLM_MODEL\` | \`openai/gpt-5.4-mini\` | \`openai/gpt-5.4-mini\` |
| \`MAIN_MODEL\` / \`RCA_MODEL\` | \`openai/gpt-5.2\` direct | \`openai/gpt-5.2\` direct |
| Webhook payload | PagerDuty V3, billing-api latency alert | same |
| Input rail block | Yes (1 thought: "blocked by safety system") | No |
| Thought count after ~90 s | 1 | 19 (and climbing) |
| First real tool call | none | \`knowledge_base_search\` with model-generated query |
| Worker log evidence | \`guardrails.input_rail - WARNING - BLOCKED\` | no rail entry on background turn |

## Test plan

- [ ] CI passes
- [ ] Fire a PagerDuty V3 webhook with \`GUARDRAILS_LLM_MODEL\` set to a mini-class judge: incident should progress past \`aurora_status='running'\` with a growing thought count and real tool calls
- [ ] Send an interactive chat message on the same incident: rail should still evaluate it (unchanged behavior)
- [ ] Spot-check the other webhook sources (\`datadog\`, \`grafana\`, \`incidentio\`, etc.) still trigger RCA successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where background Root Cause Analysis investigations were being unnecessarily blocked by input security checks during internal analysis, while maintaining security protections for standard user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->