### PR TITLE
fix(chat): force trigger_rca tool call when RCA button is pressed

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -194,7 +194,7 @@ class Agent:
             from langchain.agents import create_agent
             from langchain_core.callbacks import BaseCallbackHandler
             from .tools.cloud_tools import get_cloud_tools, set_user_context, set_tool_capture
-            from .middleware import ContextTrimMiddleware
+            from .middleware import ContextTrimMiddleware, _ForceToolChoice
 
             logging.info(f"agentic_tool_flow: State has user_id {state.user_id} and session_id {state.session_id}")
             # Set user context for tools
@@ -511,11 +511,15 @@ class Agent:
             # Tool outputs are capped/summarized upstream (utils/tool_output_cap.py).
             # ContextSafetyMiddleware is a lightweight safety net that also injects
             # correlated RCA context updates into background sessions.
+            middlewares = [ContextTrimMiddleware(model_name=model_name)]
+            if getattr(state, "trigger_rca_requested", False):
+                middlewares.insert(0, _ForceToolChoice("trigger_rca"))
+
             agent_graph = create_agent(
                 model=streaming_llm,
                 tools=tools,
                 system_prompt=system_prompt_text,
-                middleware=[ContextTrimMiddleware(model_name=model_name)],
+                middleware=middlewares,
             )
 
       

--- a/server/chat/backend/agent/middleware/__init__.py
+++ b/server/chat/backend/agent/middleware/__init__.py
@@ -1,6 +1,7 @@
 from .context_trim import ContextSafetyMiddleware
+from .force_tool import ForceToolChoice as _ForceToolChoice
 
 # Backward-compatible alias
 ContextTrimMiddleware = ContextSafetyMiddleware
 
-__all__ = ["ContextSafetyMiddleware", "ContextTrimMiddleware"]
+__all__ = ["ContextSafetyMiddleware", "ContextTrimMiddleware", "_ForceToolChoice"]

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -1,0 +1,29 @@
+"""Middleware that forces a specific tool call on the first LLM turn."""
+
+from __future__ import annotations
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+
+class ForceToolChoice(AgentMiddleware):
+    """Set tool_choice on the first model invocation, then step aside."""
+
+    def __init__(self, tool_name: str):
+        self._tool_name = tool_name
+        self._fired = False
+
+    def _patch(self, request: ModelRequest) -> ModelRequest:
+        if not self._fired:
+            self._fired = True
+            request.tool_choice = {
+                "type": "function",
+                "function": {"name": self._tool_name},
+            }
+        return request
+
+    def wrap_model_call(self, request, call_next):
+        return call_next(self._patch(request))
+
+    async def awrap_model_call(self, request, call_next):
+        return await call_next(self._patch(request))

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest
 
 
 class ForceToolChoice(AgentMiddleware):


### PR DESCRIPTION
## Summary

- Adds a `ForceToolChoice` middleware that sets `tool_choice` on the first LLM turn when the user presses the RCA button, guaranteeing the agent calls `trigger_rca` instead of `cloud_exec` or asking clarifying questions.
- After the first tool call, the middleware steps aside and the agent loop continues normally.

## Root cause

The `[RCA INVESTIGATION REQUESTED]` prefix prepended to the user message is a soft instruction that the LLM sometimes ignores -- especially with vague prompts like "check aws logs" where the model decides to run commands directly via `cloud_exec` instead. Using `tool_choice` makes this deterministic.

## Changes

- `server/chat/backend/agent/middleware/force_tool.py` -- new 20-line middleware
- `server/chat/backend/agent/middleware/__init__.py` -- export it
- `server/chat/backend/agent/agent.py` -- insert the middleware when `trigger_rca_requested` is True

## Test plan

- [ ] Press the RCA button with a vague prompt like "check aws logs" -- should always trigger RCA
- [ ] Regular Agent mode chat with the same prompt should NOT trigger RCA (uses cloud_exec directly)
- [ ] After trigger_rca fires, the agent should continue normally (middleware only forces first turn)

Made with [Cursor](https://cursor.com)