### PR TITLE
fix: suppress provider-disconnected flash on incidents page

### DIFF
--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -64,7 +64,7 @@ const incidentsFetcher = async (key: string, signal: AbortSignal) => {
 };
 
 export default function IncidentsPage() {
-  const { providerIds } = useConnectedAccounts();
+  const { providerIds, isLoading: isLoadingAccounts } = useConnectedAccounts();
 
   const isConnectedToIncidentPlatform = useMemo(
     () => providerIds.some(id => ALERT_PROVIDERS.has(id)),
@@ -131,7 +131,7 @@ export default function IncidentsPage() {
         </div>
       ) : (
         <div className="space-y-8">
-          {incidents.length > 0 && !isConnectedToIncidentPlatform && (
+          {incidents.length > 0 && !isConnectedToIncidentPlatform && !isLoadingAccounts && (
             <DisconnectedBanner />
           )}
 
@@ -183,7 +183,7 @@ export default function IncidentsPage() {
           {incidents.length === 0 && (
             <Card>
               <CardContent className="py-12 text-center">
-                {!isConnectedToIncidentPlatform ? (
+                {!isConnectedToIncidentPlatform && !isLoadingAccounts ? (
                   <ConnectPlatformCTA />
                 ) : (
                   <>


### PR DESCRIPTION
## Summary
- The incidents page briefly flashes "No alerting platform connected" (or the `ConnectPlatformCTA`) before the connected-accounts query resolves, even when a provider is connected.
- Root cause: `useConnectedAccounts()` returns `providerIds = []` while loading, and the page never checked `isLoading` before rendering the disconnected UI.
- Fix: destructure `isLoading` from the hook and suppress `DisconnectedBanner` and `ConnectPlatformCTA` until the query settles.

## Test plan
- [ ] Navigate to /incidents with a provider connected -- banner should NOT flash
- [ ] Disconnect all providers, navigate to /incidents -- banner/CTA should appear after load
- [ ] With no incidents and no provider -- `ConnectPlatformCTA` shows (not "All clear")