### PR TITLE
feat: deploy dispatch for automated CD pipeline

### DIFF
--- a/.github/workflows/dispatch-deploy.yml
+++ b/.github/workflows/dispatch-deploy.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Compute image tag
         id: tag
@@ -21,40 +22,93 @@ jobs:
           echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Image tag: sha-$SHORT_SHA"
 
+      - name: Verify images exist in GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.image_tag }}"
+          for i in $(seq 1 12); do
+            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG" && \
+               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG"; then
+              echo "Both images verified with tag $TAG"
+              exit 0
+            fi
+            echo "Waiting for images to propagate (attempt $i/12)..."
+            sleep 5
+          done
+          echo "::error::Images with tag $TAG not found after 60s"
+          exit 1
+
       - name: Dispatch to staging
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
         run: |
-          gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
-            -f event_type=deploy-staging \
-            -f 'client_payload[image_tag]=${{ steps.tag.outputs.image_tag }}' \
-            -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}' \
-            -f 'client_payload[source_ref]=${{ github.event.workflow_run.head_branch }}'
+          for attempt in 1 2 3; do
+            if gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
+              -f event_type=deploy-staging \
+              -f 'client_payload[image_tag]=${{ steps.tag.outputs.image_tag }}' \
+              -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}' \
+              -f 'client_payload[source_ref]=${{ github.event.workflow_run.head_branch }}'; then
+              echo "Dispatch succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::All dispatch attempts failed"
+          exit 1
 
   dispatch-prod:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
+      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Extract version and tag
         id: version
         run: |
           REF="${{ github.event.workflow_run.head_branch }}"
-          VERSION="${REF#refs/tags/v}"
+          VERSION="${REF#v}"
           SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Version: $VERSION, Image tag: sha-$SHORT_SHA"
 
+      - name: Verify images exist in GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.image_tag }}"
+          for i in $(seq 1 12); do
+            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG" && \
+               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG"; then
+              echo "Both images verified with tag $TAG"
+              exit 0
+            fi
+            echo "Waiting for images to propagate (attempt $i/12)..."
+            sleep 5
+          done
+          echo "::error::Images with tag $TAG not found after 60s"
+          exit 1
+
       - name: Dispatch to production
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
         run: |
-          gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
-            -f event_type=deploy-prod \
-            -f 'client_payload[image_tag]=${{ steps.version.outputs.image_tag }}' \
-            -f 'client_payload[version]=${{ steps.version.outputs.version }}' \
-            -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}'
+          for attempt in 1 2 3; do
+            if gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
+              -f event_type=deploy-prod \
+              -f 'client_payload[image_tag]=${{ steps.version.outputs.image_tag }}' \
+              -f 'client_payload[version]=${{ steps.version.outputs.version }}' \
+              -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}'; then
+              echo "Dispatch succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::All dispatch attempts failed"
+          exit 1

--- a/.github/workflows/dispatch-deploy.yml
+++ b/.github/workflows/dispatch-deploy.yml
@@ -17,38 +17,43 @@ jobs:
     steps:
       - name: Compute image tag
         id: tag
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          SHORT_SHA=$(echo "$HEAD_SHA" | cut -c1-7)
           echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Image tag: sha-$SHORT_SHA"
 
       - name: Verify images exist in GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
-          TAG="${{ steps.tag.outputs.image_tag }}"
           for i in $(seq 1 12); do
-            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG" && \
-               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG"; then
-              echo "Both images verified with tag $TAG"
+            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$IMAGE_TAG" && \
+               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$IMAGE_TAG"; then
+              echo "Both images verified with tag $IMAGE_TAG"
               exit 0
             fi
             echo "Waiting for images to propagate (attempt $i/12)..."
             sleep 5
           done
-          echo "::error::Images with tag $TAG not found after 60s"
+          echo "::error::Images with tag $IMAGE_TAG not found after 60s"
           exit 1
 
       - name: Dispatch to staging
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           for attempt in 1 2 3; do
             if gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
               -f event_type=deploy-staging \
-              -f 'client_payload[image_tag]=${{ steps.tag.outputs.image_tag }}' \
-              -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}' \
-              -f 'client_payload[source_ref]=${{ github.event.workflow_run.head_branch }}'; then
+              -f "client_payload[image_tag]=$IMAGE_TAG" \
+              -f "client_payload[source_sha]=$HEAD_SHA" \
+              -f "client_payload[source_ref]=$HEAD_BRANCH"; then
               echo "Dispatch succeeded on attempt $attempt"
               exit 0
             fi
@@ -69,10 +74,12 @@ jobs:
     steps:
       - name: Extract version and tag
         id: version
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          REF="${{ github.event.workflow_run.head_branch }}"
-          VERSION="${REF#v}"
-          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          VERSION="${HEAD_BRANCH#v}"
+          SHORT_SHA=$(echo "$HEAD_SHA" | cut -c1-7)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Version: $VERSION, Image tag: sha-$SHORT_SHA"
@@ -80,30 +87,33 @@ jobs:
       - name: Verify images exist in GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
         run: |
-          TAG="${{ steps.version.outputs.image_tag }}"
           for i in $(seq 1 12); do
-            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG" && \
-               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$TAG"; then
-              echo "Both images verified with tag $TAG"
+            if gh api "orgs/Arvo-AI/packages/container/aurora-server/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$IMAGE_TAG" && \
+               gh api "orgs/Arvo-AI/packages/container/aurora-frontend/versions" --jq ".[].metadata.container.tags[]" 2>/dev/null | grep -qF "$IMAGE_TAG"; then
+              echo "Both images verified with tag $IMAGE_TAG"
               exit 0
             fi
             echo "Waiting for images to propagate (attempt $i/12)..."
             sleep 5
           done
-          echo "::error::Images with tag $TAG not found after 60s"
+          echo "::error::Images with tag $IMAGE_TAG not found after 60s"
           exit 1
 
       - name: Dispatch to production
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           for attempt in 1 2 3; do
             if gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
               -f event_type=deploy-prod \
-              -f 'client_payload[image_tag]=${{ steps.version.outputs.image_tag }}' \
-              -f 'client_payload[version]=${{ steps.version.outputs.version }}' \
-              -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}'; then
+              -f "client_payload[image_tag]=$IMAGE_TAG" \
+              -f "client_payload[version]=$VERSION" \
+              -f "client_payload[source_sha]=$HEAD_SHA"; then
               echo "Dispatch succeeded on attempt $attempt"
               exit 0
             fi

--- a/.github/workflows/dispatch-deploy.yml
+++ b/.github/workflows/dispatch-deploy.yml
@@ -1,0 +1,60 @@
+name: Dispatch Deploy
+
+on:
+  workflow_run:
+    workflows: ["Publish Docker Images"]
+    types: [completed]
+
+jobs:
+  dispatch-staging:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Compute image tag
+        id: tag
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "Image tag: sha-$SHORT_SHA"
+
+      - name: Dispatch to staging
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
+            -f event_type=deploy-staging \
+            -f 'client_payload[image_tag]=${{ steps.tag.outputs.image_tag }}' \
+            -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}' \
+            -f 'client_payload[source_ref]=${{ github.event.workflow_run.head_branch }}'
+
+  dispatch-prod:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Extract version and tag
+        id: version
+        run: |
+          REF="${{ github.event.workflow_run.head_branch }}"
+          VERSION="${REF#refs/tags/v}"
+          SHORT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "image_tag=sha-$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION, Image tag: sha-$SHORT_SHA"
+
+      - name: Dispatch to production
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/Arvo-AI/aurora-saas-prod/dispatches \
+            -f event_type=deploy-prod \
+            -f 'client_payload[image_tag]=${{ steps.version.outputs.image_tag }}' \
+            -f 'client_payload[version]=${{ steps.version.outputs.version }}' \
+            -f 'client_payload[source_sha]=${{ github.event.workflow_run.head_sha }}'


### PR DESCRIPTION
## Summary

Adds a `dispatch-deploy.yml` workflow that triggers after successful image publish:

- **Staging** (auto): Every merge to `main` → dispatches `deploy-staging` to `aurora-saas-prod` with the new `sha-<short>` tag
- **Production** (controlled): Version tags (`v*.*.*`) → dispatches `deploy-prod` to `aurora-saas-prod`

## Flow

```
PR merged to main
  → publish-images.yml builds ghcr.io/arvo-ai/aurora-{server,frontend}:sha-<short>
  → dispatch-deploy.yml (this PR) sends repository_dispatch to aurora-saas-prod
  → staging auto-deploys via Terraform
  
Version tag (v1.2.3)
  → publish-images.yml builds :1.2.3, :latest
  → dispatch-deploy.yml sends deploy-prod dispatch
  → prod deploys via helm upgrade (requires environment approval)
```

## Prerequisites

- **`DEPLOY_DISPATCH_TOKEN`** secret: PAT with `repo` scope on `Arvo-AI/aurora-saas-prod`

## Companion PR

- Arvo-AI/aurora-saas-prod#2 — receives the dispatches and runs the actual deploys

## Test plan

- [ ] Verify workflow syntax passes CI
- [ ] Create `DEPLOY_DISPATCH_TOKEN` secret
- [ ] Test staging dispatch manually after merge
- [ ] Verify prod dispatch only fires on version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation workflows to streamline the release process for staging and production environments. Deployment triggers are now automatically dispatched based on code changes and versioned releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->