### PR TITLE
fix: prevent reasoning tokens from streaming as normal output

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -21,6 +21,29 @@ import asyncio
 _DIRECT_ONLY_PROVIDERS = frozenset({"vertex", "ollama"})
 
 
+def _extract_reasoning_from_delta(delta: dict) -> tuple:
+    """Extract reasoning text from an OpenRouter streaming delta.
+
+    Returns (reasoning_text, has_reasoning_details) where has_reasoning_details
+    indicates the delta carried a reasoning_details array regardless of whether
+    any text was extractable.
+    """
+    reasoning = delta.get("reasoning") or ""
+    reasoning_details = delta.get("reasoning_details")
+    has_reasoning_details = bool(reasoning_details) and isinstance(reasoning_details, list)
+
+    if has_reasoning_details:
+        parts = [
+            detail.get("text", "")
+            for detail in reasoning_details
+            if isinstance(detail, dict) and detail.get("text")
+        ]
+        if parts:
+            reasoning = (reasoning + "".join(parts)) if reasoning else "".join(parts)
+
+    return reasoning, has_reasoning_details
+
+
 class _ReasoningChatOpenAI(ChatOpenAI):
     """ChatOpenAI subclass that captures OpenRouter reasoning fields.
 
@@ -41,27 +64,18 @@ class _ReasoningChatOpenAI(ChatOpenAI):
         if result is None:
             return None
         choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
-        if choices:
-            delta = choices[0].get("delta") or {}
+        if not choices:
+            return result
 
-            reasoning = delta.get("reasoning") or ""
+        delta = choices[0].get("delta") or {}
+        reasoning, has_reasoning_details = _extract_reasoning_from_delta(delta)
 
-            reasoning_details = delta.get("reasoning_details")
-            if reasoning_details and isinstance(reasoning_details, list):
-                parts = []
-                for detail in reasoning_details:
-                    if isinstance(detail, dict):
-                        text = detail.get("text", "")
-                        if text:
-                            parts.append(text)
-                if parts:
-                    reasoning = (reasoning + "".join(parts)) if reasoning else "".join(parts)
+        if reasoning and hasattr(result.message, "additional_kwargs"):
+            result.message.additional_kwargs["reasoning_content"] = reasoning
 
-            if reasoning and hasattr(result.message, "additional_kwargs"):
-                result.message.additional_kwargs["reasoning_content"] = reasoning
-                # Clear content so reasoning-only chunks don't appear as output
-                if not delta.get("content"):
-                    result.message.content = ""
+        if (reasoning or has_reasoning_details) and not delta.get("content"):
+            result.message.content = ""
+
         return result
 
 class Agent:

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -528,6 +528,9 @@ class Agent:
                         openrouter_model_kwargs["extra_body"] = {"reasoning": {"effort": "high"}}
                         logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter")
                 elif detected_provider == "google":
+                    # OpenRouter path: exclude reasoning tokens from response for
+                    # user-facing chats. Direct Google SDK uses a different mechanism
+                    # (structured thinking blocks filtered by include_thinking=False).
                     reasoning_cfg = {"effort": "high"}
                     if not is_background:
                         reasoning_cfg["exclude"] = True

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -528,6 +528,8 @@ class Agent:
                         openrouter_model_kwargs["extra_body"] = {"reasoning": {"effort": "high"}}
                         logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter")
                 elif detected_provider == "google":
+                    # OpenRouter path only. Direct Google SDK uses structured
+                    # thinking blocks filtered by include_thinking=False downstream.
                     reasoning_cfg = {"effort": "high"}
                     if not is_background:
                         reasoning_cfg["exclude"] = True

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -24,10 +24,16 @@ _DIRECT_ONLY_PROVIDERS = frozenset({"vertex", "ollama"})
 class _ReasoningChatOpenAI(ChatOpenAI):
     """ChatOpenAI subclass that captures OpenRouter reasoning fields.
 
-    OpenRouter returns reasoning content in delta.reasoning / delta.reasoning_details,
-    but LangChain's _convert_delta_to_message_chunk ignores these fields. This subclass
-    captures them and puts reasoning into additional_kwargs["reasoning_content"] so that
-    workflow.py's streaming code can forward it to the ThoughtsPanel.
+    OpenRouter returns reasoning content in delta.reasoning and/or
+    delta.reasoning_details, but LangChain's _convert_delta_to_message_chunk
+    ignores these fields. This subclass captures them into
+    additional_kwargs["reasoning_content"] so workflow.py can separate reasoning
+    from user-visible output.
+
+    For Google models via OpenRouter, reasoning arrives in reasoning_details
+    (array of objects with .text) rather than the plain reasoning string field.
+    When reasoning_details is present, the chunk's content should be treated as
+    reasoning — not streamed to the user as normal output.
     """
 
     def _convert_chunk_to_generation_chunk(self, chunk, default_chunk_class, base_generation_info):
@@ -37,9 +43,25 @@ class _ReasoningChatOpenAI(ChatOpenAI):
         choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
         if choices:
             delta = choices[0].get("delta") or {}
-            reasoning = delta.get("reasoning")
+
+            reasoning = delta.get("reasoning") or ""
+
+            reasoning_details = delta.get("reasoning_details")
+            if reasoning_details and isinstance(reasoning_details, list):
+                parts = []
+                for detail in reasoning_details:
+                    if isinstance(detail, dict):
+                        text = detail.get("text", "")
+                        if text:
+                            parts.append(text)
+                if parts:
+                    reasoning = (reasoning + "".join(parts)) if reasoning else "".join(parts)
+
             if reasoning and hasattr(result.message, "additional_kwargs"):
                 result.message.additional_kwargs["reasoning_content"] = reasoning
+                # Clear content so reasoning-only chunks don't appear as output
+                if not delta.get("content"):
+                    result.message.content = ""
         return result
 
 class Agent:
@@ -484,6 +506,7 @@ class Agent:
 
                 # Enable reasoning via OpenRouter's unified reasoning param
                 openrouter_model_kwargs = {}
+                is_background = getattr(state, "is_background", False)
                 if detected_provider == "openai":
                     from chat.backend.agent.providers.openai_provider import OpenAIProvider
                     native = model_name.split("/", 1)[-1] if "/" in model_name else model_name
@@ -491,8 +514,11 @@ class Agent:
                         openrouter_model_kwargs["extra_body"] = {"reasoning": {"effort": "high"}}
                         logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter")
                 elif detected_provider == "google":
-                    openrouter_model_kwargs["extra_body"] = {"reasoning": {"effort": "high"}}
-                    logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter")
+                    reasoning_cfg = {"effort": "high"}
+                    if not is_background:
+                        reasoning_cfg["exclude"] = True
+                    openrouter_model_kwargs["extra_body"] = {"reasoning": reasoning_cfg}
+                    logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter (exclude={not is_background})")
 
                 streaming_llm = _ReasoningChatOpenAI(
                     model=openrouter_model_name,

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -528,9 +528,6 @@ class Agent:
                         openrouter_model_kwargs["extra_body"] = {"reasoning": {"effort": "high"}}
                         logging.info(f"Enabled reasoning effort=high for {openrouter_model_name} via OpenRouter")
                 elif detected_provider == "google":
-                    # OpenRouter path: exclude reasoning tokens from response for
-                    # user-facing chats. Direct Google SDK uses a different mechanism
-                    # (structured thinking blocks filtered by include_thinking=False).
                     reasoning_cfg = {"effort": "high"}
                     if not is_background:
                         reasoning_cfg["exclude"] = True

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -214,7 +214,7 @@ class Agent:
             else:
                 logging.info("Skipping storage file fetch: user_id or session_id missing")
         except Exception as e:
-            logging.error(f"Error fetching session files from storage: {e}")
+            logging.exception(f"Error fetching session files from storage: {e}")
 
     async def agentic_tool_flow(self, state: State) -> State:
         """Execute cloud tools using the agentic workflow with streaming callbacks."""
@@ -248,7 +248,7 @@ class Agent:
                         from chat.background.rca_prompt_builder import get_user_providers
                         provider_preference = get_user_providers(state.user_id)
                     except Exception as e:
-                        logging.error(f"Error getting connected providers: {e}")
+                        logging.exception(f"Error getting connected providers: {e}")
                         provider_preference = []
                     state.provider_preference = provider_preference
                 
@@ -746,9 +746,8 @@ class Agent:
                             if isinstance(content, list):
                                 text_parts = [p.get('text', '') if isinstance(p, dict) else str(p) for p in content]
                                 content = ' '.join(text_parts)
-                            if isinstance(content, str) and (
-                                content.startswith("[Tool Result:") or
-                                content.startswith("[CONVERSATION SUMMARY")
+                            if isinstance(content, str) and content.startswith(
+                                ("[Tool Result:", "[CONVERSATION SUMMARY")
                             ):
                                 continue
                             original_request = content
@@ -856,7 +855,7 @@ class Agent:
                                 raise
                                 
                 except Exception as e:
-                    logging.error(f"Agent execution failed after retries: {e}", exc_info=True)
+                    logging.exception(f"Agent execution failed after retries: {e}")
                     # Create error response message
                     error_msg = AIMessage(content=f"Error: {str(e)}\n\nTry a different approach.")
                     state.messages.append(error_msg)
@@ -904,9 +903,7 @@ class Agent:
                         # Don't let cleanup errors break the flow
             
         except Exception as e:
-            import traceback
-            logging.error(f"Error in agentic_tool_flow: {e}")
-            logging.error(f"Full traceback:\n{traceback.format_exc()}")
+            logging.exception(f"Error in agentic_tool_flow: {e}")
             
             # Still attempt cleanup on error
             try:

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1363,7 +1363,8 @@ class Workflow:
                     chunk_builders[msg.id] = builder
 
                 # Accumulate content (handles Gemini thinking model list format)
-                msg_content = _extract_text_from_content(msg.content or "", include_thinking=False)
+                # include_thinking=True so reasoning is preserved in the saved message
+                msg_content = _extract_text_from_content(msg.content or "", include_thinking=True)
                 builder["content"] += msg_content
 
                 # Process tool calls
@@ -1545,7 +1546,7 @@ class Workflow:
                     or getattr(msg, 'additional_kwargs', {}).get('tool_calls', [])
                 )
                 if not content and has_tool_calls:
-                    content = _extract_text_from_content(raw_content, include_thinking=False)
+                    content = _extract_text_from_content(raw_content, include_thinking=True)
                 
                 # Get the AIMessage's run_id for consistency (needed regardless of tool calls)
                 run_id = getattr(msg, 'id', None)

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1076,14 +1076,14 @@ class Workflow:
                         content = ""
                         reasoning = ""
 
-                        # Check for reasoning content first (OpenRouter, DeepSeek-R1 etc.)
+                        # Check for reasoning content (OpenRouter, DeepSeek-R1 etc.)
                         if hasattr(chunk_obj, 'additional_kwargs'):
                             reasoning = chunk_obj.additional_kwargs.get("reasoning_content", "")
 
-                        # Only extract content if this is NOT a reasoning-only chunk.
-                        # Some providers (Google via OpenRouter) may duplicate reasoning
-                        # into delta.content; skip it when reasoning was detected.
-                        if not reasoning and hasattr(chunk_obj, 'content') and chunk_obj.content:
+                        # Extract visible content. _ReasoningChatOpenAI clears
+                        # chunk_obj.content for reasoning-only chunks upstream, so
+                        # this is safe to call unconditionally.
+                        if hasattr(chunk_obj, 'content') and chunk_obj.content:
                             content = _extract_text_from_content(chunk_obj.content, include_thinking=False)
 
                         # For background RCA chats, reasoning feeds into incident thoughts

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -546,7 +546,7 @@ class Workflow:
                             logger.error(f"Cannot extract valid JSON from malformed args, using empty dict")
                             args = {}
                     except (json.JSONDecodeError, Exception) as e:
-                        logger.error(f"Failed to clean malformed args: {e}, using empty dict")
+                        logger.exception(f"Failed to clean malformed args: {e}, using empty dict")
                         args = {}
                 
                 elif args_stripped.startswith('{') and args_stripped.endswith('}'):
@@ -747,7 +747,7 @@ class Workflow:
                             "ui_messages": row[6],
                         }
         except Exception as e:
-            logger.error(f"[RCA-Context] Failed to fetch RCA context for session {session_id}: {e}")
+            logger.exception(f"[RCA-Context] Failed to fetch RCA context for session {session_id}: {e}")
         return None
 
     @staticmethod
@@ -1219,7 +1219,7 @@ class Workflow:
                 
             logger.info(f"[WORKFLOW STREAM] Completed: {_event_count} events, {_token_count} tokens streamed")
         except Exception as stream_exception:
-            logger.error(f"[WORKFLOW STREAM ERROR] Exception in workflow stream for session {input_state.session_id}: {stream_exception}", exc_info=True)
+            logger.exception(f"[WORKFLOW STREAM ERROR] Exception in workflow stream for session {input_state.session_id}: {stream_exception}")
             raise
         
         # Consolidate message chunks and save final state
@@ -1721,7 +1721,7 @@ class Workflow:
                     return False
                     
         except Exception as e:
-            logger.error(f"Error saving UI messages: {e}")
+            logger.exception(f"Error saving UI messages: {e}")
             return False
 
     def _append_new_turn_ui_messages(
@@ -1806,7 +1806,7 @@ class Workflow:
 
         except Exception as e:
             # Broad catch: DB/persistence errors must not abort the workflow.
-            logger.error(f"Error appending UI messages: {e}")
+            logger.exception(f"Error appending UI messages: {e}")
             return False
 
     def _redact_for_ui(self, content: Any, tool_name: str = "") -> str:
@@ -1868,7 +1868,7 @@ class Workflow:
                     )
             return redacted
         except Exception as e:
-            logger.error(f"Output redaction (ui_message) failed open: {e}")
+            logger.exception(f"Output redaction (ui_message) failed open: {e}")
             return text
 
     def _associate_tool_calls_with_output(self, ui_messages, tool_messages):

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1363,8 +1363,7 @@ class Workflow:
                     chunk_builders[msg.id] = builder
 
                 # Accumulate content (handles Gemini thinking model list format)
-                # include_thinking=True so reasoning is preserved in the saved message
-                msg_content = _extract_text_from_content(msg.content or "", include_thinking=True)
+                msg_content = _extract_text_from_content(msg.content or "", include_thinking=False)
                 builder["content"] += msg_content
 
                 # Process tool calls
@@ -1535,18 +1534,14 @@ class Workflow:
                 # Skip synthetic RCA summary injected by _compress_rca_context
                 if isinstance(raw_content, str) and raw_content.startswith(RCA_SUMMARY_PREFIX):
                     continue
-                # Extract text content (handles Gemini thinking model list format).
-                # Include thinking when text is empty and message has tool calls,
-                # so Gemini's reasoning appears in chat alongside tool cards.
-                # (Claude generates inline text with tool calls; Gemini puts reasoning
-                # in thinking blocks only, leaving text empty.)
+                # Extract text content (handles Gemini thinking model list format)
                 content = _extract_text_from_content(raw_content)
                 has_tool_calls = (
                     getattr(msg, 'tool_calls', [])
                     or getattr(msg, 'additional_kwargs', {}).get('tool_calls', [])
                 )
                 if not content and has_tool_calls:
-                    content = _extract_text_from_content(raw_content, include_thinking=True)
+                    content = _extract_text_from_content(raw_content, include_thinking=False)
                 
                 # Get the AIMessage's run_id for consistency (needed regardless of tool calls)
                 run_id = getattr(msg, 'id', None)

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1083,11 +1083,11 @@ class Workflow:
                         # Extract visible content. _ReasoningChatOpenAI clears
                         # chunk_obj.content for reasoning-only chunks upstream, so
                         # this is safe to call unconditionally.
+                        is_background = getattr(input_state, "is_background", False)
                         if hasattr(chunk_obj, 'content') and chunk_obj.content:
-                            content = _extract_text_from_content(chunk_obj.content, include_thinking=False)
+                            content = _extract_text_from_content(chunk_obj.content, include_thinking=is_background)
 
                         # For background RCA chats, reasoning feeds into incident thoughts
-                        is_background = getattr(input_state, "is_background", False)
                         if not content and reasoning and is_background:
                             content = reasoning
 

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1363,8 +1363,7 @@ class Workflow:
                     chunk_builders[msg.id] = builder
 
                 # Accumulate content (handles Gemini thinking model list format)
-                # include_thinking=True so reasoning is preserved in the saved message
-                msg_content = _extract_text_from_content(msg.content or "", include_thinking=True)
+                msg_content = _extract_text_from_content(msg.content or "", include_thinking=False)
                 builder["content"] += msg_content
 
                 # Process tool calls
@@ -1546,7 +1545,7 @@ class Workflow:
                     or getattr(msg, 'additional_kwargs', {}).get('tool_calls', [])
                 )
                 if not content and has_tool_calls:
-                    content = _extract_text_from_content(raw_content, include_thinking=True)
+                    content = _extract_text_from_content(raw_content, include_thinking=False)
                 
                 # Get the AIMessage's run_id for consistency (needed regardless of tool calls)
                 run_id = getattr(msg, 'id', None)

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1074,17 +1074,24 @@ class Workflow:
                     chunk_obj = chunk_data.get("chunk")
                     if chunk_obj:
                         content = ""
-                        if hasattr(chunk_obj, 'content') and chunk_obj.content:
-                            # Extract text content (handles Gemini thinking model list format)
-                            # include_thinking=True so reasoning flows to save_incident_thought() for RCA
-                            content = _extract_text_from_content(chunk_obj.content, include_thinking=True)
+                        reasoning = ""
 
-                        # Check for reasoning content (OpenRouter reasoning, DeepSeek-R1 etc.)
-                        # regardless of whether content was found above
-                        if not content and hasattr(chunk_obj, 'additional_kwargs'):
-                            content = chunk_obj.additional_kwargs.get("reasoning_content", "")
+                        # Check for reasoning content first (OpenRouter, DeepSeek-R1 etc.)
+                        if hasattr(chunk_obj, 'additional_kwargs'):
+                            reasoning = chunk_obj.additional_kwargs.get("reasoning_content", "")
 
-                        # Only yield if we have actual text content
+                        # Only extract content if this is NOT a reasoning-only chunk.
+                        # Some providers (Google via OpenRouter) may duplicate reasoning
+                        # into delta.content; skip it when reasoning was detected.
+                        if not reasoning and hasattr(chunk_obj, 'content') and chunk_obj.content:
+                            content = _extract_text_from_content(chunk_obj.content, include_thinking=False)
+
+                        # For background RCA chats, reasoning feeds into incident thoughts
+                        is_background = getattr(input_state, "is_background", False)
+                        if not content and reasoning and is_background:
+                            content = reasoning
+
+                        # Only yield if we have actual text content (not reasoning)
                         if content:
                             chunk_id = getattr(chunk_obj, 'id', None)
                             if chunk_id:
@@ -1133,10 +1140,13 @@ class Workflow:
                         # when tools are bound in LangGraph (langgraph#4877).
                         if _model_turn_tokens == 0:
                             content = ""
+                            is_background = getattr(input_state, "is_background", False)
                             if hasattr(output, 'content') and output.content:
-                                content = _extract_text_from_content(output.content, include_thinking=True)
+                                content = _extract_text_from_content(output.content, include_thinking=is_background)
                             if not content and hasattr(output, 'additional_kwargs'):
-                                content = output.additional_kwargs.get("reasoning_content", "")
+                                reasoning = output.additional_kwargs.get("reasoning_content", "")
+                                if reasoning and is_background:
+                                    content = reasoning
                             if content:
                                 logger.info(f"[STREAM FALLBACK] Extracted {len(content)} chars from on_chat_model_end (streaming didn't fire)")
                                 msg_id = getattr(output, 'id', None)


### PR DESCRIPTION
## Summary

- Google models (via OpenRouter and direct Gemini SDK) were leaking reasoning/thinking tokens into the frontend chat, appearing as regular assistant output
- `_ReasoningChatOpenAI` now parses `delta.reasoning_details` (array format used by Google models via OpenRouter) in addition to `delta.reasoning`
- For user-facing chats, Google models via OpenRouter use `reasoning.exclude=true` so reasoning is used internally but not returned in the stream
- `workflow.py` streaming path uses `include_thinking=False` and only forwards reasoning content in background RCA chats (for incident thought tracking)

## Test plan

- [ ] Send a message using a Google model (e.g. Gemini 3.1 Pro) via OpenRouter in a user-facing chat — verify no reasoning/thinking tokens appear in the response
- [ ] Trigger a background RCA investigation with a Google model — verify reasoning still flows into incident thoughts
- [ ] Test with direct Gemini provider (Google AI Studio) — verify thinking blocks don't leak into user-visible output
- [ ] Test OpenAI reasoning models (o-series) via OpenRouter — verify they still work correctly (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming so internal AI reasoning no longer replaces or appears in regular bot messages; reasoning is shown only where appropriate.
  * Ensured reasoning is visible in streamed output only for background analysis sessions.

* **Improvements**
  * Improved separation of reasoning vs. user-facing text during streaming and fallbacks.
  * Tuned AI reasoning settings to produce higher-quality analysis when applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/383)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->