### PR TITLE
Fix stale investigations stuck forever after pod/worker crashes

### DIFF
--- a/client/src/app/chat/components/ChatClient.tsx
+++ b/client/src/app/chat/components/ChatClient.tsx
@@ -204,6 +204,7 @@ export default function ChatClient({ initialSessionId, shouldStartNewChat, initi
     },
     onDisconnect: () => {
       console.log('Chat WebSocket disconnected');
+      setIsSending(false);
     },
     onError: (error) => {
       console.error('Chat WebSocket error:', error);

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -81,6 +81,13 @@ export default function IncidentDetailPage() {
         if (isInitial) {
           setError('Failed to load incident');
           console.error('Failed to load incident:', e instanceof Error ? e.message : 'Unknown error');
+        } else {
+          if (!pollStartRef.current) pollStartRef.current = Date.now();
+          if (Date.now() - pollStartRef.current > STALE_POLL_MS) {
+            setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
+          } else {
+            timer = setTimeout(() => fetchAndSchedule(false), 2000);
+          }
         }
       } finally {
         if (isInitial && active) setLoading(false);

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -27,6 +27,7 @@ export default function IncidentDetailPage() {
   const seenThoughtIdsRef = useRef<Set<string>>(new Set());
   const userClosedThoughtsRef = useRef<boolean>(false);
   const pollStartRef = useRef<number>(0);
+  const lastUpdatedAtRef = useRef<string>('');
 
   const applyIncidentData = useCallback((data: Incident) => {
     const newThoughts = data.streamingThoughts || [];
@@ -49,6 +50,7 @@ export default function IncidentDetailPage() {
     let active = true;
     let timer: ReturnType<typeof setTimeout>;
     pollStartRef.current = 0;
+    lastUpdatedAtRef.current = '';
 
     const fetchAndSchedule = async (isInitial: boolean) => {
       if (!active || !params.id) return;
@@ -64,12 +66,15 @@ export default function IncidentDetailPage() {
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
         if (!needsPoll || !active) { pollStartRef.current = 0; return; }
 
+        if (data.updatedAt !== lastUpdatedAtRef.current) {
+          lastUpdatedAtRef.current = data.updatedAt;
+          pollStartRef.current = Date.now();
+        }
         if (!pollStartRef.current) pollStartRef.current = Date.now();
         if (Date.now() - pollStartRef.current > STALE_POLL_MS) {
           setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
           return;
         }
-        pollStartRef.current = Date.now();
         timer = setTimeout(() => fetchAndSchedule(false), 1000);
       } catch (e) {
         if (!active) return;

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -69,6 +69,7 @@ export default function IncidentDetailPage() {
           setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
           return;
         }
+        pollStartRef.current = Date.now();
         timer = setTimeout(() => fetchAndSchedule(false), 1000);
       } catch (e) {
         if (!active) return;

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function IncidentDetailPage() {
   useEffect(() => {
     let active = true;
     let timer: ReturnType<typeof setTimeout>;
+    pollStartRef.current = 0;
 
     const fetchAndSchedule = async (isInitial: boolean) => {
       if (!active || !params.id) return;

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -24,6 +24,7 @@ export default function IncidentDetailPage() {
   const [thoughts, setThoughts] = useState<StreamingThought[]>([]);
   const seenThoughtIdsRef = useRef<Set<string>>(new Set());
   const userClosedThoughtsRef = useRef<boolean>(false);
+  const pollStartRef = useRef<number>(0);
 
   const applyIncidentData = useCallback((data: Incident) => {
     const newThoughts = data.streamingThoughts || [];
@@ -59,7 +60,15 @@ export default function IncidentDetailPage() {
 
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
         if (needsPoll && active) {
+          if (!pollStartRef.current) pollStartRef.current = Date.now();
+          const staleMins = 5;
+          if (Date.now() - pollStartRef.current > staleMins * 60 * 1000) {
+            setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
+            return;
+          }
           timer = setTimeout(() => fetchAndSchedule(false), 1000);
+        } else {
+          pollStartRef.current = 0;
         }
       } catch (e) {
         if (!active) return;

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -13,6 +13,8 @@ import { canWrite } from '@/lib/roles';
 import IncidentCard from '../components/IncidentCard';
 import ThoughtsPanel from '../components/ThoughtsPanel';
 
+const STALE_POLL_MS = 5 * 60 * 1000;
+
 export default function IncidentDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -61,8 +63,7 @@ export default function IncidentDetailPage() {
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
         if (needsPoll && active) {
           if (!pollStartRef.current) pollStartRef.current = Date.now();
-          const staleMins = 5;
-          if (Date.now() - pollStartRef.current > staleMins * 60 * 1000) {
+          if (Date.now() - pollStartRef.current > STALE_POLL_MS) {
             setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
             return;
           }

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -61,16 +61,14 @@ export default function IncidentDetailPage() {
         applyIncidentData(data);
 
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
-        if (needsPoll && active) {
-          if (!pollStartRef.current) pollStartRef.current = Date.now();
-          if (Date.now() - pollStartRef.current > STALE_POLL_MS) {
-            setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
-            return;
-          }
-          timer = setTimeout(() => fetchAndSchedule(false), 1000);
-        } else {
-          pollStartRef.current = 0;
+        if (!needsPoll || !active) { pollStartRef.current = 0; return; }
+
+        if (!pollStartRef.current) pollStartRef.current = Date.now();
+        if (Date.now() - pollStartRef.current > STALE_POLL_MS) {
+          setIncident(prev => prev ? { ...prev, auroraStatus: 'error' as const } : prev);
+          return;
         }
+        timer = setTimeout(() => fetchAndSchedule(false), 1000);
       } catch (e) {
         if (!active) return;
         if (isInitial) {

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -70,6 +70,7 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [pollingSessionId, setPollingSessionId] = useState<string | null>(null);
+  const pollStartRef = useRef<number>(0);
   
   // Track session IDs we're currently creating to avoid state conflicts with parent component.
   // When we send a message, we create an optimistic session in local state (chatSessions).
@@ -207,14 +208,21 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
 
   // Poll for session updates when a session is in progress
   useEffect(() => {
-    if (!pollingSessionId) return;
+    if (!pollingSessionId) { pollStartRef.current = 0; return; }
+    if (!pollStartRef.current) pollStartRef.current = Date.now();
 
     let isCancelled = false;
     const abortController = new AbortController();
-    const sessionIdToFetch = pollingSessionId; // Capture value to avoid stale closure
+    const sessionIdToFetch = pollingSessionId;
 
     const pollInterval = setInterval(async () => {
       if (isCancelled) return;
+
+      if (Date.now() - pollStartRef.current > 5 * 60 * 1000) {
+        setPollingSessionId(null);
+        setIsLoading(false);
+        return;
+      }
       
       try {
         const sessionResp = await fetch(`/api/chat-sessions/${sessionIdToFetch}`, {

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -221,6 +221,9 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
       if (Date.now() - pollStartRef.current > 5 * 60 * 1000) {
         setPollingSessionId(null);
         setIsLoading(false);
+        setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) =>
+          s.id === sessionIdToFetch ? { ...s, status: 'failed' } : s
+        ));
         return;
       }
       

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -215,17 +215,17 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
     const abortController = new AbortController();
     const sessionIdToFetch = pollingSessionId;
 
+    const markSessionFailed = () => {
+      setPollingSessionId(null);
+      setIsLoading(false);
+      setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) =>
+        s.id === sessionIdToFetch ? { ...s, status: 'failed' } : s
+      ));
+    };
+
     const pollInterval = setInterval(async () => {
       if (isCancelled) return;
-
-      if (Date.now() - pollStartRef.current > 5 * 60 * 1000) {
-        setPollingSessionId(null);
-        setIsLoading(false);
-        setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) =>
-          s.id === sessionIdToFetch ? { ...s, status: 'failed' } : s
-        ));
-        return;
-      }
+      if (Date.now() - pollStartRef.current > 5 * 60 * 1000) { markSessionFailed(); return; }
       
       try {
         const sessionResp = await fetch(`/api/chat-sessions/${sessionIdToFetch}`, {

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -215,7 +215,7 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
   // Poll for session updates when a session is in progress
   useEffect(() => {
     if (!pollingSessionId) { pollStartRef.current = 0; return; }
-    if (!pollStartRef.current) pollStartRef.current = Date.now();
+    pollStartRef.current = Date.now();
 
     let isCancelled = false;
     const abortController = new AbortController();

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -239,13 +239,13 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
 
         const sessionData = await sessionResp.json();
         if (isCancelled) return;
-        
-        // Update the session in our local state
+
         setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) => 
           s.id === sessionIdToFetch 
             ? { ...s, messages: sessionData.messages || [], status: sessionData.status }
             : s
         ));
+        pollStartRef.current = Date.now();
 
         // If completed or failed, stop polling and remove from creating set
         if (sessionData.status === 'completed' || sessionData.status === 'failed') {

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -216,6 +216,7 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
   useEffect(() => {
     if (!pollingSessionId) { pollStartRef.current = 0; return; }
     pollStartRef.current = Date.now();
+    let lastMsgCount = -1;
 
     let isCancelled = false;
     const abortController = new AbortController();
@@ -240,12 +241,17 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
         const sessionData = await sessionResp.json();
         if (isCancelled) return;
 
+        const msgCount = sessionData.messages?.length ?? 0;
+        if (msgCount !== lastMsgCount) {
+          lastMsgCount = msgCount;
+          pollStartRef.current = Date.now();
+        }
+
         setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) => 
           s.id === sessionIdToFetch 
             ? { ...s, messages: sessionData.messages || [], status: sessionData.status }
             : s
         ));
-        pollStartRef.current = Date.now();
 
         // If completed or failed, stop polling and remove from creating set
         if (sessionData.status === 'completed' || sessionData.status === 'failed') {

--- a/client/src/app/incidents/components/ThoughtsPanel.tsx
+++ b/client/src/app/incidents/components/ThoughtsPanel.tsx
@@ -71,6 +71,12 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
   const [isLoading, setIsLoading] = useState(false);
   const [pollingSessionId, setPollingSessionId] = useState<string | null>(null);
   const pollStartRef = useRef<number>(0);
+
+  const failSession = useCallback((sid: string) => {
+    setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) =>
+      s.id === sid ? { ...s, status: 'failed' } : s
+    ));
+  }, []);
   
   // Track session IDs we're currently creating to avoid state conflicts with parent component.
   // When we send a message, we create an optimistic session in local state (chatSessions).
@@ -218,9 +224,7 @@ export default function ThoughtsPanel({ thoughts, incident, isVisible, canIntera
     const markSessionFailed = () => {
       setPollingSessionId(null);
       setIsLoading(false);
-      setChatSessions((prev: ChatSession[]) => prev.map((s: ChatSession) =>
-        s.id === sessionIdToFetch ? { ...s, status: 'failed' } : s
-      ));
+      failSession(sessionIdToFetch);
     };
 
     const pollInterval = setInterval(async () => {

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { Zap, Clock, ChevronRight, Loader2, CheckCircle2, Link2, GitMerge, Plus } from 'lucide-react';
+import { Zap, Clock, ChevronRight, Loader2, CheckCircle2, Link2, GitMerge, Plus, AlertTriangle } from 'lucide-react';
 import { Incident, incidentsService } from '@/lib/services/incidents';
 import { useConnectedAccounts } from '@/hooks/useConnectedAccounts';
 import { connectorRegistry } from '@/components/connectors/ConnectorRegistry';
@@ -236,8 +236,11 @@ function IncidentRow({ incident }: { incident: Incident }) {
                 )}
                 {isActive && (
                   <span className="flex items-center gap-1 text-muted-foreground">
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                    Aurora investigating
+                    {Date.now() - new Date(incident.startedAt).getTime() > 30 * 60 * 1000 ? (
+                      <><AlertTriangle className="h-3 w-3 text-red-400" /> Investigation stalled</>
+                    ) : (
+                      <><Loader2 className="h-3 w-3 animate-spin" /> Aurora investigating</>
+                    )}
                   </span>
                 )}
                 {isMerged && (

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2077,7 +2077,7 @@ def _is_task_dead(task_id: str, last_activity, threshold, cursor=None, incident_
     if result.state in ('FAILURE', 'REVOKED'):
         return True
     if result.state == 'PENDING' and result.result is None:
-        return bool(last_activity and last_activity < threshold)
+        return True
     if result.state == 'STARTED' and last_activity and last_activity < threshold:
         if cursor and incident_id:
             cursor.execute("""

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2134,7 +2134,10 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
                     cursor.execute("""
                         UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
                         WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
+                        RETURNING id
                     """, (threshold, uid))
+                    for (sid,) in cursor.fetchall():
+                        _propagate_suggestion_status(str(sid), 'failed')
                     conn.commit()
 
         if cleaned:
@@ -2180,7 +2183,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                         _propagate_suggestion_status(str(session_id), 'failed')
                         if incident_id:
                             cursor.execute(
-                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW() WHERE id = %s",
+                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s",
                                 (incident_id,)
                             )
                             _record_rca_error(cursor, str(incident_id), uid)
@@ -2200,14 +2203,19 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                                              cursor=cursor, incident_id=inc_id):
                             continue
                         cursor.execute(
-                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running'",
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
                             (inc_id,)
                         )
+                        if not cursor.fetchone():
+                            conn.commit()
+                            continue
                         if session_id:
                             cursor.execute(
-                                "UPDATE chat_sessions SET status = 'failed', updated_at = NOW() WHERE id = %s AND status = 'in_progress'",
+                                "UPDATE chat_sessions SET status = 'failed', updated_at = NOW() WHERE id = %s AND status = 'in_progress' RETURNING id",
                                 (str(session_id),)
                             )
+                            if cursor.fetchone():
+                                _propagate_suggestion_status(str(session_id), 'failed')
                         _record_rca_error(cursor, str(inc_id), uid)
                         conn.commit()
                         dead_task_count += 1
@@ -2224,7 +2232,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                     """, (stale_threshold, uid))
                     for (inc_id,) in cursor.fetchall():
                         cursor.execute(
-                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
                             (inc_id,)
                         )
                         if cursor.fetchone():

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2048,6 +2048,41 @@ def create_background_chat_session(
     
     return session_id
 
+def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
+    """Mark investigations left in 'running' state by a previous process as failed.
+
+    Intended to be called once on process startup (chatbot or worker).
+    Returns the number of incidents cleaned.
+    """
+    cleaned = 0
+    try:
+        from datetime import timedelta
+        threshold = datetime.now() - timedelta(minutes=threshold_minutes)
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+                for uid, org_id in cursor.fetchall():
+                    set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
+                    cursor.execute("""
+                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW()
+                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
+                        RETURNING id
+                    """, (threshold, uid))
+                    stale_incidents = cursor.fetchall()
+                    cursor.execute("""
+                        UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
+                        WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
+                    """, (threshold, uid))
+                    conn.commit()
+                    if stale_incidents:
+                        ids = [str(r[0]) for r in stale_incidents]
+                        cleaned += len(ids)
+                        logger.info(f"[StartupCleanup] Marked {len(ids)} orphaned investigations as error for user {uid}: {ids}")
+    except Exception as e:
+        logger.error(f"[StartupCleanup] Failed to clean orphaned investigations: {e}")
+    return cleaned
+
+
 @celery_app.task(name="chat.background.cleanup_stale_sessions")
 def cleanup_stale_background_chats() -> Dict[str, Any]:
     """Cleanup background chat sessions stuck in 'in_progress' and incidents

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2062,8 +2062,8 @@ def _record_rca_error(cursor, conn, incident_id: str, user_id: str) -> None:
     except Exception as e:
         try:
             cursor.execute("ROLLBACK TO SAVEPOINT sp_rca_err")
-        except Exception:
-            pass
+        except Exception as rollback_err:
+            logger.debug("[Cleanup] Rollback failed for incident %s: %s", incident_id, rollback_err)
         logger.debug("[Cleanup] Failed to record rca_error for incident %s: %s", incident_id, e)
 
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2077,7 +2077,7 @@ def _is_task_dead(task_id: str, last_activity, threshold, cursor=None, incident_
     if result.state in ('FAILURE', 'REVOKED'):
         return True
     if result.state == 'PENDING' and result.result is None:
-        return True
+        return bool(last_activity and last_activity < threshold)
     if result.state == 'STARTED' and last_activity and last_activity < threshold:
         if cursor and incident_id:
             cursor.execute("""

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2082,9 +2082,9 @@ def _is_task_dead(task_id: str, last_activity, threshold, cursor=None, incident_
         if cursor and incident_id:
             cursor.execute("""
                 SELECT 1 FROM execution_steps
-                WHERE incident_id = %s AND status = 'running' AND started_at > %s
+                WHERE incident_id = %s AND status = 'running'
                 LIMIT 1
-            """, (incident_id, threshold))
+            """, (incident_id,))
             if cursor.fetchone():
                 return False
         return True

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2110,7 +2110,8 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 for uid in _affected_users(cursor):
-                    set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
+                    if not set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]"):
+                        continue
                     cursor.execute("""
                         SELECT id, rca_celery_task_id,
                                COALESCE((SELECT cs.updated_at FROM chat_sessions cs
@@ -2125,7 +2126,7 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
                         cursor.execute("""
                             UPDATE incidents SET aurora_status = 'error', status = 'analyzed',
                                    rca_celery_task_id = NULL, updated_at = NOW()
-                            WHERE id = %s AND aurora_status = 'running' RETURNING id
+                            WHERE id = %s AND aurora_status = 'running' AND status != 'merged' RETURNING id
                         """, (inc_id,))
                         if cursor.fetchone():
                             _record_rca_error(cursor, str(inc_id), uid)
@@ -2163,7 +2164,8 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
 
             with conn.cursor() as cursor:
                 for uid in _affected_users(cursor):
-                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                    if not set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]"):
+                        continue
 
                     # --- 1. Stale sessions (>20 min with no update) ---
                     cursor.execute("""
@@ -2183,7 +2185,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                         _propagate_suggestion_status(str(session_id), 'failed')
                         if incident_id:
                             cursor.execute(
-                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s",
+                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND status != 'merged'",
                                 (incident_id,)
                             )
                             _record_rca_error(cursor, str(incident_id), uid)
@@ -2203,7 +2205,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                                              cursor=cursor, incident_id=inc_id):
                             continue
                         cursor.execute(
-                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' AND status != 'merged' RETURNING id",
                             (inc_id,)
                         )
                         if not cursor.fetchone():
@@ -2232,7 +2234,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                     """, (stale_threshold, uid))
                     for (inc_id,) in cursor.fetchall():
                         cursor.execute(
-                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running' AND status != 'merged' RETURNING id",
                             (inc_id,)
                         )
                         if cursor.fetchone():

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from celery_config import celery_app
@@ -2056,7 +2056,6 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
     """
     cleaned = 0
     try:
-        from datetime import timedelta
         threshold = datetime.now() - timedelta(minutes=threshold_minutes)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
@@ -2064,7 +2063,8 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
                 for uid, org_id in cursor.fetchall():
                     set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
                     cursor.execute("""
-                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW()
+                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed',
+                               rca_celery_task_id = NULL, updated_at = NOW()
                         WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
                         RETURNING id
                     """, (threshold, uid))
@@ -2088,7 +2088,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
     """Cleanup background chat sessions stuck in 'in_progress' and incidents
     whose Celery task is no longer alive. Runs every 5 minutes.
     """    
-    stale_threshold = datetime.now() - __import__('datetime').timedelta(minutes=20)
+    stale_threshold = datetime.now() - timedelta(minutes=20)
     
     try:
         with db_pool.get_admin_connection() as conn:
@@ -2179,7 +2179,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
 
             # Check for incidents whose Celery task is dead (catches crashes immediately, no 20-min wait)
             dead_task_count = 0
-            dead_task_threshold = datetime.now() - __import__('datetime').timedelta(minutes=3)
+            dead_task_threshold = datetime.now() - timedelta(minutes=3)
             with conn.cursor() as cursor:
                 for uid, org_id in all_users:
                     set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
@@ -2234,8 +2234,8 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                         RETURNING id
                     """, (datetime.now(), stale_threshold, uid))
                     orphaned = cursor.fetchall()
+                    conn.commit()
                     if orphaned:
-                        conn.commit()
                         logger.info(f"[BackgroundChat:Cleanup] Marked {len(orphaned)} orphaned incidents as error for user {uid}")
 
             return {"cleaned": cleaned_count, "dead_tasks": dead_task_count, "session_ids": [s[0] for s in stale_sessions]}

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2078,7 +2078,6 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                 
                 if not stale_sessions:
                     logger.info("[BackgroundChat:Cleanup] No stale sessions found")
-                    return {"cleaned": 0}
                 
                 # Mark sessions as failed per-user (respecting RLS)
                 actually_failed_ids = set()

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2050,9 +2050,8 @@ def create_background_chat_session(
 
 @celery_app.task(name="chat.background.cleanup_stale_sessions")
 def cleanup_stale_background_chats() -> Dict[str, Any]:
-    """Cleanup background chat sessions stuck in 'in_progress' for >20 minutes.
-    
-    Runs periodically to mark abandoned sessions as 'failed' and update their incidents.
+    """Cleanup background chat sessions stuck in 'in_progress' and incidents
+    whose Celery task is no longer alive. Runs every 5 minutes.
     """    
     stale_threshold = datetime.now() - __import__('datetime').timedelta(minutes=20)
     
@@ -2143,7 +2142,69 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                 conn.commit()
             
             logger.info(f"[BackgroundChat:Cleanup] Marked {cleaned_count} stale sessions as failed")
-            return {"cleaned": cleaned_count, "session_ids": [s[0] for s in stale_sessions]}
+
+            # Check for incidents whose Celery task is dead (catches crashes immediately, no 20-min wait)
+            dead_task_count = 0
+            dead_task_threshold = datetime.now() - __import__('datetime').timedelta(minutes=3)
+            with conn.cursor() as cursor:
+                for uid, org_id in all_users:
+                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                    cursor.execute("""
+                        SELECT i.id, i.rca_celery_task_id, i.aurora_chat_session_id,
+                               COALESCE(cs.updated_at, i.updated_at) as last_activity
+                        FROM incidents i
+                        LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
+                        WHERE i.aurora_status = 'running' AND i.rca_celery_task_id IS NOT NULL
+                          AND i.updated_at < %s AND i.user_id = %s
+                    """, (dead_task_threshold, uid))
+                    for inc_id, task_id, session_id, last_activity in cursor.fetchall():
+                        result = celery_app.AsyncResult(task_id)
+                        is_dead = result.state in ('FAILURE', 'REVOKED') or (result.state == 'PENDING' and result.result is None)
+                        # STARTED in result backend is stale if no DB activity for 3+ min (worker died without updating Redis)
+                        if not is_dead and result.state == 'STARTED' and last_activity and last_activity < dead_task_threshold:
+                            # Check for running tool calls -- a long tool (e.g. terraform) may not update the session
+                            cursor.execute("""
+                                SELECT 1 FROM execution_steps
+                                WHERE incident_id = %s AND status = 'running' AND started_at > %s
+                                LIMIT 1
+                            """, (inc_id, dead_task_threshold))
+                            if not cursor.fetchone():
+                                is_dead = True
+                        if is_dead:
+                            set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                            cursor.execute(
+                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = %s WHERE id = %s AND aurora_status = 'running'",
+                                (datetime.now(), inc_id)
+                            )
+                            if session_id:
+                                cursor.execute(
+                                    "UPDATE chat_sessions SET status = 'failed', updated_at = %s WHERE id = %s AND status = 'in_progress'",
+                                    (datetime.now(), str(session_id))
+                                )
+                            conn.commit()
+                            dead_task_count += 1
+                            logger.info(f"[BackgroundChat:Cleanup] Dead Celery task {task_id} for incident {inc_id} (state={result.state})")
+
+            # Also catch incidents stuck in 'running' with no linked in-progress session
+            with conn.cursor() as cursor:
+                for uid, org_id in all_users:
+                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                    cursor.execute("""
+                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s
+                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
+                          AND NOT EXISTS (
+                              SELECT 1 FROM chat_sessions cs
+                              WHERE cs.id::text = incidents.aurora_chat_session_id::text
+                                AND cs.status = 'in_progress'
+                          )
+                        RETURNING id
+                    """, (datetime.now(), stale_threshold, uid))
+                    orphaned = cursor.fetchall()
+                    if orphaned:
+                        conn.commit()
+                        logger.info(f"[BackgroundChat:Cleanup] Marked {len(orphaned)} orphaned incidents as error for user {uid}")
+
+            return {"cleaned": cleaned_count, "dead_tasks": dead_task_count, "session_ids": [s[0] for s in stale_sessions]}
             
     except Exception as e:
         logger.exception(f"[BackgroundChat:Cleanup] Failed: {e}")

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2048,7 +2048,7 @@ def create_background_chat_session(
     
     return session_id
 
-def _record_rca_error(cursor, conn, incident_id: str, user_id: str) -> None:
+def _record_rca_error(cursor, incident_id: str, user_id: str) -> None:
     """Write an rca_error lifecycle event, wrapped in a savepoint to avoid aborting the caller."""
     try:
         cursor.execute("SAVEPOINT sp_rca_err")
@@ -2128,7 +2128,7 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
                             WHERE id = %s AND aurora_status = 'running' RETURNING id
                         """, (inc_id,))
                         if cursor.fetchone():
-                            _record_rca_error(cursor, conn, str(inc_id), uid)
+                            _record_rca_error(cursor, str(inc_id), uid)
                             cleaned += 1
                         conn.commit()
                     cursor.execute("""
@@ -2183,7 +2183,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                                 "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW() WHERE id = %s",
                                 (incident_id,)
                             )
-                            _record_rca_error(cursor, conn, str(incident_id), uid)
+                            _record_rca_error(cursor, str(incident_id), uid)
                         conn.commit()
 
                     # --- 2. Dead Celery tasks (task no longer alive in broker) ---
@@ -2208,7 +2208,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                                 "UPDATE chat_sessions SET status = 'failed', updated_at = NOW() WHERE id = %s AND status = 'in_progress'",
                                 (str(session_id),)
                             )
-                        _record_rca_error(cursor, conn, str(inc_id), uid)
+                        _record_rca_error(cursor, str(inc_id), uid)
                         conn.commit()
                         dead_task_count += 1
 
@@ -2228,7 +2228,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
                             (inc_id,)
                         )
                         if cursor.fetchone():
-                            _record_rca_error(cursor, conn, str(inc_id), uid)
+                            _record_rca_error(cursor, str(inc_id), uid)
                             orphaned_count += 1
                         conn.commit()
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2048,36 +2048,82 @@ def create_background_chat_session(
     
     return session_id
 
+def _record_rca_error(cursor, conn, incident_id: str, user_id: str) -> None:
+    """Write an rca_error lifecycle event, wrapped in a savepoint to avoid aborting the caller."""
+    try:
+        cursor.execute("SAVEPOINT sp_rca_err")
+        cursor.execute(
+            """INSERT INTO incident_lifecycle_events
+               (incident_id, user_id, org_id, event_type, new_value)
+               VALUES (%s, %s, %s, %s, %s)""",
+            (incident_id, user_id, None, 'rca_error', 'error')
+        )
+        cursor.execute("RELEASE SAVEPOINT sp_rca_err")
+    except Exception as e:
+        try:
+            cursor.execute("ROLLBACK TO SAVEPOINT sp_rca_err")
+        except Exception:
+            pass
+        logger.debug("[Cleanup] Failed to record rca_error for incident %s: %s", incident_id, e)
+
+
+def _is_task_dead(task_id: str, last_activity, threshold) -> bool:
+    """Check whether a Celery task is no longer running."""
+    result = celery_app.AsyncResult(task_id)
+    if result.state in ('FAILURE', 'REVOKED'):
+        return True
+    if result.state == 'PENDING' and result.result is None:
+        return True
+    if result.state == 'STARTED' and last_activity and last_activity < threshold:
+        return True
+    return False
+
+
 def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
     """Mark investigations left in 'running' state by a previous process as failed.
 
     Intended to be called once on process startup (chatbot or worker).
+    Uses AsyncResult to avoid killing investigations whose Celery task is still alive.
     Returns the number of incidents cleaned.
     """
     cleaned = 0
+    threshold = datetime.now() - timedelta(minutes=threshold_minutes)
     try:
-        threshold = datetime.now() - timedelta(minutes=threshold_minutes)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-                for uid, org_id in cursor.fetchall():
+                cursor.execute("""
+                    SELECT i.id, i.user_id, i.rca_celery_task_id,
+                           COALESCE(cs.updated_at, i.updated_at) as last_activity
+                    FROM incidents i
+                    LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
+                    WHERE i.aurora_status = 'running' AND i.updated_at < %s
+                """, (threshold,))
+                candidates = cursor.fetchall()
+
+                for inc_id, uid, task_id, last_activity in candidates:
+                    if task_id and not _is_task_dead(task_id, last_activity, threshold):
+                        continue
                     set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
                     cursor.execute("""
                         UPDATE incidents SET aurora_status = 'error', status = 'analyzed',
                                rca_celery_task_id = NULL, updated_at = NOW()
-                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
+                        WHERE id = %s AND aurora_status = 'running'
                         RETURNING id
-                    """, (threshold, uid))
-                    stale_incidents = cursor.fetchall()
-                    cursor.execute("""
-                        UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
-                        WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
-                    """, (threshold, uid))
+                    """, (inc_id,))
+                    if cursor.fetchone():
+                        _record_rca_error(cursor, conn, str(inc_id), uid)
+                        cleaned += 1
                     conn.commit()
-                    if stale_incidents:
-                        ids = [str(r[0]) for r in stale_incidents]
-                        cleaned += len(ids)
-                        logger.info(f"[StartupCleanup] Marked {len(ids)} orphaned investigations as error for user {uid}: {ids}")
+
+                # Fail any orphaned in-progress sessions older than threshold
+                cursor.execute("""
+                    UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
+                    WHERE status = 'in_progress' AND updated_at < %s
+                """, (threshold,))
+                conn.commit()
+
+        if cleaned:
+            logger.info(f"[StartupCleanup] Marked {cleaned} orphaned investigations as error")
     except Exception as e:
         logger.error(f"[StartupCleanup] Failed to clean orphaned investigations: {e}")
     return cleaned
@@ -2089,156 +2135,119 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
     whose Celery task is no longer alive. Runs every 5 minutes.
     """    
     stale_threshold = datetime.now() - timedelta(minutes=20)
-    
+    dead_task_threshold = datetime.now() - timedelta(minutes=3)
+
     try:
         with db_pool.get_admin_connection() as conn:
+            # --- 1. Stale sessions (>20 min with no update) ---
             with conn.cursor() as cursor:
-                # users table is not RLS-protected; iterate per-user to set RLS before querying protected tables
-                cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-                all_users = cursor.fetchall()
+                cursor.execute("""
+                    SELECT cs.id, cs.user_id, i.id as incident_id
+                    FROM chat_sessions cs
+                    LEFT JOIN incidents i ON i.aurora_chat_session_id = cs.id::uuid
+                    WHERE cs.status = 'in_progress' AND cs.updated_at < %s
+                """, (stale_threshold,))
+                stale_sessions = cursor.fetchall()
 
-                stale_sessions = []
-                for uid, org_id in all_users:
-                    cursor.execute("SET myapp.current_user_id = %s;", (uid,))
-                    cursor.execute("SET myapp.current_org_id = %s;", (org_id,))
-                    conn.commit()
+            if not stale_sessions:
+                logger.info("[BackgroundChat:Cleanup] No stale sessions found")
+
+            actually_failed_ids = set()
+            for session_id, user_id, incident_id in stale_sessions:
+                with conn.cursor() as cursor:
+                    set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:Cleanup]")
                     cursor.execute("""
-                        SELECT cs.id, cs.user_id, i.id as incident_id
-                        FROM chat_sessions cs
-                        LEFT JOIN incidents i ON i.aurora_chat_session_id = cs.id::uuid
-                        WHERE cs.status = 'in_progress' AND cs.updated_at < %s
-                          AND cs.user_id = %s
-                    """, (stale_threshold, uid))
-                    stale_sessions.extend(cursor.fetchall())
-                
-                if not stale_sessions:
-                    logger.info("[BackgroundChat:Cleanup] No stale sessions found")
-                
-                # Mark sessions as failed per-user (respecting RLS)
-                actually_failed_ids = set()
-                for session_id, user_id, incident_id in stale_sessions:
-                    if not set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:Cleanup]"):
-                        continue
-                    cursor.execute("""
-                        UPDATE chat_sessions 
-                        SET status = 'failed', updated_at = %s 
-                        WHERE id = %s AND status = 'in_progress'
-                        RETURNING id
+                        UPDATE chat_sessions SET status = 'failed', updated_at = %s
+                        WHERE id = %s AND status = 'in_progress' RETURNING id
                     """, (datetime.now(), session_id))
-                    row = cursor.fetchone()
-                    if row:
-                        actually_failed_ids.add(str(row[0]))
+                    if cursor.fetchone():
+                        actually_failed_ids.add(str(session_id))
+                    if incident_id and str(session_id) in actually_failed_ids:
+                        cursor.execute(
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s WHERE id = %s",
+                            (datetime.now(), incident_id)
+                        )
+                        _record_rca_error(cursor, conn, str(incident_id), user_id)
                     conn.commit()
-                
-                cleaned_count = len(actually_failed_ids)
-            
-            # Propagate failed status only for sessions that were actually updated
+
             for session_id, user_id, incident_id in stale_sessions:
                 if str(session_id) in actually_failed_ids:
                     _propagate_suggestion_status(str(session_id), 'failed')
 
-            # Update associated incidents (both aurora_status and status)
-            if actually_failed_ids:
-                with conn.cursor() as cursor:
-                    for session_id, user_id, incident_id in stale_sessions:
-                        if incident_id and str(session_id) in actually_failed_ids:
-                            if not user_id or not set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:Cleanup]"):
-                                continue
-                            cursor.execute(
-                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s WHERE id = %s",
-                                (datetime.now(), incident_id)
-                            )
-                            # Record lifecycle event for stale session error. Wrap in savepoint
-                            # so a failure here doesn't abort the outer transaction and stop
-                            # the status UPDATE from committing for remaining sessions.
-                            try:
-                                cursor.execute("SAVEPOINT sp_rca_error")
-                                cursor.execute(
-                                    """INSERT INTO incident_lifecycle_events
-                                       (incident_id, user_id, org_id, event_type, new_value)
-                                       VALUES (%s, %s, %s, %s, %s)""",
-                                    (incident_id, user_id, None, 'rca_error', 'error')
-                                )
-                                cursor.execute("RELEASE SAVEPOINT sp_rca_error")
-                            except Exception as lc_exc:
-                                try:
-                                    cursor.execute("ROLLBACK TO SAVEPOINT sp_rca_error")
-                                except Exception as rb_exc:
-                                    logger.debug(
-                                        "[BackgroundChat:Cleanup] Rollback to sp_rca_error failed for incident %s: %s",
-                                        incident_id, rb_exc,
-                                    )
-                                logger.warning(
-                                    "[BackgroundChat:Cleanup] Failed to record rca_error lifecycle event "
-                                    "for incident %s (user %s): %s",
-                                    incident_id, user_id, lc_exc,
-                                )
-                conn.commit()
-            
+            cleaned_count = len(actually_failed_ids)
             logger.info(f"[BackgroundChat:Cleanup] Marked {cleaned_count} stale sessions as failed")
 
-            # Check for incidents whose Celery task is dead (catches crashes immediately, no 20-min wait)
+            # --- 2. Dead Celery tasks (task no longer alive in broker) ---
             dead_task_count = 0
-            dead_task_threshold = datetime.now() - timedelta(minutes=3)
             with conn.cursor() as cursor:
-                for uid, org_id in all_users:
-                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                    cursor.execute("""
-                        SELECT i.id, i.rca_celery_task_id, i.aurora_chat_session_id,
-                               COALESCE(cs.updated_at, i.updated_at) as last_activity
-                        FROM incidents i
-                        LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
-                        WHERE i.aurora_status = 'running' AND i.rca_celery_task_id IS NOT NULL
-                          AND i.updated_at < %s AND i.user_id = %s
-                    """, (dead_task_threshold, uid))
-                    for inc_id, task_id, session_id, last_activity in cursor.fetchall():
-                        result = celery_app.AsyncResult(task_id)
-                        is_dead = result.state in ('FAILURE', 'REVOKED') or (result.state == 'PENDING' and result.result is None)
-                        # STARTED in result backend is stale if no DB activity for 3+ min (worker died without updating Redis)
-                        if not is_dead and result.state == 'STARTED' and last_activity and last_activity < dead_task_threshold:
-                            # Check for running tool calls -- a long tool (e.g. terraform) may not update the session
-                            cursor.execute("""
-                                SELECT 1 FROM execution_steps
-                                WHERE incident_id = %s AND status = 'running' AND started_at > %s
-                                LIMIT 1
-                            """, (inc_id, dead_task_threshold))
-                            if not cursor.fetchone():
-                                is_dead = True
-                        if is_dead:
-                            set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                            cursor.execute(
-                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = %s WHERE id = %s AND aurora_status = 'running'",
-                                (datetime.now(), inc_id)
-                            )
-                            if session_id:
-                                cursor.execute(
-                                    "UPDATE chat_sessions SET status = 'failed', updated_at = %s WHERE id = %s AND status = 'in_progress'",
-                                    (datetime.now(), str(session_id))
-                                )
-                            conn.commit()
-                            dead_task_count += 1
-                            logger.info(f"[BackgroundChat:Cleanup] Dead Celery task {task_id} for incident {inc_id} (state={result.state})")
+                cursor.execute("""
+                    SELECT i.id, i.user_id, i.rca_celery_task_id, i.aurora_chat_session_id,
+                           COALESCE(cs.updated_at, i.updated_at) as last_activity
+                    FROM incidents i
+                    LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
+                    WHERE i.aurora_status = 'running' AND i.rca_celery_task_id IS NOT NULL
+                      AND i.updated_at < %s
+                """, (dead_task_threshold,))
+                running_incidents = cursor.fetchall()
 
-            # Also catch incidents stuck in 'running' with no linked in-progress session
-            with conn.cursor() as cursor:
-                for uid, org_id in all_users:
+            for inc_id, uid, task_id, session_id, last_activity in running_incidents:
+                is_dead = _is_task_dead(task_id, last_activity, dead_task_threshold)
+                if not is_dead:
+                    continue
+                # For STARTED tasks, also check execution_steps
+                result_state = celery_app.AsyncResult(task_id).state
+                if result_state == 'STARTED':
+                    with conn.cursor() as cursor:
+                        set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                        cursor.execute("""
+                            SELECT 1 FROM execution_steps
+                            WHERE incident_id = %s AND status = 'running' AND started_at > %s
+                            LIMIT 1
+                        """, (inc_id, dead_task_threshold))
+                        if cursor.fetchone():
+                            continue
+                with conn.cursor() as cursor:
                     set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                    cursor.execute("""
-                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s
-                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
-                          AND NOT EXISTS (
-                              SELECT 1 FROM chat_sessions cs
-                              WHERE cs.id::text = incidents.aurora_chat_session_id::text
-                                AND cs.status = 'in_progress'
-                          )
-                        RETURNING id
-                    """, (datetime.now(), stale_threshold, uid))
-                    orphaned = cursor.fetchall()
+                    cursor.execute(
+                        "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = %s WHERE id = %s AND aurora_status = 'running'",
+                        (datetime.now(), inc_id)
+                    )
+                    if session_id:
+                        cursor.execute(
+                            "UPDATE chat_sessions SET status = 'failed', updated_at = %s WHERE id = %s AND status = 'in_progress'",
+                            (datetime.now(), str(session_id))
+                        )
+                    _record_rca_error(cursor, conn, str(inc_id), uid)
                     conn.commit()
-                    if orphaned:
-                        logger.info(f"[BackgroundChat:Cleanup] Marked {len(orphaned)} orphaned incidents as error for user {uid}")
+                dead_task_count += 1
+                logger.info(f"[BackgroundChat:Cleanup] Dead Celery task {task_id} for incident {inc_id} (state={result_state})")
 
-            return {"cleaned": cleaned_count, "dead_tasks": dead_task_count, "session_ids": [s[0] for s in stale_sessions]}
+            # --- 3. Orphaned incidents (running but no in-progress session) ---
+            orphaned_count = 0
+            with conn.cursor() as cursor:
+                cursor.execute("""
+                    SELECT i.id, i.user_id FROM incidents i
+                    WHERE i.aurora_status = 'running' AND i.updated_at < %s
+                      AND NOT EXISTS (
+                          SELECT 1 FROM chat_sessions cs
+                          WHERE cs.id::text = i.aurora_chat_session_id::text
+                            AND cs.status = 'in_progress'
+                      )
+                """, (stale_threshold,))
+                for inc_id, uid in cursor.fetchall():
+                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+                    cursor.execute(
+                        "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s WHERE id = %s AND aurora_status = 'running' RETURNING id",
+                        (datetime.now(), inc_id)
+                    )
+                    if cursor.fetchone():
+                        _record_rca_error(cursor, conn, str(inc_id), uid)
+                        orphaned_count += 1
+                    conn.commit()
+                if orphaned_count:
+                    logger.info(f"[BackgroundChat:Cleanup] Marked {orphaned_count} orphaned incidents as error")
+
+            return {"cleaned": cleaned_count, "dead_tasks": dead_task_count, "orphaned": orphaned_count}
             
     except Exception as e:
         logger.exception(f"[BackgroundChat:Cleanup] Failed: {e}")

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2067,16 +2067,34 @@ def _record_rca_error(cursor, conn, incident_id: str, user_id: str) -> None:
         logger.debug("[Cleanup] Failed to record rca_error for incident %s: %s", incident_id, e)
 
 
-def _is_task_dead(task_id: str, last_activity, threshold) -> bool:
-    """Check whether a Celery task is no longer running."""
+def _is_task_dead(task_id: str, last_activity, threshold, cursor=None, incident_id=None) -> bool:
+    """Check whether a Celery task is no longer running.
+
+    For STARTED tasks, optionally checks execution_steps for active tool calls
+    when cursor and incident_id are provided.
+    """
     result = celery_app.AsyncResult(task_id)
     if result.state in ('FAILURE', 'REVOKED'):
         return True
     if result.state == 'PENDING' and result.result is None:
         return True
     if result.state == 'STARTED' and last_activity and last_activity < threshold:
+        if cursor and incident_id:
+            cursor.execute("""
+                SELECT 1 FROM execution_steps
+                WHERE incident_id = %s AND status = 'running' AND started_at > %s
+                LIMIT 1
+            """, (incident_id, threshold))
+            if cursor.fetchone():
+                return False
         return True
     return False
+
+
+def _iter_rls_users(cursor, conn):
+    """Return (user_id, org_id) pairs. users table is not RLS-protected."""
+    cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+    return cursor.fetchall()
 
 
 def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
@@ -2091,36 +2109,33 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute("""
-                    SELECT i.id, i.user_id, i.rca_celery_task_id,
-                           COALESCE(cs.updated_at, i.updated_at) as last_activity
-                    FROM incidents i
-                    LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
-                    WHERE i.aurora_status = 'running' AND i.updated_at < %s
-                """, (threshold,))
-                candidates = cursor.fetchall()
-
-                for inc_id, uid, task_id, last_activity in candidates:
-                    if task_id and not _is_task_dead(task_id, last_activity, threshold):
-                        continue
+                for uid, org_id in _iter_rls_users(cursor, conn):
                     set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
                     cursor.execute("""
-                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed',
-                               rca_celery_task_id = NULL, updated_at = NOW()
-                        WHERE id = %s AND aurora_status = 'running'
-                        RETURNING id
-                    """, (inc_id,))
-                    if cursor.fetchone():
-                        _record_rca_error(cursor, conn, str(inc_id), uid)
-                        cleaned += 1
+                        SELECT id, rca_celery_task_id,
+                               COALESCE((SELECT cs.updated_at FROM chat_sessions cs
+                                         WHERE cs.id::text = i.aurora_chat_session_id::text), i.updated_at)
+                        FROM incidents i
+                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
+                    """, (threshold, uid))
+                    for inc_id, task_id, last_activity in cursor.fetchall():
+                        if task_id and not _is_task_dead(task_id, last_activity, threshold,
+                                                         cursor=cursor, incident_id=inc_id):
+                            continue
+                        cursor.execute("""
+                            UPDATE incidents SET aurora_status = 'error', status = 'analyzed',
+                                   rca_celery_task_id = NULL, updated_at = NOW()
+                            WHERE id = %s AND aurora_status = 'running' RETURNING id
+                        """, (inc_id,))
+                        if cursor.fetchone():
+                            _record_rca_error(cursor, conn, str(inc_id), uid)
+                            cleaned += 1
+                        conn.commit()
+                    cursor.execute("""
+                        UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
+                        WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
+                    """, (threshold, uid))
                     conn.commit()
-
-                # Fail any orphaned in-progress sessions older than threshold
-                cursor.execute("""
-                    UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
-                    WHERE status = 'in_progress' AND updated_at < %s
-                """, (threshold,))
-                conn.commit()
 
         if cleaned:
             logger.info(f"[StartupCleanup] Marked {cleaned} orphaned investigations as error")
@@ -2133,122 +2148,95 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
 def cleanup_stale_background_chats() -> Dict[str, Any]:
     """Cleanup background chat sessions stuck in 'in_progress' and incidents
     whose Celery task is no longer alive. Runs every 5 minutes.
-    """    
+    """
     stale_threshold = datetime.now() - timedelta(minutes=20)
     dead_task_threshold = datetime.now() - timedelta(minutes=3)
 
     try:
         with db_pool.get_admin_connection() as conn:
-            # --- 1. Stale sessions (>20 min with no update) ---
-            with conn.cursor() as cursor:
-                cursor.execute("""
-                    SELECT cs.id, cs.user_id, i.id as incident_id
-                    FROM chat_sessions cs
-                    LEFT JOIN incidents i ON i.aurora_chat_session_id = cs.id::uuid
-                    WHERE cs.status = 'in_progress' AND cs.updated_at < %s
-                """, (stale_threshold,))
-                stale_sessions = cursor.fetchall()
-
-            if not stale_sessions:
-                logger.info("[BackgroundChat:Cleanup] No stale sessions found")
-
-            actually_failed_ids = set()
-            for session_id, user_id, incident_id in stale_sessions:
-                with conn.cursor() as cursor:
-                    set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:Cleanup]")
-                    cursor.execute("""
-                        UPDATE chat_sessions SET status = 'failed', updated_at = %s
-                        WHERE id = %s AND status = 'in_progress' RETURNING id
-                    """, (datetime.now(), session_id))
-                    if cursor.fetchone():
-                        actually_failed_ids.add(str(session_id))
-                    if incident_id and str(session_id) in actually_failed_ids:
-                        cursor.execute(
-                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s WHERE id = %s",
-                            (datetime.now(), incident_id)
-                        )
-                        _record_rca_error(cursor, conn, str(incident_id), user_id)
-                    conn.commit()
-
-            for session_id, user_id, incident_id in stale_sessions:
-                if str(session_id) in actually_failed_ids:
-                    _propagate_suggestion_status(str(session_id), 'failed')
-
-            cleaned_count = len(actually_failed_ids)
-            logger.info(f"[BackgroundChat:Cleanup] Marked {cleaned_count} stale sessions as failed")
-
-            # --- 2. Dead Celery tasks (task no longer alive in broker) ---
+            cleaned_count = 0
             dead_task_count = 0
-            with conn.cursor() as cursor:
-                cursor.execute("""
-                    SELECT i.id, i.user_id, i.rca_celery_task_id, i.aurora_chat_session_id,
-                           COALESCE(cs.updated_at, i.updated_at) as last_activity
-                    FROM incidents i
-                    LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
-                    WHERE i.aurora_status = 'running' AND i.rca_celery_task_id IS NOT NULL
-                      AND i.updated_at < %s
-                """, (dead_task_threshold,))
-                running_incidents = cursor.fetchall()
-
-            for inc_id, uid, task_id, session_id, last_activity in running_incidents:
-                is_dead = _is_task_dead(task_id, last_activity, dead_task_threshold)
-                if not is_dead:
-                    continue
-                # For STARTED tasks, also check execution_steps
-                result_state = celery_app.AsyncResult(task_id).state
-                if result_state == 'STARTED':
-                    with conn.cursor() as cursor:
-                        set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                        cursor.execute("""
-                            SELECT 1 FROM execution_steps
-                            WHERE incident_id = %s AND status = 'running' AND started_at > %s
-                            LIMIT 1
-                        """, (inc_id, dead_task_threshold))
-                        if cursor.fetchone():
-                            continue
-                with conn.cursor() as cursor:
-                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                    cursor.execute(
-                        "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = %s WHERE id = %s AND aurora_status = 'running'",
-                        (datetime.now(), inc_id)
-                    )
-                    if session_id:
-                        cursor.execute(
-                            "UPDATE chat_sessions SET status = 'failed', updated_at = %s WHERE id = %s AND status = 'in_progress'",
-                            (datetime.now(), str(session_id))
-                        )
-                    _record_rca_error(cursor, conn, str(inc_id), uid)
-                    conn.commit()
-                dead_task_count += 1
-                logger.info(f"[BackgroundChat:Cleanup] Dead Celery task {task_id} for incident {inc_id} (state={result_state})")
-
-            # --- 3. Orphaned incidents (running but no in-progress session) ---
             orphaned_count = 0
-            with conn.cursor() as cursor:
-                cursor.execute("""
-                    SELECT i.id, i.user_id FROM incidents i
-                    WHERE i.aurora_status = 'running' AND i.updated_at < %s
-                      AND NOT EXISTS (
-                          SELECT 1 FROM chat_sessions cs
-                          WHERE cs.id::text = i.aurora_chat_session_id::text
-                            AND cs.status = 'in_progress'
-                      )
-                """, (stale_threshold,))
-                for inc_id, uid in cursor.fetchall():
-                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
-                    cursor.execute(
-                        "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = %s WHERE id = %s AND aurora_status = 'running' RETURNING id",
-                        (datetime.now(), inc_id)
-                    )
-                    if cursor.fetchone():
-                        _record_rca_error(cursor, conn, str(inc_id), uid)
-                        orphaned_count += 1
-                    conn.commit()
-                if orphaned_count:
-                    logger.info(f"[BackgroundChat:Cleanup] Marked {orphaned_count} orphaned incidents as error")
 
+            with conn.cursor() as cursor:
+                for uid, org_id in _iter_rls_users(cursor, conn):
+                    set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
+
+                    # --- 1. Stale sessions (>20 min with no update) ---
+                    cursor.execute("""
+                        SELECT cs.id, i.id as incident_id
+                        FROM chat_sessions cs
+                        LEFT JOIN incidents i ON i.aurora_chat_session_id = cs.id::uuid
+                        WHERE cs.status = 'in_progress' AND cs.updated_at < %s AND cs.user_id = %s
+                    """, (stale_threshold, uid))
+                    for session_id, incident_id in cursor.fetchall():
+                        cursor.execute("""
+                            UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
+                            WHERE id = %s AND status = 'in_progress' RETURNING id
+                        """, (session_id,))
+                        if not cursor.fetchone():
+                            continue
+                        cleaned_count += 1
+                        _propagate_suggestion_status(str(session_id), 'failed')
+                        if incident_id:
+                            cursor.execute(
+                                "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW() WHERE id = %s",
+                                (incident_id,)
+                            )
+                            _record_rca_error(cursor, conn, str(incident_id), uid)
+                        conn.commit()
+
+                    # --- 2. Dead Celery tasks (task no longer alive in broker) ---
+                    cursor.execute("""
+                        SELECT i.id, i.rca_celery_task_id, i.aurora_chat_session_id,
+                               COALESCE(cs.updated_at, i.updated_at) as last_activity
+                        FROM incidents i
+                        LEFT JOIN chat_sessions cs ON cs.id::text = i.aurora_chat_session_id::text
+                        WHERE i.aurora_status = 'running' AND i.rca_celery_task_id IS NOT NULL
+                          AND i.updated_at < %s AND i.user_id = %s
+                    """, (dead_task_threshold, uid))
+                    for inc_id, task_id, session_id, last_activity in cursor.fetchall():
+                        if not _is_task_dead(task_id, last_activity, dead_task_threshold,
+                                             cursor=cursor, incident_id=inc_id):
+                            continue
+                        cursor.execute(
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', rca_celery_task_id = NULL, updated_at = NOW() WHERE id = %s AND aurora_status = 'running'",
+                            (inc_id,)
+                        )
+                        if session_id:
+                            cursor.execute(
+                                "UPDATE chat_sessions SET status = 'failed', updated_at = NOW() WHERE id = %s AND status = 'in_progress'",
+                                (str(session_id),)
+                            )
+                        _record_rca_error(cursor, conn, str(inc_id), uid)
+                        conn.commit()
+                        dead_task_count += 1
+
+                    # --- 3. Orphaned incidents (running but no in-progress session) ---
+                    cursor.execute("""
+                        SELECT i.id FROM incidents i
+                        WHERE i.aurora_status = 'running' AND i.updated_at < %s AND i.user_id = %s
+                          AND NOT EXISTS (
+                              SELECT 1 FROM chat_sessions cs
+                              WHERE cs.id::text = i.aurora_chat_session_id::text
+                                AND cs.status = 'in_progress'
+                          )
+                    """, (stale_threshold, uid))
+                    for (inc_id,) in cursor.fetchall():
+                        cursor.execute(
+                            "UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW() WHERE id = %s AND aurora_status = 'running' RETURNING id",
+                            (inc_id,)
+                        )
+                        if cursor.fetchone():
+                            _record_rca_error(cursor, conn, str(inc_id), uid)
+                            orphaned_count += 1
+                        conn.commit()
+
+            if cleaned_count or dead_task_count or orphaned_count:
+                logger.info("[BackgroundChat:Cleanup] stale=%d dead_tasks=%d orphaned=%d",
+                            cleaned_count, dead_task_count, orphaned_count)
             return {"cleaned": cleaned_count, "dead_tasks": dead_task_count, "orphaned": orphaned_count}
-            
+
     except Exception as e:
         logger.exception(f"[BackgroundChat:Cleanup] Failed: {e}")
         return {"error": str(e), "cleaned": 0}

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -2091,10 +2091,10 @@ def _is_task_dead(task_id: str, last_activity, threshold, cursor=None, incident_
     return False
 
 
-def _iter_rls_users(cursor, conn):
-    """Return (user_id, org_id) pairs. users table is not RLS-protected."""
-    cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-    return cursor.fetchall()
+def _affected_users(cursor):
+    """Return user_ids that could have stale work. users table has no RLS."""
+    cursor.execute("SELECT DISTINCT id FROM users WHERE org_id IS NOT NULL")
+    return [r[0] for r in cursor.fetchall()]
 
 
 def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
@@ -2109,7 +2109,7 @@ def cleanup_orphaned_investigations(threshold_minutes: int = 25) -> int:
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                for uid, org_id in _iter_rls_users(cursor, conn):
+                for uid in _affected_users(cursor):
                     set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
                     cursor.execute("""
                         SELECT id, rca_celery_task_id,
@@ -2159,7 +2159,7 @@ def cleanup_stale_background_chats() -> Dict[str, Any]:
             orphaned_count = 0
 
             with conn.cursor() as cursor:
-                for uid, org_id in _iter_rls_users(cursor, conn):
+                for uid in _affected_users(cursor):
                     set_rls_context(cursor, conn, uid, log_prefix="[BackgroundChat:Cleanup]")
 
                     # --- 1. Stale sessions (>20 min with no update) ---

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1588,7 +1588,7 @@ async def main():
 
     # Mark any investigations orphaned by a previous crash as failed
     from chat.background.task import cleanup_orphaned_investigations
-    cleanup_orphaned_investigations()
+    await asyncio.to_thread(cleanup_orphaned_investigations)
 
     # Start HTTP server (health check + internal API)
     http_server = await asyncio.start_server(handle_http_request, "0.0.0.0", HEALTH_PORT)

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1577,6 +1577,34 @@ async def handle_connection(websocket) -> None:
         if weaviate_client:
             weaviate_client.close()
 
+def _cleanup_orphaned_investigations():
+    """Mark investigations left in 'running' state by a previous process as failed."""
+    try:
+        from datetime import timedelta
+        threshold = datetime.now() - timedelta(minutes=25)
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+                for uid, org_id in cursor.fetchall():
+                    set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
+                    cursor.execute("""
+                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW()
+                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
+                        RETURNING id
+                    """, (threshold, uid))
+                    stale_incidents = cursor.fetchall()
+                    cursor.execute("""
+                        UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
+                        WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
+                    """, (threshold, uid))
+                    conn.commit()
+                    if stale_incidents:
+                        ids = [str(r[0]) for r in stale_incidents]
+                        logger.info(f"[StartupCleanup] Marked {len(ids)} orphaned investigations as error for user {uid}: {ids}")
+    except Exception as e:
+        logger.error(f"[StartupCleanup] Failed to clean orphaned investigations: {e}")
+
+
 async def main():
     """Start the WebSocket server and health check endpoint."""
     WS_PORT = 5006
@@ -1585,6 +1613,9 @@ async def main():
 
     # Clean up old terraform files on startup
     cleanup_terraform_directory()
+
+    # Mark any investigations orphaned by a previous crash as failed
+    _cleanup_orphaned_investigations()
 
     # Start HTTP server (health check + internal API)
     http_server = await asyncio.start_server(handle_http_request, "0.0.0.0", HEALTH_PORT)

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1577,34 +1577,6 @@ async def handle_connection(websocket) -> None:
         if weaviate_client:
             weaviate_client.close()
 
-def _cleanup_orphaned_investigations():
-    """Mark investigations left in 'running' state by a previous process as failed."""
-    try:
-        from datetime import timedelta
-        threshold = datetime.now() - timedelta(minutes=25)
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                cursor.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-                for uid, org_id in cursor.fetchall():
-                    set_rls_context(cursor, conn, uid, log_prefix="[StartupCleanup]")
-                    cursor.execute("""
-                        UPDATE incidents SET aurora_status = 'error', status = 'analyzed', updated_at = NOW()
-                        WHERE aurora_status = 'running' AND updated_at < %s AND user_id = %s
-                        RETURNING id
-                    """, (threshold, uid))
-                    stale_incidents = cursor.fetchall()
-                    cursor.execute("""
-                        UPDATE chat_sessions SET status = 'failed', updated_at = NOW()
-                        WHERE status = 'in_progress' AND updated_at < %s AND user_id = %s
-                    """, (threshold, uid))
-                    conn.commit()
-                    if stale_incidents:
-                        ids = [str(r[0]) for r in stale_incidents]
-                        logger.info(f"[StartupCleanup] Marked {len(ids)} orphaned investigations as error for user {uid}: {ids}")
-    except Exception as e:
-        logger.error(f"[StartupCleanup] Failed to clean orphaned investigations: {e}")
-
-
 async def main():
     """Start the WebSocket server and health check endpoint."""
     WS_PORT = 5006
@@ -1615,7 +1587,8 @@ async def main():
     cleanup_terraform_directory()
 
     # Mark any investigations orphaned by a previous crash as failed
-    _cleanup_orphaned_investigations()
+    from chat.background.task import cleanup_orphaned_investigations
+    cleanup_orphaned_investigations()
 
     # Start HTTP server (health check + internal API)
     http_server = await asyncio.start_server(handle_http_request, "0.0.0.0", HEALTH_PORT)


### PR DESCRIPTION
## Problem

When a pod restarts, a Celery worker crashes, or a container gets killed mid-investigation, the incident stays in `running`/`investigating` state forever. The UI shows an infinite spinner and there's no mechanism to detect or recover from this.

## What this does

**Backend - startup cleanup** (`cleanup_orphaned_investigations`):
When the chatbot container starts, it scans for incidents still marked `running` whose Celery task is dead (PENDING/FAILURE/REVOKED in the result backend). Marks them as `error`/`analyzed` and records a lifecycle event. This catches the most common case — container restart killed the worker mid-RCA.

**Backend - periodic cleanup** (existing `cleanup_stale_background_chats`, hardened):
The Celery beat task now has three checks instead of one:
1. Stale sessions — same as before (>20 min with no update)
2. Dead Celery tasks — incidents whose `rca_celery_task_id` points to a task that no longer exists in the broker. For `STARTED` tasks (which can linger in Redis after a worker crash), cross-checks `execution_steps` for recent activity before declaring dead.
3. Orphaned incidents — `running` status but no associated `in_progress` chat session

Previously this function had an early return when no stale sessions were found, which meant the dead-task and orphaned checks never ran.

**Frontend safety nets:**
- Incident detail page: stops polling after 5 min and shows error state locally
- Incidents list: shows "Investigation stalled" with a warning icon for any `investigating` incident older than 30 min
- ThoughtsPanel: stops polling chat sessions after 5 min and marks them as failed locally
- Chat input: clears `isSending` on WebSocket disconnect so users aren't stuck with a disabled input

## How I tested it

1. Set an incident to `running` with a fake Celery task ID, backdated 30 min
2. Restarted chatbot container — logs show `[StartupCleanup] Marked 1 orphaned investigations as error`
3. Verified DB: `aurora_status='error'`, `status='analyzed'`, `rca_celery_task_id=NULL`
4. Checked incidents list — shows "Investigation stalled" with warning icon
5. Checked incident detail — shows "Analysis Error" badge, no spinner

## Files changed

- `server/chat/background/task.py` — new helpers (`_is_task_dead`, `_record_rca_error`, `_affected_users`, `cleanup_orphaned_investigations`), hardened `cleanup_stale_background_chats`
- `server/main_chatbot.py` — calls `cleanup_orphaned_investigations()` on startup
- `client/src/app/incidents/[id]/page.tsx` — 5-min poll timeout
- `client/src/app/incidents/page.tsx` — stalled indicator for old investigations
- `client/src/app/incidents/components/ThoughtsPanel.tsx` — 5-min poll timeout on chat sessions
- `client/src/app/chat/components/ChatClient.tsx` — clear isSending on WS disconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Investigations running >30 minutes now show an "Investigation stalled" indicator.

* **Bug Fixes**
  * Chat sending state now resets when connections drop to avoid a stuck sending UI.
  * Session polling now enforces timeouts (5-minute for sessions, stale cutoff for incident polls) to stop endless loading and mark stalled sessions/incidents as failed.
  * Polling logic prevents stale retry loops during long-running checks.

* **Chores**
  * Startup now performs crash-recovery cleanup to detect and mark orphaned or stale investigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->