### PR TITLE
fix: replace 1s incident polling with exponential backoff

### DIFF
--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -41,10 +41,13 @@ export default function IncidentDetailPage() {
     }
   }, []);
 
-  // Single fetch + poll loop — one effect, no duplicates
+  // Single fetch + poll loop with backoff — one effect, no duplicates
   useEffect(() => {
     let active = true;
     let timer: ReturnType<typeof setTimeout>;
+    let pollCount = 0;
+
+    const getInterval = () => Math.min(3000 * Math.pow(1.5, pollCount), 15000);
 
     const fetchAndSchedule = async (isInitial: boolean) => {
       if (!active || !params.id) return;
@@ -59,7 +62,8 @@ export default function IncidentDetailPage() {
 
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
         if (needsPoll && active) {
-          timer = setTimeout(() => fetchAndSchedule(false), 1000);
+          timer = setTimeout(() => fetchAndSchedule(false), getInterval());
+          pollCount++;
         }
       } catch (e) {
         if (!active) return;


### PR DESCRIPTION
## Summary
- Incident detail page was polling every 1 second while `investigating` or `summarizing`, causing frontend pod CPU to exceed 90% of its 300m limit
- Multiple open tabs compound this linearly — each tab adds another 1req/s
- Replaced with exponential backoff: 3s → 4.5s → 6.75s → ... → 15s cap
- Real-time updates still arrive via SSE; this poll is only a fallback for stale state detection, so the slower interval has zero UX impact

## Test plan
- [ ] Open an active investigation, verify thoughts/status still update in real-time via SSE
- [ ] Verify stale investigations still get detected (just takes a few more seconds)
- [ ] Monitor frontend pod CPU on staging after deploy — should drop well below 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the incident detail page's data loading mechanism by implementing exponential backoff in the polling timer, reducing unnecessary frequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->