### PR TITLE
Fix: ws token dev bypass

### DIFF
--- a/client/src/app/api/ws-token/route.ts
+++ b/client/src/app/api/ws-token/route.ts
@@ -3,6 +3,7 @@ import { SignJWT } from 'jose';
 import { auth } from '@/auth';
 
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || '';
+const AURORA_ENV = process.env.AURORA_ENV || 'production';
 
 export async function GET() {
   const session = await auth();
@@ -12,6 +13,9 @@ export async function GET() {
   }
 
   if (!INTERNAL_API_SECRET) {
+    if (AURORA_ENV === 'dev') {
+      return NextResponse.json({ token: null });
+    }
     return NextResponse.json(
       { error: 'Server misconfiguration: INTERNAL_API_SECRET not set' },
       { status: 500 },


### PR DESCRIPTION
In dev, ws-token returns null when api secret is unset