### PR TITLE
fix: replace Docker-based GitHub MCP server with native Go binary

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,15 @@
 # ============================================
+# Build GitHub MCP Server from source (pinned)
+# ============================================
+FROM golang:1.23-bookworm AS github-mcp-build
+
+ARG GITHUB_MCP_VERSION=v0.2.0
+RUN git clone --depth 1 --branch ${GITHUB_MCP_VERSION} \
+        https://github.com/github/github-mcp-server.git /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /github-mcp-server ./cmd/github-mcp-server
+
+# ============================================
 # Base Stage - Common dependencies
 # ============================================
 FROM python:3.12-slim AS base
@@ -199,6 +210,9 @@ RUN curl -fsSL https://tailscale.com/install.sh | sh
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy GitHub MCP Server binary from build stage
+COPY --from=github-mcp-build /github-mcp-server /usr/local/bin/github-mcp-server
 
 # Install kubectl for orchestrator to manage terminal pods
 RUN ARCH=$(uname -m) && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,9 @@
 # ============================================
 # Build GitHub MCP Server from source (pinned)
 # ============================================
-FROM golang:1.23-bookworm AS github-mcp-build
+FROM golang:1.25-bookworm AS github-mcp-build
 
-ARG GITHUB_MCP_VERSION=v0.2.0
+ARG GITHUB_MCP_VERSION=v1.0.3
 RUN git clone --depth 1 --branch ${GITHUB_MCP_VERSION} \
         https://github.com/github/github-mcp-server.git /src
 WORKDIR /src

--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -117,8 +117,8 @@ class RealMCPServerManager:
             #     "description": "Azure MCP Server"
             # },
             "github": {
-                "command": ["docker", "run", "-i", "--rm"],
-                "description": "GitHub Official MCP Server (Docker)"
+                "command": ["github-mcp-server", "stdio"],
+                "description": "GitHub Official MCP Server"
             },
             "context7": {
                 "command": ["npx", "-y", "@upstash/context7-mcp"],
@@ -222,10 +222,8 @@ class RealMCPServerManager:
                 python_cmd = shutil.which("python") or "/usr/local/bin/python"
                 cmd = [python_cmd, "-m", "awslabs.aws_api_mcp_server.server"]
             elif server_type == "github":
-                # Official GitHub MCP Server via Docker
-                # Command is built dynamically below to include the token
-                docker_cmd = shutil.which("docker") or "/usr/bin/docker"
-                # Get GitHub token from credentials
+                # Official GitHub MCP Server - native binary baked into the image
+                github_binary = shutil.which("github-mcp-server") or "/usr/local/bin/github-mcp-server"
                 github_token = ""
                 if user_credentials and "github" in user_credentials:
                     github_token = str(user_credentials["github"].get("access_token", ""))
@@ -234,16 +232,8 @@ class RealMCPServerManager:
                     logging.error(" GitHub token is required for GitHub MCP server")
                     return None
                 
-                # Build Docker command with token passed via -e flag
-                # Using GITHUB_TOOLSETS=all to enable all 60+ tools
-                cmd = [
-                    docker_cmd, "run", "-i", "--rm",
-                    "-e", f"GITHUB_PERSONAL_ACCESS_TOKEN={github_token}",
-                    "-e", "GITHUB_TOOLSETS=all",
-                    "ghcr.io/github/github-mcp-server"
-                ]
-                
-                logging.info(f" GitHub MCP server command prepared (Docker with all toolsets)")
+                cmd = [github_binary, "stdio"]
+                logging.info(f" GitHub MCP server command prepared (native binary, all toolsets)")
                 logging.info(f" GitHub token configured (length: {len(github_token)})")
             elif server_type == "context7":
                 # Context7 MCP server via npx - provides up-to-date docs for OVH CLI/Terraform
@@ -302,11 +292,11 @@ output = json
                     env["AWS_SHARED_CREDENTIALS_FILE"] = credentials_file
                     env["AWS_CONFIG_FILE"] = config_file
                     
-                # GitHub credentials are passed via Docker -e flag in the command itself
-                # (handled above when building the docker command)
+                # GitHub credentials passed as env vars to the native binary
                 elif server_type == "github":
-                    # Token already passed in Docker command args, nothing to add to env
-                    pass
+                    if "github" in user_credentials:
+                        env["GITHUB_PERSONAL_ACCESS_TOKEN"] = str(user_credentials["github"].get("access_token", ""))
+                        env["GITHUB_TOOLSETS"] = "all"
 
             
             # Offload the blocking Popen spawn to a worker thread so we don't
@@ -326,8 +316,7 @@ output = json
             )
 
             # Give the process a moment to start
-            # Docker containers need more time, especially on first run (image pull)
-            startup_wait = 2.0 if server_type == "github" else 0.5
+            startup_wait = 0.5
             await asyncio.sleep(startup_wait)
             
             # Check if process started successfully


### PR DESCRIPTION
## Summary

- The GitHub MCP server was previously spawned via `docker run`, requiring `/var/run/docker.sock` which is unavailable in Kubernetes pods. This caused the agent's GitHub tools (`get_file_contents`, etc.) to hang indefinitely on staging.
- Compiles the official `github/github-mcp-server` Go binary (v0.2.0) in a multi-stage Dockerfile build with `CGO_ENABLED=0` for a static binary that works on both amd64 and arm64.
- Invokes the binary directly as a subprocess, passing credentials via environment variables instead of Docker `-e` flags.

## Changes

- **`server/Dockerfile`**: Added a `github-mcp-build` stage that clones the pinned tag and produces a static binary, then copies it into the base image at `/usr/local/bin/github-mcp-server`.
- **`server/chat/backend/agent/tools/mcp_tools.py`**: Replaced Docker command construction with native binary invocation. GitHub token and `GITHUB_TOOLSETS=all` are now passed as env vars to the subprocess. Removed the 2s Docker startup delay (now 0.5s uniform).

## Test plan

- [ ] Build image locally: `docker build --target prod -t aurora-server-test server/`
- [ ] Verify binary exists: `docker run --rm aurora-server-test which github-mcp-server`
- [ ] Connect GitHub in the app and test agent GitHub tools (get_file_contents, search_repositories)
- [ ] Deploy to staging and verify no more Docker socket errors in celery worker logs