### PR TITLE
fix(org-switch): wait for orgId to actually change after invite accept (DEV-1100)

### DIFF
--- a/client/src/app/org/switching/page.tsx
+++ b/client/src/app/org/switching/page.tsx
@@ -9,6 +9,21 @@ interface Step {
 }
 
 async function refreshSession(): Promise<void> {
+  // Capture the orgId in the JWT cookie BEFORE we trigger a refresh, so we
+  // can detect when the cookie has actually been rewritten with the new org.
+  // Without this, a user who was already in a non-Default org (e.g. switching
+  // between two real orgs by accepting an invite) would see the polling exit
+  // early on the stale cookie — leaving every subsequent API call carrying
+  // the old X-Org-ID and getting 403 Forbidden.
+  let priorOrgId: string | null = null;
+  try {
+    const initial = await fetch("/api/auth/session", { cache: "no-store" });
+    if (initial.ok) {
+      const data = await initial.json();
+      priorOrgId = data?.user?.orgId ?? null;
+    }
+  } catch { /* tolerate; we'll fall back to default-org check */ }
+
   const csrfResp = await fetch("/api/auth/csrf");
   if (!csrfResp.ok) throw new Error("csrf");
   const { csrfToken } = await csrfResp.json();
@@ -21,12 +36,17 @@ async function refreshSession(): Promise<void> {
   if (!res.ok) throw new Error("refresh");
 
   for (let attempt = 0; attempt < 10; attempt++) {
-    const check = await fetch("/api/auth/session");
+    const check = await fetch("/api/auth/session", { cache: "no-store" });
     if (check.ok) {
       const session = await check.json();
       const orgId = session?.user?.orgId;
       const orgName = session?.user?.orgName?.toLowerCase();
-      if (orgId && orgName !== "default organization") {
+      // Success requires: a valid orgId, not the placeholder Default org,
+      // AND a different orgId than what was in the cookie before the refresh.
+      // If we couldn't read priorOrgId, fall back to the looser check (which
+      // still catches the Default-org → real-org case).
+      const orgChanged = priorOrgId === null || (!!orgId && orgId !== priorOrgId);
+      if (orgId && orgName !== "default organization" && orgChanged) {
         return;
       }
     }


### PR DESCRIPTION
## Summary
- Fixes [DEV-1100](https://linear.app/arvoai/issue/DEV-1100/qa-when-inviting-an-existing-member-they-cant-do-anything-after): when an existing user (already a member of another org) accepted an invitation to a new org, every subsequent action returned 403 regardless of the role they were assigned.
- Root cause: the backend `/api/orgs/join` flow correctly transfers the user (`users.org_id` updated, Casbin role removed from old org and added to new org via `_transfer_user_to_org` in `server/routes/org_routes.py`). The frontend then routes to `/org/switching`, which polls until the Auth.js JWT cookie reflects the new org, so subsequent requests carry the correct `X-Org-ID`. The poll's exit condition was `if (orgId && orgName !== "default organization")` — for a user coming from a *real* org, the **stale** cookie already satisfied that on attempt 0. The loop returned success against the OLD session, the page navigated to `/`, every API call sent `X-Org-ID: <old org>`, Casbin had no role for that mapping (just removed), → 403 across the board.
- Fix: read the current `orgId` from `/api/auth/session` first (with `cache: "no-store"`), then require the polled `orgId` to actually **differ** from that prior value. Falls back to the old looser condition if the pre-read fails so the default-org → real-org path is preserved.
- Single-file change: `client/src/app/org/switching/page.tsx`.

## Test plan
- [ ] Bring up the stack (`make dev`)
- [ ] Create User A as admin of Org A
- [ ] Create User B as a member of Org B (a real org, **not** the default org)
- [ ] As User A, invite User B (by email) to Org A with any role
- [ ] As User B, accept the invitation
- [ ] Verify User B lands in Org A and can perform actions appropriate to the assigned role (no blanket 403s on the dashboard / org pages / API calls)
- [ ] Regression: invite a **brand-new** user (default-org → real-org) and confirm that flow still works end-to-end (this was the path the original condition handled correctly)