### PR TITLE
fix: resolve org-scoped credentials for all connector token lookups

### DIFF
--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -15,22 +15,38 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
 
     try:
         from utils.auth.stateless_auth import set_rls_context
+        from utils.secrets.secret_ref_utils import _resolve_org
+        org_id = _resolve_org(user_id)
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:
                 if not set_rls_context(cur, conn, user_id, log_prefix="[ContextFetchers]"):
                     return ""
-                cur.execute(
-                    """
-                    SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
-                           ut.provider, ut.token_data
-                    FROM user_manual_vms mv
-                    LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
-                    WHERE mv.user_id = %s
-                    ORDER BY mv.updated_at DESC
-                    LIMIT 10;
-                    """,
-                    (user_id,),
-                )
+                if org_id:
+                    cur.execute(
+                        """
+                        SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
+                               ut.provider, ut.token_data
+                        FROM user_manual_vms mv
+                        LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
+                        WHERE mv.org_id = %s
+                        ORDER BY mv.updated_at DESC
+                        LIMIT 10;
+                        """,
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
+                               ut.provider, ut.token_data
+                        FROM user_manual_vms mv
+                        LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
+                        WHERE mv.user_id = %s
+                        ORDER BY mv.updated_at DESC
+                        LIMIT 10;
+                        """,
+                        (user_id,),
+                    )
                 rows = cur.fetchall()
     except Exception as e:
         logging.getLogger(__name__).warning(f"Failed to fetch manual VMs for user {user_id}: {e}")

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -17,36 +17,24 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org
         org_id = _resolve_org(user_id)
+        vm_filter = "mv.org_id = %s" if org_id else "mv.user_id = %s"
+        vm_param = org_id if org_id else user_id
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:
                 if not set_rls_context(cur, conn, user_id, log_prefix="[ContextFetchers]"):
                     return ""
-                if org_id:
-                    cur.execute(
-                        """
-                        SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
-                               ut.provider, ut.token_data
-                        FROM user_manual_vms mv
-                        LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
-                        WHERE mv.org_id = %s
-                        ORDER BY mv.updated_at DESC
-                        LIMIT 10;
-                        """,
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        """
-                        SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
-                               ut.provider, ut.token_data
-                        FROM user_manual_vms mv
-                        LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
-                        WHERE mv.user_id = %s
-                        ORDER BY mv.updated_at DESC
-                        LIMIT 10;
-                        """,
-                        (user_id,),
-                    )
+                cur.execute(
+                    f"""
+                    SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
+                           ut.provider, ut.token_data
+                    FROM user_manual_vms mv
+                    LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
+                    WHERE {vm_filter}
+                    ORDER BY mv.updated_at DESC
+                    LIMIT 10;
+                    """,
+                    (vm_param,),
+                )
                 rows = cur.fetchall()
     except Exception as e:
         logging.getLogger(__name__).warning(f"Failed to fetch manual VMs for user {user_id}: {e}")

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -15,9 +15,9 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
 
     try:
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        _, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        _, pred_params = org_read_predicate(user_id, org_id)
         vm_predicate = "(mv.user_id = %s OR mv.org_id = %s)" if org_id else "mv.user_id = %s"
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -16,28 +16,25 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
     try:
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
-        if org_id:
-            vm_filter = "(mv.user_id = %s OR mv.org_id = %s)"
-            vm_params = (user_id, org_id)
-        else:
-            vm_filter = "mv.user_id = %s"
-            vm_params = (user_id,)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        vm_predicate = pgsql.SQL("(mv.user_id = %s OR mv.org_id = %s)") if org_id else pgsql.SQL("mv.user_id = %s")
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:
                 if not set_rls_context(cur, conn, user_id, log_prefix="[ContextFetchers]"):
                     return ""
                 cur.execute(
-                    f"""
+                    pgsql.SQL("""
                     SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
                            ut.provider, ut.token_data
                     FROM user_manual_vms mv
                     LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
-                    WHERE {vm_filter}
+                    WHERE {}
                     ORDER BY mv.updated_at DESC
                     LIMIT 10;
-                    """,
-                    vm_params,
+                    """).format(vm_predicate),
+                    pred_params,
                 )
                 rows = cur.fetchall()
     except Exception as e:

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -16,24 +16,23 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
     try:
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
-        vm_predicate = pgsql.SQL("(mv.user_id = %s OR mv.org_id = %s)") if org_id else pgsql.SQL("mv.user_id = %s")
+        vm_predicate = "(mv.user_id = %s OR mv.org_id = %s)" if org_id else "mv.user_id = %s"
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:
                 if not set_rls_context(cur, conn, user_id, log_prefix="[ContextFetchers]"):
                     return ""
                 cur.execute(
-                    pgsql.SQL("""
+                    f"""
                     SELECT mv.name, mv.ip_address, mv.port, mv.ssh_username, mv.ssh_jump_command, mv.ssh_key_id,
                            ut.provider, ut.token_data
                     FROM user_manual_vms mv
                     LEFT JOIN user_tokens ut ON ut.id = mv.ssh_key_id
-                    WHERE {}
+                    WHERE {vm_predicate}
                     ORDER BY mv.updated_at DESC
                     LIMIT 10;
-                    """).format(vm_predicate),
+                    """,
                     pred_params,
                 )
                 rows = cur.fetchall()

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -15,10 +15,14 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
 
     try:
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
         org_id = _resolve_org(user_id)
-        vm_filter = "mv.org_id = %s" if org_id else "mv.user_id = %s"
-        vm_param = org_id if org_id else user_id
+        if org_id:
+            vm_filter = "(mv.user_id = %s OR mv.org_id = %s)"
+            vm_params = (user_id, org_id)
+        else:
+            vm_filter = "mv.user_id = %s"
+            vm_params = (user_id,)
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:
                 if not set_rls_context(cur, conn, user_id, log_prefix="[ContextFetchers]"):
@@ -33,7 +37,7 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
                     ORDER BY mv.updated_at DESC
                     LIMIT 10;
                     """,
-                    (vm_param,),
+                    vm_params,
                 )
                 rows = cur.fetchall()
     except Exception as e:

--- a/server/chat/backend/agent/prompt/context_fetchers.py
+++ b/server/chat/backend/agent/prompt/context_fetchers.py
@@ -17,7 +17,7 @@ def build_manual_vm_access_segment(user_id: Optional[str]) -> str:
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
         org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        _, pred_params = _org_read_predicate(user_id, org_id)
         vm_predicate = "(mv.user_id = %s OR mv.org_id = %s)" if org_id else "mv.user_id = %s"
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cur:

--- a/server/chat/backend/agent/tools/bitbucket/utils.py
+++ b/server/chat/backend/agent/tools/bitbucket/utils.py
@@ -51,7 +51,9 @@ def get_bb_client_for_user(user_id: str):
             if access_token != old_access_token:
                 try:
                     from utils.auth.token_management import store_tokens_in_db
-                    store_tokens_in_db(user_id, bb_creds, "bitbucket")
+                    from utils.secrets.secret_ref_utils import get_token_owner_id
+                    owner_id = get_token_owner_id(user_id, "bitbucket")
+                    store_tokens_in_db(owner_id, bb_creds, "bitbucket")
                     logger.info("Persisted refreshed Bitbucket token")
                 except Exception as e:
                     logger.warning(f"Failed to persist refreshed Bitbucket token: {e}")

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -617,7 +617,9 @@ def setup_ovh_environment_isolated(user_id: str, selected_project_id: str | None
                         }
                         if project_id:
                             updated_storage["projectId"] = project_id
-                        store_tokens_in_db(user_id, updated_storage, 'ovh')
+                        from utils.secrets.secret_ref_utils import get_token_owner_id
+                        owner_id = get_token_owner_id(user_id, "ovh")
+                        store_tokens_in_db(owner_id, updated_storage, 'ovh')
                         logger.info("Successfully refreshed OVH access token")
                     else:
                         logger.error(f"Failed to refresh OVH token: {refresh_response.status_code}")

--- a/server/chat/backend/agent/tools/github_rca_tool.py
+++ b/server/chat/backend/agent/tools/github_rca_tool.py
@@ -86,9 +86,9 @@ def _resolve_repository(
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRCA:resolve]")

--- a/server/chat/backend/agent/tools/github_rca_tool.py
+++ b/server/chat/backend/agent/tools/github_rca_tool.py
@@ -87,16 +87,17 @@ def _resolve_repository(
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRCA:resolve]")
                 cur.execute(
-                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name
+                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name) repo_full_name
                        FROM github_connected_repos
-                       WHERE {predicate}
-                       ORDER BY repo_full_name, updated_at DESC""",
+                       WHERE {}
+                       ORDER BY repo_full_name, updated_at DESC""").format(predicate),
                     pred_params,
                 )
                 rows = cur.fetchall()

--- a/server/chat/backend/agent/tools/github_rca_tool.py
+++ b/server/chat/backend/agent/tools/github_rca_tool.py
@@ -86,13 +86,24 @@ def _resolve_repository(
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
+        from utils.secrets.secret_ref_utils import _resolve_org
+        org_id = _resolve_org(user_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRCA:resolve]")
-                cur.execute(
-                    "SELECT repo_full_name FROM github_connected_repos WHERE user_id = %s",
-                    (user_id,),
-                )
+                if org_id:
+                    cur.execute(
+                        """SELECT DISTINCT ON (repo_full_name) repo_full_name
+                           FROM github_connected_repos
+                           WHERE org_id = %s
+                           ORDER BY repo_full_name, updated_at DESC""",
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        "SELECT repo_full_name FROM github_connected_repos WHERE user_id = %s",
+                        (user_id,),
+                    )
                 rows = cur.fetchall()
 
         if not rows:

--- a/server/chat/backend/agent/tools/github_rca_tool.py
+++ b/server/chat/backend/agent/tools/github_rca_tool.py
@@ -87,17 +87,16 @@ def _resolve_repository(
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRCA:resolve]")
                 cur.execute(
-                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name) repo_full_name
+                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name
                        FROM github_connected_repos
-                       WHERE {}
-                       ORDER BY repo_full_name, updated_at DESC""").format(predicate),
+                       WHERE {predicate}
+                       ORDER BY repo_full_name, updated_at DESC""",
                     pred_params,
                 )
                 rows = cur.fetchall()

--- a/server/chat/backend/agent/tools/github_rca_tool.py
+++ b/server/chat/backend/agent/tools/github_rca_tool.py
@@ -86,24 +86,19 @@ def _resolve_repository(
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
         org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRCA:resolve]")
-                if org_id:
-                    cur.execute(
-                        """SELECT DISTINCT ON (repo_full_name) repo_full_name
-                           FROM github_connected_repos
-                           WHERE org_id = %s
-                           ORDER BY repo_full_name, updated_at DESC""",
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        "SELECT repo_full_name FROM github_connected_repos WHERE user_id = %s",
-                        (user_id,),
-                    )
+                cur.execute(
+                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name
+                       FROM github_connected_repos
+                       WHERE {predicate}
+                       ORDER BY repo_full_name, updated_at DESC""",
+                    pred_params,
+                )
                 rows = cur.fetchall()
 
         if not rows:

--- a/server/chat/backend/agent/tools/github_repos_tool.py
+++ b/server/chat/backend/agent/tools/github_repos_tool.py
@@ -25,18 +25,17 @@ def get_connected_repos(**kwargs) -> str:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRepos:list]")
                 cur.execute(
-                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name)
+                    f"""SELECT DISTINCT ON (repo_full_name)
                               repo_full_name, default_branch, is_private, metadata_summary, metadata_status
                        FROM github_connected_repos
-                       WHERE {}
-                       ORDER BY repo_full_name, updated_at DESC""").format(predicate),
+                       WHERE {predicate}
+                       ORDER BY repo_full_name, updated_at DESC""",
                     pred_params,
                 )
                 rows = cur.fetchall()

--- a/server/chat/backend/agent/tools/github_repos_tool.py
+++ b/server/chat/backend/agent/tools/github_repos_tool.py
@@ -24,9 +24,9 @@ def get_connected_repos(**kwargs) -> str:
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRepos:list]")

--- a/server/chat/backend/agent/tools/github_repos_tool.py
+++ b/server/chat/backend/agent/tools/github_repos_tool.py
@@ -24,28 +24,20 @@ def get_connected_repos(**kwargs) -> str:
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
-        from utils.secrets.secret_ref_utils import _resolve_org
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
         org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRepos:list]")
-                if org_id:
-                    cur.execute(
-                        """SELECT DISTINCT ON (repo_full_name)
-                                  repo_full_name, default_branch, is_private, metadata_summary, metadata_status
-                           FROM github_connected_repos
-                           WHERE org_id = %s
-                           ORDER BY repo_full_name, updated_at DESC""",
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        """SELECT repo_full_name, default_branch, is_private, metadata_summary, metadata_status
-                           FROM github_connected_repos
-                           WHERE user_id = %s
-                           ORDER BY repo_full_name""",
-                        (user_id,),
-                    )
+                cur.execute(
+                    f"""SELECT DISTINCT ON (repo_full_name)
+                              repo_full_name, default_branch, is_private, metadata_summary, metadata_status
+                       FROM github_connected_repos
+                       WHERE {predicate}
+                       ORDER BY repo_full_name, updated_at DESC""",
+                    pred_params,
+                )
                 rows = cur.fetchall()
 
         if not rows:

--- a/server/chat/backend/agent/tools/github_repos_tool.py
+++ b/server/chat/backend/agent/tools/github_repos_tool.py
@@ -25,17 +25,18 @@ def get_connected_repos(**kwargs) -> str:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRepos:list]")
                 cur.execute(
-                    f"""SELECT DISTINCT ON (repo_full_name)
+                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name)
                               repo_full_name, default_branch, is_private, metadata_summary, metadata_status
                        FROM github_connected_repos
-                       WHERE {predicate}
-                       ORDER BY repo_full_name, updated_at DESC""",
+                       WHERE {}
+                       ORDER BY repo_full_name, updated_at DESC""").format(predicate),
                     pred_params,
                 )
                 rows = cur.fetchall()

--- a/server/chat/backend/agent/tools/github_repos_tool.py
+++ b/server/chat/backend/agent/tools/github_repos_tool.py
@@ -24,16 +24,28 @@ def get_connected_repos(**kwargs) -> str:
     try:
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
+        from utils.secrets.secret_ref_utils import _resolve_org
+        org_id = _resolve_org(user_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[GithubRepos:list]")
-                cur.execute(
-                    """SELECT repo_full_name, default_branch, is_private, metadata_summary, metadata_status
-                       FROM github_connected_repos
-                       WHERE user_id = %s
-                       ORDER BY repo_full_name""",
-                    (user_id,),
-                )
+                if org_id:
+                    cur.execute(
+                        """SELECT DISTINCT ON (repo_full_name)
+                                  repo_full_name, default_branch, is_private, metadata_summary, metadata_status
+                           FROM github_connected_repos
+                           WHERE org_id = %s
+                           ORDER BY repo_full_name, updated_at DESC""",
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        """SELECT repo_full_name, default_branch, is_private, metadata_summary, metadata_status
+                           FROM github_connected_repos
+                           WHERE user_id = %s
+                           ORDER BY repo_full_name""",
+                        (user_id,),
+                    )
                 rows = cur.fetchall()
 
         if not rows:

--- a/server/connectors/gcp_connector/auth/oauth.py
+++ b/server/connectors/gcp_connector/auth/oauth.py
@@ -192,7 +192,9 @@ def get_credentials(token_data=None):
                 
                 if user_id:
                     from utils.auth.token_management import store_tokens_in_db
-                    store_tokens_in_db(user_id, token_data, "gcp")
+                    from utils.secrets.secret_ref_utils import get_token_owner_id
+                    owner_id = get_token_owner_id(user_id, "gcp")
+                    store_tokens_in_db(owner_id, token_data, "gcp")
                     logger.info("Successfully refreshed and stored access token")
                 else:
                     logger.warning("Token refreshed but no user_id available to store updated token")

--- a/server/routes/bitbucket/bitbucket_browsing.py
+++ b/server/routes/bitbucket/bitbucket_browsing.py
@@ -36,7 +36,9 @@ def _get_bb_client(user_id):
         if bb_creds.get("access_token") != old_access_token:
             try:
                 from utils.auth.token_management import store_tokens_in_db
-                store_tokens_in_db(user_id, bb_creds, "bitbucket")
+                from utils.secrets.secret_ref_utils import get_token_owner_id
+                owner_id = get_token_owner_id(user_id, "bitbucket")
+                store_tokens_in_db(owner_id, bb_creds, "bitbucket")
             except Exception as e:
                 logger.warning(f"Failed to persist refreshed Bitbucket token: {e}")
 

--- a/server/routes/gcp/projects.py
+++ b/server/routes/gcp/projects.py
@@ -16,6 +16,7 @@ from connectors.gcp_connector.auth.service_accounts import (
 )
 from connectors.gcp_connector.billing import has_active_billing
 from googleapiclient.discovery import build
+from utils.secrets.secret_ref_utils import get_token_owner_id
 
 gcp_projects_bp = Blueprint("gcp_projects", __name__)
 
@@ -195,12 +196,18 @@ def sa_project_access_get(user_id):
             result = _sa_mode_project_list(token_data, root_project)
             return jsonify({"projects": result, "root_project": root_project}), 200
 
+        # Resolve SA owner before refresh — after a refresh the token may be
+        # stored under user_id (creating a duplicate row), which would cause
+        # get_token_owner_id to return user_id (wrong SA hash) instead of the
+        # original connector owner's ID.
+        sa_owner_id = get_token_owner_id(user_id, "gcp")
+
         token_data, err = _refresh_and_reload_gcp_token(user_id)
         if err:
             return err
 
         credentials = get_credentials(token_data)
-        sa_email = get_aurora_service_account_email(user_id)
+        sa_email = get_aurora_service_account_email(sa_owner_id)
         result = _oauth_mode_project_list(credentials, sa_email, root_project)
         return jsonify({"projects": result, "root_project": root_project}), 200
 
@@ -237,12 +244,17 @@ def sa_project_access_post(user_id):
             if pid:
                 selections[pid] = enabled
 
+        # Resolve SA owner before refresh — refresh may create a token row
+        # under user_id (org-member), which would make get_token_owner_id
+        # return the wrong ID if called after.
+        sa_owner_id = get_token_owner_id(user_id, "gcp")
+
         token_data, err = _refresh_and_reload_gcp_token(user_id)
         if err:
             return err
 
         credentials = get_credentials(token_data)
-        sa_email = get_aurora_service_account_email(user_id)
+        sa_email = get_aurora_service_account_email(sa_owner_id)
         update_service_account_project_access(credentials, sa_email, selections)
 
         return jsonify({"success": True}), 200

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -5,6 +5,7 @@ Manages which repos a user has connected for RCA investigation.
 import logging
 import json
 from flask import Blueprint, jsonify, request
+from psycopg2 import sql as pgsql
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
@@ -39,11 +40,11 @@ def get_repo_selections(user_id):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:get_repo_selections]")
                 cur.execute(
-                    f"""SELECT DISTINCT ON (repo_full_name)
+                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name)
                               repo_full_name, repo_id, default_branch, is_private,
                               metadata_summary, metadata_status, repo_data, created_at
                        FROM github_connected_repos
-                       WHERE {predicate} ORDER BY repo_full_name, updated_at DESC""",
+                       WHERE {} ORDER BY repo_full_name, updated_at DESC""").format(predicate),
                     pred_params,
                 )
                 rows = cur.fetchall()
@@ -87,10 +88,10 @@ def save_repo_selections(user_id):
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:save_repo_selections]")
 
                 cur.execute(
-                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name, user_id
+                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name) repo_full_name, user_id
                         FROM github_connected_repos
-                        WHERE {predicate}
-                        ORDER BY repo_full_name, updated_at DESC""",
+                        WHERE {}
+                        ORDER BY repo_full_name, updated_at DESC""").format(predicate),
                     pred_params,
                 )
                 # {repo_full_name: owner_user_id} — we need the owner to delete the right row
@@ -199,7 +200,7 @@ def update_repo_metadata(user_id, repo_full_name):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:update_repo_metadata]")
                 cur.execute(
-                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
+                    pgsql.SQL("SELECT user_id FROM github_connected_repos WHERE {} AND repo_full_name = %s LIMIT 1").format(predicate),
                     (*pred_params, repo_full_name),
                 )
                 owner_row = cur.fetchone()
@@ -236,7 +237,7 @@ def trigger_metadata_generation(user_id):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:trigger_metadata_generation]")
                 cur.execute(
-                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
+                    pgsql.SQL("SELECT user_id FROM github_connected_repos WHERE {} AND repo_full_name = %s LIMIT 1").format(predicate),
                     (*pred_params, repo_full_name),
                 )
                 owner_row = cur.fetchone()

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -8,22 +8,10 @@ from flask import Blueprint, jsonify, request
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
+from utils.secrets.secret_ref_utils import _resolve_org
 
 github_repo_selection_bp = Blueprint('github_repo_selection', __name__)
 logger = logging.getLogger(__name__)
-
-
-def _get_user_org_id(user_id: str) -> str | None:
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cur:
-                # No RLS needed — users not RLS-protected
-                cur.execute("SELECT org_id FROM users WHERE id = %s", (user_id,))
-                row = cur.fetchone()
-                return row[0] if row else None
-    except Exception as e:
-        logger.warning(f"Error fetching org_id for user {user_id}: {e}")
-        return None
 
 
 def _update_metadata_status(user_id: str, repo_full_name: str, status: str):
@@ -43,18 +31,29 @@ def _update_metadata_status(user_id: str, repo_full_name: str, status: str):
 @github_repo_selection_bp.route("/repo-selections", methods=["GET"])
 @require_permission("connectors", "read")
 def get_repo_selections(user_id):
-    """Return all connected repos with metadata for this user."""
+    """Return all connected repos with metadata for this org."""
     try:
+        org_id = _resolve_org(user_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:get_repo_selections]")
-                cur.execute(
-                    """SELECT repo_full_name, repo_id, default_branch, is_private,
-                              metadata_summary, metadata_status, repo_data, created_at
-                       FROM github_connected_repos
-                       WHERE user_id = %s ORDER BY repo_full_name""",
-                    (user_id,),
-                )
+                if org_id:
+                    cur.execute(
+                        """SELECT DISTINCT ON (repo_full_name)
+                                  repo_full_name, repo_id, default_branch, is_private,
+                                  metadata_summary, metadata_status, repo_data, created_at
+                           FROM github_connected_repos
+                           WHERE org_id = %s ORDER BY repo_full_name, updated_at DESC""",
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        """SELECT repo_full_name, repo_id, default_branch, is_private,
+                                  metadata_summary, metadata_status, repo_data, created_at
+                           FROM github_connected_repos
+                           WHERE user_id = %s ORDER BY repo_full_name""",
+                        (user_id,),
+                    )
                 rows = cur.fetchall()
 
         repos = [
@@ -88,16 +87,26 @@ def save_repo_selections(user_id):
         if not isinstance(repositories, list):
             return jsonify({"error": "repositories array is required"}), 400
 
-        org_id = _get_user_org_id(user_id)
+        org_id = _resolve_org(user_id)
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:save_repo_selections]")
-                cur.execute(
-                    "SELECT repo_full_name FROM github_connected_repos WHERE user_id = %s",
-                    (user_id,),
-                )
-                existing = {r[0] for r in cur.fetchall()}
+
+                # Build existing set at org scope so deselections by any org member
+                # correctly remove rows originally created by a different member.
+                if org_id:
+                    cur.execute(
+                        "SELECT repo_full_name, user_id FROM github_connected_repos WHERE org_id = %s",
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        "SELECT repo_full_name, user_id FROM github_connected_repos WHERE user_id = %s",
+                        (user_id,),
+                    )
+                # {repo_full_name: owner_user_id} — we need the owner to delete the right row
+                existing = {r[0]: r[1] for r in cur.fetchall()}
 
                 incoming = set()
                 newly_added = []
@@ -138,11 +147,13 @@ def save_repo_selections(user_id):
                 if repositories and not incoming:
                     return jsonify({"error": "No valid repositories in request (all missing full_name)"}), 400
 
-                removed = existing - incoming
-                if removed:
+                # Delete deselected repos, targeting the row's original owner
+                removed = set(existing.keys()) - incoming
+                for repo_name in removed:
+                    owner_id = existing[repo_name]
                     cur.execute(
-                        "DELETE FROM github_connected_repos WHERE user_id = %s AND repo_full_name = ANY(%s)",
-                        (user_id, list(removed)),
+                        "DELETE FROM github_connected_repos WHERE user_id = %s AND repo_full_name = %s",
+                        (owner_id, repo_name),
                     )
 
                 conn.commit()

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -87,7 +87,10 @@ def save_repo_selections(user_id):
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:save_repo_selections]")
 
                 cur.execute(
-                    f"SELECT repo_full_name, user_id FROM github_connected_repos WHERE {predicate}",
+                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name, user_id
+                        FROM github_connected_repos
+                        WHERE {predicate}
+                        ORDER BY repo_full_name, updated_at DESC""",
                     pred_params,
                 )
                 # {repo_full_name: owner_user_id} — we need the owner to delete the right row
@@ -104,6 +107,7 @@ def save_repo_selections(user_id):
                         continue
                     incoming.add(full_name)
 
+                    owner_id = existing.get(full_name, user_id)
                     cur.execute(
                         """INSERT INTO github_connected_repos
                                (user_id, org_id, repo_full_name, repo_id, default_branch,
@@ -115,7 +119,7 @@ def save_repo_selections(user_id):
                                is_private = EXCLUDED.is_private,
                                updated_at = NOW()""",
                         (
-                            user_id,
+                            owner_id,
                             org_id,
                             full_name,
                             repo.get("id"),
@@ -188,17 +192,26 @@ def update_repo_metadata(user_id, repo_full_name):
         if summary is None:
             return jsonify({"error": "metadata_summary is required"}), 400
 
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
+
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:update_repo_metadata]")
                 cur.execute(
+                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
+                    (*pred_params, repo_full_name),
+                )
+                owner_row = cur.fetchone()
+                if owner_row is None:
+                    return jsonify({"error": "Repository not found"}), 404
+                owner_id = owner_row[0]
+                cur.execute(
                     """UPDATE github_connected_repos
                        SET metadata_summary = %s, metadata_status = 'ready', updated_at = NOW()
                        WHERE user_id = %s AND repo_full_name = %s""",
-                    (summary, user_id, repo_full_name),
+                    (summary, owner_id, repo_full_name),
                 )
-                if cur.rowcount == 0:
-                    return jsonify({"error": "Repository not found"}), 404
                 conn.commit()
         return jsonify({"message": "Metadata updated"})
     except Exception as e:
@@ -216,24 +229,33 @@ def trigger_metadata_generation(user_id):
         if not repo_full_name:
             return jsonify({"error": "repo_full_name is required"}), 400
 
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
+
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:trigger_metadata_generation]")
                 cur.execute(
+                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
+                    (*pred_params, repo_full_name),
+                )
+                owner_row = cur.fetchone()
+                if owner_row is None:
+                    return jsonify({"error": "Repository not found"}), 404
+                owner_id = owner_row[0]
+                cur.execute(
                     """UPDATE github_connected_repos SET metadata_status = 'generating', updated_at = NOW()
                        WHERE user_id = %s AND repo_full_name = %s""",
-                    (user_id, repo_full_name),
+                    (owner_id, repo_full_name),
                 )
-                if cur.rowcount == 0:
-                    return jsonify({"error": "Repository not found"}), 404
                 conn.commit()
 
         from routes.github.github_repo_metadata import generate_repo_metadata
         try:
-            generate_repo_metadata.delay(user_id, repo_full_name)
+            generate_repo_metadata.delay(owner_id, repo_full_name)
         except Exception as e:
             logger.error(f"Failed to enqueue metadata gen for {repo_full_name}: {e}")
-            _update_metadata_status(user_id, repo_full_name, "pending")
+            _update_metadata_status(owner_id, repo_full_name, "pending")
             return jsonify({"error": "Failed to start metadata generation"}), 500
         return jsonify({"message": "Metadata generation started"})
     except Exception as e:

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -5,7 +5,6 @@ Manages which repos a user has connected for RCA investigation.
 import logging
 import json
 from flask import Blueprint, jsonify, request
-from psycopg2 import sql as pgsql
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
@@ -40,11 +39,11 @@ def get_repo_selections(user_id):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:get_repo_selections]")
                 cur.execute(
-                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name)
+                    f"""SELECT DISTINCT ON (repo_full_name)
                               repo_full_name, repo_id, default_branch, is_private,
                               metadata_summary, metadata_status, repo_data, created_at
                        FROM github_connected_repos
-                       WHERE {} ORDER BY repo_full_name, updated_at DESC""").format(predicate),
+                       WHERE {predicate} ORDER BY repo_full_name, updated_at DESC""",
                     pred_params,
                 )
                 rows = cur.fetchall()
@@ -88,10 +87,10 @@ def save_repo_selections(user_id):
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:save_repo_selections]")
 
                 cur.execute(
-                    pgsql.SQL("""SELECT DISTINCT ON (repo_full_name) repo_full_name, user_id
+                    f"""SELECT DISTINCT ON (repo_full_name) repo_full_name, user_id
                         FROM github_connected_repos
-                        WHERE {}
-                        ORDER BY repo_full_name, updated_at DESC""").format(predicate),
+                        WHERE {predicate}
+                        ORDER BY repo_full_name, updated_at DESC""",
                     pred_params,
                 )
                 # {repo_full_name: owner_user_id} — we need the owner to delete the right row
@@ -200,7 +199,7 @@ def update_repo_metadata(user_id, repo_full_name):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:update_repo_metadata]")
                 cur.execute(
-                    pgsql.SQL("SELECT user_id FROM github_connected_repos WHERE {} AND repo_full_name = %s LIMIT 1").format(predicate),
+                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
                     (*pred_params, repo_full_name),
                 )
                 owner_row = cur.fetchone()
@@ -237,7 +236,7 @@ def trigger_metadata_generation(user_id):
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:trigger_metadata_generation]")
                 cur.execute(
-                    pgsql.SQL("SELECT user_id FROM github_connected_repos WHERE {} AND repo_full_name = %s LIMIT 1").format(predicate),
+                    f"SELECT user_id FROM github_connected_repos WHERE {predicate} AND repo_full_name = %s LIMIT 1",
                     (*pred_params, repo_full_name),
                 )
                 owner_row = cur.fetchone()

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -8,7 +8,7 @@ from flask import Blueprint, jsonify, request
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
-from utils.secrets.secret_ref_utils import _resolve_org
+from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
 
 github_repo_selection_bp = Blueprint('github_repo_selection', __name__)
 logger = logging.getLogger(__name__)
@@ -34,26 +34,18 @@ def get_repo_selections(user_id):
     """Return all connected repos with metadata for this org."""
     try:
         org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:get_repo_selections]")
-                if org_id:
-                    cur.execute(
-                        """SELECT DISTINCT ON (repo_full_name)
-                                  repo_full_name, repo_id, default_branch, is_private,
-                                  metadata_summary, metadata_status, repo_data, created_at
-                           FROM github_connected_repos
-                           WHERE org_id = %s ORDER BY repo_full_name, updated_at DESC""",
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        """SELECT repo_full_name, repo_id, default_branch, is_private,
-                                  metadata_summary, metadata_status, repo_data, created_at
-                           FROM github_connected_repos
-                           WHERE user_id = %s ORDER BY repo_full_name""",
-                        (user_id,),
-                    )
+                cur.execute(
+                    f"""SELECT DISTINCT ON (repo_full_name)
+                              repo_full_name, repo_id, default_branch, is_private,
+                              metadata_summary, metadata_status, repo_data, created_at
+                       FROM github_connected_repos
+                       WHERE {predicate} ORDER BY repo_full_name, updated_at DESC""",
+                    pred_params,
+                )
                 rows = cur.fetchall()
 
         repos = [
@@ -88,23 +80,16 @@ def save_repo_selections(user_id):
             return jsonify({"error": "repositories array is required"}), 400
 
         org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:save_repo_selections]")
 
-                # Build existing set at org scope so deselections by any org member
-                # correctly remove rows originally created by a different member.
-                if org_id:
-                    cur.execute(
-                        "SELECT repo_full_name, user_id FROM github_connected_repos WHERE org_id = %s",
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        "SELECT repo_full_name, user_id FROM github_connected_repos WHERE user_id = %s",
-                        (user_id,),
-                    )
+                cur.execute(
+                    f"SELECT repo_full_name, user_id FROM github_connected_repos WHERE {predicate}",
+                    pred_params,
+                )
                 # {repo_full_name: owner_user_id} — we need the owner to delete the right row
                 existing = {r[0]: r[1] for r in cur.fetchall()}
 

--- a/server/routes/github/github_repo_selection.py
+++ b/server/routes/github/github_repo_selection.py
@@ -8,7 +8,7 @@ from flask import Blueprint, jsonify, request
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
-from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+from utils.db.org_scope import resolve_org, org_read_predicate
 
 github_repo_selection_bp = Blueprint('github_repo_selection', __name__)
 logger = logging.getLogger(__name__)
@@ -33,8 +33,8 @@ def _update_metadata_status(user_id: str, repo_full_name: str, status: str):
 def get_repo_selections(user_id):
     """Return all connected repos with metadata for this org."""
     try:
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:get_repo_selections]")
@@ -79,8 +79,8 @@ def save_repo_selections(user_id):
         if not isinstance(repositories, list):
             return jsonify({"error": "repositories array is required"}), 400
 
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
@@ -169,12 +169,14 @@ def save_repo_selections(user_id):
 @github_repo_selection_bp.route("/repo-selections", methods=["DELETE"])
 @require_permission("connectors", "write")
 def clear_repo_selections(user_id):
-    """Remove all connected repos for a user."""
+    """Remove all connected repos for the org."""
     try:
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[github_repo_selection:clear_repo_selections]")
-                cur.execute("DELETE FROM github_connected_repos WHERE user_id = %s", (user_id,))
+                cur.execute(f"DELETE FROM github_connected_repos WHERE {predicate}", pred_params)
                 conn.commit()
         return jsonify({"message": "All repository selections cleared"})
     except Exception as e:
@@ -192,8 +194,8 @@ def update_repo_metadata(user_id, repo_full_name):
         if summary is None:
             return jsonify({"error": "metadata_summary is required"}), 400
 
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
@@ -229,8 +231,8 @@ def trigger_metadata_generation(user_id):
         if not repo_full_name:
             return jsonify({"error": "repo_full_name is required"}), 400
 
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -23,13 +23,14 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
     """
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:has_row]")
                 cursor.execute(
-                    f"SELECT is_active FROM user_tokens WHERE {predicate} AND provider = 'grafana' ORDER BY is_active DESC LIMIT 1",
+                    pgsql.SQL("SELECT is_active FROM user_tokens WHERE {} AND provider = 'grafana' ORDER BY is_active DESC LIMIT 1").format(predicate),
                     (*pred_params,),
                 )
                 row = cursor.fetchone()
@@ -45,14 +46,15 @@ def _set_grafana_active(user_id: str, active: bool) -> bool:
     """Flip is_active on the existing Grafana user_tokens row (org-scoped)."""
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:set_active]")
                 cursor.execute(
-                    f"UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
-                    f"WHERE {predicate} AND provider = 'grafana'",
+                    pgsql.SQL("UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
+                              "WHERE {} AND provider = 'grafana'").format(predicate),
                     (active, *pred_params),
                 )
                 updated = cursor.rowcount > 0

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -22,9 +22,9 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
     Returns (row_exists, is_active).
     """
     try:
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:has_row]")
@@ -44,9 +44,9 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
 def _set_grafana_active(user_id: str, active: bool) -> bool:
     """Flip is_active on the existing Grafana user_tokens row (org-scoped)."""
     try:
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:set_active]")

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -23,14 +23,13 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
     """
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:has_row]")
                 cursor.execute(
-                    pgsql.SQL("SELECT is_active FROM user_tokens WHERE {} AND provider = 'grafana' ORDER BY is_active DESC LIMIT 1").format(predicate),
+                    f"SELECT is_active FROM user_tokens WHERE {predicate} AND provider = 'grafana' ORDER BY is_active DESC LIMIT 1",
                     (*pred_params,),
                 )
                 row = cursor.fetchone()
@@ -46,15 +45,14 @@ def _set_grafana_active(user_id: str, active: bool) -> bool:
     """Flip is_active on the existing Grafana user_tokens row (org-scoped)."""
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:set_active]")
                 cursor.execute(
-                    pgsql.SQL("UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
-                              "WHERE {} AND provider = 'grafana'").format(predicate),
+                    f"UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
+                    f"WHERE {predicate} AND provider = 'grafana'",
                     (active, *pred_params),
                 )
                 updated = cursor.rowcount > 0

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -17,7 +17,7 @@ grafana_bp = Blueprint("grafana", __name__)
 
 
 def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
-    """Check if a user_tokens row exists for Grafana visible to user_id (including org-shared).
+    """Check if a user_tokens row exists for Grafana (regardless of is_active).
 
     Returns (row_exists, is_active).
     """
@@ -42,7 +42,7 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
 
 
 def _set_grafana_active(user_id: str, active: bool) -> bool:
-    """Flip is_active on the existing Grafana user_tokens row (org-scoped)."""
+    """Flip is_active on the existing Grafana user_tokens row."""
     try:
         from utils.db.org_scope import resolve_org, org_read_predicate
         org_id = resolve_org(user_id)

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -17,17 +17,20 @@ grafana_bp = Blueprint("grafana", __name__)
 
 
 def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
-    """Check if a user_tokens row exists for Grafana (regardless of is_active).
+    """Check if a user_tokens row exists for Grafana visible to user_id (including org-shared).
 
     Returns (row_exists, is_active).
     """
     try:
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:has_row]")
                 cursor.execute(
-                    "SELECT is_active FROM user_tokens WHERE user_id = %s AND provider = 'grafana' LIMIT 1",
-                    (user_id,),
+                    f"SELECT is_active FROM user_tokens WHERE {predicate} AND provider = 'grafana' LIMIT 1",
+                    (*pred_params,),
                 )
                 row = cursor.fetchone()
                 if row is None:
@@ -220,18 +223,23 @@ def get_alerts(user_id):
 @grafana_bp.route("/alerts/webhook-url", methods=["GET"])
 @require_permission("connectors", "read")
 def get_webhook_url(user_id):
-    """Get the webhook URL that should be configured in Grafana."""
-    # Use ngrok URL for development if available, otherwise use backend URL
+    """Get the webhook URL that should be configured in Grafana.
+
+    When credentials are org-shared, returns the URL belonging to the token
+    owner so org members see the same webhook URL without needing their own row.
+    """
+    from utils.secrets.secret_ref_utils import get_token_owner_id
+    webhook_owner_id = get_token_owner_id(user_id, "grafana")
+
     ngrok_url = os.getenv("NGROK_URL", "").rstrip("/")
     backend_url = os.getenv("NEXT_PUBLIC_BACKEND_URL", "").rstrip("/")
 
-    # For development, prefer ngrok URL if available
     if ngrok_url and backend_url.startswith("http://localhost"):
         base_url = ngrok_url
     else:
         base_url = backend_url
 
-    webhook_url = f"{base_url}/grafana/alerts/webhook/{user_id}"
+    webhook_url = f"{base_url}/grafana/alerts/webhook/{webhook_owner_id}"
 
     return jsonify({
         "webhookUrl": webhook_url,

--- a/server/routes/grafana/grafana_routes.py
+++ b/server/routes/grafana/grafana_routes.py
@@ -29,7 +29,7 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:has_row]")
                 cursor.execute(
-                    f"SELECT is_active FROM user_tokens WHERE {predicate} AND provider = 'grafana' LIMIT 1",
+                    f"SELECT is_active FROM user_tokens WHERE {predicate} AND provider = 'grafana' ORDER BY is_active DESC LIMIT 1",
                     (*pred_params,),
                 )
                 row = cursor.fetchone()
@@ -42,15 +42,18 @@ def _has_grafana_row(user_id: str) -> Tuple[bool, bool]:
 
 
 def _set_grafana_active(user_id: str, active: bool) -> bool:
-    """Flip is_active on the existing Grafana user_tokens row."""
+    """Flip is_active on the existing Grafana user_tokens row (org-scoped)."""
     try:
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[GRAFANA:set_active]")
                 cursor.execute(
-                    "UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
-                    "WHERE user_id = %s AND provider = 'grafana'",
-                    (active, user_id),
+                    f"UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
+                    f"WHERE {predicate} AND provider = 'grafana'",
+                    (active, *pred_params),
                 )
                 updated = cursor.rowcount > 0
             conn.commit()

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -57,14 +57,13 @@ def _build_source_url(source_type: str, user_id: str) -> str:
     """Build platform URL from user's integration settings."""
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
                 cursor.execute(
-                    pgsql.SQL("SELECT client_id FROM user_tokens WHERE {} AND provider=%s LIMIT 1").format(predicate),
+                    f"SELECT client_id FROM user_tokens WHERE {predicate} AND provider=%s LIMIT 1",
                     (*pred_params, source_type),
                 )
                 row = cursor.fetchone()

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -56,9 +56,9 @@ def _parse_suggestion_id(suggestion_id: str) -> Optional[int]:
 def _build_source_url(source_type: str, user_id: str) -> str:
     """Build platform URL from user's integration settings."""
     try:
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -57,13 +57,14 @@ def _build_source_url(source_type: str, user_id: str) -> str:
     """Build platform URL from user's integration settings."""
     try:
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
                 cursor.execute(
-                    f"SELECT client_id FROM user_tokens WHERE {predicate} AND provider=%s LIMIT 1",
+                    pgsql.SQL("SELECT client_id FROM user_tokens WHERE {} AND provider=%s LIMIT 1").format(predicate),
                     (*pred_params, source_type),
                 )
                 row = cursor.fetchone()

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -56,12 +56,15 @@ def _parse_suggestion_id(suggestion_id: str) -> Optional[int]:
 def _build_source_url(source_type: str, user_id: str) -> str:
     """Build platform URL from user's integration settings."""
     try:
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
                 cursor.execute(
-                    "SELECT client_id FROM user_tokens WHERE user_id=%s AND provider=%s",
-                    (user_id, source_type),
+                    f"SELECT client_id FROM user_tokens WHERE {predicate} AND provider=%s LIMIT 1",
+                    (*pred_params, source_type),
                 )
                 row = cursor.fetchone()
                 client_id = row[0] if row else None

--- a/server/routes/setup_terraform_environment.py
+++ b/server/routes/setup_terraform_environment.py
@@ -270,7 +270,7 @@ def setup_ovh_terraform_environment_isolated(user_id: str):
             logger.error("OVH token data missing access_token")
             return False, None, None
 
-        # Get user's OVH root project (service_name in OVH API terms), org-aware
+        # Get user's OVH root project (service_name in OVH API terms)
         from utils.auth.stateless_auth import get_user_preference
         project_id = get_user_preference(user_id, 'ovh_root_project')
 
@@ -348,7 +348,7 @@ def setup_scaleway_terraform_environment_isolated(user_id: str):
                     organization_id = row[1]  # subscription_id = organization_id
                     project_id = row[2]  # subscription_name = default_project_id
                 
-                # Get user's Scaleway root project preference if set, org-aware
+                # Get user's Scaleway root project preference if set
                 from utils.auth.stateless_auth import get_user_preference
                 scaleway_pref = get_user_preference(user_id, 'scaleway_root_project')
                 if scaleway_pref:

--- a/server/routes/setup_terraform_environment.py
+++ b/server/routes/setup_terraform_environment.py
@@ -270,24 +270,9 @@ def setup_ovh_terraform_environment_isolated(user_id: str):
             logger.error("OVH token data missing access_token")
             return False, None, None
 
-        # Get user's OVH root project (service_name in OVH API terms)
-        from utils.db.db_utils import connect_to_db_as_user
-        project_id = None
-        try:
-            conn = connect_to_db_as_user()
-            with conn.cursor() as cur:
-                from utils.auth.stateless_auth import set_rls_context
-                set_rls_context(cur, conn, user_id, log_prefix="[Terraform]")
-                cur.execute(
-                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'ovh_root_project';",
-                    (user_id,)
-                )
-                row = cur.fetchone()
-                if row:
-                    project_id = row[0]
-            conn.close()
-        except Exception as e:
-            logger.warning(f"Could not fetch OVH root project preference: {e}")
+        # Get user's OVH root project (service_name in OVH API terms), org-aware
+        from utils.auth.stateless_auth import get_user_preference
+        project_id = get_user_preference(user_id, 'ovh_root_project')
 
         if not project_id:
             logger.warning("No OVH root project set - Terraform may need project_id variable")
@@ -363,14 +348,11 @@ def setup_scaleway_terraform_environment_isolated(user_id: str):
                     organization_id = row[1]  # subscription_id = organization_id
                     project_id = row[2]  # subscription_name = default_project_id
                 
-                # Get user's Scaleway root project preference if set
-                cur.execute(
-                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'scaleway_root_project';",
-                    (user_id,)
-                )
-                pref_row = cur.fetchone()
-                if pref_row and pref_row[0]:
-                    project_id = pref_row[0]  # Override with user preference
+                # Get user's Scaleway root project preference if set, org-aware
+                from utils.auth.stateless_auth import get_user_preference
+                scaleway_pref = get_user_preference(user_id, 'scaleway_root_project')
+                if scaleway_pref:
+                    project_id = scaleway_pref  # Override with preference
         except Exception as e:
             logger.warning(f"Could not fetch Scaleway credentials from database: {e}")
         finally:

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -103,13 +103,29 @@ def get_batch_preferences(user_id):
         org_id = set_rls_context(cursor, conn, user_id, log_prefix="[UserPrefs:get]")
 
         placeholders = ','.join(['%s'] * len(keys))
-        pref_col = "org_id" if org_id else "user_id"
-        pref_val = org_id if org_id else user_id
-        cursor.execute(
-            f"SELECT preference_key, preference_value FROM user_preferences WHERE {pref_col} = %s AND preference_key IN ({placeholders})",
-            [pref_val] + keys
-        )
-        results = cursor.fetchall()
+        if org_id:
+            cursor.execute(
+                f"SELECT preference_key, preference_value, user_id FROM user_preferences "
+                f"WHERE (org_id = %s OR user_id = %s) AND preference_key IN ({placeholders})",
+                [org_id, user_id] + keys,
+            )
+            rows = cursor.fetchall()
+            # Prefer user-scoped row over org-scoped row for the same key
+            user_prefs: dict = {}
+            org_prefs: dict = {}
+            for key, value, row_user_id in rows:
+                if row_user_id == user_id:
+                    user_prefs[key] = value
+                else:
+                    org_prefs[key] = value
+            results = list({**org_prefs, **user_prefs}.items())
+        else:
+            cursor.execute(
+                f"SELECT preference_key, preference_value FROM user_preferences "
+                f"WHERE user_id = %s AND preference_key IN ({placeholders})",
+                [user_id] + keys,
+            )
+            results = cursor.fetchall()
         
         preferences = {}
         for key, value in results:

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -100,13 +100,19 @@ def get_batch_preferences(user_id):
         from utils.db.db_utils import connect_to_db_as_user
         conn = connect_to_db_as_user()
         cursor = conn.cursor()
-        set_rls_context(cursor, conn, user_id, log_prefix="[UserPrefs:get]")
+        org_id = set_rls_context(cursor, conn, user_id, log_prefix="[UserPrefs:get]")
 
         placeholders = ','.join(['%s'] * len(keys))
-        cursor.execute(
-            f"SELECT preference_key, preference_value FROM user_preferences WHERE user_id = %s AND preference_key IN ({placeholders})",
-            [user_id] + keys
-        )
+        if org_id:
+            cursor.execute(
+                f"SELECT preference_key, preference_value FROM user_preferences WHERE org_id = %s AND preference_key IN ({placeholders})",
+                [org_id] + keys
+            )
+        else:
+            cursor.execute(
+                f"SELECT preference_key, preference_value FROM user_preferences WHERE user_id = %s AND preference_key IN ({placeholders})",
+                [user_id] + keys
+            )
         results = cursor.fetchall()
         
         preferences = {}

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -103,16 +103,12 @@ def get_batch_preferences(user_id):
         org_id = set_rls_context(cursor, conn, user_id, log_prefix="[UserPrefs:get]")
 
         placeholders = ','.join(['%s'] * len(keys))
-        if org_id:
-            cursor.execute(
-                f"SELECT preference_key, preference_value FROM user_preferences WHERE org_id = %s AND preference_key IN ({placeholders})",
-                [org_id] + keys
-            )
-        else:
-            cursor.execute(
-                f"SELECT preference_key, preference_value FROM user_preferences WHERE user_id = %s AND preference_key IN ({placeholders})",
-                [user_id] + keys
-            )
+        pref_col = "org_id" if org_id else "user_id"
+        pref_val = org_id if org_id else user_id
+        cursor.execute(
+            f"SELECT preference_key, preference_value FROM user_preferences WHERE {pref_col} = %s AND preference_key IN ({placeholders})",
+            [pref_val] + keys
+        )
         results = cursor.fetchall()
         
         preferences = {}

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -70,9 +70,9 @@ def _serialize_vm_row(row: tuple, is_shared: bool = False) -> Dict[str, Any]:
 @limiter.limit("30 per minute;200 per hour")
 @require_permission("vms", "read")
 def list_manual_vms(user_id):
-    from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-    org_id = _resolve_org(user_id)
-    predicate, pred_params = _org_read_predicate(user_id, org_id)
+    from utils.db.org_scope import resolve_org, org_read_predicate
+    org_id = resolve_org(user_id)
+    predicate, pred_params = org_read_predicate(user_id, org_id)
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -37,7 +37,7 @@ def _validate_required(fields: Dict[str, Any]):
         raise ValueError(f"Missing required field(s): {', '.join(missing)}")
 
 
-def _serialize_vm_row(row: tuple) -> Dict[str, Any]:
+def _serialize_vm_row(row: tuple, is_shared: bool = False) -> Dict[str, Any]:
     (
         vm_id,
         name,
@@ -62,6 +62,7 @@ def _serialize_vm_row(row: tuple) -> Dict[str, Any]:
         "createdAt": created_at.isoformat() if created_at else None,
         "updatedAt": updated_at.isoformat() if updated_at else None,
         "source": "manual",
+        "isShared": is_shared,
     }
 
 
@@ -77,7 +78,7 @@ def list_manual_vms(user_id):
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")
             cur.execute(
                 f"""
-                SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
+                SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at, user_id
                 FROM user_manual_vms
                 WHERE {predicate}
                 ORDER BY created_at DESC
@@ -85,7 +86,12 @@ def list_manual_vms(user_id):
                 pred_params,
             )
             rows = cur.fetchall()
-    return jsonify({"vms": [_serialize_vm_row(r) for r in rows]})
+    vms = []
+    for r in rows:
+        row_data = r[:10]
+        row_owner_id = r[10]
+        vms.append(_serialize_vm_row(row_data, is_shared=(row_owner_id != user_id)))
+    return jsonify({"vms": vms})
 
 
 @manual_vms_bp.route("/api/vms/manual", methods=["POST"])

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -69,18 +69,31 @@ def _serialize_vm_row(row: tuple) -> Dict[str, Any]:
 @limiter.limit("30 per minute;200 per hour")
 @require_permission("vms", "read")
 def list_manual_vms(user_id):
+    from utils.secrets.secret_ref_utils import _resolve_org
+    org_id = _resolve_org(user_id)
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")
-            cur.execute(
-                """
-                SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
-                FROM user_manual_vms
-                WHERE user_id = %s
-                ORDER BY created_at DESC
-                """,
-                (user_id,),
-            )
+            if org_id:
+                cur.execute(
+                    """
+                    SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
+                    FROM user_manual_vms
+                    WHERE org_id = %s
+                    ORDER BY created_at DESC
+                    """,
+                    (org_id,),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
+                    FROM user_manual_vms
+                    WHERE user_id = %s
+                    ORDER BY created_at DESC
+                    """,
+                    (user_id,),
+                )
             rows = cur.fetchall()
     return jsonify({"vms": [_serialize_vm_row(r) for r in rows]})
 

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -228,6 +228,16 @@ def update_manual_vm(user_id, vm_id: int):
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:update]")
+            cur.execute(
+                "SELECT user_id FROM user_manual_vms WHERE id = %s",
+                (vm_id,),
+            )
+            existing = cur.fetchone()
+            if not existing:
+                return jsonify({"error": "Manual VM not found"}), 404
+            if existing[0] != user_id:
+                return jsonify({"error": "Cannot modify a shared VM"}), 403
+
             query = sql.SQL(
                 """
                 UPDATE user_manual_vms
@@ -253,6 +263,15 @@ def delete_manual_vm(user_id, vm_id: int):
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:delete]")
+            cur.execute(
+                "SELECT user_id FROM user_manual_vms WHERE id = %s",
+                (vm_id,),
+            )
+            existing = cur.fetchone()
+            if not existing:
+                return jsonify({"error": "Manual VM not found"}), 404
+            if existing[0] != user_id:
+                return jsonify({"error": "Cannot delete a shared VM"}), 403
             cur.execute(
                 "DELETE FROM user_manual_vms WHERE id = %s AND user_id = %s RETURNING id;",
                 (vm_id, user_id),
@@ -292,15 +311,17 @@ def check_manual_vm_connection(user_id):
                 set_rls_context(cur, conn, user_id, log_prefix="[VMs:check-load]")
                 cur.execute(
                     """
-                    SELECT ip_address, port, ssh_jump_command, ssh_key_id, ssh_username
+                    SELECT ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, user_id
                     FROM user_manual_vms
-                    WHERE id = %s AND user_id = %s
+                    WHERE id = %s
                     """,
-                    (vm_id, user_id),
+                    (vm_id,),
                 )
                 vm_row = cur.fetchone()
         if not vm_row:
             return jsonify({"error": "Manual VM not found"}), 404
+        if vm_row[5] != user_id:
+            return jsonify({"error": "Cannot run connection check on a shared VM"}), 403
 
         ip_address = ip_address or vm_row[0]
         port = port or vm_row[1]

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -69,31 +69,21 @@ def _serialize_vm_row(row: tuple) -> Dict[str, Any]:
 @limiter.limit("30 per minute;200 per hour")
 @require_permission("vms", "read")
 def list_manual_vms(user_id):
-    from utils.secrets.secret_ref_utils import _resolve_org
+    from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
     org_id = _resolve_org(user_id)
+    predicate, pred_params = _org_read_predicate(user_id, org_id)
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")
-            if org_id:
-                cur.execute(
-                    """
-                    SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
-                    FROM user_manual_vms
-                    WHERE org_id = %s
-                    ORDER BY created_at DESC
-                    """,
-                    (org_id,),
-                )
-            else:
-                cur.execute(
-                    """
-                    SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
-                    FROM user_manual_vms
-                    WHERE user_id = %s
-                    ORDER BY created_at DESC
-                    """,
-                    (user_id,),
-                )
+            cur.execute(
+                f"""
+                SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at
+                FROM user_manual_vms
+                WHERE {predicate}
+                ORDER BY created_at DESC
+                """,
+                pred_params,
+            )
             rows = cur.fetchall()
     return jsonify({"vms": [_serialize_vm_row(r) for r in rows]})
 

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -71,18 +71,19 @@ def _serialize_vm_row(row: tuple, is_shared: bool = False) -> Dict[str, Any]:
 @require_permission("vms", "read")
 def list_manual_vms(user_id):
     from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+    from psycopg2 import sql as pgsql
     org_id = _resolve_org(user_id)
     predicate, pred_params = _org_read_predicate(user_id, org_id)
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")
             cur.execute(
-                f"""
+                pgsql.SQL("""
                 SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at, user_id
                 FROM user_manual_vms
-                WHERE {predicate}
+                WHERE {}
                 ORDER BY created_at DESC
-                """,
+                """).format(predicate),
                 pred_params,
             )
             rows = cur.fetchall()

--- a/server/routes/vms/manual_vms_routes.py
+++ b/server/routes/vms/manual_vms_routes.py
@@ -71,19 +71,18 @@ def _serialize_vm_row(row: tuple, is_shared: bool = False) -> Dict[str, Any]:
 @require_permission("vms", "read")
 def list_manual_vms(user_id):
     from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-    from psycopg2 import sql as pgsql
     org_id = _resolve_org(user_id)
     predicate, pred_params = _org_read_predicate(user_id, org_id)
     with db_pool.get_user_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[VMs:list]")
             cur.execute(
-                pgsql.SQL("""
+                f"""
                 SELECT id, name, ip_address, port, ssh_jump_command, ssh_key_id, ssh_username, connection_verified, created_at, updated_at, user_id
                 FROM user_manual_vms
-                WHERE {}
+                WHERE {predicate}
                 ORDER BY created_at DESC
-                """).format(predicate),
+                """,
                 pred_params,
             )
             rows = cur.fetchall()

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -239,14 +239,9 @@ def run_user_discovery(self, user_id):
         providers = {name: {} for name in provider_names}
 
         if "gcp" in providers:
-            # Fetch root project while we still have the cursor
-            cur.execute(
-                "SELECT preference_value FROM user_preferences "
-                "WHERE user_id = %s AND preference_key = 'gcp_root_project'",
-                (user_id,)
-            )
-            root_row = cur.fetchone()
-            root_project = root_row[0] if root_row and root_row[0] else None
+            # Fetch root project, respecting org-shared preferences
+            from utils.auth.stateless_auth import get_user_preference
+            root_project = get_user_preference(user_id, 'gcp_root_project')
 
         # Query active kubectl clusters for this user
         cur.execute("""

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -239,7 +239,7 @@ def run_user_discovery(self, user_id):
         providers = {name: {} for name in provider_names}
 
         if "gcp" in providers:
-            # Fetch root project, respecting org-shared preferences
+            # Fetch root project while we still have the cursor
             from utils.auth.stateless_auth import get_user_preference
             root_project = get_user_preference(user_id, 'gcp_root_project')
 

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -15,9 +15,8 @@ from utils.secrets import secret_ref_utils as sru
 from utils.secrets.secret_ref_utils import (
     SUPPORTED_SECRET_PROVIDERS,
     SecretRefManager,
-    _org_read_predicate,
-    _validate_uuid,
 )
+from utils.db.org_scope import org_read_predicate as _org_read_predicate, _validate_uuid
 
 _UID = "00000000-0000-0000-0000-000000000001"
 _OID = "00000000-0000-0000-0000-000000000007"

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -10,14 +10,43 @@ must be refused before they reach the DB or Vault).
 from unittest.mock import MagicMock
 
 import pytest
-from psycopg2 import sql as pgsql
 
 from utils.secrets import secret_ref_utils as sru
 from utils.secrets.secret_ref_utils import (
     SUPPORTED_SECRET_PROVIDERS,
     SecretRefManager,
     _org_read_predicate,
+    _validate_uuid,
 )
+
+_UID = "00000000-0000-0000-0000-000000000001"
+_OID = "00000000-0000-0000-0000-000000000007"
+
+
+# ---------------------------------------------------------------------------
+# _validate_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUuid:
+    """UUID sanitization gate that every SQL parameter passes through."""
+
+    def test_valid_uuid_returned_unchanged(self):
+        assert _validate_uuid(_UID, "user_id") == _UID
+
+    def test_uppercase_uuid_accepted(self):
+        assert _validate_uuid(_UID.upper(), "user_id") == _UID.upper()
+
+    @pytest.mark.parametrize("bad", [
+        "",
+        "not-a-uuid",
+        "'; DROP TABLE user_tokens;--",
+        "../etc/passwd",
+        "00000000-0000-0000-0000-00000000000Z",
+    ])
+    def test_invalid_inputs_raise_value_error(self, bad):
+        with pytest.raises(ValueError):
+            _validate_uuid(bad, "user_id")
 
 
 # ---------------------------------------------------------------------------
@@ -29,27 +58,33 @@ class TestOrgReadPredicate:
     """SQL predicate builder for all credential queries — reads, writes, and deletes."""
 
     def test_none_org_returns_user_id_only_predicate(self):
-        clause, params = _org_read_predicate("u-1", None)
-        assert clause == pgsql.SQL("user_id = %s")
-        assert params == ("u-1",)
+        clause, params = _org_read_predicate(_UID, None)
+        assert clause == "user_id = %s"
+        assert params == (_UID,)
 
     def test_concrete_org_returns_user_or_org_predicate(self):
-        clause, params = _org_read_predicate("u-1", "org-7")
-        assert clause == pgsql.SQL("(user_id = %s OR org_id = %s)")
-        assert params == ("u-1", "org-7")
+        clause, params = _org_read_predicate(_UID, _OID)
+        assert clause == "(user_id = %s OR org_id = %s)"
+        assert params == (_UID, _OID)
 
     def test_params_is_tuple_not_list(self):
-        _, params = _org_read_predicate("u-1", "org-7")
+        _, params = _org_read_predicate(_UID, _OID)
         assert isinstance(params, tuple)
 
-    def test_clause_uses_parameter_placeholders_not_inlined_values(self):
-        """SQL injection guard: values must go through %s."""
-        user_in = "'; DROP TABLE user_tokens;--"
-        org_in = "'; DROP TABLE orgs;--"
-        clause, params = _org_read_predicate(user_in, org_in)
-        assert isinstance(clause, pgsql.SQL)
-        assert "DROP TABLE" not in clause.as_string(None) if hasattr(clause, "as_string") else True
-        assert params == (user_in, org_in)
+    def test_clause_is_plain_string(self):
+        """Predicate is a plain SQL fragment — values go through %s params, not inline."""
+        clause, _ = _org_read_predicate(_UID, _OID)
+        assert isinstance(clause, str)
+        assert clause.count("%s") == 2
+
+    def test_malicious_user_id_raises_before_sql(self):
+        """SQL injection attempt must be rejected at the UUID validation gate."""
+        with pytest.raises(ValueError):
+            _org_read_predicate("'; DROP TABLE user_tokens;--", _OID)
+
+    def test_malicious_org_id_raises_before_sql(self):
+        with pytest.raises(ValueError):
+            _org_read_predicate(_UID, "'; DROP TABLE orgs;--")
 
 
 # ---------------------------------------------------------------------------
@@ -97,8 +132,8 @@ def manager_with_mocked_db(monkeypatch):
 
     connect = MagicMock(return_value=conn)
     monkeypatch.setattr(sru, "connect_to_db_as_admin", connect)
-    monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value="org-7"))
-    monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value="org-7"))
+    monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=_OID))
+    monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=_OID))
 
     return SecretRefManager(), connect, cursor
 
@@ -110,13 +145,13 @@ class TestProviderLookupCaseInsensitive:
     def test_mixed_case_gcp_accepted(self, manager_with_mocked_db, spelling):
         manager, connect, _ = manager_with_mocked_db
 
-        assert manager.has_user_credentials("u-1", spelling) is True
+        assert manager.has_user_credentials(_UID, spelling) is True
         connect.assert_called_once()
 
     @pytest.mark.parametrize("spelling", ["aws", "AWS", "Aws", "aWs"])
     def test_mixed_case_aws_accepted(self, manager_with_mocked_db, spelling):
         manager, _, _ = manager_with_mocked_db
-        assert manager.has_user_credentials("u-1", spelling) is True
+        assert manager.has_user_credentials(_UID, spelling) is True
 
     @pytest.mark.parametrize(
         "compound",
@@ -127,7 +162,7 @@ class TestProviderLookupCaseInsensitive:
     ):
         """Only the prefix before the first ``_`` is checked against the set."""
         manager, _, _ = manager_with_mocked_db
-        assert manager.has_user_credentials("u-1", compound) is True
+        assert manager.has_user_credentials(_UID, compound) is True
 
     def test_get_user_token_data_also_canonicalizes_case(
         self, manager_with_mocked_db, monkeypatch,
@@ -139,7 +174,7 @@ class TestProviderLookupCaseInsensitive:
             manager, "get_secret", MagicMock(return_value='{"token": "t"}'),
         )
 
-        assert manager.get_user_token_data("u-1", "GCP") == {"token": "t"}
+        assert manager.get_user_token_data(_UID, "GCP") == {"token": "t"}
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +220,7 @@ class TestProviderParserRejectsMalformed:
     ):
         manager = SecretRefManager()
 
-        assert manager.has_user_credentials("u-1", bad_provider) is False
+        assert manager.has_user_credentials(_UID, bad_provider) is False
         db_explodes_if_called.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -203,7 +238,7 @@ class TestProviderParserRejectsMalformed:
     ):
         manager = SecretRefManager()
 
-        assert manager.get_user_token_data("u-1", bad_provider) is None
+        assert manager.get_user_token_data(_UID, bad_provider) is None
         db_explodes_if_called.assert_not_called()
 
 
@@ -230,7 +265,7 @@ class TestHasUserCredentialsNullOrgPath:
         monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=None))
 
         manager = SecretRefManager()
-        result = manager.has_user_credentials("u-1", "gcp")
+        result = manager.has_user_credentials(_UID, "gcp")
 
         assert result is True
         cursor.execute.assert_called()
@@ -247,7 +282,7 @@ class TestHasUserCredentialsNullOrgPath:
         monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=None))
 
         manager = SecretRefManager()
-        manager.has_user_credentials("u-1", "gcp")
+        manager.has_user_credentials(_UID, "gcp")
 
         for call in cursor.execute.call_args_list:
             params = call.args[1] if len(call.args) > 1 else ()
@@ -273,8 +308,8 @@ class TestProviderCanonicalizedInSQL:
         conn = MagicMock()
         conn.cursor.return_value = cursor
         monkeypatch.setattr(sru, "connect_to_db_as_admin", MagicMock(return_value=conn))
-        monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value="org-7"))
-        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value="org-7"))
+        monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=_OID))
+        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=_OID))
         return cursor
 
     @pytest.mark.parametrize("raw_provider", ["GCP", "Gcp", "gCp", "GcP"])
@@ -283,7 +318,7 @@ class TestProviderCanonicalizedInSQL:
     ):
         cursor = self._make_db(monkeypatch, (1,))
         manager = SecretRefManager()
-        manager.has_user_credentials("u-1", raw_provider)
+        manager.has_user_credentials(_UID, raw_provider)
 
         _, params = cursor.execute.call_args.args
         assert "gcp" in params, (
@@ -299,7 +334,7 @@ class TestProviderCanonicalizedInSQL:
     ):
         cursor = self._make_db(monkeypatch, None)
         manager = SecretRefManager()
-        manager.get_user_token_data("u-1", raw_provider)
+        manager.get_user_token_data(_UID, raw_provider)
 
         for call in cursor.execute.call_args_list:
             params = call.args[1] if len(call.args) > 1 else ()

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -34,8 +34,9 @@ class TestValidateUuid:
     def test_valid_uuid_returned_unchanged(self):
         assert _validate_uuid(_UID, "user_id") == _UID
 
-    def test_uppercase_uuid_accepted(self):
-        assert _validate_uuid(_UID.upper(), "user_id") == _UID.upper()
+    def test_uppercase_uuid_normalised_to_lowercase(self):
+        """Returns canonical (lowercase) form, not the original casing."""
+        assert _validate_uuid(_UID.upper(), "user_id") == _UID
 
     @pytest.mark.parametrize("bad", [
         "",

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -10,6 +10,7 @@ must be refused before they reach the DB or Vault).
 from unittest.mock import MagicMock
 
 import pytest
+from psycopg2 import sql as pgsql
 
 from utils.secrets import secret_ref_utils as sru
 from utils.secrets.secret_ref_utils import (
@@ -29,12 +30,12 @@ class TestOrgReadPredicate:
 
     def test_none_org_returns_user_id_only_predicate(self):
         clause, params = _org_read_predicate("u-1", None)
-        assert clause == "user_id = %s"
+        assert clause == pgsql.SQL("user_id = %s")
         assert params == ("u-1",)
 
     def test_concrete_org_returns_user_or_org_predicate(self):
         clause, params = _org_read_predicate("u-1", "org-7")
-        assert clause == "(user_id = %s OR org_id = %s)"
+        assert clause == pgsql.SQL("(user_id = %s OR org_id = %s)")
         assert params == ("u-1", "org-7")
 
     def test_params_is_tuple_not_list(self):
@@ -46,8 +47,8 @@ class TestOrgReadPredicate:
         user_in = "'; DROP TABLE user_tokens;--"
         org_in = "'; DROP TABLE orgs;--"
         clause, params = _org_read_predicate(user_in, org_in)
-        assert clause.count("%s") == 2
-        assert "DROP TABLE" not in clause
+        assert isinstance(clause, pgsql.SQL)
+        assert "DROP TABLE" not in clause.as_string(None) if hasattr(clause, "as_string") else True
         assert params == (user_in, org_in)
 
 

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -15,49 +15,58 @@ from utils.secrets import secret_ref_utils as sru
 from utils.secrets.secret_ref_utils import (
     SUPPORTED_SECRET_PROVIDERS,
     SecretRefManager,
-    _org_clause,
+    _org_read_predicate,
+    _org_write_filter,
 )
 
 
 # ---------------------------------------------------------------------------
-# _org_clause
+# _org_read_predicate / _org_write_filter
 # ---------------------------------------------------------------------------
 
 
-class TestOrgClause:
-    """Pure SQL fragment builder concatenated into every credential WHERE clause."""
+class TestOrgReadPredicate:
+    """SQL predicate builder for credential reads — allows org-shared rows."""
 
-    def test_none_org_returns_empty_fragment_and_empty_params(self):
-        assert _org_clause(None) == ("", ())
+    def test_none_org_returns_user_id_only_predicate(self):
+        clause, params = _org_read_predicate("u-1", None)
+        assert clause == "user_id = %s"
+        assert params == ("u-1",)
 
-    def test_empty_string_org_returns_empty_fragment(self):
-        """Falsy values follow the same path as ``None``."""
-        assert _org_clause("") == ("", ())
-
-    def test_concrete_org_returns_and_clause_and_param_tuple(self):
-        clause, params = _org_clause("org-7")
-
-        assert clause == "AND (org_id = %s OR org_id IS NULL)"
-        assert params == ("org-7",)
-
-    def test_clause_starts_with_and_so_it_appends_to_existing_where(self):
-        """Callers concatenate this onto a WHERE; missing AND is a SyntaxError."""
-        clause, _ = _org_clause("org-7")
-        assert clause.startswith("AND ")
-
-    def test_clause_includes_org_id_is_null_for_legacy_rows(self):
-        """Pre-multi-tenancy rows have NULL org_id; they must remain visible."""
-        clause, _ = _org_clause("org-7")
-        assert "org_id IS NULL" in clause
+    def test_concrete_org_returns_user_or_org_predicate(self):
+        clause, params = _org_read_predicate("u-1", "org-7")
+        assert clause == "(user_id = %s OR org_id = %s)"
+        assert params == ("u-1", "org-7")
 
     def test_params_is_tuple_not_list(self):
-        _, params = _org_clause("org-7")
+        _, params = _org_read_predicate("u-1", "org-7")
+        assert isinstance(params, tuple)
+
+    def test_clause_uses_parameter_placeholders_not_inlined_values(self):
+        """SQL injection guard: values must go through %s."""
+        clause, params = _org_read_predicate(
+            "'; DROP TABLE user_tokens;--", "'; DROP TABLE orgs;--"
+        )
+        assert clause.count("%s") == 2
+        assert "DROP TABLE" not in clause
+        assert "DROP TABLE" not in "".join(str(p) for p in params if "DROP" not in str(p))
+
+
+class TestOrgWriteFilter:
+    """SQL filter for writes/updates/deletes — scoped to requesting user only."""
+
+    def test_returns_user_id_predicate(self):
+        clause, params = _org_write_filter("u-1")
+        assert clause == "user_id = %s"
+        assert params == ("u-1",)
+
+    def test_params_is_tuple_not_list(self):
+        _, params = _org_write_filter("u-1")
         assert isinstance(params, tuple)
 
     def test_clause_uses_parameter_placeholder_not_inlined_value(self):
-        """SQL injection guard: org_id must go through %s, not f-string interpolation."""
-        clause, params = _org_clause("'; DROP TABLE user_tokens;--")
-
+        """SQL injection guard: user_id must go through %s."""
+        clause, params = _org_write_filter("'; DROP TABLE user_tokens;--")
         assert "%s" in clause
         assert "DROP TABLE" not in clause
         assert params == ("'; DROP TABLE user_tokens;--",)
@@ -226,7 +235,8 @@ class TestProviderParserRejectsMalformed:
 class TestHasUserCredentialsNullOrgPath:
     """When _resolve_org returns None the SQL must not pass None as a %s param
     for org_id — ``org_id = NULL`` is always false in PostgreSQL.  The fix is
-    to route through ``_org_clause`` which returns an empty fragment for None.
+    to route through ``_org_read_predicate`` which falls back to user_id-only
+    matching when org_id is None.
     """
 
     def test_db_still_queried_when_org_is_none(self, monkeypatch):

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -16,17 +16,16 @@ from utils.secrets.secret_ref_utils import (
     SUPPORTED_SECRET_PROVIDERS,
     SecretRefManager,
     _org_read_predicate,
-    _org_write_filter,
 )
 
 
 # ---------------------------------------------------------------------------
-# _org_read_predicate / _org_write_filter
+# _org_read_predicate
 # ---------------------------------------------------------------------------
 
 
 class TestOrgReadPredicate:
-    """SQL predicate builder for credential reads — allows org-shared rows."""
+    """SQL predicate builder for all credential queries — reads, writes, and deletes."""
 
     def test_none_org_returns_user_id_only_predicate(self):
         clause, params = _org_read_predicate("u-1", None)
@@ -50,26 +49,6 @@ class TestOrgReadPredicate:
         assert clause.count("%s") == 2
         assert "DROP TABLE" not in clause
         assert "DROP TABLE" not in "".join(str(p) for p in params if "DROP" not in str(p))
-
-
-class TestOrgWriteFilter:
-    """SQL filter for writes/updates/deletes — scoped to requesting user only."""
-
-    def test_returns_user_id_predicate(self):
-        clause, params = _org_write_filter("u-1")
-        assert clause == "user_id = %s"
-        assert params == ("u-1",)
-
-    def test_params_is_tuple_not_list(self):
-        _, params = _org_write_filter("u-1")
-        assert isinstance(params, tuple)
-
-    def test_clause_uses_parameter_placeholder_not_inlined_value(self):
-        """SQL injection guard: user_id must go through %s."""
-        clause, params = _org_write_filter("'; DROP TABLE user_tokens;--")
-        assert "%s" in clause
-        assert "DROP TABLE" not in clause
-        assert params == ("'; DROP TABLE user_tokens;--",)
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +217,6 @@ class TestHasUserCredentialsNullOrgPath:
     to route through ``_org_read_predicate`` which falls back to user_id-only
     matching when org_id is None.
     """
-
     def test_db_still_queried_when_org_is_none(self, monkeypatch):
         """_resolve_org=None must not short-circuit; row found by user_id alone."""
         cursor = MagicMock()

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -43,12 +43,12 @@ class TestOrgReadPredicate:
 
     def test_clause_uses_parameter_placeholders_not_inlined_values(self):
         """SQL injection guard: values must go through %s."""
-        clause, params = _org_read_predicate(
-            "'; DROP TABLE user_tokens;--", "'; DROP TABLE orgs;--"
-        )
+        user_in = "'; DROP TABLE user_tokens;--"
+        org_in = "'; DROP TABLE orgs;--"
+        clause, params = _org_read_predicate(user_in, org_in)
         assert clause.count("%s") == 2
         assert "DROP TABLE" not in clause
-        assert "DROP TABLE" not in "".join(str(p) for p in params if "DROP" not in str(p))
+        assert params == (user_in, org_in)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/secrets/test_secret_ref_utils.py
+++ b/server/tests/secrets/test_secret_ref_utils.py
@@ -133,7 +133,7 @@ def manager_with_mocked_db(monkeypatch):
     connect = MagicMock(return_value=conn)
     monkeypatch.setattr(sru, "connect_to_db_as_admin", connect)
     monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=_OID))
-    monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=_OID))
+    monkeypatch.setattr(sru, "resolve_org", MagicMock(return_value=_OID))
 
     return SecretRefManager(), connect, cursor
 
@@ -197,7 +197,7 @@ class TestProviderParserRejectsMalformed:
             "set_rls_context",
             MagicMock(side_effect=AssertionError("set_rls_context must not run")),
         )
-        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=None))
+        monkeypatch.setattr(sru, "resolve_org", MagicMock(return_value=None))
         return connect
 
     @pytest.mark.parametrize(
@@ -243,18 +243,18 @@ class TestProviderParserRejectsMalformed:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_org returning None: _org_clause must be used (no NULL param bug)
+# resolve_org returning None: org_read_predicate must be used (no NULL param bug)
 # ---------------------------------------------------------------------------
 
 
 class TestHasUserCredentialsNullOrgPath:
-    """When _resolve_org returns None the SQL must not pass None as a %s param
+    """When resolve_org returns None the SQL must not pass None as a %s param
     for org_id — ``org_id = NULL`` is always false in PostgreSQL.  The fix is
-    to route through ``_org_read_predicate`` which falls back to user_id-only
+    to route through ``org_read_predicate`` which falls back to user_id-only
     matching when org_id is None.
     """
     def test_db_still_queried_when_org_is_none(self, monkeypatch):
-        """_resolve_org=None must not short-circuit; row found by user_id alone."""
+        """resolve_org=None must not short-circuit; row found by user_id alone."""
         cursor = MagicMock()
         cursor.fetchone.return_value = (1,)
         conn = MagicMock()
@@ -262,7 +262,7 @@ class TestHasUserCredentialsNullOrgPath:
 
         monkeypatch.setattr(sru, "connect_to_db_as_admin", MagicMock(return_value=conn))
         monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=None))
-        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=None))
+        monkeypatch.setattr(sru, "resolve_org", MagicMock(return_value=None))
 
         manager = SecretRefManager()
         result = manager.has_user_credentials(_UID, "gcp")
@@ -279,7 +279,7 @@ class TestHasUserCredentialsNullOrgPath:
 
         monkeypatch.setattr(sru, "connect_to_db_as_admin", MagicMock(return_value=conn))
         monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=None))
-        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=None))
+        monkeypatch.setattr(sru, "resolve_org", MagicMock(return_value=None))
 
         manager = SecretRefManager()
         manager.has_user_credentials(_UID, "gcp")
@@ -309,7 +309,7 @@ class TestProviderCanonicalizedInSQL:
         conn.cursor.return_value = cursor
         monkeypatch.setattr(sru, "connect_to_db_as_admin", MagicMock(return_value=conn))
         monkeypatch.setattr(sru, "set_rls_context", MagicMock(return_value=_OID))
-        monkeypatch.setattr(sru, "_resolve_org", MagicMock(return_value=_OID))
+        monkeypatch.setattr(sru, "resolve_org", MagicMock(return_value=_OID))
         return cursor
 
     @pytest.mark.parametrize("raw_provider", ["GCP", "Gcp", "gCp", "GcP"])

--- a/server/utils/auth/cloud_auth.py
+++ b/server/utils/auth/cloud_auth.py
@@ -194,10 +194,15 @@ def generate_azure_access_token(user_id: str, subscription_id: Optional[str] = N
             "mode": normalized_mode,
         })
         
-        # Store token data for reuse
+        # Store token data for reuse, always under the token owner's user_id.
+        # When credentials are org-shared, user_id may be an org member (User B)
+        # rather than the connector owner (User A). Writing under User B's ID
+        # creates a ghost row and causes org-wide credential inconsistency.
         try:
             from utils.auth.token_management import store_tokens_in_db
-            store_tokens_in_db(user_id, azure_token_data, "azure")
+            from utils.secrets.secret_ref_utils import get_token_owner_id
+            owner_id = get_token_owner_id(user_id, "azure")
+            store_tokens_in_db(owner_id, azure_token_data, "azure")
             logger.info(f"Stored new Azure token in database for user {user_id}")
         except Exception as store_error:
             logger.warning(f"Failed to store Azure token in database: {store_error}")
@@ -297,10 +302,18 @@ def generate_gcp_access_token(
     selected_project_id: str = None,
     mode: Optional[str] = None,
 ) -> Dict:
-    """Generate access token via GCP service account impersonation."""
-    from connectors.gcp_connector.auth.service_accounts import generate_sa_access_token
+    """Generate access token via GCP service account impersonation.
 
-    return generate_sa_access_token(user_id, scopes, lifetime, selected_project_id, mode=mode)
+    When credentials are org-shared, the Aurora service account was provisioned
+    under the original connector owner's user_id.  Resolve that owner here so
+    that all downstream callers automatically use the correct SA identity,
+    regardless of which org member triggered the tool.
+    """
+    from connectors.gcp_connector.auth.service_accounts import generate_sa_access_token
+    from utils.secrets.secret_ref_utils import get_token_owner_id
+
+    sa_owner_id = get_token_owner_id(user_id, "gcp")
+    return generate_sa_access_token(sa_owner_id, scopes, lifetime, selected_project_id, mode=mode)
 
 
 def get_provider_preference_from_context() -> Optional[str]:

--- a/server/utils/auth/token_management.py
+++ b/server/utils/auth/token_management.py
@@ -89,7 +89,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
             if provider == "azure":
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id, tenant_id, client_id, client_secret) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -121,7 +121,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, client_secret, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -140,7 +140,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -152,13 +152,13 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
             elif provider == "grafana":
                 # Store Grafana metadata for display (org info + base URL)
                 org_name = token_data.get("org_name") if isinstance(token_data, dict) else None
-                org_id = token_data.get("org_id") if isinstance(token_data, dict) else None
+                grafana_org_id = token_data.get("org_id") if isinstance(token_data, dict) else None
                 base_url = token_data.get("base_url") if isinstance(token_data, dict) else None
                 user_email = token_data.get("user_email") if isinstance(token_data, dict) else None
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id, client_id, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -167,17 +167,17 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                     "email = EXCLUDED.email, "
                     "timestamp = CURRENT_TIMESTAMP, "
                     "is_active = TRUE",
-                    (user_id, request_org_id, secret_ref, provider, org_name, org_id, base_url, user_email)
+                    (user_id, request_org_id, secret_ref, provider, org_name, grafana_org_id, base_url, user_email)
                 )
             elif provider == "datadog":
                 org_name = token_data.get("org_name") if isinstance(token_data, dict) else None
-                org_id = token_data.get("org_id") if isinstance(token_data, dict) else None
+                datadog_org_id = token_data.get("org_id") if isinstance(token_data, dict) else None
                 site = token_data.get("site") if isinstance(token_data, dict) else None
                 service_account = token_data.get("service_account_name") if isinstance(token_data, dict) else None
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id, client_id, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -186,7 +186,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                     "email = EXCLUDED.email, "
                     "timestamp = CURRENT_TIMESTAMP, "
                     "is_active = TRUE",
-                    (user_id, request_org_id, secret_ref, provider, org_name, org_id, site, service_account)
+                    (user_id, request_org_id, secret_ref, provider, org_name, datadog_org_id, site, service_account)
                 )
             elif provider == "netdata":
                 space_name = token_data.get("space_name") if isinstance(token_data, dict) else None
@@ -194,7 +194,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, client_id) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -212,7 +212,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, subscription_id, subscription_name) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -231,7 +231,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, subscription_id, subscription_name) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -251,7 +251,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, email, subscription_id, subscription_name) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "email = EXCLUDED.email, "
@@ -269,7 +269,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, subscription_name, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -285,7 +285,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_id) "
-                    "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_id = EXCLUDED.subscription_id, "
@@ -296,7 +296,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
             elif provider == "google_chat":
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider) "
-                    "VALUES (%s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "timestamp = CURRENT_TIMESTAMP, "
@@ -309,7 +309,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
@@ -328,7 +328,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id, email, client_id) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -345,7 +345,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_id) "
-                    "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_id = EXCLUDED.subscription_id, "
@@ -361,20 +361,21 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 user_email = token_data.get("user_email") if isinstance(token_data, dict) else None
 
                 cursor.execute(
-                    "INSERT INTO user_tokens (user_id, secret_ref, provider, subscription_id, subscription_name, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_id, subscription_name, email) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
+                    "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_id = EXCLUDED.subscription_id, "
                     "subscription_name = EXCLUDED.subscription_name, "
                     "email = EXCLUDED.email, "
                     "timestamp = CURRENT_TIMESTAMP, "
                     "is_active = TRUE",
-                    (user_id, secret_ref, provider, site_id, site_name, user_email)
+                    (user_id, request_org_id, secret_ref, provider, site_id, site_name, user_email)
                 )
             elif provider == "bitbucket_workspace_selection":
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider) "
-                    "VALUES (%s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "timestamp = CURRENT_TIMESTAMP, "
@@ -387,14 +388,15 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
                 auth_type = token_data.get("auth_type", "token") if isinstance(token_data, dict) else None
 
                 cursor.execute(
-                    "INSERT INTO user_tokens (user_id, secret_ref, provider, client_id, subscription_name) "
-                    "VALUES (%s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, client_id, subscription_name) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
+                    "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "client_id = EXCLUDED.client_id, "
                     "subscription_name = EXCLUDED.subscription_name, "
                     "timestamp = CURRENT_TIMESTAMP, "
                     "is_active = TRUE",
-                    (user_id, secret_ref, provider, base_url, auth_type)
+                    (user_id, request_org_id, secret_ref, provider, base_url, auth_type)
                 )
             elif provider == "newrelic":
                 account_id_val = token_data.get("account_id") if isinstance(token_data, dict) else None
@@ -404,7 +406,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
 
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_id, subscription_name, client_id, email) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_id = EXCLUDED.subscription_id, "
@@ -418,7 +420,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
             elif subscription_name is not None and subscription_id is not None:
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider, subscription_name, subscription_id) "
-                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "subscription_name = EXCLUDED.subscription_name, "
@@ -430,7 +432,7 @@ def store_tokens_in_db(user_id: str, token_data: Dict, provider: str,
             else:
                 cursor.execute(
                     "INSERT INTO user_tokens (user_id, org_id, secret_ref, provider) "
-                    "VALUES (%s, %s, %s, %s) ON CONFLICT (user_id, provider) DO UPDATE "
+                    "VALUES (%s, %s, %s, %s) ON CONFLICT (org_id, provider) DO UPDATE "
                     "SET secret_ref = EXCLUDED.secret_ref, "
                     "org_id = COALESCE(EXCLUDED.org_id, user_tokens.org_id), "
                     "timestamp = CURRENT_TIMESTAMP, "

--- a/server/utils/auth/token_refresh.py
+++ b/server/utils/auth/token_refresh.py
@@ -5,6 +5,7 @@ import requests
 import boto3
 import os
 from utils.auth.token_management import get_token_data, store_tokens_in_db
+from utils.secrets.secret_ref_utils import get_token_owner_id
 
 # GCP OAuth2 constants
 TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -69,7 +70,12 @@ def refresh_token_if_needed(user_id, provider):
             token_data['expires_at'] = current_time + new_token_data['expires_in']
             token_data['refresh_token'] = token_data.get('refresh_token')  # Keep the existing one
 
-            store_tokens_in_db(user_id, token_data, provider)
+            # Always write back under the token owner's user_id. When credentials
+            # are org-shared, user_id may belong to an org member who didn't
+            # originally connect the provider. Writing under their ID would
+            # create a duplicate row and break SA identity resolution for GCP.
+            owner_id = get_token_owner_id(user_id, provider)
+            store_tokens_in_db(owner_id, token_data, provider)
             logging.info(f"{provider.upper()} token refreshed successfully")
 
         return token_data

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -313,7 +313,7 @@ def initialize_tables():
                         session_data JSONB,
                         last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         is_active BOOLEAN DEFAULT true,
-                        UNIQUE(user_id, provider)
+                        UNIQUE(org_id, provider)
                     );
                 """,
                 "github_connected_repos": """
@@ -1459,6 +1459,56 @@ def initialize_tables():
                 conn.commit()
             except Exception as e:
                 logging.warning(f"Error adding stateless columns to user_tokens: {e}")
+                conn.rollback()
+
+            # Migration: replace per-user unique constraint with per-org unique constraint on
+            # user_tokens so that an org shares one credential row per provider.
+            try:
+                cursor.execute("""
+                    DO $$
+                    BEGIN
+                        -- Deduplicate any existing rows with the same (org_id, provider) before
+                        -- adding the constraint. Keep the most recently updated row per pair and
+                        -- delete the rest. This handles prod data that violated the old invariant.
+                        DELETE FROM user_tokens
+                        WHERE id IN (
+                            SELECT id FROM (
+                                SELECT id,
+                                       ROW_NUMBER() OVER (
+                                           PARTITION BY org_id, provider
+                                           ORDER BY COALESCE(last_activity, timestamp) DESC
+                                       ) AS rn
+                                FROM user_tokens
+                                WHERE org_id IS NOT NULL
+                            ) ranked
+                            WHERE rn > 1
+                        );
+
+                        -- Drop the old per-user constraint if it still exists
+                        IF EXISTS (
+                            SELECT 1 FROM pg_constraint
+                            WHERE conname = 'user_tokens_user_id_provider_key'
+                              AND conrelid = 'user_tokens'::regclass
+                        ) THEN
+                            ALTER TABLE user_tokens DROP CONSTRAINT user_tokens_user_id_provider_key;
+                        END IF;
+
+                        -- Add the new per-org constraint if it doesn't exist yet
+                        IF NOT EXISTS (
+                            SELECT 1 FROM pg_constraint
+                            WHERE conname = 'user_tokens_org_id_provider_key'
+                              AND conrelid = 'user_tokens'::regclass
+                        ) THEN
+                            ALTER TABLE user_tokens ADD CONSTRAINT user_tokens_org_id_provider_key
+                                UNIQUE (org_id, provider);
+                        END IF;
+                    END
+                    $$;
+                """)
+                logging.info("Migrated user_tokens unique constraint to (org_id, provider).")
+                conn.commit()
+            except Exception as e:
+                logging.warning(f"Error migrating user_tokens unique constraint: {e}")
                 conn.rollback()
 
             # Migration: Add ui_state column to chat_sessions if it doesn't exist

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -313,7 +313,7 @@ def initialize_tables():
                         session_data JSONB,
                         last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         is_active BOOLEAN DEFAULT true,
-                        UNIQUE(org_id, provider)
+                        UNIQUE NULLS NOT DISTINCT (org_id, provider)
                     );
                 """,
                 "github_connected_repos": """
@@ -1464,12 +1464,51 @@ def initialize_tables():
             # Migration: replace per-user unique constraint with per-org unique constraint on
             # user_tokens so that an org shares one credential row per provider.
             try:
+                # Step 1: collect secret_refs of rows that will be removed by deduplication
+                # so their Vault entries can be cleaned up before the rows are deleted.
+                orphaned_refs = []
+                try:
+                    cursor.execute("""
+                        SELECT secret_ref FROM user_tokens
+                        WHERE id IN (
+                            SELECT id FROM (
+                                SELECT id,
+                                       ROW_NUMBER() OVER (
+                                           PARTITION BY org_id, provider
+                                           ORDER BY COALESCE(last_activity, timestamp) DESC
+                                       ) AS rn
+                                FROM user_tokens
+                            ) ranked
+                            WHERE rn > 1
+                        ) AND secret_ref IS NOT NULL
+                    """)
+                    orphaned_refs = [row[0] for row in cursor.fetchall() if row[0]]
+                except Exception as e:
+                    logging.warning(f"Could not collect orphaned secret_refs before dedup: {e}")
+
+                # Step 2: delete orphaned Vault secrets before removing DB rows
+                if orphaned_refs:
+                    try:
+                        from utils.secrets.secret_ref_utils import SecretRefManager
+                        sm = SecretRefManager()
+                        for ref in orphaned_refs:
+                            try:
+                                sm.delete_secret(ref)
+                            except Exception as ref_err:
+                                logging.warning(f"Failed to delete orphaned Vault secret: {ref_err}")
+                        logging.info(
+                            "Cleaned up %d orphaned Vault secret(s) before deduplication.",
+                            len(orphaned_refs),
+                        )
+                    except Exception as e:
+                        logging.warning(f"Could not clean up orphaned Vault secrets: {e}")
+
+                # Step 3: dedup rows and swap the unique constraint.
+                # NULLS NOT DISTINCT (PG ≥ 15) makes (NULL, provider) a unique key, so
+                # the dedup runs over ALL rows — not only those with a non-NULL org_id.
                 cursor.execute("""
                     DO $$
                     BEGIN
-                        -- Deduplicate any existing rows with the same (org_id, provider) before
-                        -- adding the constraint. Keep the most recently updated row per pair and
-                        -- delete the rest. This handles prod data that violated the old invariant.
                         DELETE FROM user_tokens
                         WHERE id IN (
                             SELECT id FROM (
@@ -1479,7 +1518,6 @@ def initialize_tables():
                                            ORDER BY COALESCE(last_activity, timestamp) DESC
                                        ) AS rn
                                 FROM user_tokens
-                                WHERE org_id IS NOT NULL
                             ) ranked
                             WHERE rn > 1
                         );
@@ -1493,14 +1531,15 @@ def initialize_tables():
                             ALTER TABLE user_tokens DROP CONSTRAINT user_tokens_user_id_provider_key;
                         END IF;
 
-                        -- Add the new per-org constraint if it doesn't exist yet
+                        -- Add the new per-org constraint if it doesn't exist yet.
+                        -- NULLS NOT DISTINCT ensures (NULL, provider) is also unique.
                         IF NOT EXISTS (
                             SELECT 1 FROM pg_constraint
                             WHERE conname = 'user_tokens_org_id_provider_key'
                               AND conrelid = 'user_tokens'::regclass
                         ) THEN
                             ALTER TABLE user_tokens ADD CONSTRAINT user_tokens_org_id_provider_key
-                                UNIQUE (org_id, provider);
+                                UNIQUE NULLS NOT DISTINCT (org_id, provider);
                         END IF;
                     END
                     $$;

--- a/server/utils/db/org_scope.py
+++ b/server/utils/db/org_scope.py
@@ -1,0 +1,66 @@
+"""
+Org-scoped SQL predicate helpers.
+
+Provides two public utilities used wherever a database query must match rows
+belonging to the requesting user OR any row shared across their org:
+
+    resolve_org(user_id)  →  org_id string or None
+    org_read_predicate(user_id, org_id)  →  (sql_fragment, params_tuple)
+
+Security note
+-------------
+``org_read_predicate`` validates both IDs as well-formed UUIDs before they
+are placed into query parameters.  This breaks the SQL-injection taint chain
+for static analysis tools (e.g. CodeQL) even though psycopg2 parameterized
+queries already prevent execution-level injection.  Do NOT bypass this
+validation by calling ``_validate_uuid`` directly and constructing your own
+predicate — always go through ``org_read_predicate``.
+"""
+
+import uuid as _uuid
+from typing import Optional, Tuple
+
+
+def _validate_uuid(value: str, label: str) -> str:
+    """Return the canonical UUID string for *value*, raising ValueError if malformed."""
+    try:
+        return str(_uuid.UUID(str(value)))
+    except (ValueError, AttributeError):
+        raise ValueError(f"Invalid {label} format") from None
+
+
+def resolve_org(user_id: str) -> Optional[str]:
+    """Best-effort org_id resolution for use in database queries.
+
+    Wraps ``stateless_auth.resolve_org_id`` and swallows all exceptions so
+    that callers can safely fall back to user-only scoping when org resolution
+    is unavailable (e.g. during Celery tasks before RLS context is set).
+    """
+    try:
+        from utils.auth.stateless_auth import resolve_org_id
+        return resolve_org_id(user_id)
+    except Exception:
+        return None
+
+
+def org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
+    """Build a SQL WHERE predicate that matches the requesting user OR their org.
+
+    Both *user_id* and *org_id* are validated as well-formed UUIDs before
+    being placed into the returned parameter tuple, breaking the taint chain
+    from user-supplied input.
+
+    Returns a ``(sql_fragment, params)`` pair for direct use in a WHERE
+    clause::
+
+        predicate, params = org_read_predicate(user_id, org_id)
+        cursor.execute(f"SELECT ... FROM t WHERE {predicate} AND ...", params + (...,))
+
+    When *org_id* is ``None`` or empty the predicate narrows to
+    ``user_id = %s`` only (single-param tuple).
+    """
+    safe_user_id = _validate_uuid(user_id, "user_id")
+    if org_id:
+        safe_org_id = _validate_uuid(org_id, "org_id")
+        return "(user_id = %s OR org_id = %s)", (safe_user_id, safe_org_id)
+    return "user_id = %s", (safe_user_id,)

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -7,9 +7,9 @@ Vault instead of storing actual token data in the database.
 
 import logging
 import json
+import uuid as _uuid
 from typing import TYPE_CHECKING, Optional, Dict, Any, Set, Tuple
 
-from psycopg2 import sql as pgsql
 from utils.db.db_utils import connect_to_db_as_admin
 from utils.auth.stateless_auth import set_rls_context
 from utils.log_sanitizer import safe_provider
@@ -81,19 +81,37 @@ def _resolve_org(user_id: str) -> Optional[str]:
         return None
 
 
-def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[pgsql.SQL, Tuple]:
+def _validate_uuid(value: str, label: str) -> str:
+    """Validate that value is a well-formed UUID before use in SQL.
+
+    This sanitizes user-supplied IDs so taint-analysis tools can confirm
+    that only structurally valid values reach database queries.
+    Raises ValueError if the format is invalid.
+    """
+    try:
+        _uuid.UUID(str(value))
+    except (ValueError, AttributeError):
+        raise ValueError(f"Invalid {label} format: {value!r}")
+    return str(value)
+
+
+def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
     """SQL predicate for all credential queries: match the requesting user OR
     any row belonging to their org.  Every user belongs to an org and there is
     exactly one credential row per provider per org, so this predicate is used
     for reads, writes, updates, and deletes alike.
 
-    Returns (sql_fragment, params) where sql_fragment is a psycopg2.sql.SQL
-    object for safe query composition.  Use as:
-        ``sql.SQL("... WHERE {} AND ...").format(predicate)``
+    Both user_id and org_id are validated as UUIDs before being placed into
+    the query parameters, breaking the taint chain from user-supplied input.
+
+    Returns (sql_fragment, params) for use in a WHERE clause, e.g.:
+        ``f"... WHERE {predicate} AND provider = %s"``
     """
+    safe_user_id = _validate_uuid(user_id, "user_id")
     if org_id:
-        return pgsql.SQL("(user_id = %s OR org_id = %s)"), (user_id, org_id)
-    return pgsql.SQL("user_id = %s"), (user_id,)
+        safe_org_id = _validate_uuid(org_id, "org_id")
+        return "(user_id = %s OR org_id = %s)", (safe_user_id, safe_org_id)
+    return "user_id = %s", (safe_user_id,)
 
 
 class SecretRefManager:
@@ -168,8 +186,8 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:updateToken]")
             cursor.execute(
-                pgsql.SQL("UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
-                          "WHERE {} AND provider = %s").format(predicate),
+                f"UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
+                f"WHERE {predicate} AND provider = %s",
                 (secret_ref,) + pred_params + (provider,),
             )
             if cursor.rowcount > 0:
@@ -204,12 +222,12 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:hasCreds]")
             cursor.execute(
-                pgsql.SQL("""SELECT 1 FROM user_tokens
-                   WHERE {}
+                f"""SELECT 1 FROM user_tokens
+                   WHERE {predicate}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                   LIMIT 1""").format(predicate),
+                   LIMIT 1""",
                 (*pred_params, provider_base),
             )
             return cursor.fetchone() is not None
@@ -238,13 +256,13 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:getToken]")
             cursor.execute(
-                pgsql.SQL("""SELECT secret_ref, client_id, client_secret
+                f"""SELECT secret_ref, client_id, client_secret
                    FROM user_tokens
-                   WHERE {}
+                   WHERE {predicate}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                   LIMIT 1""").format(predicate),
+                   LIMIT 1""",
                 (*pred_params, provider_base),
             )
 
@@ -310,8 +328,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:migrate]")
 
             cursor.execute(
-                pgsql.SQL("SELECT token_data FROM user_tokens "
-                          "WHERE {} AND provider = %s AND secret_ref IS NULL").format(predicate),
+                f"SELECT token_data FROM user_tokens "
+                f"WHERE {predicate} AND provider = %s AND secret_ref IS NULL",
                 pred_params + (provider,),
             )
 
@@ -328,8 +346,8 @@ class SecretRefManager:
             secret_ref = self.store_secret(secret_name, token_json)
 
             cursor.execute(
-                pgsql.SQL("UPDATE user_tokens SET secret_ref = %s "
-                          "WHERE {} AND provider = %s").format(predicate),
+                f"UPDATE user_tokens SET secret_ref = %s "
+                f"WHERE {predicate} AND provider = %s",
                 (secret_ref,) + pred_params + (provider,),
             )
 
@@ -363,8 +381,8 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:clearRef]")
             cursor.execute(
-                pgsql.SQL("UPDATE user_tokens SET is_active = FALSE, secret_ref = NULL "
-                          "WHERE {} AND provider = %s").format(predicate),
+                f"UPDATE user_tokens SET is_active = FALSE, secret_ref = NULL "
+                f"WHERE {predicate} AND provider = %s",
                 (*pred_params, provider),
             )
             conn.commit()
@@ -402,8 +420,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:deleteSecret]")
 
             cursor.execute(
-                pgsql.SQL("SELECT secret_ref FROM user_tokens "
-                          "WHERE {} AND provider = %s AND secret_ref IS NOT NULL").format(predicate),
+                f"SELECT secret_ref FROM user_tokens "
+                f"WHERE {predicate} AND provider = %s AND secret_ref IS NOT NULL",
                 (*pred_params, provider),
             )
             for row in cursor.fetchall():
@@ -412,7 +430,7 @@ class SecretRefManager:
                     delete_success = False
 
             cursor.execute(
-                pgsql.SQL("DELETE FROM user_tokens WHERE {} AND provider = %s").format(predicate),
+                f"DELETE FROM user_tokens WHERE {predicate} AND provider = %s",
                 (*pred_params, provider),
             )
             deleted_rows = cursor.rowcount
@@ -470,13 +488,13 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:tokenOwner]")
         cursor.execute(
-            pgsql.SQL("""SELECT user_id FROM user_tokens
-               WHERE {}
+            f"""SELECT user_id FROM user_tokens
+               WHERE {predicate}
                  AND provider = %s
                  AND secret_ref IS NOT NULL
                  AND is_active = TRUE
                ORDER BY (org_id IS NOT NULL) DESC, created_at DESC
-               LIMIT 1""").format(predicate),
+               LIMIT 1""",
             (*pred_params, provider_base),
         )
         row = cursor.fetchone()

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -81,26 +81,16 @@ def _resolve_org(user_id: str) -> Optional[str]:
 
 
 def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
-    """SQL predicate for credential reads: match the requesting user OR any row
-    shared with their org.  This is an OR-based scope so that org members can
-    retrieve tokens stored by any other member in the same org.
+    """SQL predicate for all credential queries: match the requesting user OR
+    any row belonging to their org.  Every user belongs to an org and there is
+    exactly one credential row per provider per org, so this predicate is used
+    for reads, writes, updates, and deletes alike.
 
-    Returns (sql_fragment, params) intended for use as the first condition in a
-    WHERE clause, e.g. ``WHERE {predicate} AND provider = %s``.
+    Returns (sql_fragment, params) for use as the first condition in a WHERE
+    clause, e.g. ``WHERE {predicate} AND provider = %s``.
     """
     if org_id:
         return "(user_id = %s OR org_id = %s)", (user_id, org_id)
-    return "user_id = %s", (user_id,)
-
-
-def _org_write_filter(user_id: str) -> Tuple[str, Tuple]:
-    """SQL filter for credential writes/updates/deletes: restrict to the
-    requesting user's own row only.
-
-    Writes must never silently touch another org member's row.  Use this for
-    UPDATE and the migration SELECT that locates the row to mutate.
-    Returns (sql_fragment, params) for use in a WHERE clause.
-    """
     return "user_id = %s", (user_id,)
 
 
@@ -167,7 +157,8 @@ class SecretRefManager:
 
     def update_user_token_with_secret_ref(self, user_id: str, provider: str, secret_ref: str) -> bool:
         """Update a user's token record to point at a Vault secret reference."""
-        write_filter, write_params = _org_write_filter(user_id)
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -176,8 +167,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:updateToken]")
             cursor.execute(
                 f"UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
-                f"WHERE {write_filter} AND provider = %s",
-                (secret_ref,) + write_params + (provider,),
+                f"WHERE {predicate} AND provider = %s",
+                (secret_ref,) + pred_params + (provider,),
             )
             if cursor.rowcount > 0:
                 conn.commit()
@@ -251,9 +242,8 @@ class SecretRefManager:
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                   ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END
                    LIMIT 1""",
-                (*pred_params, provider_base, user_id),
+                (*pred_params, provider_base),
             )
 
             result = cursor.fetchone()
@@ -308,7 +298,8 @@ class SecretRefManager:
 
     def migrate_token_to_secret_ref(self, user_id: str, provider: str, secret_name_prefix: str = "aurora-dev") -> bool:
         """Migrate an existing token from token_data column to Vault."""
-        write_filter, write_params = _org_write_filter(user_id)
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -318,8 +309,8 @@ class SecretRefManager:
 
             cursor.execute(
                 f"SELECT token_data FROM user_tokens "
-                f"WHERE {write_filter} AND provider = %s AND secret_ref IS NULL",
-                write_params + (provider,),
+                f"WHERE {predicate} AND provider = %s AND secret_ref IS NULL",
+                pred_params + (provider,),
             )
 
             result = cursor.fetchone()
@@ -336,8 +327,8 @@ class SecretRefManager:
 
             cursor.execute(
                 f"UPDATE user_tokens SET secret_ref = %s "
-                f"WHERE {write_filter} AND provider = %s",
-                (secret_ref,) + write_params + (provider,),
+                f"WHERE {predicate} AND provider = %s",
+                (secret_ref,) + pred_params + (provider,),
             )
 
             conn.commit()
@@ -482,9 +473,8 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
                  AND provider = %s
                  AND secret_ref IS NOT NULL
                  AND is_active = TRUE
-               ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END
                LIMIT 1""",
-            (*pred_params, provider_base, user_id),
+            (*pred_params, provider_base),
         )
         row = cursor.fetchone()
         return row[0] if row else user_id

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -7,12 +7,12 @@ Vault instead of storing actual token data in the database.
 
 import logging
 import json
-import uuid as _uuid
 from typing import TYPE_CHECKING, Optional, Dict, Any, Set, Tuple
 
 from utils.db.db_utils import connect_to_db_as_admin
 from utils.auth.stateless_auth import set_rls_context
 from utils.log_sanitizer import safe_provider
+from utils.db.org_scope import resolve_org, org_read_predicate
 from utils.secrets.secret_cache import (
     get_cached_secret,
     update_secret_cache,
@@ -72,47 +72,10 @@ SUPPORTED_SECRET_PROVIDERS: Set[str] = {
 }
 
 
-def _resolve_org(user_id: str) -> Optional[str]:
-    """Best-effort org_id resolution for use in admin-connection queries."""
-    try:
-        from utils.auth.stateless_auth import resolve_org_id
-        return resolve_org_id(user_id)
-    except Exception:
-        return None
-
-
-def _validate_uuid(value: str, label: str) -> str:
-    """Validate that value is a well-formed UUID before use in SQL.
-
-    Returns the canonical string form of the UUID (always lowercase, standard
-    hyphenated format). This both validates the input and produces a value
-    derived from a uuid.UUID object rather than from the raw user input,
-    which breaks the taint chain for static analysis tools such as CodeQL.
-    Raises ValueError if the format is invalid.
-    """
-    try:
-        return str(_uuid.UUID(str(value)))
-    except (ValueError, AttributeError):
-        raise ValueError(f"Invalid {label} format") from None
-
-
-def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
-    """SQL predicate for all credential queries: match the requesting user OR
-    any row belonging to their org.  Every user belongs to an org and there is
-    exactly one credential row per provider per org, so this predicate is used
-    for reads, writes, updates, and deletes alike.
-
-    Both user_id and org_id are validated as UUIDs before being placed into
-    the query parameters, breaking the taint chain from user-supplied input.
-
-    Returns (sql_fragment, params) for use in a WHERE clause, e.g.:
-        ``f"... WHERE {predicate} AND provider = %s"``
-    """
-    safe_user_id = _validate_uuid(user_id, "user_id")
-    if org_id:
-        safe_org_id = _validate_uuid(org_id, "org_id")
-        return "(user_id = %s OR org_id = %s)", (safe_user_id, safe_org_id)
-    return "user_id = %s", (safe_user_id,)
+# Deprecated aliases kept for any external callers that still import the
+# private names.  Prefer importing from utils.db.org_scope directly.
+_resolve_org = resolve_org
+_org_read_predicate = org_read_predicate
 
 
 class SecretRefManager:
@@ -178,8 +141,8 @@ class SecretRefManager:
 
     def update_user_token_with_secret_ref(self, user_id: str, provider: str, secret_ref: str) -> bool:
         """Update a user's token record to point at a Vault secret reference."""
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -214,8 +177,8 @@ class SecretRefManager:
         if provider_base not in SUPPORTED_SECRET_PROVIDERS:
             return False
 
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -247,8 +210,8 @@ class SecretRefManager:
         if provider_base not in SUPPORTED_SECRET_PROVIDERS:
             return None
 
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
 
@@ -319,8 +282,8 @@ class SecretRefManager:
 
     def migrate_token_to_secret_ref(self, user_id: str, provider: str, secret_name_prefix: str = "aurora-dev") -> bool:
         """Migrate an existing token from token_data column to Vault."""
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -372,9 +335,9 @@ class SecretRefManager:
     # ------------------------------------------------------------------
 
     def _clear_secret_ref(self, user_id: str, provider: str) -> None:
-        """Set secret_ref to NULL for the org-visible row for provider (stale reference cleanup)."""
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        """Set secret_ref to NULL for the org's row for provider (stale reference cleanup)."""
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -407,8 +370,8 @@ class SecretRefManager:
         Deleting the shared row removes access for all org members, which is the
         correct outcome — the credential no longer exists for the org.
         """
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         delete_success = True
@@ -480,8 +443,8 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
     Falls back to the requesting user_id if no row is found or the lookup fails.
     """
     provider_base = provider.lower().split('_')[0]
-    org_id = _resolve_org(user_id)
-    predicate, pred_params = _org_read_predicate(user_id, org_id)
+    org_id = resolve_org(user_id)
+    predicate, pred_params = org_read_predicate(user_id, org_id)
     conn = None
     cursor = None
     try:

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -72,12 +72,6 @@ SUPPORTED_SECRET_PROVIDERS: Set[str] = {
 }
 
 
-# Deprecated aliases kept for any external callers that still import the
-# private names.  Prefer importing from utils.db.org_scope directly.
-_resolve_org = resolve_org
-_org_read_predicate = org_read_predicate
-
-
 class SecretRefManager:
     """Manager for handling secret references in the database.
 

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -9,6 +9,7 @@ import logging
 import json
 from typing import TYPE_CHECKING, Optional, Dict, Any, Set, Tuple
 
+from psycopg2 import sql as pgsql
 from utils.db.db_utils import connect_to_db_as_admin
 from utils.auth.stateless_auth import set_rls_context
 from utils.log_sanitizer import safe_provider
@@ -80,18 +81,19 @@ def _resolve_org(user_id: str) -> Optional[str]:
         return None
 
 
-def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
+def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[pgsql.SQL, Tuple]:
     """SQL predicate for all credential queries: match the requesting user OR
     any row belonging to their org.  Every user belongs to an org and there is
     exactly one credential row per provider per org, so this predicate is used
     for reads, writes, updates, and deletes alike.
 
-    Returns (sql_fragment, params) for use as the first condition in a WHERE
-    clause, e.g. ``WHERE {predicate} AND provider = %s``.
+    Returns (sql_fragment, params) where sql_fragment is a psycopg2.sql.SQL
+    object for safe query composition.  Use as:
+        ``sql.SQL("... WHERE {} AND ...").format(predicate)``
     """
     if org_id:
-        return "(user_id = %s OR org_id = %s)", (user_id, org_id)
-    return "user_id = %s", (user_id,)
+        return pgsql.SQL("(user_id = %s OR org_id = %s)"), (user_id, org_id)
+    return pgsql.SQL("user_id = %s"), (user_id,)
 
 
 class SecretRefManager:
@@ -166,8 +168,8 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:updateToken]")
             cursor.execute(
-                f"UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
-                f"WHERE {predicate} AND provider = %s",
+                pgsql.SQL("UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
+                          "WHERE {} AND provider = %s").format(predicate),
                 (secret_ref,) + pred_params + (provider,),
             )
             if cursor.rowcount > 0:
@@ -202,12 +204,12 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:hasCreds]")
             cursor.execute(
-                f"""SELECT 1 FROM user_tokens
-                   WHERE {predicate}
+                pgsql.SQL("""SELECT 1 FROM user_tokens
+                   WHERE {}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                   LIMIT 1""",
+                   LIMIT 1""").format(predicate),
                 (*pred_params, provider_base),
             )
             return cursor.fetchone() is not None
@@ -236,13 +238,13 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:getToken]")
             cursor.execute(
-                f"""SELECT secret_ref, client_id, client_secret
+                pgsql.SQL("""SELECT secret_ref, client_id, client_secret
                    FROM user_tokens
-                   WHERE {predicate}
+                   WHERE {}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                   LIMIT 1""",
+                   LIMIT 1""").format(predicate),
                 (*pred_params, provider_base),
             )
 
@@ -308,8 +310,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:migrate]")
 
             cursor.execute(
-                f"SELECT token_data FROM user_tokens "
-                f"WHERE {predicate} AND provider = %s AND secret_ref IS NULL",
+                pgsql.SQL("SELECT token_data FROM user_tokens "
+                          "WHERE {} AND provider = %s AND secret_ref IS NULL").format(predicate),
                 pred_params + (provider,),
             )
 
@@ -326,8 +328,8 @@ class SecretRefManager:
             secret_ref = self.store_secret(secret_name, token_json)
 
             cursor.execute(
-                f"UPDATE user_tokens SET secret_ref = %s "
-                f"WHERE {predicate} AND provider = %s",
+                pgsql.SQL("UPDATE user_tokens SET secret_ref = %s "
+                          "WHERE {} AND provider = %s").format(predicate),
                 (secret_ref,) + pred_params + (provider,),
             )
 
@@ -361,8 +363,8 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:clearRef]")
             cursor.execute(
-                f"UPDATE user_tokens SET is_active = FALSE, secret_ref = NULL "
-                f"WHERE {predicate} AND provider = %s",
+                pgsql.SQL("UPDATE user_tokens SET is_active = FALSE, secret_ref = NULL "
+                          "WHERE {} AND provider = %s").format(predicate),
                 (*pred_params, provider),
             )
             conn.commit()
@@ -400,8 +402,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:deleteSecret]")
 
             cursor.execute(
-                f"SELECT secret_ref FROM user_tokens "
-                f"WHERE {predicate} AND provider = %s AND secret_ref IS NOT NULL",
+                pgsql.SQL("SELECT secret_ref FROM user_tokens "
+                          "WHERE {} AND provider = %s AND secret_ref IS NOT NULL").format(predicate),
                 (*pred_params, provider),
             )
             for row in cursor.fetchall():
@@ -410,7 +412,7 @@ class SecretRefManager:
                     delete_success = False
 
             cursor.execute(
-                f"DELETE FROM user_tokens WHERE {predicate} AND provider = %s",
+                pgsql.SQL("DELETE FROM user_tokens WHERE {} AND provider = %s").format(predicate),
                 (*pred_params, provider),
             )
             deleted_rows = cursor.rowcount
@@ -468,13 +470,13 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:tokenOwner]")
         cursor.execute(
-            f"""SELECT user_id FROM user_tokens
-               WHERE {predicate}
+            pgsql.SQL("""SELECT user_id FROM user_tokens
+               WHERE {}
                  AND provider = %s
                  AND secret_ref IS NOT NULL
                  AND is_active = TRUE
                ORDER BY (org_id IS NOT NULL) DESC, created_at DESC
-               LIMIT 1""",
+               LIMIT 1""").format(predicate),
             (*pred_params, provider_base),
         )
         row = cursor.fetchone()

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -93,7 +93,7 @@ def _validate_uuid(value: str, label: str) -> str:
     try:
         return str(_uuid.UUID(str(value)))
     except (ValueError, AttributeError):
-        raise ValueError(f"Invalid {label} format: {value!r}")
+        raise ValueError(f"Invalid {label} format") from None
 
 
 def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
@@ -494,7 +494,7 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
                  AND provider = %s
                  AND secret_ref IS NOT NULL
                  AND is_active = TRUE
-               ORDER BY (org_id IS NOT NULL) DESC, created_at DESC
+               ORDER BY (org_id IS NOT NULL) DESC, timestamp DESC
                LIMIT 1""",
             (*pred_params, provider_base),
         )

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -80,16 +80,28 @@ def _resolve_org(user_id: str) -> Optional[str]:
         return None
 
 
-def _org_clause(org_id: Optional[str]) -> Tuple[str, Tuple]:
-    """Build a reusable SQL fragment for org-scoped token queries.
+def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:
+    """SQL predicate for credential reads: match the requesting user OR any row
+    shared with their org.  This is an OR-based scope so that org members can
+    retrieve tokens stored by any other member in the same org.
 
-    Returns (sql_fragment, params) to append to a WHERE clause.
-    When org_id is available the fragment restricts to matching rows;
-    otherwise it returns an always-true fragment so the query still works.
+    Returns (sql_fragment, params) intended for use as the first condition in a
+    WHERE clause, e.g. ``WHERE {predicate} AND provider = %s``.
     """
     if org_id:
-        return "AND (org_id = %s OR org_id IS NULL)", (org_id,)
-    return "", ()
+        return "(user_id = %s OR org_id = %s)", (user_id, org_id)
+    return "user_id = %s", (user_id,)
+
+
+def _org_write_filter(user_id: str) -> Tuple[str, Tuple]:
+    """SQL filter for credential writes/updates/deletes: restrict to the
+    requesting user's own row only.
+
+    Writes must never silently touch another org member's row.  Use this for
+    UPDATE and the migration SELECT that locates the row to mutate.
+    Returns (sql_fragment, params) for use in a WHERE clause.
+    """
+    return "user_id = %s", (user_id,)
 
 
 class SecretRefManager:
@@ -155,8 +167,7 @@ class SecretRefManager:
 
     def update_user_token_with_secret_ref(self, user_id: str, provider: str, secret_ref: str) -> bool:
         """Update a user's token record to point at a Vault secret reference."""
-        org_id = _resolve_org(user_id)
-        clause, params = _org_clause(org_id)
+        write_filter, write_params = _org_write_filter(user_id)
         conn = None
         cursor = None
         try:
@@ -165,8 +176,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:updateToken]")
             cursor.execute(
                 f"UPDATE user_tokens SET secret_ref = %s, is_active = TRUE "
-                f"WHERE user_id = %s AND provider = %s {clause}",
-                (secret_ref, user_id, provider) + params,
+                f"WHERE {write_filter} AND provider = %s",
+                (secret_ref,) + write_params + (provider,),
             )
             if cursor.rowcount > 0:
                 conn.commit()
@@ -192,7 +203,7 @@ class SecretRefManager:
             return False
 
         org_id = _resolve_org(user_id)
-        clause, params = _org_clause(org_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -201,13 +212,12 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:hasCreds]")
             cursor.execute(
                 f"""SELECT 1 FROM user_tokens
-                   WHERE user_id = %s
+                   WHERE {predicate}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                     {clause}
                    LIMIT 1""",
-                (user_id, provider_base, *params),
+                (*pred_params, provider_base),
             )
             return cursor.fetchone() is not None
         except Exception as e:
@@ -226,10 +236,10 @@ class SecretRefManager:
             return None
 
         org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
 
-        clause, clause_params = _org_clause(org_id)
         try:
             conn = connect_to_db_as_admin()
             cursor = conn.cursor()
@@ -237,14 +247,13 @@ class SecretRefManager:
             cursor.execute(
                 f"""SELECT secret_ref, client_id, client_secret
                    FROM user_tokens
-                   WHERE user_id = %s
+                   WHERE {predicate}
                      AND provider = %s
                      AND secret_ref IS NOT NULL
                      AND is_active = TRUE
-                     {clause}
                    ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END
                    LIMIT 1""",
-                (user_id, provider_base, *clause_params, user_id),
+                (*pred_params, provider_base, user_id),
             )
 
             result = cursor.fetchone()
@@ -299,8 +308,7 @@ class SecretRefManager:
 
     def migrate_token_to_secret_ref(self, user_id: str, provider: str, secret_name_prefix: str = "aurora-dev") -> bool:
         """Migrate an existing token from token_data column to Vault."""
-        org_id = _resolve_org(user_id)
-        clause, params = _org_clause(org_id)
+        write_filter, write_params = _org_write_filter(user_id)
         conn = None
         cursor = None
         try:
@@ -310,8 +318,8 @@ class SecretRefManager:
 
             cursor.execute(
                 f"SELECT token_data FROM user_tokens "
-                f"WHERE user_id = %s AND provider = %s {clause} AND secret_ref IS NULL",
-                (user_id, provider) + params,
+                f"WHERE {write_filter} AND provider = %s AND secret_ref IS NULL",
+                write_params + (provider,),
             )
 
             result = cursor.fetchone()
@@ -328,8 +336,8 @@ class SecretRefManager:
 
             cursor.execute(
                 f"UPDATE user_tokens SET secret_ref = %s "
-                f"WHERE user_id = %s AND provider = %s {clause}",
-                (secret_ref, user_id, provider) + params,
+                f"WHERE {write_filter} AND provider = %s",
+                (secret_ref,) + write_params + (provider,),
             )
 
             conn.commit()
@@ -353,8 +361,7 @@ class SecretRefManager:
 
     def _clear_secret_ref(self, user_id: str, provider: str) -> None:
         """Set secret_ref to NULL for the given user/provider (stale reference cleanup)."""
-        org_id = _resolve_org(user_id)
-        clause, params = _org_clause(org_id)
+        write_filter, write_params = _org_write_filter(user_id)
         conn = None
         cursor = None
         try:
@@ -363,8 +370,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:clearRef]")
             cursor.execute(
                 f"UPDATE user_tokens SET is_active = FALSE, secret_ref = '' "
-                f"WHERE user_id = %s AND provider = %s {clause}",
-                (user_id, provider) + params,
+                f"WHERE {write_filter} AND provider = %s",
+                write_params + (provider,),
             )
             conn.commit()
             logger.info(
@@ -382,11 +389,15 @@ class SecretRefManager:
     def delete_user_secret(self, user_id: str, provider: str) -> Tuple[bool, int]:
         """Delete a user's secret from Vault and clear its reference from the database.
 
-        Scoping mirrors get_user_token_data: (user_id OR org_id) so that
-        org-shared credentials are also removed and the status check can't
-        fall back to another member's token after disconnect.
+        Scoping: deletes only the requesting user's own row.  This prevents one
+        org member's disconnect from wiping another member's independently-stored
+        credentials for the same provider.
+
+        After deletion, other org members whose only access was via this row will
+        see the provider as disconnected, which is the correct outcome — the
+        credential no longer exists for the org.
         """
-        org_id = _resolve_org(user_id)
+        write_filter, write_params = _org_write_filter(user_id)
         conn = None
         cursor = None
         delete_success = True
@@ -396,18 +407,12 @@ class SecretRefManager:
             conn = connect_to_db_as_admin()
             cursor = conn.cursor()
 
-            resolved_org = set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:deleteSecret]")
-            if resolved_org:
-                scope_where = "(user_id = %s OR org_id = %s)"
-                scope_params: Tuple = (user_id, org_id)
-            else:
-                scope_where = "user_id = %s"
-                scope_params = (user_id,)
+            set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:deleteSecret]")
 
             cursor.execute(
                 f"SELECT secret_ref FROM user_tokens "
-                f"WHERE {scope_where} AND provider = %s AND secret_ref IS NOT NULL",
-                scope_params + (provider,),
+                f"WHERE {write_filter} AND provider = %s AND secret_ref IS NOT NULL",
+                write_params + (provider,),
             )
             for row in cursor.fetchall():
                 if not self.delete_secret(row[0]):
@@ -415,8 +420,8 @@ class SecretRefManager:
                     delete_success = False
 
             cursor.execute(
-                f"DELETE FROM user_tokens WHERE {scope_where} AND provider = %s",
-                scope_params + (provider,),
+                f"DELETE FROM user_tokens WHERE {write_filter} AND provider = %s",
+                write_params + (provider,),
             )
             deleted_rows = cursor.rowcount
             conn.commit()
@@ -450,6 +455,48 @@ def has_user_credentials(user_id: str, provider: str) -> bool:
 def get_user_token_data(user_id: str, provider: str) -> Optional[Dict[str, Any]]:
     """Get user token data, automatically handling secret references."""
     return secret_manager.get_user_token_data(user_id, provider)
+
+
+def get_token_owner_id(user_id: str, provider: str) -> str:
+    """Return the user_id of the row that owns the provider token visible to user_id.
+
+    When credentials are shared within an org the stored row belongs to the
+    user who originally connected the provider (User A), not the requesting
+    user (User B).  Resources derived from that identity — such as GCP service
+    account names that embed a hash of the owner's user_id — must be looked up
+    using the owner's user_id, not the requester's.
+
+    Falls back to the requesting user_id if no row is found or the lookup fails.
+    """
+    provider_base = provider.lower().split('_')[0]
+    org_id = _resolve_org(user_id)
+    predicate, pred_params = _org_read_predicate(user_id, org_id)
+    conn = None
+    cursor = None
+    try:
+        conn = connect_to_db_as_admin()
+        cursor = conn.cursor()
+        set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:tokenOwner]")
+        cursor.execute(
+            f"""SELECT user_id FROM user_tokens
+               WHERE {predicate}
+                 AND provider = %s
+                 AND secret_ref IS NOT NULL
+                 AND is_active = TRUE
+               ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END
+               LIMIT 1""",
+            (*pred_params, provider_base, user_id),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else user_id
+    except Exception as e:
+        logger.debug("get_token_owner_id lookup failed for provider %s: %s", safe_provider(provider), e)
+        return user_id
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
 
 
 def migrate_user_token_to_secret_ref(user_id: str, provider: str) -> bool:

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -84,15 +84,16 @@ def _resolve_org(user_id: str) -> Optional[str]:
 def _validate_uuid(value: str, label: str) -> str:
     """Validate that value is a well-formed UUID before use in SQL.
 
-    This sanitizes user-supplied IDs so taint-analysis tools can confirm
-    that only structurally valid values reach database queries.
+    Returns the canonical string form of the UUID (always lowercase, standard
+    hyphenated format). This both validates the input and produces a value
+    derived from a uuid.UUID object rather than from the raw user input,
+    which breaks the taint chain for static analysis tools such as CodeQL.
     Raises ValueError if the format is invalid.
     """
     try:
-        _uuid.UUID(str(value))
+        return str(_uuid.UUID(str(value)))
     except (ValueError, AttributeError):
         raise ValueError(f"Invalid {label} format: {value!r}")
-    return str(value)
 
 
 def _org_read_predicate(user_id: str, org_id: Optional[str]) -> Tuple[str, Tuple]:

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -361,7 +361,7 @@ class SecretRefManager:
             cursor = conn.cursor()
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:clearRef]")
             cursor.execute(
-                f"UPDATE user_tokens SET is_active = FALSE, secret_ref = '' "
+                f"UPDATE user_tokens SET is_active = FALSE, secret_ref = NULL "
                 f"WHERE {predicate} AND provider = %s",
                 (*pred_params, provider),
             )
@@ -473,6 +473,7 @@ def get_token_owner_id(user_id: str, provider: str) -> str:
                  AND provider = %s
                  AND secret_ref IS NOT NULL
                  AND is_active = TRUE
+               ORDER BY (org_id IS NOT NULL) DESC, created_at DESC
                LIMIT 1""",
             (*pred_params, provider_base),
         )

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -360,8 +360,9 @@ class SecretRefManager:
     # ------------------------------------------------------------------
 
     def _clear_secret_ref(self, user_id: str, provider: str) -> None:
-        """Set secret_ref to NULL for the given user/provider (stale reference cleanup)."""
-        write_filter, write_params = _org_write_filter(user_id)
+        """Set secret_ref to NULL for the org-visible row for provider (stale reference cleanup)."""
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         try:
@@ -370,8 +371,8 @@ class SecretRefManager:
             set_rls_context(cursor, conn, user_id, log_prefix="[SecretRef:clearRef]")
             cursor.execute(
                 f"UPDATE user_tokens SET is_active = FALSE, secret_ref = '' "
-                f"WHERE {write_filter} AND provider = %s",
-                write_params + (provider,),
+                f"WHERE {predicate} AND provider = %s",
+                (*pred_params, provider),
             )
             conn.commit()
             logger.info(
@@ -387,17 +388,15 @@ class SecretRefManager:
                 conn.close()
 
     def delete_user_secret(self, user_id: str, provider: str) -> Tuple[bool, int]:
-        """Delete a user's secret from Vault and clear its reference from the database.
+        """Delete a provider's credentials from Vault and the database for the whole org.
 
-        Scoping: deletes only the requesting user's own row.  This prevents one
-        org member's disconnect from wiping another member's independently-stored
-        credentials for the same provider.
-
-        After deletion, other org members whose only access was via this row will
-        see the provider as disconnected, which is the correct outcome — the
-        credential no longer exists for the org.
+        Scoping uses the org-read predicate (user_id OR org_id) so any authorized
+        org member can disconnect a connector regardless of who originally created it.
+        Deleting the shared row removes access for all org members, which is the
+        correct outcome — the credential no longer exists for the org.
         """
-        write_filter, write_params = _org_write_filter(user_id)
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         conn = None
         cursor = None
         delete_success = True
@@ -411,8 +410,8 @@ class SecretRefManager:
 
             cursor.execute(
                 f"SELECT secret_ref FROM user_tokens "
-                f"WHERE {write_filter} AND provider = %s AND secret_ref IS NOT NULL",
-                write_params + (provider,),
+                f"WHERE {predicate} AND provider = %s AND secret_ref IS NOT NULL",
+                (*pred_params, provider),
             )
             for row in cursor.fetchall():
                 if not self.delete_secret(row[0]):
@@ -420,8 +419,8 @@ class SecretRefManager:
                     delete_success = False
 
             cursor.execute(
-                f"DELETE FROM user_tokens WHERE {write_filter} AND provider = %s",
-                write_params + (provider,),
+                f"DELETE FROM user_tokens WHERE {predicate} AND provider = %s",
+                (*pred_params, provider),
             )
             deleted_rows = cursor.rowcount
             conn.commit()

--- a/server/utils/terminal/terminal_ssh_setup.py
+++ b/server/utils/terminal/terminal_ssh_setup.py
@@ -18,19 +18,16 @@ SSH_PROVIDER_PATTERN = '%_ssh_%'
 
 def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
     """
-    Return all SSH private keys visible to user_id (including org-shared keys),
-    keyed by a readable name: e.g., {"scaleway_4b9511a5": "<private key>"}
+    Return all SSH private keys for a user, keyed by a readable name:
+    e.g., {"scaleway_4b9511a5": "<private key>"}
     """
-    from utils.db.org_scope import resolve_org, org_read_predicate
-    org_id = resolve_org(user_id)
-    predicate, pred_params = org_read_predicate(user_id, org_id)
     ssh_keys: Dict[str, str] = {}
     with db_pool.get_admin_connection() as conn:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetup:_fetch_user_ssh_keys]")
         cursor.execute(
-            f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
-            (*pred_params, SSH_PROVIDER_PATTERN)
+            "SELECT provider FROM user_tokens WHERE user_id = %s AND provider LIKE %s",
+            (user_id, SSH_PROVIDER_PATTERN)
         )
         for row in cursor.fetchall():
             provider = row[0] if isinstance(row, tuple) else row

--- a/server/utils/terminal/terminal_ssh_setup.py
+++ b/server/utils/terminal/terminal_ssh_setup.py
@@ -22,6 +22,7 @@ def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
     keyed by a readable name: e.g., {"scaleway_4b9511a5": "<private key>"}
     """
     from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+    from psycopg2 import sql as pgsql
     org_id = _resolve_org(user_id)
     predicate, pred_params = _org_read_predicate(user_id, org_id)
     ssh_keys: Dict[str, str] = {}
@@ -29,7 +30,7 @@ def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetup:_fetch_user_ssh_keys]")
         cursor.execute(
-            f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
+            pgsql.SQL("SELECT provider FROM user_tokens WHERE {} AND provider LIKE %s").format(predicate),
             (*pred_params, SSH_PROVIDER_PATTERN)
         )
         for row in cursor.fetchall():

--- a/server/utils/terminal/terminal_ssh_setup.py
+++ b/server/utils/terminal/terminal_ssh_setup.py
@@ -22,7 +22,6 @@ def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
     keyed by a readable name: e.g., {"scaleway_4b9511a5": "<private key>"}
     """
     from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-    from psycopg2 import sql as pgsql
     org_id = _resolve_org(user_id)
     predicate, pred_params = _org_read_predicate(user_id, org_id)
     ssh_keys: Dict[str, str] = {}
@@ -30,7 +29,7 @@ def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetup:_fetch_user_ssh_keys]")
         cursor.execute(
-            pgsql.SQL("SELECT provider FROM user_tokens WHERE {} AND provider LIKE %s").format(predicate),
+            f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
             (*pred_params, SSH_PROVIDER_PATTERN)
         )
         for row in cursor.fetchall():

--- a/server/utils/terminal/terminal_ssh_setup.py
+++ b/server/utils/terminal/terminal_ssh_setup.py
@@ -18,24 +18,26 @@ SSH_PROVIDER_PATTERN = '%_ssh_%'
 
 def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
     """
-    Return all SSH private keys for a user, keyed by a readable name:
-    e.g., {"scaleway_4b9511a5": "<private key>", "ovh_abc123": "<private key>"}
+    Return all SSH private keys visible to user_id (including org-shared keys),
+    keyed by a readable name: e.g., {"scaleway_4b9511a5": "<private key>"}
     """
+    from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+    org_id = _resolve_org(user_id)
+    predicate, pred_params = _org_read_predicate(user_id, org_id)
     ssh_keys: Dict[str, str] = {}
     with db_pool.get_admin_connection() as conn:
         cursor = conn.cursor()
         set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetup:_fetch_user_ssh_keys]")
         cursor.execute(
-            "SELECT provider FROM user_tokens WHERE user_id = %s AND provider LIKE %s",
-            (user_id, SSH_PROVIDER_PATTERN)
+            f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
+            (*pred_params, SSH_PROVIDER_PATTERN)
         )
         for row in cursor.fetchall():
             provider = row[0] if isinstance(row, tuple) else row
             try:
                 token_data = get_token_data(user_id, provider)
                 if token_data and "private_key" in token_data:
-                    # provider is like "scaleway_ssh_<vmId>" or "ovh_ssh_<vmId>"
-                    vm_key = provider.replace("_ssh_", "_")  # scaleway_<vmId>
+                    vm_key = provider.replace("_ssh_", "_")
                     ssh_keys[vm_key] = token_data["private_key"]
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(f"Failed to load SSH key for {provider}: {e}")

--- a/server/utils/terminal/terminal_ssh_setup.py
+++ b/server/utils/terminal/terminal_ssh_setup.py
@@ -21,9 +21,9 @@ def _fetch_user_ssh_keys(user_id: str) -> Dict[str, str]:
     Return all SSH private keys visible to user_id (including org-shared keys),
     keyed by a readable name: e.g., {"scaleway_4b9511a5": "<private key>"}
     """
-    from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-    org_id = _resolve_org(user_id)
-    predicate, pred_params = _org_read_predicate(user_id, org_id)
+    from utils.db.org_scope import resolve_org, org_read_predicate
+    org_id = resolve_org(user_id)
+    predicate, pred_params = org_read_predicate(user_id, org_id)
     ssh_keys: Dict[str, str] = {}
     with db_pool.get_admin_connection() as conn:
         cursor = conn.cursor()

--- a/server/utils/terminal/terminal_ssh_setup_local.py
+++ b/server/utils/terminal/terminal_ssh_setup_local.py
@@ -18,6 +18,7 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
         
         # Get user's SSH keys (org-aware: includes keys connected by any org member)
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         ssh_keys = {}
@@ -26,7 +27,7 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
             from utils.auth.stateless_auth import set_rls_context
             set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetupLocal:ensure_local_ssh_keys]")
             cursor.execute(
-                f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
+                pgsql.SQL("SELECT provider FROM user_tokens WHERE {} AND provider LIKE %s").format(predicate),
                 (*pred_params, '%_ssh_%')
             )
             

--- a/server/utils/terminal/terminal_ssh_setup_local.py
+++ b/server/utils/terminal/terminal_ssh_setup_local.py
@@ -17,9 +17,9 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
         from utils.db.connection_pool import db_pool
         
         # Get user's SSH keys (org-aware: includes keys connected by any org member)
-        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        org_id = _resolve_org(user_id)
-        predicate, pred_params = _org_read_predicate(user_id, org_id)
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
         ssh_keys = {}
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()

--- a/server/utils/terminal/terminal_ssh_setup_local.py
+++ b/server/utils/terminal/terminal_ssh_setup_local.py
@@ -18,7 +18,6 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
         
         # Get user's SSH keys (org-aware: includes keys connected by any org member)
         from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
-        from psycopg2 import sql as pgsql
         org_id = _resolve_org(user_id)
         predicate, pred_params = _org_read_predicate(user_id, org_id)
         ssh_keys = {}
@@ -27,7 +26,7 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
             from utils.auth.stateless_auth import set_rls_context
             set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetupLocal:ensure_local_ssh_keys]")
             cursor.execute(
-                pgsql.SQL("SELECT provider FROM user_tokens WHERE {} AND provider LIKE %s").format(predicate),
+                f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
                 (*pred_params, '%_ssh_%')
             )
             

--- a/server/utils/terminal/terminal_ssh_setup_local.py
+++ b/server/utils/terminal/terminal_ssh_setup_local.py
@@ -16,18 +16,15 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
         from utils.auth.token_management import get_token_data
         from utils.db.connection_pool import db_pool
         
-        # Get user's SSH keys (org-aware: includes keys connected by any org member)
-        from utils.db.org_scope import resolve_org, org_read_predicate
-        org_id = resolve_org(user_id)
-        predicate, pred_params = org_read_predicate(user_id, org_id)
+        # Get user's SSH keys
         ssh_keys = {}
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
             from utils.auth.stateless_auth import set_rls_context
             set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetupLocal:ensure_local_ssh_keys]")
             cursor.execute(
-                f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
-                (*pred_params, '%_ssh_%')
+                "SELECT provider FROM user_tokens WHERE user_id = %s AND provider LIKE %s",
+                (user_id, '%_ssh_%')
             )
             
             for row in cursor.fetchall():

--- a/server/utils/terminal/terminal_ssh_setup_local.py
+++ b/server/utils/terminal/terminal_ssh_setup_local.py
@@ -16,15 +16,18 @@ def ensure_local_ssh_keys(user_id: str) -> bool:
         from utils.auth.token_management import get_token_data
         from utils.db.connection_pool import db_pool
         
-        # Get user's SSH keys
+        # Get user's SSH keys (org-aware: includes keys connected by any org member)
+        from utils.secrets.secret_ref_utils import _resolve_org, _org_read_predicate
+        org_id = _resolve_org(user_id)
+        predicate, pred_params = _org_read_predicate(user_id, org_id)
         ssh_keys = {}
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
             from utils.auth.stateless_auth import set_rls_context
             set_rls_context(cursor, conn, user_id, log_prefix="[SSHSetupLocal:ensure_local_ssh_keys]")
             cursor.execute(
-                "SELECT provider FROM user_tokens WHERE user_id = %s AND provider LIKE %s",
-                (user_id, '%_ssh_%')
+                f"SELECT provider FROM user_tokens WHERE {predicate} AND provider LIKE %s",
+                (*pred_params, '%_ssh_%')
             )
             
             for row in cursor.fetchall():


### PR DESCRIPTION
get_user_token_data() only matched rows by user_id, so org members other than the original connector saw "connected" in the UI but got auth failures at runtime. Introduces _org_read_predicate() — a single helper that emits WHERE (user_id = %s OR org_id = %s) — and applies it consistently across all credential reads, writes, deletes, and GitHub repo queries. Modifies tests pinning the SQL shape, case normalization, and SQL-injection guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-scoped access for shared credentials, repositories, manual VMs (responses now include isShared) and SSH keys; repo metadata/selection and webhook/service-account flows respect org-shared credentials.
* **Bug Fixes**
  * Corrected token owner resolution to prevent duplicate/ghost credential rows and improved org-aware preference handling.
* **Chore**
  * Database migration to enforce org-level uniqueness for provider credentials.
* **Tests**
  * Updated tests to cover org-scoped predicates and UUID validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/396)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->