### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,30 @@ PostgreSQL tables use `FORCE ROW LEVEL SECURITY`. All queries on RLS-protected t
 - **Cross-org tasks** (iterating all users): Query the `users` table first (NOT RLS-protected), then iterate per-org setting RLS context before querying RLS tables.
 - **RLS-protected tables**: incidents, chat_sessions, user_tokens, user_connections, postmortems, llm_usage_tracking, incident_alerts, incident_lifecycle_events, github_connected_repos, execution_steps, and all monitoring event tables (datadog_events, grafana_alerts, etc.)
 - **NOT RLS-protected**: users, incident_thoughts, incident_suggestions (CASCADE delete from incidents)
+
+## Cursor Cloud specific instructions
+
+### Environment prerequisites
+- Docker and Docker Compose must be installed and the Docker daemon must be running before any `make` commands. The VM update script handles Docker installation.
+- After Docker starts, run `sudo chmod 666 /var/run/docker.sock` if you get permission errors.
+
+### Starting the dev environment
+1. Run `make init` if `.env` does not exist (idempotent, safe to re-run).
+2. Ensure at least one LLM API key is set in `.env` (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`). These are injected as environment variables from Cursor secrets.
+3. Run `make dev` to build and start all containers. First build takes several minutes due to large Docker images (server image includes gcloud SDK, AWS CLI, Azure CLI, Terraform, etc.).
+4. After first start, get the Vault root token from `docker logs aurora-vault-init 2>&1 | grep "Root Token:"` and set `VAULT_TOKEN` in `.env`, then `make down && make dev`.
+
+### Running tests
+- **Python CI tests** (no Docker required): `cd server && python3 -m pytest tests/architectural/ tests/auth/test_command_policy.py tests/auth/test_enforcer.py tests/auth/test_rbac_decorators.py tests/auth/test_stateless_auth.py tests/chat/test_tool_output_cap.py tests/db/test_connection_pool.py tests/secrets/test_secret_ref_utils.py tests/utils/ tests/security/ -v`. Requires: `pip install pytest Flask psycopg2-binary python-dotenv pyyaml pydantic langchain-core`.
+- **Note**: `tests/auth/test_oauth2_state_cache.py` requires Redis on the Docker network hostname `redis:6379` and will fail when run from the host.
+
+### Frontend lint known issue
+- `cd client && npm run lint` (or `bun run lint`) fails with `minimatch` default-export error due to `"minimatch": "^10.2.1"` override in `client/package.json` conflicting with `@eslint/eslintrc`. This is a pre-existing issue. CI does not enforce frontend ESLint. Use `bun run build` to validate frontend correctness instead.
+
+### Useful service ports (when running)
+- Frontend: port 3000
+- Backend API: port 5080 (health endpoint: `/health/`)
+- Chatbot WebSocket: port 5006
+- Vault UI: port 8200
+- SeaweedFS file browser: port 8888
+- Memgraph Lab: port 3001


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical guidance for future cloud agents working in this repository.

### What's included

- **Docker setup prerequisites**: Notes on Docker daemon, fuse-overlayfs, and permission handling in Cloud Agent VMs
- **Python test commands**: The exact pytest command that works outside Docker (matching CI), plus a note that `test_oauth2_state_cache.py` requires Docker-network Redis
- **Frontend lint known issue**: Documents the pre-existing `minimatch` override conflict with `@eslint/eslintrc` — recommends `bun run build` for validation since CI doesn't enforce ESLint
- **Service ports**: Quick reference for all dev-stack ports

### Dev environment verification

All services started and verified healthy via `make dev`:

[Aurora incidents dashboard](https://cursor.com/agents/bc-39536602-41b3-4112-9dc3-0159c13804a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faurora_dashboard.webp)

AI chat agent responding to queries:

[AI chat response](https://cursor.com/agents/bc-39536602-41b3-4112-9dc3-0159c13804a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_chat_response.webp)

Demo video of full dashboard + chat walkthrough:

[aurora_dashboard_chat_demo.mp4](https://cursor.com/agents/bc-39536602-41b3-4112-9dc3-0159c13804a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faurora_dashboard_chat_demo.mp4)

### Test results

- Backend health check: all subsystems healthy (database, Redis, Weaviate, Celery, chatbot)
- Python CI tests: 598 passed
- Frontend build: successful
- Frontend lint: pre-existing failure (minimatch override issue, not introduced by this PR)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39536602-41b3-4112-9dc3-0159c13804a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39536602-41b3-4112-9dc3-0159c13804a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

