### PR TITLE
fix: include org_id in workspace INSERT to satisfy RLS policy

### DIFF
--- a/server/routes/incidentio/tasks.py
+++ b/server/routes/incidentio/tasks.py
@@ -276,6 +276,10 @@ def _store_and_process_event(user_id: str, event_type: str,
             received_at = datetime.now(timezone.utc)
             normalized_severity = _map_severity(fields["severity"])
 
+            if not fields.get("incident_id"):
+                logger.error("[INCIDENTIO] Alert event has no extractable incident_id, dropping event for user %s", user_id)
+                return
+
             alert_db_id = _upsert_alert(cursor, conn, user_id=user_id, org_id=org_id,
                                         fields=fields, payload=payload,
                                         severity=normalized_severity, received_at=received_at)

--- a/server/routes/incidentio/tasks.py
+++ b/server/routes/incidentio/tasks.py
@@ -26,7 +26,12 @@ def _should_postback(user_id: str) -> bool:
 
 
 def _resolve_incident_object(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Find the incident dict inside an incident.io webhook payload."""
+    """Find the incident dict inside an incident.io webhook payload.
+
+    incident.io sends two families of events:
+    - Incident events: nested under event.incident or payload.incident
+    - Alert events (public_alert.*): alert data is a direct child of the payload
+    """
     event = payload.get("event", {}) or {}
     incident = event.get("incident") or payload.get("incident") or None
 
@@ -35,6 +40,11 @@ def _resolve_incident_object(payload: Dict[str, Any]) -> Dict[str, Any]:
             if key.startswith("public_incident.") and isinstance(value, dict):
                 incident = value.get("incident") or value
                 break
+
+    if not incident:
+        alert = event.get("alert") or payload.get("alert")
+        if isinstance(alert, dict):
+            return alert
 
     return incident or {}
 
@@ -47,9 +57,40 @@ def _safe_name(obj, default: str = "") -> str:
 
 
 def _extract_incident_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract normalized incident fields from the webhook event envelope."""
+    """Extract normalized incident fields from the webhook event envelope.
+
+    Handles both incident events (event.incident.*) and alert events
+    (public_alert.*). Alert events carry title/description/status/metadata
+    directly on the alert object rather than in incident-shaped fields.
+    """
     event = payload.get("event", {}) or {}
     incident = _resolve_incident_object(payload)
+
+    event_type = payload.get("event_type") or event.get("type", "")
+    is_alert_event = "alert" in event_type.lower()
+
+    if is_alert_event and not incident.get("name"):
+        severity_raw = "unknown"
+        metadata = incident.get("metadata", {}) or {}
+        if isinstance(metadata, dict):
+            for key in ("severity", "priority", "level"):
+                if key in metadata:
+                    severity_raw = str(metadata[key])
+                    break
+
+        return {
+            "incident_id": incident.get("id") or incident.get("deduplication_key") or payload.get("id"),
+            "incident_name": incident.get("title") or "Untitled Alert",
+            "incident_status": incident.get("status") or "firing",
+            "severity": severity_raw,
+            "incident_type": metadata.get("source", ""),
+            "summary": incident.get("description") or "",
+            "created_at": incident.get("created_at"),
+            "updated_at": incident.get("updated_at"),
+            "permalink": "",
+            "custom_fields": [],
+            "roles": [],
+        }
 
     return {
         "incident_id": incident.get("id") or payload.get("id"),
@@ -84,6 +125,7 @@ _NEW_INCIDENT_EVENTS = frozenset((
     "incident.created", "v2.incidents.created",
     "incident.declared", "public_incident.incident_created",
     "public_incident.incident_created_v2",
+    "public_alert.alert_created_v1",
 ))
 
 

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -12,34 +12,39 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 
-def get_or_create_workspace(user_id: str, workspace_name: str = "default") -> Dict[str, Any]:
+def get_or_create_workspace(user_id: str, workspace_name: str = "default", org_id: str = None) -> Dict[str, Any]:
     """
     Get existing workspace or create a new one for a user.
-    
+
     Args:
         user_id: User identifier
         workspace_name: Workspace name (defaults to "default")
-        
+        org_id: Organization ID (required for RLS-protected inserts)
+
     Returns:
         Dictionary with workspace data
-        
+
     Raises:
         Exception: Database or validation errors
     """
     if not user_id:
         raise ValueError("user_id is required")
-    
+
+    if not org_id:
+        from utils.auth.stateless_auth import get_org_id_for_user
+        org_id = get_org_id_for_user(user_id)
+
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-            
+
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "
                 "aws_discovery_artifact_key, aws_discovery_summary, created_at, updated_at "
                 "FROM workspaces WHERE user_id = %s AND name = %s",
                 (user_id, workspace_name)
             )
-            
+
             result = cursor.fetchone()
             if result:
                 # Deserialize JSON data from database
@@ -49,7 +54,7 @@ def get_or_create_workspace(user_id: str, workspace_name: str = "default") -> Di
                         discovery_summary = json.loads(discovery_summary)
                     except (json.JSONDecodeError, TypeError):
                         discovery_summary = None
-                
+
                 workspace = {
                     'id': result[0],
                     'user_id': result[1],
@@ -63,19 +68,19 @@ def get_or_create_workspace(user_id: str, workspace_name: str = "default") -> Di
                 }
                 logger.info(f"Retrieved existing workspace {workspace['id']} for user {user_id}")
                 return workspace
-            
+
             # Create new workspace
             workspace_id = str(uuid.uuid4())
             external_id = str(uuid.uuid4())  # Generate ExternalId immediately
-            
+
             cursor.execute(
-                "INSERT INTO workspaces (id, user_id, name, aws_external_id) "
-                "VALUES (%s, %s, %s, %s)",
-                (workspace_id, user_id, workspace_name, external_id)
+                "INSERT INTO workspaces (id, user_id, org_id, name, aws_external_id) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (workspace_id, user_id, org_id, workspace_name, external_id)
             )
-            
+
             conn.commit()
-            
+
             # Return the created workspace
             workspace = {
                 'id': workspace_id,
@@ -88,7 +93,7 @@ def get_or_create_workspace(user_id: str, workspace_name: str = "default") -> Di
                 'created_at': None,  # Will be set by database
                 'updated_at': None
             }
-            
+
             logger.info(f"Created new workspace {workspace_id} for user {user_id} with external_id {external_id}")
             return workspace
             

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -12,7 +12,7 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 
-def get_or_create_workspace(user_id: str, workspace_name: str = "default", org_id: str = None) -> Dict[str, Any]:
+def get_or_create_workspace(user_id: str, workspace_name: str = "default", org_id: Optional[str] = None) -> Dict[str, Any]:
     """
     Get existing workspace or create a new one for a user.
 
@@ -30,13 +30,21 @@ def get_or_create_workspace(user_id: str, workspace_name: str = "default", org_i
     if not user_id:
         raise ValueError("user_id is required")
 
+    from utils.auth.stateless_auth import get_org_id_for_user, set_rls_context
+
     if not org_id:
-        from utils.auth.stateless_auth import get_org_id_for_user
         org_id = get_org_id_for_user(user_id)
+
+    if not org_id:
+        raise ValueError(
+            f"Cannot resolve org_id for user {sanitize(user_id)}; "
+            "workspace INSERT would violate RLS policy"
+        )
 
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
+            set_rls_context(cursor, conn, user_id)
 
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "


### PR DESCRIPTION
## Summary
- AWS onboarding on prod fails with `new row violates row-level security policy for table "workspaces"` because the INSERT in `get_or_create_workspace()` doesn't include `org_id`
- The `workspaces` table has `FORCE ROW LEVEL SECURITY` with policies requiring `org_id IS NOT NULL AND org_id = current_setting('myapp.current_org_id')`
- Added `org_id` parameter to `get_or_create_workspace()` — if not passed by caller, it resolves automatically via `get_org_id_for_user()` (queries `users` table, which is excluded from RLS)
- Backward-compatible: all existing callers continue to work without changes

## Test plan
- [ ] Deploy to staging, attempt AWS onboarding as a new user — workspace should be created successfully
- [ ] Verify existing workspaces (SELECT path) still work
- [ ] Verify chatbot and Celery callers of `get_or_create_workspace()` still function (they lack Flask request context but `get_org_id_for_user()` handles that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of public alert webhooks: improved field extraction, automatic severity mapping from alert metadata, and support for additional alert event types
  * Prevented storage/correlation of alert events that lack an extractable incident identifier
  * Workspace creation now requires/derives an organization ID and enforces validation when the org cannot be determined
<!-- end of auto-generated comment: release notes by coderabbit.ai -->