### PR TITLE
fix: resolve HOME to actual process home when pod isolation is off

### DIFF
--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -13,6 +13,14 @@ from typing import Dict, Any, Optional, Tuple
 from langchain_core.tools import StructuredTool
 from pathlib import Path
 
+# Home directory for isolated subprocess environments.
+# Terminal pods (Dockerfile-user-terminal) create 'appuser' at /home/appuser.
+# The server container (Dockerfile) creates 'app' at /home/app.
+# In local dev (no pod isolation), use the actual process home so cloud CLIs
+# can write config/cache files (.kube, .azure, .config/gcloud, etc.).
+_POD_ISOLATION = os.getenv("ENABLE_POD_ISOLATION", "true") == "true"
+_ISOLATED_HOME = "/home/appuser" if _POD_ISOLATION else str(Path.home())
+
 from utils.auth.cloud_auth import generate_contextual_access_token
 from utils.auth.cloud_auth import generate_azure_access_token
 from .output_sanitizer import sanitize_command_output, filter_error_messages, truncate_json_fields
@@ -130,12 +138,12 @@ def setup_azure_environment_isolated(user_id: str, subscription_id: str | None =
         # BUILD ISOLATED ENVIRONMENT - NO global os.environ modification!
         isolated_env = {
             "PATH": os.environ.get("PATH", ""),
-            "HOME": "/home/appuser",  # Use terminal pod's writable home directory
+            "HOME": _ISOLATED_HOME,
             "USER": os.environ.get("USER", ""),
             "AZURE_CLIENT_ID": str(client_id),
             "AZURE_CLIENT_SECRET": str(client_secret),
             "AZURE_TENANT_ID": str(tenant_id),
-            "AZURE_CONFIG_DIR": "/home/appuser/.azure",  # Ensure Azure CLI uses correct config directory
+            "AZURE_CONFIG_DIR": f"{_ISOLATED_HOME}/.azure",
         }
         
         # Store auth command for chaining with user commands (NEVER log the secret!)
@@ -276,7 +284,7 @@ def setup_aws_environment_isolated(user_id: str, selected_region: str | None = N
         # BUILD ISOLATED ENVIRONMENT - NO global os.environ modification!
         isolated_env = {
             "PATH": os.environ.get("PATH", ""),
-            "HOME": "/home/appuser",  # Use terminal pod's writable home directory
+            "HOME": _ISOLATED_HOME,
             "USER": os.environ.get("USER", ""),
             "AWS_ACCESS_KEY_ID": str(access_key_id),
             "AWS_SECRET_ACCESS_KEY": str(secret_access_key),
@@ -515,7 +523,7 @@ def setup_gcp_environment_isolated(user_id: str, selected_project_id: str | None
 
         isolated_env = {
             "PATH": os.environ.get("PATH", ""),
-            "HOME": "/home/appuser",
+            "HOME": _ISOLATED_HOME,
             "USER": os.environ.get("USER", ""),
             "GOOGLE_OAUTH_ACCESS_TOKEN": access_token,
             "CLOUDSDK_AUTH_ACCESS_TOKEN": access_token,
@@ -644,7 +652,7 @@ def setup_ovh_environment_isolated(user_id: str, selected_project_id: str | None
         # BUILD ISOLATED ENVIRONMENT - NO global os.environ modification!
         isolated_env = {
             "PATH": os.environ.get("PATH", ""),
-            "HOME": "/home/appuser",
+            "HOME": _ISOLATED_HOME,
             "USER": os.environ.get("USER", ""),
             "OVH_ACCESS_TOKEN": access_token,
             "OVH_ENDPOINT": ovh_endpoint,
@@ -698,7 +706,7 @@ def setup_scaleway_environment_isolated(user_id: str, selected_project_id: str |
         # SCW_DEFAULT_REGION, SCW_DEFAULT_ZONE
         isolated_env = {
             "PATH": os.environ.get("PATH", ""),
-            "HOME": "/home/appuser",
+            "HOME": _ISOLATED_HOME,
             "USER": os.environ.get("USER", ""),
             "SCW_ACCESS_KEY": access_key,
             "SCW_SECRET_KEY": secret_key,

--- a/server/chat/backend/agent/tools/terminal_exec_tool.py
+++ b/server/chat/backend/agent/tools/terminal_exec_tool.py
@@ -10,7 +10,10 @@ import re
 import shlex
 from typing import Optional, Dict
 from utils.terminal.terminal_run import terminal_run
-from .cloud_exec_tool import cloud_exec, _ISOLATED_HOME
+from . import cloud_exec_tool
+
+cloud_exec = cloud_exec_tool.cloud_exec
+_ISOLATED_HOME = getattr(cloud_exec_tool, "_ISOLATED_HOME", os.path.expanduser("~"))
 from .iac_tool import run_iac_tool
 
 logger = logging.getLogger(__name__)

--- a/server/chat/backend/agent/tools/terminal_exec_tool.py
+++ b/server/chat/backend/agent/tools/terminal_exec_tool.py
@@ -10,7 +10,7 @@ import re
 import shlex
 from typing import Optional, Dict
 from utils.terminal.terminal_run import terminal_run
-from .cloud_exec_tool import cloud_exec
+from .cloud_exec_tool import cloud_exec, _ISOLATED_HOME
 from .iac_tool import run_iac_tool
 
 logger = logging.getLogger(__name__)
@@ -339,7 +339,7 @@ def terminal_exec(
             "final_command": command,
             "return_code": result.returncode,
             "chat_output": output,
-            "working_dir": working_dir or "/home/appuser",
+            "working_dir": working_dir or _ISOLATED_HOME,
             "provider": "terminal"
         }
         


### PR DESCRIPTION
## Summary

- `gcloud container clusters get-credentials` (and all cloud CLI tools) fail in production with `Permission denied` when trying to create `~/.kube/` because HOME is hardcoded to `/home/appuser` — a directory that doesn't exist in the server container
- The server Dockerfile creates user `app` at `/home/app`, but the terminal pod Dockerfile creates `appuser` at `/home/appuser`. The hardcoded path only works in terminal pods.
- Introduces `_ISOLATED_HOME` constant that resolves dynamically: `/home/appuser` when pod isolation is on (production terminal pods), `Path.home()` when off (server container, local dev)
- Fixes all 6 hardcoded references in `cloud_exec_tool.py` (Azure, AWS, GCP, OVH, Scaleway) plus 1 in `terminal_exec_tool.py`

## Test plan

- [x] `ENABLE_POD_ISOLATION=true` → `_ISOLATED_HOME=/home/appuser` (terminal pod path)
- [x] `ENABLE_POD_ISOLATION=false` → `_ISOLATED_HOME` resolves to actual process home
- [x] Verified inside dev container: `/home/appuser` doesn't exist, `Path.home()=/root` is writable
- [x] No direct subprocess calls bypass `terminal_run` — all cloud tools route through it

Closes DEV-1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud CLI tools for Azure, AWS, GCP, OVH, and Scaleway now properly support pod-aware HOME directory configuration for improved environment isolation.
  * Terminal execution now correctly respects pod isolation settings for consistent working directory handling.
  * Azure CLI configuration is now aligned with the isolated HOME directory for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/397)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->