### PR TITLE
fix: incident SSE broadcasts not reaching frontend

### DIFF
--- a/server/routes/datadog/tasks.py
+++ b/server/routes/datadog/tasks.py
@@ -360,6 +360,7 @@ def process_datadog_event(
                                 "incident_id": str(incident_id),
                                 "source": "datadog",
                             },
+                            org_id=org_id,
                         )
                     except Exception as e:
                         logger.warning(f"[DATADOG][WEBHOOK] Failed to notify SSE: {e}")

--- a/server/routes/grafana/tasks.py
+++ b/server/routes/grafana/tasks.py
@@ -378,6 +378,7 @@ def process_grafana_alert(
                                     source_alert_id=per_alert_source_id, alert_title=per_alert_title,
                                     alert_service=service, alert_severity=severity,
                                     alert_metadata=alert_metadata,
+                                    org_id=org_id,
                                 )
                                 cursor.execute("RELEASE SAVEPOINT sp_correlation")
                             except Exception as exc:

--- a/server/routes/grafana/tasks.py
+++ b/server/routes/grafana/tasks.py
@@ -486,6 +486,7 @@ def process_grafana_alert(
                                 from routes.incidents_sse import broadcast_incident_update_to_user_connections
                                 broadcast_incident_update_to_user_connections(
                                     user_id, {"type": "incident_update", "incident_id": str(incident_id), "source": "grafana"},
+                                    org_id=org_id,
                                 )
                             except Exception as e:
                                 logger.warning("[GRAFANA][ALERT] Failed to notify SSE: %s", e)

--- a/server/routes/incidentio/tasks.py
+++ b/server/routes/incidentio/tasks.py
@@ -71,15 +71,15 @@ def _extract_incident_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     if is_alert_event and not incident.get("name"):
         severity_raw = "unknown"
-        metadata = incident.get("metadata", {}) or {}
-        if isinstance(metadata, dict):
-            for key in ("severity", "priority", "level"):
-                if key in metadata:
-                    severity_raw = str(metadata[key])
-                    break
+        raw_metadata = incident.get("metadata")
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+        for key in ("severity", "priority", "level"):
+            if key in metadata:
+                severity_raw = str(metadata[key])
+                break
 
         return {
-            "incident_id": incident.get("id") or incident.get("deduplication_key") or payload.get("id"),
+            "incident_id": None,
             "incident_name": incident.get("title") or "Untitled Alert",
             "incident_status": incident.get("status") or "firing",
             "severity": severity_raw,
@@ -440,8 +440,8 @@ def _trigger_rca_pipeline(
 
         logger.info("[INCIDENTIO] Triggered RCA for incident %s (task=%s)", incident_id, task.id)
 
-        # Post-back RCA summary if enabled
-        if _should_postback(user_id):
+        # Post-back RCA summary if enabled (skip for alert-only events with no incident ID)
+        if _should_postback(user_id) and fields.get("incident_id"):
             postback_rca_to_incidentio.delay(user_id, str(incident_id), fields["incident_id"])
 
     except Exception as exc:

--- a/server/routes/incidentio/tasks.py
+++ b/server/routes/incidentio/tasks.py
@@ -26,7 +26,12 @@ def _should_postback(user_id: str) -> bool:
 
 
 def _resolve_incident_object(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Find the incident dict inside an incident.io webhook payload."""
+    """Find the incident dict inside an incident.io webhook payload.
+
+    incident.io sends two families of events:
+    - Incident events: nested under event.incident or payload.incident
+    - Alert events (public_alert.*): alert data is a direct child of the payload
+    """
     event = payload.get("event", {}) or {}
     incident = event.get("incident") or payload.get("incident") or None
 
@@ -35,6 +40,11 @@ def _resolve_incident_object(payload: Dict[str, Any]) -> Dict[str, Any]:
             if key.startswith("public_incident.") and isinstance(value, dict):
                 incident = value.get("incident") or value
                 break
+
+    if not incident:
+        alert = event.get("alert") or payload.get("alert")
+        if isinstance(alert, dict):
+            return alert
 
     return incident or {}
 
@@ -47,9 +57,40 @@ def _safe_name(obj, default: str = "") -> str:
 
 
 def _extract_incident_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract normalized incident fields from the webhook event envelope."""
+    """Extract normalized incident fields from the webhook event envelope.
+
+    Handles both incident events (event.incident.*) and alert events
+    (public_alert.*). Alert events carry title/description/status/metadata
+    directly on the alert object rather than in incident-shaped fields.
+    """
     event = payload.get("event", {}) or {}
     incident = _resolve_incident_object(payload)
+
+    event_type = payload.get("event_type") or event.get("type", "")
+    is_alert_event = "alert" in event_type.lower()
+
+    if is_alert_event and not incident.get("name"):
+        severity_raw = "unknown"
+        metadata = incident.get("metadata", {}) or {}
+        if isinstance(metadata, dict):
+            for key in ("severity", "priority", "level"):
+                if key in metadata:
+                    severity_raw = str(metadata[key])
+                    break
+
+        return {
+            "incident_id": incident.get("id") or incident.get("deduplication_key") or payload.get("id"),
+            "incident_name": incident.get("title") or "Untitled Alert",
+            "incident_status": incident.get("status") or "firing",
+            "severity": severity_raw,
+            "incident_type": metadata.get("source", ""),
+            "summary": incident.get("description") or "",
+            "created_at": incident.get("created_at"),
+            "updated_at": incident.get("updated_at"),
+            "permalink": "",
+            "custom_fields": [],
+            "roles": [],
+        }
 
     return {
         "incident_id": incident.get("id") or payload.get("id"),
@@ -84,6 +125,7 @@ _NEW_INCIDENT_EVENTS = frozenset((
     "incident.created", "v2.incidents.created",
     "incident.declared", "public_incident.incident_created",
     "public_incident.incident_created_v2",
+    "public_alert.alert_created_v1",
 ))
 
 

--- a/server/routes/incidents_sse.py
+++ b/server/routes/incidents_sse.py
@@ -1,32 +1,32 @@
-"""Server-Sent Events for real-time incident updates."""
-import logging
+"""Server-Sent Events for real-time incident updates via Redis pub/sub."""
 import json
-import queue
+import logging
+import os
+
+import redis
 from flask import Blueprint, Response
+
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request
+from utils.cache.redis_client import get_redis_ssl_kwargs
 
 logger = logging.getLogger(__name__)
 
 incidents_sse_bp = Blueprint('incidents_sse', __name__)
 
-# Store active SSE connection queues per org: {org_id: [queue1, queue2, ...]}
-_active_connection_queues_by_org = {}
+_CHANNEL_PREFIX = "incidents:sse:"
 
 
 def broadcast_incident_update_to_user_connections(user_id: str, incident_data: dict, org_id: str = None):
-    """Send incident update to all active SSE connections for a given org (or user as fallback)."""
+    """Publish an incident update via Redis so any process can broadcast to SSE clients."""
     scope_key = org_id or user_id
-    org_queues = _active_connection_queues_by_org.get(scope_key, [])
-    if not org_queues:
-        return
-    for message_queue in org_queues:
-        try:
-            message_queue.put_nowait(incident_data)
-        except queue.Full:
-            logger.warning("Message queue full for scope %s, dropping message", scope_key)
-        except Exception as e:
-            logger.error("Error sending message to queue for scope %s: %s", scope_key, e)
+    channel = f"{_CHANNEL_PREFIX}{scope_key}"
+    try:
+        r = redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"), **get_redis_ssl_kwargs())
+        r.publish(channel, json.dumps(incident_data))
+        r.close()
+    except Exception as e:
+        logger.warning("Failed to publish incident SSE update to Redis: %s", e)
 
 
 @incidents_sse_bp.route('/api/incidents/stream', methods=['GET'])
@@ -35,32 +35,34 @@ def incident_stream(user_id):
     """SSE endpoint that streams real-time incident updates to the client."""
     org_id = get_org_id_from_request()
     scope_key = org_id or user_id
-    
+    channel = f"{_CHANNEL_PREFIX}{scope_key}"
+
     def generate_sse_events():
-        message_queue = queue.Queue(maxsize=50)
-        
-        if scope_key not in _active_connection_queues_by_org:
-            _active_connection_queues_by_org[scope_key] = []
-        _active_connection_queues_by_org[scope_key].append(message_queue)
-        
+        r = None
+        pubsub = None
         try:
+            r = redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"), **get_redis_ssl_kwargs())
+            pubsub = r.pubsub()
+            pubsub.subscribe(channel)
+
             while True:
-                try:
-                    message = message_queue.get(timeout=10)
-                    yield f"data: {json.dumps(message)}\n\n"
-                except queue.Empty:
+                message = pubsub.get_message(timeout=10.0)
+                if message and message['type'] == 'message':
+                    data = message['data']
+                    if isinstance(data, bytes):
+                        data = data.decode('utf-8')
+                    yield f"data: {data}\n\n"
+                elif message is None:
                     yield ": keepalive\n\n"
         except GeneratorExit:
             pass
         finally:
-            if scope_key in _active_connection_queues_by_org:
-                try:
-                    _active_connection_queues_by_org[scope_key].remove(message_queue)
-                    if not _active_connection_queues_by_org[scope_key]:
-                        del _active_connection_queues_by_org[scope_key]
-                except ValueError:
-                    pass
-    
+            if pubsub:
+                pubsub.unsubscribe(channel)
+                pubsub.close()
+            if r:
+                r.close()
+
     return Response(
         generate_sse_events(),
         mimetype='text/event-stream',
@@ -70,4 +72,3 @@ def incident_stream(user_id):
             'Connection': 'keep-alive'
         }
     )
-

--- a/server/routes/incidents_sse.py
+++ b/server/routes/incidents_sse.py
@@ -8,7 +8,7 @@ from flask import Blueprint, Response
 
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request
-from utils.cache.redis_client import get_redis_ssl_kwargs
+from utils.cache.redis_client import get_redis_client, get_redis_ssl_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +21,12 @@ def broadcast_incident_update_to_user_connections(user_id: str, incident_data: d
     """Publish an incident update via Redis so any process can broadcast to SSE clients."""
     scope_key = org_id or user_id
     channel = f"{_CHANNEL_PREFIX}{scope_key}"
-    r = None
     try:
-        r = redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"), **get_redis_ssl_kwargs())
-        r.publish(channel, json.dumps(incident_data))
+        r = get_redis_client()
+        if r:
+            r.publish(channel, json.dumps(incident_data))
     except Exception as e:
         logger.warning("Failed to publish incident SSE update to Redis: %s", e)
-    finally:
-        if r:
-            r.close()
 
 
 @incidents_sse_bp.route('/api/incidents/stream', methods=['GET'])

--- a/server/routes/incidents_sse.py
+++ b/server/routes/incidents_sse.py
@@ -21,12 +21,15 @@ def broadcast_incident_update_to_user_connections(user_id: str, incident_data: d
     """Publish an incident update via Redis so any process can broadcast to SSE clients."""
     scope_key = org_id or user_id
     channel = f"{_CHANNEL_PREFIX}{scope_key}"
+    r = None
     try:
         r = redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"), **get_redis_ssl_kwargs())
         r.publish(channel, json.dumps(incident_data))
-        r.close()
     except Exception as e:
         logger.warning("Failed to publish incident SSE update to Redis: %s", e)
+    finally:
+        if r:
+            r.close()
 
 
 @incidents_sse_bp.route('/api/incidents/stream', methods=['GET'])

--- a/server/routes/jenkins/tasks.py
+++ b/server/routes/jenkins/tasks.py
@@ -282,6 +282,7 @@ def process_jenkins_deployment(
                             broadcast_incident_update_to_user_connections(
                                 user_id,
                                 {"type": "incident_update", "incident_id": str(incident_id), "source": source},
+                                org_id=org_id,
                             )
                         except Exception as e:
                             logger.warning("%s SSE notify failed: %s", log_prefix, e)

--- a/server/routes/newrelic/tasks.py
+++ b/server/routes/newrelic/tasks.py
@@ -383,6 +383,7 @@ def process_newrelic_event(
                         broadcast_incident_update_to_user_connections(
                             user_id,
                             {"type": "incident_update", "incident_id": str(incident_id), "source": "newrelic"},
+                            org_id=org_id,
                         )
                     except Exception as e:
                         logger.warning("[NEWRELIC][WEBHOOK] Failed to notify SSE: %s", e)

--- a/server/routes/opsgenie/tasks.py
+++ b/server/routes/opsgenie/tasks.py
@@ -276,6 +276,7 @@ def process_opsgenie_event(
                                 "incident_id": str(incident_id),
                                 "source": "opsgenie",
                             },
+                            org_id=org_id,
                         )
                     except Exception as e:
                         logger.warning("[OPSGENIE][WEBHOOK] Failed to notify SSE: %s", e)

--- a/server/routes/pagerduty/tasks.py
+++ b/server/routes/pagerduty/tasks.py
@@ -224,6 +224,7 @@ def _process_custom_field_update(
                         "source": "pagerduty",
                         "custom_fields_updated": True,
                     },
+                    org_id=org_id,
                 )
             except Exception as e:
                 logger.warning(
@@ -774,6 +775,7 @@ def process_pagerduty_event(
                                 "incident_id": str(incident_db_id),
                                 "source": "pagerduty",
                             },
+                            org_id=org_id,
                         )
                     except Exception as e:
                         logger.warning(

--- a/server/routes/spinnaker/tasks.py
+++ b/server/routes/spinnaker/tasks.py
@@ -288,6 +288,7 @@ def process_spinnaker_deployment(
                             broadcast_incident_update_to_user_connections(
                                 user_id,
                                 {"type": "incident_update", "incident_id": str(incident_id), "source": "spinnaker"},
+                                org_id=org_id,
                             )
                         except Exception as e:
                             logger.warning("%s SSE notify failed: %s", log_prefix, e)

--- a/server/services/correlation/alert_correlator.py
+++ b/server/services/correlation/alert_correlator.py
@@ -442,6 +442,7 @@ def handle_correlated_alert(
                 "alert_title": alert_title,
                 "correlation_score": correlation_result.score,
             },
+            org_id=org_id,
         )
     except Exception as e:
         logger.warning("[CORRELATION] Failed to notify SSE: %s", e)


### PR DESCRIPTION
## Summary
- **Root cause**: SSE connections were registered under `org_id` but all broadcast callers only passed `user_id`, so the key lookup missed. On top of that, broadcasts used in-memory queues that only existed in the Flask process — Celery workers and the chatbot process (where incidents are actually created) couldn't reach them.
- **Fix**: Switch `incidents_sse.py` to Redis pub/sub (same pattern as `visualization_stream.py`) so broadcasts work cross-process, and pass `org_id` from all 9 callers.

## Test plan
- [ ] Trigger a new incident via chat RCA → confirm it appears on the incidents page without refresh
- [ ] Trigger a new incident via Grafana webhook → confirm it appears without refresh
- [ ] Verify SSE keepalive heartbeats still work (connection stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time incident updates now include organization context for clearer multi-org visibility.
  * Improved real-time delivery and scalability of SSE incident streams for more reliable updates.

* **Bug Fixes**
  * Webhook parsing enhanced to correctly handle alert-shaped events and extract incident fields from incident.io.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->