### PR TITLE
Fix provider-specific forced tool choice

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -514,9 +514,13 @@ class Agent:
             middlewares = [ContextTrimMiddleware(model_name=model_name)]
             tool_choice_provider = detected_provider if _use_direct else "openrouter"
             if getattr(state, "trigger_action_id", None):
-                middlewares.insert(0, _ForceToolChoice("trigger_action", provider=tool_choice_provider))
+                middlewares.insert(
+                    0, _ForceToolChoice("trigger_action", provider=tool_choice_provider)
+                )
             elif getattr(state, "trigger_rca_requested", False):
-                middlewares.insert(0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider))
+                middlewares.insert(
+                    0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider)
+                )
 
             agent_graph = create_agent(
                 model=streaming_llm,

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -512,10 +512,11 @@ class Agent:
             # ContextSafetyMiddleware is a lightweight safety net that also injects
             # correlated RCA context updates into background sessions.
             middlewares = [ContextTrimMiddleware(model_name=model_name)]
+            tool_choice_provider = detected_provider if _use_direct else "openrouter"
             if getattr(state, "trigger_action_id", None):
-                middlewares.insert(0, _ForceToolChoice("trigger_action"))
+                middlewares.insert(0, _ForceToolChoice("trigger_action", provider=tool_choice_provider))
             elif getattr(state, "trigger_rca_requested", False):
-                middlewares.insert(0, _ForceToolChoice("trigger_rca"))
+                middlewares.insert(0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider))
 
             agent_graph = create_agent(
                 model=streaming_llm,

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -76,7 +76,11 @@ class ForceToolChoice(AgentMiddleware):
     def _patch(self, request: ModelRequest) -> ModelRequest:
         if not self._fired:
             self._fired = True
-            request.tool_choice = self._tool_choice(request)
+            tool_choice = self._tool_choice(request)
+            override = getattr(request, "override", None)
+            if callable(override):
+                return override(tool_choice=tool_choice)
+            request.tool_choice = tool_choice
         return request
 
     def wrap_model_call(self, request, call_next):

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest
 
@@ -9,17 +11,72 @@ from langchain.agents.middleware.types import ModelRequest
 class ForceToolChoice(AgentMiddleware):
     """Set tool_choice on the first model invocation, then step aside."""
 
-    def __init__(self, tool_name: str):
+    def __init__(self, tool_name: str, provider: str | None = None):
         self._tool_name = tool_name
+        self._provider = provider
         self._fired = False
+
+    @staticmethod
+    def _infer_provider(model: Any) -> str | None:
+        seen: set[int] = set()
+        candidates = [model]
+
+        while candidates:
+            candidate = candidates.pop(0)
+            if candidate is None or id(candidate) in seen:
+                continue
+            seen.add(id(candidate))
+
+            module = candidate.__class__.__module__.lower()
+            name = candidate.__class__.__name__.lower()
+            llm_type = str(getattr(candidate, "_llm_type", "")).lower()
+
+            if (
+                "langchain_anthropic" in module
+                or name == "chatanthropic"
+                or "anthropic" in llm_type
+            ):
+                return "anthropic"
+            if (
+                "langchain_google" in module
+                or name == "chatgooglegenerativeai"
+                or "google" in llm_type
+            ):
+                return "google"
+            if (
+                "langchain_openai" in module
+                or name == "chatopenai"
+                or "openai" in llm_type
+            ):
+                return "openai"
+
+            for attr in ("bound", "model", "runnable"):
+                nested = getattr(candidate, attr, None)
+                if nested is not candidate:
+                    candidates.append(nested)
+
+        return None
+
+    def _tool_choice(self, request: ModelRequest):
+        provider = (
+            self._provider
+            or self._infer_provider(getattr(request, "model", None))
+            or ""
+        ).lower()
+
+        if provider == "anthropic":
+            return {"type": "tool", "name": self._tool_name}
+        if provider in {"google", "vertex"}:
+            return self._tool_name
+        return {
+            "type": "function",
+            "function": {"name": self._tool_name},
+        }
 
     def _patch(self, request: ModelRequest) -> ModelRequest:
         if not self._fired:
             self._fired = True
-            request.tool_choice = {
-                "type": "function",
-                "function": {"name": self._tool_name},
-            }
+            request.tool_choice = self._tool_choice(request)
         return request
 
     def wrap_model_call(self, request, call_next):

--- a/server/chat/backend/agent/providers/openai_provider.py
+++ b/server/chat/backend/agent/providers/openai_provider.py
@@ -66,13 +66,6 @@ class OpenAIProvider(BaseLLMProvider):
             "stream_usage": True,
         }
 
-        # Enable reasoning for models that support it (GPT-5+, o-series).
-        # This makes the model emit text preambles alongside tool calls,
-        # which flow to the ThoughtsPanel during RCA.
-        if self._supports_reasoning(native_model):
-            config["reasoning_effort"] = "high"
-            logger.info(f"Enabled reasoning_effort=high for {native_model}")
-
         config.update(kwargs)
 
         return ChatOpenAI(**config)

--- a/server/tests/chat/test_force_tool_choice.py
+++ b/server/tests/chat/test_force_tool_choice.py
@@ -117,3 +117,19 @@ def test_forces_only_first_model_call(force_tool_module):
 
     assert first.tool_choice == {"type": "tool", "name": "trigger_rca"}
     assert second.tool_choice is None
+
+
+def test_uses_model_request_override_when_available(force_tool_module):
+    class Request(SimpleNamespace):
+        def override(self, **kwargs):
+            return Request(**{**self.__dict__, **kwargs})
+
+    request = Request(model=None, tool_choice=None)
+
+    patched = force_tool_module.ForceToolChoice("trigger_rca", provider="google")._patch(
+        request
+    )
+
+    assert patched is not request
+    assert patched.tool_choice == "trigger_rca"
+    assert request.tool_choice is None

--- a/server/tests/chat/test_force_tool_choice.py
+++ b/server/tests/chat/test_force_tool_choice.py
@@ -1,0 +1,119 @@
+"""Provider-specific forced tool choice formatting."""
+
+import importlib.util
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+_SERVER_DIR = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+_FORCE_TOOL_PATH = os.path.join(
+    _SERVER_DIR, "chat", "backend", "agent", "middleware", "force_tool.py"
+)
+
+
+@pytest.fixture()
+def force_tool_module(monkeypatch):
+    """Load the middleware with minimal LangChain stubs for focused tests."""
+    langchain = types.ModuleType("langchain")
+    agents = types.ModuleType("langchain.agents")
+    middleware = types.ModuleType("langchain.agents.middleware")
+    middleware_types = types.ModuleType("langchain.agents.middleware.types")
+
+    class AgentMiddleware:
+        pass
+
+    class ModelRequest:
+        pass
+
+    middleware.AgentMiddleware = AgentMiddleware
+    middleware_types.ModelRequest = ModelRequest
+
+    monkeypatch.setitem(sys.modules, "langchain", langchain)
+    monkeypatch.setitem(sys.modules, "langchain.agents", agents)
+    monkeypatch.setitem(sys.modules, "langchain.agents.middleware", middleware)
+    monkeypatch.setitem(sys.modules, "langchain.agents.middleware.types", middleware_types)
+
+    spec = importlib.util.spec_from_file_location(
+        "_force_tool_under_test", _FORCE_TOOL_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _request(model=None):
+    return SimpleNamespace(model=model, tool_choice=None)
+
+
+def _model(class_name: str, module: str, **attrs):
+    cls = type(class_name, (), {})
+    cls.__module__ = module
+    instance = cls()
+    for key, value in attrs.items():
+        setattr(instance, key, value)
+    return instance
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("openrouter", {"type": "function", "function": {"name": "trigger_rca"}}),
+        ("openai", {"type": "function", "function": {"name": "trigger_rca"}}),
+        ("anthropic", {"type": "tool", "name": "trigger_rca"}),
+        ("google", "trigger_rca"),
+        ("vertex", "trigger_rca"),
+        (None, {"type": "function", "function": {"name": "trigger_rca"}}),
+    ],
+)
+def test_formats_tool_choice_for_transport_provider(force_tool_module, provider, expected):
+    request = _request()
+
+    force_tool_module.ForceToolChoice("trigger_rca", provider=provider)._patch(request)
+
+    assert request.tool_choice == expected
+
+
+def test_infers_openai_shape_from_chat_openai_for_openrouter_model(force_tool_module):
+    model = _model(
+        "ChatOpenAI",
+        "langchain_openai.chat_models.base",
+        model_name="anthropic/claude-sonnet-4.5",
+    )
+    request = _request(model=model)
+
+    force_tool_module.ForceToolChoice("trigger_rca")._patch(request)
+
+    assert request.tool_choice == {
+        "type": "function",
+        "function": {"name": "trigger_rca"},
+    }
+
+
+def test_infers_google_shape_through_wrapped_model(force_tool_module):
+    google_model = _model(
+        "ChatGoogleGenerativeAI",
+        "langchain_google_genai.chat_models",
+    )
+    wrapper = SimpleNamespace(bound=google_model)
+    request = _request(model=wrapper)
+
+    force_tool_module.ForceToolChoice("trigger_rca")._patch(request)
+
+    assert request.tool_choice == "trigger_rca"
+
+
+def test_forces_only_first_model_call(force_tool_module):
+    middleware = force_tool_module.ForceToolChoice("trigger_rca", provider="anthropic")
+    first = _request()
+    second = _request()
+
+    middleware._patch(first)
+    middleware._patch(second)
+
+    assert first.tool_choice == {"type": "tool", "name": "trigger_rca"}
+    assert second.tool_choice is None

--- a/server/tests/chat/test_openai_provider.py
+++ b/server/tests/chat/test_openai_provider.py
@@ -1,0 +1,90 @@
+"""OpenAI direct provider compatibility tests."""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+
+_SERVER_DIR = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+_PROVIDER_PATH = os.path.join(
+    _SERVER_DIR, "chat", "backend", "agent", "providers", "openai_provider.py"
+)
+
+
+@pytest.fixture()
+def openai_provider_module(monkeypatch):
+    """Load the provider with minimal dependency stubs."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    langchain_openai = types.ModuleType("langchain_openai")
+    langchain_core = types.ModuleType("langchain_core")
+    language_models = types.ModuleType("langchain_core.language_models")
+    chat_models = types.ModuleType("langchain_core.language_models.chat_models")
+
+    class ChatOpenAI:
+        def __init__(self, **config):
+            self.config = config
+
+    class BaseChatModel:
+        pass
+
+    langchain_openai.ChatOpenAI = ChatOpenAI
+    chat_models.BaseChatModel = BaseChatModel
+
+    base_provider = types.ModuleType("chat.backend.agent.providers.base_provider")
+
+    class BaseLLMProvider:
+        def __init__(self):
+            pass
+
+    base_provider.BaseLLMProvider = BaseLLMProvider
+
+    model_mapper = types.ModuleType("chat.backend.agent.model_mapper")
+
+    class ModelMapper:
+        @staticmethod
+        def get_native_name(model_name, target_provider):
+            assert target_provider == "openai"
+            return model_name.split("/", 1)[1] if "/" in model_name else model_name
+
+        @staticmethod
+        def is_model_supported_by_provider(model_name, provider):
+            return provider == "openai" and model_name.startswith("gpt-")
+
+        @staticmethod
+        def get_supported_models_for_provider(provider):
+            return ["openai/gpt-5.5"] if provider == "openai" else []
+
+    model_mapper.ModelMapper = ModelMapper
+
+    monkeypatch.setitem(sys.modules, "langchain_openai", langchain_openai)
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.language_models", language_models)
+    monkeypatch.setitem(
+        sys.modules, "langchain_core.language_models.chat_models", chat_models
+    )
+    monkeypatch.setitem(
+        sys.modules, "chat.backend.agent.providers.base_provider", base_provider
+    )
+    monkeypatch.setitem(sys.modules, "chat.backend.agent.model_mapper", model_mapper)
+
+    spec = importlib.util.spec_from_file_location(
+        "chat.backend.agent.providers.openai_provider", _PROVIDER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_direct_openai_does_not_enable_reasoning_effort_by_default(openai_provider_module):
+    provider = openai_provider_module.OpenAIProvider()
+
+    model = provider.get_chat_model("openai/gpt-5.5", streaming=True)
+
+    assert model.config["model"] == "gpt-5.5"
+    assert model.config["streaming"] is True
+    assert "reasoning_effort" not in model.config


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Format forced tool choices by the actual provider transport so OpenRouter/OpenAI, Anthropic direct, and Google/Vertex direct receive compatible payloads.
- Pass the resolved provider routing decision into the force-tool middleware and keep a model-class fallback for isolated middleware use.
- Use `ModelRequest.override()` when available to avoid deprecated request mutation.
- Remove direct OpenAI's default `reasoning_effort` on the Chat Completions agent path so GPT-5.5 + function tools does not fail; add regression coverage.

### Walkthrough
[openrouter_gpt55_rca_trigger.mp4](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenrouter_gpt55_rca_trigger.mp4)
[OpenRouter Claude Sonnet 4.6 RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenrouter_sonnet46_rca_result.webp)
[OpenRouter Claude Opus 4.7 RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenrouter_opus47_rca_result.webp)
[OpenRouter Gemini 3.1 RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenrouter_gemini31_rca_result.webp)
[OpenRouter GPT-5.5 RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenrouter_gpt55_matrix_rca_result.webp)
[Direct Anthropic RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirect_anthropic_rca_result.webp)
[Direct Google RCA result](https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirect_google_rca_result.webp)

### Testing
- `python3 -m pytest tests/chat/test_force_tool_choice.py tests/chat/test_openai_provider.py -q`
- `git diff --check`
- UI RCA OpenRouter model matrix: Claude Sonnet 4.6, Claude Opus 4.7, Gemini 3.1 Pro, GPT-5.5.
- UI RCA direct mode: Anthropic Claude Sonnet 4.6 and Google Gemini 3.1 Pro.
- Direct OpenAI e2e still needs `OPENAI_API_KEY` present in `/workspace/.env` or container env; it is currently blank in this cloud VM.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a6f4b7e-9c26-40da-ab1d-e44a5e372956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

