### PR TITLE
fix(auth): add /api/auth/me to internal secret open paths

### DIFF
--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -188,7 +188,7 @@ if _AURORA_ENV != "dev" and not _INTERNAL_API_SECRET:
         "Refusing to start without authentication secrets in production." % _AURORA_ENV
     )
 
-_OPEN_PATHS = frozenset(("/api/auth/login", "/api/auth/register"))
+_OPEN_PATHS = frozenset(("/api/auth/login", "/api/auth/register", "/api/auth/me"))
 
 _HEALTH_PATH = "/health"
 


### PR DESCRIPTION
## Summary

- Adds `/api/auth/me` to `_OPEN_PATHS` in the internal secret middleware, fixing a regression from #280 where NextAuth's server-side JWT refresh calls were blocked with 403.
- The route already authenticates via `@require_auth_only` (validates `X-User-ID`), so exempting it from the internal secret check is safe.

## Root cause

`client/src/auth.ts` calls `/api/auth/me` server-side from Next.js to refresh role/org data in the JWT. Unlike other server-side calls that go through `auth-helper.ts` (which attaches `X-Internal-Secret`), this call is made directly by NextAuth callbacks and only sends `X-User-ID`. The internal secret middleware introduced in #280 exempted `/api/auth/login` and `/api/auth/register` but missed `/api/auth/me`.

## Impact

Without this fix, every frontend page load triggers repeated 403s on `/api/auth/me`, which causes the session to appear stale and prevents chat messages, RCA triggers, and other authenticated actions from working in the UI.

## Test plan

- [ ] Verify `/api/auth/me` no longer returns 403 in server logs
- [ ] Verify frontend loads normally without repeated auth errors
- [ ] Verify chat and RCA triggers work from the UI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated authentication endpoint to properly handle API requests without requiring additional verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->