### PR TITLE
fix: disable weaviate-client PyPI version check that blocks health checks

### DIFF
--- a/server/chat/backend/agent/weaviate_client.py
+++ b/server/chat/backend/agent/weaviate_client.py
@@ -37,6 +37,7 @@ class WeaviateClient:
             grpc_port=int(os.getenv("WEAVIATE_GRPC_PORT", "50051")),
             grpc_secure=weaviate_secure,
             headers=headers,
+            skip_init_checks=True,
         )
 
         assert self.client.is_ready(), "Weaviate client is not ready. Check the connection."

--- a/server/routes/incident_feedback/weaviate_client.py
+++ b/server/routes/incident_feedback/weaviate_client.py
@@ -98,6 +98,7 @@ def _get_weaviate_client():
                     additional_config=AdditionalConfig(
                         timeout=Timeout(init=10, query=30, insert=60)
                     ),
+                    skip_init_checks=True,
                 )
             else:
                 _client = weaviate.connect_to_local(
@@ -108,6 +109,7 @@ def _get_weaviate_client():
                     additional_config=AdditionalConfig(
                         timeout=Timeout(init=10, query=30, insert=60)
                     ),
+                    skip_init_checks=True,
                 )
 
             logger.info(f"[AURORA LEARN] Connected to {WEAVIATE_HOST}:{WEAVIATE_PORT}")

--- a/server/routes/knowledge_base/weaviate_client.py
+++ b/server/routes/knowledge_base/weaviate_client.py
@@ -77,6 +77,7 @@ def _get_weaviate_client():
                 additional_config=AdditionalConfig(
                     timeout=Timeout(init=10, query=30, insert=60)
                 ),
+                skip_init_checks=True,
             )
         else:
             _client = weaviate.connect_to_local(
@@ -87,6 +88,7 @@ def _get_weaviate_client():
                 additional_config=AdditionalConfig(
                     timeout=Timeout(init=10, query=30, insert=60)
                 ),
+                skip_init_checks=True,
             )
 
         logger.info(f"[KB Weaviate] Connected to {WEAVIATE_HOST}:{WEAVIATE_PORT}")


### PR DESCRIPTION
## Summary

- Pass `skip_init_checks=True` to all `weaviate.connect_to_custom()` and `weaviate.connect_to_local()` calls across the codebase
- The weaviate-client v4 library fetches `https://pypi.org/pypi/weaviate-client/json` on every connection to check for newer versions, adding ~4 seconds of latency per connection
- This causes the Docker health check (5s timeout) to consistently fail because the chatbot's `/health/` probe creates a new WeaviateClient per WebSocket connection

## Root Cause

The `weaviate-client>=4.15.0` dependency is unpinned. Fresh Docker builds (after cache bust) pulled v4.21.0 which does a PyPI version check on init. Combined with the Celery inspect call (~1s), the total health check time exceeds the 5s Docker timeout, leaving `aurora-server` permanently unhealthy and blocking dependent containers (MCP).

## Test plan

- [ ] `make dev` completes without `aurora-server` health check failure
- [ ] Weaviate queries (knowledge base, incident feedback, chatbot) still work correctly
- [ ] Health check endpoint returns in <3s (vs previous ~6s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend database client initialization configuration across multiple services to optimize connection setup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/394)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->