### PR TITLE
fix: auto-reload Casbin policies to prevent stale RBAC cache

### DIFF
--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1178,9 +1178,8 @@ async def handle_connection(websocket) -> None:
                             row = cur.fetchone()
                     if row and row[0]:
                         _rbac_incident_id = str(row[0])
-                        from utils.auth.enforcer import get_enforcer
-                        enforcer = get_enforcer()
-                        if not enforcer.enforce(user_id, org_id, "incidents", "write"):
+                        from utils.auth.enforcer import enforce_with_reload
+                        if not enforce_with_reload(user_id, org_id, "incidents", "write"):
                             logger.warning(
                                 "RBAC denied: viewer user=%s tried to chat in incident session=%s",
                                 user_id, session_id,

--- a/server/utils/auth/command_gate.py
+++ b/server/utils/auth/command_gate.py
@@ -329,8 +329,8 @@ def _user_is_org_admin(user_id: str, org_id: Optional[str]) -> bool:
     if not user_id or not org_id:
         return False
     try:
-        from utils.auth.enforcer import get_enforcer
-        return bool(get_enforcer().enforce(user_id, org_id, "admin", "access"))
+        from utils.auth.enforcer import enforce_with_reload
+        return enforce_with_reload(user_id, org_id, "admin", "access")
     except Exception as e:
         logger.warning(f"[CommandGate] admin check failed for {user_id}/{org_id}: {e}")
         return False

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -21,7 +21,7 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 _enforcer: casbin.Enforcer | None = None
-_lock = threading.Lock()
+_lock = threading.RLock()
 _last_reload: float = 0.0
 _RELOAD_INTERVAL = 300.0
 

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 _enforcer: casbin.Enforcer | None = None
 _lock = threading.Lock()
+_last_reload: float = 0.0
+_RELOAD_INTERVAL = 300.0
 
 # Default permission policies seeded on first run.
 # Format: (role, domain, resource, action)
@@ -125,9 +127,21 @@ def _seed_default_policies(enforcer: casbin.Enforcer) -> None:
 
 
 def get_enforcer() -> casbin.Enforcer:
-    """Return the module-level Casbin enforcer, creating it on first call."""
-    global _enforcer
+    """Return the module-level Casbin enforcer, creating it on first call.
+
+    Periodically reloads policies from the DB (every 5 min) as a safety net
+    for role revocations.  For role *grants*, callers should use
+    ``enforce_with_reload`` which reloads on deny for instant propagation.
+    """
+    global _enforcer, _last_reload
     if _enforcer is not None:
+        import time
+        now = time.monotonic()
+        if now - _last_reload > _RELOAD_INTERVAL:
+            with _lock:
+                if now - _last_reload > _RELOAD_INTERVAL:
+                    _enforcer.load_policy()
+                    _last_reload = now
         return _enforcer
 
     with _lock:
@@ -153,9 +167,25 @@ def get_enforcer() -> casbin.Enforcer:
 
         _seed_default_policies(_enforcer)
         _enforcer.load_policy()
+        import time
+        _last_reload = time.monotonic()
 
         logger.info("Casbin enforcer ready.")
         return _enforcer
+
+
+def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -> bool:
+    """Enforce a permission check, reloading from DB on first denial.
+
+    Handles the common case where a role was just granted: the in-memory
+    cache says deny, but the DB says allow.  One reload + retry keeps
+    the hot path fast (no DB hit) while making grants take effect instantly.
+    """
+    enforcer = get_enforcer()
+    if enforcer.enforce(user_id, org_id, resource, action):
+        return True
+    reload_policies()
+    return enforcer.enforce(user_id, org_id, resource, action)
 
 
 def reload_policies() -> None:

--- a/server/utils/auth/rbac_decorators.py
+++ b/server/utils/auth/rbac_decorators.py
@@ -19,7 +19,7 @@ from flask import jsonify, request
 from werkzeug.exceptions import HTTPException
 
 from utils.auth.stateless_auth import get_user_id_from_request, get_org_id_from_request
-from utils.auth.enforcer import get_enforcer, reload_policies
+from utils.auth.enforcer import enforce_with_reload
 from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
@@ -68,18 +68,15 @@ def require_permission(resource: str, action: str):
                 _audit_auth_failure(user_id, None, "rbac_denied", {"endpoint": fn.__name__, "reason": "no_org_context"})
                 return jsonify({"error": "Forbidden - no organization context"}), 403
 
-            enforcer = get_enforcer()
-            if not enforcer.enforce(user_id, org_id, resource, action):
-                reload_policies()
-                if not enforcer.enforce(user_id, org_id, resource, action):
-                    logger.warning(
-                        "RBAC denied: user=%s org=%s resource=%s action=%s endpoint=%s",
-                        sanitize(user_id), sanitize(org_id), resource, action, fn.__name__,
-                    )
-                    _audit_auth_failure(user_id, org_id, "rbac_denied", {
-                        "endpoint": fn.__name__, "resource": resource, "action": action,
-                    })
-                    return jsonify({"error": "Forbidden"}), 403
+            if not enforce_with_reload(user_id, org_id, resource, action):
+                logger.warning(
+                    "RBAC denied: user=%s org=%s resource=%s action=%s endpoint=%s",
+                    sanitize(user_id), sanitize(org_id), resource, action, fn.__name__,
+                )
+                _audit_auth_failure(user_id, org_id, "rbac_denied", {
+                    "endpoint": fn.__name__, "resource": resource, "action": action,
+                })
+                return jsonify({"error": "Forbidden"}), 403
 
             try:
                 return fn(user_id, *args, **kwargs)


### PR DESCRIPTION
## Summary
- The Casbin RBAC enforcer loaded policies once at startup and cached them in-memory forever
- Role changes were invisible to long-running processes (chatbot, celery workers) until pod restart — an admin was blocked from incident chat sessions because the 8-day-old chatbot still saw them as having no role
- **Root cause**: `main_chatbot.py` and `command_gate.py` called `enforcer.enforce()` directly without reload-on-deny. The HTTP route decorator (`rbac_decorators.py`) had its own inline retry but the pattern wasn't shared

## Fix
- Adds `enforce_with_reload()` — reloads policies from DB on first denial, then retries. Role grants take effect instantly with zero overhead on the hot path (no DB hit when already allowed)
- 5-min periodic reload in `get_enforcer()` as safety net for role **revocations** (where reload-on-deny can't help since stale cache would still allow)
- All 3 enforce callers now use `enforce_with_reload()`: chatbot WebSocket, command gate, and HTTP route decorator

## Files changed
- `server/utils/auth/enforcer.py` — adds `enforce_with_reload()`, periodic reload
- `server/main_chatbot.py` — fixes the RBAC check that blocked the admin
- `server/utils/auth/command_gate.py` — same fix for admin access check
- `server/utils/auth/rbac_decorators.py` — consolidates onto shared helper

## Test plan
- [ ] Assign admin role to a user, verify they can immediately chat in incident sessions without pod restart
- [ ] Verify viewer users are still correctly blocked from incident chat
- [ ] Verify no performance regression (hot path has zero DB queries)
- [ ] Verify role revocation takes effect within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)