### PR TITLE
fix: kubectl agent token lookup blocked by RLS

### DIFF
--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -2139,6 +2139,30 @@ def initialize_tables():
             """)
             logging.info("Added MCP token resolve RLS policies on mcp_tokens.")
 
+            # kubectl agent token verification is a bootstrap auth query — the
+            # agent connects with a Bearer token before any org context exists.
+            # Same pattern as mcp_tokens: a permissive policy keyed on a session
+            # variable so the handler can opt in to a scoped RLS bypass.
+            cursor.execute("""
+                DO $$ BEGIN
+                    DROP POLICY IF EXISTS select_by_token_resolve ON kubectl_agent_tokens;
+                    CREATE POLICY select_by_token_resolve ON kubectl_agent_tokens
+                    FOR SELECT USING (
+                        current_setting('myapp.kubectl_token_resolve', true) = 'true'
+                    );
+                END $$;
+            """)
+            cursor.execute("""
+                DO $$ BEGIN
+                    DROP POLICY IF EXISTS update_by_token_resolve ON kubectl_agent_tokens;
+                    CREATE POLICY update_by_token_resolve ON kubectl_agent_tokens
+                    FOR UPDATE USING (
+                        current_setting('myapp.kubectl_token_resolve', true) = 'true'
+                    );
+                END $$;
+            """)
+            logging.info("Added kubectl token resolve RLS policies on kubectl_agent_tokens.")
+
             conn.commit()
 
             # Migration: Add role column to users table for RBAC

--- a/server/utils/kubectl/agent_ws_handler.py
+++ b/server/utils/kubectl/agent_ws_handler.py
@@ -94,13 +94,16 @@ async def handle_kubectl_agent(websocket) -> None:
         conn = connect_to_db_as_admin()
         try:
             cursor = conn.cursor()
-            # No RLS needed — webhook bootstrap, no user_id
-            cursor.execute("SELECT cluster_name, status, expires_at, user_id FROM kubectl_agent_tokens WHERE token = %s", (token,))
+            # Token verification is a bootstrap auth query — no org context yet.
+            # kubectl_agent_tokens has FORCE RLS; opt in to the permissive
+            # select_by_token_resolve policy (same pattern as mcp_tokens).
+            cursor.execute("SET LOCAL myapp.kubectl_token_resolve = 'true'")
+            cursor.execute("SELECT cluster_name, status, expires_at, user_id, org_id FROM kubectl_agent_tokens WHERE token = %s", (token,))
             result = cursor.fetchone()
             if not result:
                 await websocket.close(code=1008, reason="Invalid token")
                 return
-            cluster_name, status, expires_at, user_id = result
+            cluster_name, status, expires_at, user_id, org_id = result
             if status != 'active':
                 await websocket.close(code=1008, reason="Token revoked")
                 return


### PR DESCRIPTION
## Summary

- Kubectl agent connections were always rejected with "Invalid token" even when the token existed in the database
- Root cause: `kubectl_agent_tokens` has `FORCE ROW LEVEL SECURITY` enabled, but the WebSocket handler (`agent_ws_handler.py`) queried it without any org context — this is a bootstrap auth query where the agent authenticates with a Bearer token before any org is known
- Every SELECT returned 0 rows because the `select_by_org` RLS policy requires `myapp.current_org_id` to be set
- Fix: add permissive RLS policies keyed on `myapp.kubectl_token_resolve` session variable (same pattern as `mcp_tokens`), and set the flag in the handler before the token lookup

## Test plan

- [ ] Deploy to staging and verify kubectl agent connects successfully (currently in reconnect loop getting "Invalid token")
- [ ] Verify token lookup works: agent pod logs should show "Connected to backend" instead of "Connection closed by server"
- [ ] Verify the agent appears as connected on the infrapoo.org Kubernetes connectors page
- [ ] Verify existing kubectl token CRUD from the UI still works (org-scoped RLS still enforced for normal requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)