### PR TITLE
Remove incident run action button

### DIFF
--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -16,13 +16,11 @@ import {
   FileText,
   Coins,
   Activity,
-  Workflow,
 } from 'lucide-react';
-import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
-import { fetchR } from '@/lib/query';
 import { useUser } from '@/hooks/useAuthHooks';
 import { canWrite as checkCanWrite } from '@/lib/roles';
 import Link from 'next/link';
@@ -105,93 +103,6 @@ function isSafeUrl(url: string | undefined): boolean {
   } catch {
     return false;
   }
-}
-
-function RunActionDropdown({ incidentId, incidentTitle }: { readonly incidentId: string; readonly incidentTitle: string }) {
-  const [open, setOpen] = useState(false);
-  const [actions, setActions] = useState<{ id: string; name: string }[]>([]);
-  const [loading, setLoading] = useState(false);
-  const { toast } = useToast();
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [open]);
-
-  const handleOpen = async () => {
-    if (open) { setOpen(false); return; }
-    setOpen(true);
-    setLoading(true);
-    try {
-      const res = await fetch('/api/actions?enabled=true', { credentials: 'include' });
-      if (res.ok) {
-        const data = await res.json();
-        setActions((data.actions || []).filter((a: { enabled: boolean }) => a.enabled));
-      }
-    } catch {
-      toast({ title: 'Failed to load actions', variant: 'destructive' });
-    }
-    setLoading(false);
-  };
-
-  const handleTrigger = async (actionId: string) => {
-    setOpen(false);
-    try {
-      await fetchR(`/api/actions/${actionId}/run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ incident_id: incidentId, trigger_label: `Incident: ${incidentTitle}` }),
-      });
-      toast({ title: 'Action triggered', description: 'Background task started.' });
-    } catch {
-      toast({ title: 'Failed to trigger action', variant: 'destructive' });
-    }
-  };
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        onClick={handleOpen}
-        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-zinc-800/80 border border-zinc-700/50 text-xs font-medium text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700/80 transition-all"
-      >
-        <Workflow className="h-3.5 w-3.5" />
-        Run Action
-        <ChevronDown className="h-3 w-3" />
-      </button>
-      {open && (
-        <div className="absolute right-0 top-full mt-1 w-64 bg-zinc-900 border border-zinc-700/60 rounded-lg shadow-xl z-50 py-1">
-          <ActionDropdownContent loading={loading} actions={actions} onTrigger={handleTrigger} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ActionDropdownContent({ loading, actions, onTrigger }: {
-  readonly loading: boolean;
-  readonly actions: { id: string; name: string }[];
-  readonly onTrigger: (id: string) => void;
-}) {
-  if (loading) return <p className="text-xs text-zinc-500 px-3 py-2">Loading...</p>;
-  if (actions.length === 0) return <p className="text-xs text-zinc-500 px-3 py-2">No actions configured</p>;
-  return (
-    <>
-      {actions.map(a => (
-        <button
-          key={a.id}
-          onClick={() => onTrigger(a.id)}
-          className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-800 transition-colors"
-        >
-          {a.name}
-        </button>
-      ))}
-    </>
-  );
 }
 
 export default function IncidentCard({ incident, duration, showThoughts, onToggleThoughts, citations = [], onRefresh }: IncidentCardProps) {
@@ -467,9 +378,6 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
           </div>
           <div className="flex items-center gap-3">
             <StatusPill status={incident.auroraStatus} />
-            {incident.auroraStatus === 'complete' && (
-              <RunActionDropdown incidentId={incident.id} incidentTitle={alert.title} />
-            )}
           </div>
         </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the Run Action dropdown from the incident detail header
- Remove the now-unused frontend action-fetch/trigger code and imports from the incident card

## Testing
- Installed frontend dependencies with `npm ci`
- `npm run lint` is blocked by existing ESLint/minimatch config issue before linting files (`minimatch` default export error)
- `npx tsc --noEmit` reports existing repo-wide TypeScript errors, with no errors in `IncidentCard.tsx`
- Verified no remaining incident-card references to the removed Run Action UI/API calls
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febae510-fe83-4b44-9748-a2837c75bd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febae510-fe83-4b44-9748-a2837c75bd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "Run Action" dropdown menu from incident cards. This menu is no longer available when viewing incidents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->