### PR TITLE
Fix: dropdown for postmortem exports

### DIFF
--- a/client/src/app/incidents/components/PostmortemPanel.tsx
+++ b/client/src/app/incidents/components/PostmortemPanel.tsx
@@ -2,10 +2,16 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { Download, Edit2, Save, X, ExternalLink, RefreshCw, FileText } from 'lucide-react';
+import { Download, Edit2, Save, X, ExternalLink, RefreshCw, FileText, Upload, ChevronDown } from 'lucide-react';
 import { postmortemService, PostmortemData } from '@/lib/services/incidents';
 import { postmortemMarkdownComponents } from '@/lib/markdown-components';
 import ExportToNotionDialog from '@/components/postmortem/ExportToNotionDialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface PostmortemPanelProps {
   incidentId: string;
@@ -22,12 +28,11 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
   const [exportingToConfluence, setExportingToConfluence] = useState(false);
-  const [showConfluenceForm, setShowConfluenceForm] = useState(false);
+  const [activeExport, setActiveExport] = useState<'confluence' | 'notion' | null>(null);
   const [confluenceSpaceKey, setConfluenceSpaceKey] = useState('');
   const [confluenceParentPageId, setConfluenceParentPageId] = useState('');
   const [exportSuccess, setExportSuccess] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
-  const [showNotionDialog, setShowNotionDialog] = useState(false);
 
   const loadPostmortem = useCallback(async () => {
     const result = await postmortemService.getPostmortem(incidentId);
@@ -95,7 +100,7 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
       );
       if (result.success) {
         setExportSuccess(result.pageUrl || 'Exported successfully');
-        setShowConfluenceForm(false);
+        setActiveExport(null);
         await loadPostmortem(); // Refresh to get confluence URL
       } else {
         setExportError(result.error || 'Export failed');
@@ -140,20 +145,28 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
                 <Download className="w-3 h-3" />
                 Download
               </button>
-              <button
-                onClick={() => setShowConfluenceForm(!showConfluenceForm)}
-                className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
-              >
-                <ExternalLink className="w-3 h-3" />
-                Export to Confluence
-              </button>
-              <button
-                onClick={() => setShowNotionDialog(true)}
-                className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
-              >
-                <ExternalLink className="w-3 h-3" />
-                Export to Notion
-              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                  >
+                    <Upload className="w-3 h-3" />
+                    Export
+                    <ChevronDown className="w-3 h-3" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  <DropdownMenuItem onClick={() => setActiveExport('confluence')}>
+                    <ExternalLink className="w-3 h-3" />
+                    Confluence
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setActiveExport('notion')}>
+                    <ExternalLink className="w-3 h-3" />
+                    Notion
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </>
           )}
           {editing && (
@@ -179,7 +192,7 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
       </div>
 
       {/* Confluence export form */}
-      {showConfluenceForm && (
+      {activeExport === 'confluence' && (
         <div className="mb-4 p-4 rounded-lg bg-zinc-900 border border-zinc-800">
           <p className="text-xs text-zinc-400 mb-3">Export postmortem to Confluence</p>
           <div className="space-y-2">
@@ -214,7 +227,7 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
                 {exportingToConfluence ? 'Exporting...' : 'Export'}
               </button>
               <button
-                onClick={() => setShowConfluenceForm(false)}
+                onClick={() => setActiveExport(null)}
                 className="px-3 py-1.5 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
               >
                 Cancel
@@ -291,8 +304,8 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
       )}
 
       <ExportToNotionDialog
-        open={showNotionDialog}
-        onOpenChange={setShowNotionDialog}
+        open={activeExport === 'notion'}
+        onOpenChange={(open) => { if (!open) setActiveExport(null); }}
         incidentId={incidentId}
         onExported={() => { loadPostmortem(); }}
       />

--- a/client/src/components/PostmortemsSettings.tsx
+++ b/client/src/components/PostmortemsSettings.tsx
@@ -2,14 +2,20 @@
 
 import { useState, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { Download, ExternalLink, ChevronDown, ChevronRight, FileText, Edit2, Save, X } from 'lucide-react';
+import { Download, ExternalLink, ChevronDown, ChevronRight, FileText, Edit2, Save, X, Upload } from 'lucide-react';
 import { postmortemService, PostmortemListItem } from '@/lib/services/incidents';
 import { postmortemMarkdownComponents } from '@/lib/markdown-components';
+import ExportToNotionDialog from '@/components/postmortem/ExportToNotionDialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface ConfluenceFormState {
   spaceKey: string;
   parentPageId: string;
-  showForm: boolean;
   exporting: boolean;
   exportSuccess: string | null;
   exportError: string | null;
@@ -18,11 +24,12 @@ interface ConfluenceFormState {
 const defaultConfluenceState: ConfluenceFormState = {
   spaceKey: '',
   parentPageId: '',
-  showForm: false,
   exporting: false,
   exportSuccess: null,
   exportError: null,
 };
+
+type ActiveExport = { id: string; type: 'confluence' | 'notion' } | null;
 
 interface EditState {
   editing: boolean;
@@ -43,6 +50,7 @@ export function PostmortemsSettings() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [confluenceState, setConfluenceState] = useState<Record<string, ConfluenceFormState>>({});
   const [editState, setEditState] = useState<Record<string, EditState>>({});
+  const [activeExport, setActiveExport] = useState<ActiveExport>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,8 +120,8 @@ export function PostmortemsSettings() {
         updateConfluence(item.id, {
           exporting: false,
           exportSuccess: result.pageUrl || 'Exported successfully',
-          showForm: false,
         });
+        setActiveExport(null);
       } else {
         updateConfluence(item.id, {
           exporting: false,
@@ -274,13 +282,32 @@ export function PostmortemsSettings() {
                         <Download className="w-3 h-3" />
                         Download
                       </button>
-                      <button
-                        onClick={() => updateConfluence(item.id, { showForm: !cfl.showForm })}
-                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
-                      >
-                        <ExternalLink className="w-3 h-3" />
-                        Export to Confluence
-                      </button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                          >
+                            <Upload className="w-3 h-3" />
+                            Export
+                            <ChevronDown className="w-3 h-3" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-40">
+                          <DropdownMenuItem
+                            onClick={() => setActiveExport({ id: item.id, type: 'confluence' })}
+                          >
+                            <ExternalLink className="w-3 h-3" />
+                            Confluence
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => setActiveExport({ id: item.id, type: 'notion' })}
+                          >
+                            <ExternalLink className="w-3 h-3" />
+                            Notion
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </>
                   )}
                 </div>
@@ -303,7 +330,7 @@ export function PostmortemsSettings() {
                 )}
 
                 {/* Confluence export form */}
-                {cfl.showForm && (
+                {activeExport?.id === item.id && activeExport.type === 'confluence' && (
                   <div className="p-4 rounded-lg bg-zinc-900 border border-zinc-800">
                     <p className="text-xs text-zinc-400 mb-3">Export postmortem to Confluence</p>
                     <div className="space-y-2">
@@ -338,7 +365,7 @@ export function PostmortemsSettings() {
                           {cfl.exporting ? 'Exporting...' : 'Export'}
                         </button>
                         <button
-                          onClick={() => updateConfluence(item.id, { showForm: false })}
+                          onClick={() => setActiveExport(null)}
                           className="px-3 py-1.5 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
                         >
                           Cancel
@@ -365,11 +392,44 @@ export function PostmortemsSettings() {
                     </a>
                   </div>
                 )}
+
+                {/* Existing Notion link */}
+                {item.notionPageUrl && (
+                  <div className="mt-3">
+                    <a
+                      href={item.notionPageUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+                    >
+                      <ExternalLink className="w-3 h-3" />
+                      View in Notion
+                    </a>
+                  </div>
+                )}
               </div>
             )}
           </div>
         );
       })}
+
+      {activeExport?.type === 'notion' && (() => {
+        const target = items.find(i => i.id === activeExport.id);
+        if (!target) return null;
+        return (
+          <ExportToNotionDialog
+            open
+            onOpenChange={(open) => { if (!open) setActiveExport(null); }}
+            incidentId={target.incidentId}
+            onExported={({ pageUrl, pageId }) => {
+              setItems(prev => prev.map(i => i.id === target.id
+                ? { ...i, notionPageUrl: pageUrl, notionPageId: pageId, notionExportedAt: new Date().toISOString() }
+                : i
+              ));
+            }}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/client/src/components/PostmortemsSettings.tsx
+++ b/client/src/components/PostmortemsSettings.tsx
@@ -146,6 +146,15 @@ export function PostmortemsSettings() {
     }
   }
 
+  function handleNotionExported(targetId: string, pageUrl: string, pageId: string) {
+    const exportedAt = new Date().toISOString();
+    setItems(prev => prev.map(i =>
+      i.id === targetId
+        ? { ...i, notionPageUrl: pageUrl, notionPageId: pageId, notionExportedAt: exportedAt }
+        : i
+    ));
+  }
+
   function formatDate(dateStr: string): string {
     try {
       return new Date(dateStr).toLocaleDateString(undefined, {
@@ -193,6 +202,10 @@ export function PostmortemsSettings() {
       </div>
     );
   }
+
+  const notionTarget = activeExport?.type === 'notion'
+    ? items.find(i => i.id === activeExport.id) ?? null
+    : null;
 
   return (
     <div className="p-6">
@@ -413,23 +426,14 @@ export function PostmortemsSettings() {
         );
       })}
 
-      {activeExport?.type === 'notion' && (() => {
-        const target = items.find(i => i.id === activeExport.id);
-        if (!target) return null;
-        return (
-          <ExportToNotionDialog
-            open
-            onOpenChange={(open) => { if (!open) setActiveExport(null); }}
-            incidentId={target.incidentId}
-            onExported={({ pageUrl, pageId }) => {
-              setItems(prev => prev.map(i => i.id === target.id
-                ? { ...i, notionPageUrl: pageUrl, notionPageId: pageId, notionExportedAt: new Date().toISOString() }
-                : i
-              ));
-            }}
-          />
-        );
-      })()}
+      {notionTarget && (
+        <ExportToNotionDialog
+          open
+          onOpenChange={(open) => { if (!open) setActiveExport(null); }}
+          incidentId={notionTarget.incidentId}
+          onExported={({ pageUrl, pageId }) => handleNotionExported(notionTarget.id, pageUrl, pageId)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Changed postmortem exports into a dropdown. Added export to Notion in postmortem page in settings menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Confluence and Notion export options into a single "Export" dropdown menu, replacing separate export buttons for a streamlined experience.
  * Reorganized export state management across postmortem components.

* **New Features**
  * Postmortem results now display connected Notion page links.
  * Notion export updates postmortem records with page identifiers and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->