### PR TITLE
ci: run all unit tests in linters workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -38,15 +38,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: pip install pytest
+        run: pip install pytest pyyaml flask
 
-      - name: Run static analysis tests
+      - name: Run all unit tests
         working-directory: server
-        run: |
-          tests=(tests/test_connector_rbac.py)
-          if [ -f tests/test_rls_coverage.py ]; then
-            tests+=(tests/test_rls_coverage.py)
-          else
-            echo "::warning::tests/test_rls_coverage.py not present yet (waiting on PR #314); skipping."
-          fi
-          python -m pytest "${tests[@]}" -v
+        run: python -m pytest tests/ -v


### PR DESCRIPTION
## Summary
- CI was only running 2 of 11 test files — 9 test files (241 tests) were never running in CI
- Replace cherry-picked file list with `python -m pytest tests/ -v` to discover all tests automatically
- Add `pyyaml` and `flask` to test deps (needed by sigma canary and connection pool tests)

Tests not previously running in CI:
- `architectural/test_sigma_canary.py` (67 tests) — guardrail false positive/negative detection
- `db/test_connection_pool.py` (13 tests) — S.1 cross-tenant RLS leak prevention
- `services/correlation/test_*.py` (56 tests) — alert correlation scoring
- `test_output_redaction.py` (7 tests) — sensitive output filtering
- `utils/test_log_sanitizer.py` (34 tests) — log injection prevention
- `utils/test_payload_timestamp.py` (28 tests) — webhook timestamp parsing

All 241 tests pass locally in 2.5s.

## Test plan
- [ ] CI workflow runs and all 241 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated testing infrastructure to expand dependency coverage and ensure comprehensive test execution across all test suites.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development and testing infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->