### PR TITLE
Update dropdown models to gpt-5.5, sonnet-4.6, opus-4.7

### DIFF
--- a/client/src/app/chat/components/useChatSendHandlers.ts
+++ b/client/src/app/chat/components/useChatSendHandlers.ts
@@ -65,7 +65,7 @@ export function useChatSendHandlers({
   const { toast } = useToast();
   const { providerIds, isProviderConnected } = useConnectedAccounts();
 
-  const [selectedModel, setSelectedModel] = useState("openai/gpt-5.2");
+  const [selectedModel, setSelectedModel] = useState("openai/gpt-5.5");
   const [selectedMode, setSelectedMode] = useState("agent");
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
   const [isSending, setIsSending] = useState(false);

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -38,38 +38,38 @@ interface ModelSelectorProps {
 
 // Pricing information mapping (input/output per 1M tokens)
 const modelPricing: Record<string, string> = {
-  'openai/gpt-5.2': 'Premium Cost ($1.75/$14 per 1M)',
-  'anthropic/claude-sonnet-4-5': 'Medium Cost ($3/$15 per 1M)',
-  'anthropic/claude-opus-4-5': 'High Cost ($5/$25 per 1M)',
+  'openai/gpt-5.5': 'Premium Cost ($5/$30 per 1M)',
+  'anthropic/claude-sonnet-4.6': 'Medium Cost ($3/$15 per 1M)',
+  'anthropic/claude-opus-4.7': 'High Cost ($5/$25 per 1M)',
   'google/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
 };
 
 const modelOptions: ModelOption[] = [
   {
-    id: 'openai/gpt-5.2',
-    name: 'gpt-5.2',
-    displayName: 'GPT-5.2',
+    id: 'openai/gpt-5.5',
+    name: 'gpt-5.5',
+    displayName: 'GPT-5.5',
     provider: 'OpenAI',
     tier: 'premium',
-    contextLength: '400K',
+    contextLength: '1M',
     hasReasoning: true
   },
   {
-    id: 'anthropic/claude-sonnet-4-5',
-    name: 'claude-sonnet-4-5',
-    displayName: 'Claude Sonnet 4.5',
+    id: 'anthropic/claude-sonnet-4.6',
+    name: 'claude-sonnet-4.6',
+    displayName: 'Claude Sonnet 4.6',
     provider: 'Anthropic',
     tier: 'pro',
-    contextLength: '200K',
+    contextLength: '1M',
     hasReasoning: true
   },
   {
-    id: 'anthropic/claude-opus-4-5',
-    name: 'claude-opus-4-5',
-    displayName: 'Claude Opus 4.5',
+    id: 'anthropic/claude-opus-4.7',
+    name: 'claude-opus-4.7',
+    displayName: 'Claude Opus 4.7',
     provider: 'Anthropic',
     tier: 'premium',
-    contextLength: '200K',
+    contextLength: '1M',
     hasReasoning: true,
     isSlow: true
   },

--- a/server/chat/backend/agent/model_mapper.py
+++ b/server/chat/backend/agent/model_mapper.py
@@ -64,11 +64,6 @@ MODEL_MAPPINGS = {
         "anthropic": "claude-opus-4-7",
         "provider": "anthropic",
     },
-    "anthropic/claude-opus-4-7": {
-        "openrouter": "anthropic/claude-opus-4.7",
-        "anthropic": "claude-opus-4-7",
-        "provider": "anthropic",
-    },
     "anthropic/claude-opus-4.6": {
         "openrouter": "anthropic/claude-opus-4.6",
         "anthropic": "claude-opus-4-6",

--- a/server/chat/backend/agent/model_mapper.py
+++ b/server/chat/backend/agent/model_mapper.py
@@ -12,6 +12,11 @@ from typing import Dict, Optional, Tuple
 
 # Model name mappings from OpenRouter format to native provider formats
 MODEL_MAPPINGS = {
+    "openai/gpt-5.5": {
+        "openrouter": "openai/gpt-5.5",
+        "openai": "gpt-5.5",
+        "provider": "openai",
+    },
     "openai/gpt-5.2": {
         "openrouter": "openai/gpt-5.2",
         "openai": "gpt-5.2",
@@ -52,6 +57,16 @@ MODEL_MAPPINGS = {
     "anthropic/claude-sonnet-4-6": {
         "openrouter": "anthropic/claude-sonnet-4.6",
         "anthropic": "claude-sonnet-4-6",
+        "provider": "anthropic",
+    },
+    "anthropic/claude-opus-4.7": {
+        "openrouter": "anthropic/claude-opus-4.7",
+        "anthropic": "claude-opus-4-7",
+        "provider": "anthropic",
+    },
+    "anthropic/claude-opus-4-7": {
+        "openrouter": "anthropic/claude-opus-4.7",
+        "anthropic": "claude-opus-4-7",
         "provider": "anthropic",
     },
     "anthropic/claude-opus-4.6": {

--- a/server/chat/backend/agent/utils/chat_context_manager.py
+++ b/server/chat/backend/agent/utils/chat_context_manager.py
@@ -27,8 +27,12 @@ class ChatContextManager:
     # Model context limits (tokens) - leaving some buffer for system prompts and tool calls
     # Keys use OpenRouter format (dot notation) since ModelMapper resolves to this
     MODEL_CONTEXT_LIMITS = {
+        "openai/gpt-5.5": 1000000,  # 1.05M - 50K buffer
         "openai/gpt-5.2": 950000,  # 1M - 50K buffer
+        "anthropic/claude-sonnet-4.6": 950000,  # 1M - 50K buffer
         "anthropic/claude-sonnet-4.5": 950000,  # 1M - 50K buffer
+        "anthropic/claude-opus-4.7": 950000,  # 1M - 50K buffer
+        "anthropic/claude-opus-4.6": 950000,  # 1M - 50K buffer
         "anthropic/claude-opus-4.5": 180000,  # 200K - 20K buffer
         "anthropic/claude-3-haiku": 180000,  # 200K - 20K buffer
         "google/gemini-3.1-pro-preview": 1000000,  # 1M context

--- a/server/chat/backend/agent/utils/llm_usage_tracker.py
+++ b/server/chat/backend/agent/utils/llm_usage_tracker.py
@@ -37,6 +37,7 @@ class LLMUsageTracker:
     MODEL_PRICING = {
         # OpenAI (direct API pricing per 1K tokens)
         # cached_input = automatic prompt caching discount
+        "openai/gpt-5.5": {"input": 0.005, "output": 0.030, "cached_input": 0.00125},
         "openai/gpt-5.4": {"input": 0.0025, "output": 0.015, "cached_input": 0.000625},
         "openai/gpt-5.2": {"input": 0.00175, "output": 0.014, "cached_input": 0.0004375},
         "openai/o3": {"input": 0.002, "output": 0.008, "cached_input": 0.0005},
@@ -47,6 +48,8 @@ class LLMUsageTracker:
         "openai/gpt-4o": {"input": 0.0025, "output": 0.01, "cached_input": 0.00125},
         "openai/gpt-4o-mini": {"input": 0.00015, "output": 0.0006, "cached_input": 0.000075},
         # Anthropic (cached input = 90% discount)
+        "anthropic/claude-opus-4.7": {"input": 0.005, "output": 0.025, "cached_input": 0.0005},
+        "anthropic/claude-opus-4-7": {"input": 0.005, "output": 0.025, "cached_input": 0.0005},
         "anthropic/claude-opus-4.6": {"input": 0.005, "output": 0.025, "cached_input": 0.0005},
         "anthropic/claude-opus-4-6": {"input": 0.005, "output": 0.025, "cached_input": 0.0005},
         "anthropic/claude-sonnet-4.6": {"input": 0.003, "output": 0.015, "cached_input": 0.0003},

--- a/server/chat/backend/agent/utils/openrouter_pricing_service.py
+++ b/server/chat/backend/agent/utils/openrouter_pricing_service.py
@@ -36,6 +36,7 @@ class OpenRouterPricingService:
 
         self.fallback_pricing = {
             # OpenAI (OpenRouter pricing per 1K tokens)
+            "openai/gpt-5.5": {"input": 0.005, "output": 0.030},
             "openai/gpt-5.4": {"input": 0.0025, "output": 0.015},
             "openai/gpt-5.2": {"input": 0.00175, "output": 0.014},
             "openai/o3": {"input": 0.002, "output": 0.008},
@@ -46,6 +47,7 @@ class OpenRouterPricingService:
             "openai/gpt-4o": {"input": 0.0025, "output": 0.01},
             "openai/gpt-4o-mini": {"input": 0.00015, "output": 0.0006},
             # Anthropic
+            "anthropic/claude-opus-4-7": {"input": 0.005, "output": 0.025},
             "anthropic/claude-opus-4-6": {"input": 0.005, "output": 0.025},
             "anthropic/claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
             "anthropic/claude-opus-4-5": {"input": 0.005, "output": 0.025},


### PR DESCRIPTION
## Summary
- Bump model dropdown to the latest OpenRouter-verified models: `openai/gpt-5.5` (1M ctx, $5/$30 per 1M), `anthropic/claude-sonnet-4.6` (1M ctx, $3/$15), `anthropic/claude-opus-4.7` (1M ctx, $5/$25). Gemini 3.1 Pro stays — already latest.
- Add native-API mappings + pricing rows + context limits for the new models in `model_mapper`, `openrouter_pricing_service`, `llm_usage_tracker`, `chat_context_manager`.
- Default `selectedModel` in chat moves from `gpt-5.2` to `gpt-5.5`.

All values pulled directly from `https://openrouter.ai/api/v1/models` — no guessed pricing or context numbers.

## Test plan
- [x] Sent one message per model in a single session — all 4 succeeded with native-API routing (no OpenRouter fallback) and `error_message` null in `llm_usage_tracking`
- [x] Cost math reconciled: $0.067 + $0.060 + $0.133 + $0.029 = $0.290, matches UI `$0.29 / 4 req`
- [x] `tsc --noEmit` clean on changed frontend files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new AI model versions: OpenAI GPT-5.5, Anthropic Claude Sonnet 4.6, and Claude Opus 4.7, featuring expanded context windows up to 1M tokens.

* **Chores**
  * Updated default chat model selection to OpenAI GPT-5.5 and refreshed pricing information for improved cost accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->