### PR TITLE
fix(org): restore Back button in add-member wizard (DEV-1099)

### DIFF
--- a/client/src/app/org/components/OrgMembers.tsx
+++ b/client/src/app/org/components/OrgMembers.tsx
@@ -156,7 +156,7 @@ function AddUserDialog({ onCreated }: { onCreated: () => void }) {
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
         {step === "email" ? (
-          <form onSubmit={handleEmailSubmit}>
+          <form key="email-step" onSubmit={handleEmailSubmit}>
             <DialogHeader>
               <DialogTitle>Add team member</DialogTitle>
               <DialogDescription>
@@ -194,7 +194,7 @@ function AddUserDialog({ onCreated }: { onCreated: () => void }) {
             </DialogFooter>
           </form>
         ) : (
-          <form onSubmit={handleCreateUser}>
+          <form key="new-user-step" onSubmit={handleCreateUser}>
             <DialogHeader>
               <DialogTitle>Create new account</DialogTitle>
               <DialogDescription>
@@ -220,7 +220,19 @@ function AddUserDialog({ onCreated }: { onCreated: () => void }) {
               {error && <p className="text-sm text-destructive">{error}</p>}
             </div>
             <DialogFooter className="gap-2 sm:gap-0">
-              <Button type="button" variant="outline" size="sm" onClick={() => { setStep("email"); setError(""); }}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setPassword("");
+                  setConfirmPassword("");
+                  setError("");
+                  setStep("email");
+                }}
+              >
                 Back
               </Button>
               <Button type="submit" disabled={saving} size="sm" className="gap-2">


### PR DESCRIPTION
## Summary
- Fixes [DEV-1099](https://linear.app/arvoai/issue/DEV-1099/qa-back-button-when-adding-members-to-your-organization): in the org → Add Member wizard, after entering an email belonging to a user with no Aurora account and clicking Continue, the Back button on the new-user step did nothing (or re-submitted the email check and snapped you forward again).
- Root cause: the two wizard steps each render a `<form>` at the same sibling position. React's reconciler reused the same DOM `<form>` and the same first `<button>` across the step transition. The first button on step 1 is a `type="submit"` Continue; on step 2 it's a `type="button"` Back. The reused DOM node carried stale form-submit semantics and stale React event bindings, so Back was a no-op.
- Fix: distinct `key` props on each step's `<form>` (`email-step` / `new-user-step`) so React unmounts and remounts cleanly. Hardened the Back handler with `preventDefault`/`stopPropagation` and clears `password`/`confirmPassword` state on the way back so sensitive values don't linger.
- Single-file change: `client/src/app/org/components/OrgMembers.tsx`.

## Test plan
- [ ] Org Settings → Members → Add Member
- [ ] Enter an email that has **no** existing Aurora account → Continue
- [ ] On the new-user step, click Back → returns to the email step with the email field populated, no console errors
- [ ] Click Continue again → advances; Back still works (verify on the second cycle, not just the first)
- [ ] Repeat with an email that **does** belong to an existing user → existing flow unchanged (no new-user step, member added directly)
- [ ] No password / confirmPassword values leak across the Back transition (inspect React state in devtools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Back button in the add-member dialog to properly reset form fields when navigating between steps, ensuring a cleaner experience when adding new members to your organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->