### PR TITLE
fix(client): increase makeAuthenticatedRequest timeout to 30s

### DIFF
--- a/client/src/lib/auth-helper.ts
+++ b/client/src/lib/auth-helper.ts
@@ -56,9 +56,9 @@ export async function makeAuthenticatedRequest(
     throw new Error('User not authenticated')
   }
 
-  // Default 10s timeout unless caller provides their own signal
+  // Default 30s timeout unless caller provides their own signal
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
+  const timeout = setTimeout(() => controller.abort(), 30_000)
   if (options.signal) {
     options.signal.addEventListener('abort', () => controller.abort())
   }


### PR DESCRIPTION
## Summary
- Bumps default timeout in `makeAuthenticatedRequest` from 10s to 30s
- During cold start, Next.js route compilation adds seconds to the first backend call, causing AbortError → 500 on `/api/chat-sessions` and similar routes
- Aligns with `forwardRequest` in `backend-proxy.ts` which already uses 30s

## Test plan
- [ ] Cold-start the frontend container and load the app — `/api/chat-sessions` should not 500
- [ ] Verify normal requests still complete well under 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved timeout handling for network requests to enhance reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->