### PR TITLE
fix: set RLS context in action scheduler and workspace lookups

### DIFF
--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -240,7 +240,8 @@ def setup_aws_environment_isolated(user_id: str, selected_region: str | None = N
                 external_id=external_id,
                 workspace_id=ws["id"],
                 region=selected_region or "us-east-1",
-                session_policy=session_policy
+                session_policy=session_policy,
+                user_id=user_id,
             )
 
             aws_credentials = {
@@ -413,6 +414,7 @@ def setup_aws_environments_all_accounts(user_id: str):
                 workspace_id=ws["id"],
                 region=region,
                 session_policy=session_policy,
+                user_id=user_id,
             )
         except Exception as e:
             logger.error("Failed to assume role for account %s: %s", account_id, e)

--- a/server/services/actions/scheduler.py
+++ b/server/services/actions/scheduler.py
@@ -4,8 +4,23 @@ from datetime import datetime, timezone
 
 from celery_config import celery_app
 from utils.db.connection_pool import db_pool
+from utils.auth.stateless_auth import set_rls_context
 
 logger = logging.getLogger(__name__)
+
+_ACTIONS_QUERY = """
+    SELECT a.id, a.org_id, a.created_by,
+           (a.trigger_config->>'interval_seconds')::int AS interval_seconds,
+           MAX(r.started_at) AS last_run_at
+    FROM actions a
+    LEFT JOIN action_runs r ON r.action_id = a.id
+    WHERE a.trigger_type = 'on_schedule' AND a.enabled = true
+      AND NOT EXISTS (
+        SELECT 1 FROM action_runs ar
+        WHERE ar.action_id = a.id AND ar.status IN ('pending', 'running')
+      )
+    GROUP BY a.id
+"""
 
 
 def _is_due(interval_seconds, last_run_at, now):
@@ -21,24 +36,26 @@ def _is_due(interval_seconds, last_run_at, now):
 
 @celery_app.task(name="services.actions.scheduler.run_scheduled_actions")
 def run_scheduled_actions():
-    """Check all on_schedule actions and dispatch any that are due."""
+    """Check all on_schedule actions and dispatch any that are due.
+
+    The actions and action_runs tables are RLS-protected, so we iterate
+    per-org to satisfy row-level security policies.
+    """
+    rows = []
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("""
-                    SELECT a.id, a.org_id, a.created_by,
-                           (a.trigger_config->>'interval_seconds')::int AS interval_seconds,
-                           MAX(r.started_at) AS last_run_at
-                    FROM actions a
-                    LEFT JOIN action_runs r ON r.action_id = a.id
-                    WHERE a.trigger_type = 'on_schedule' AND a.enabled = true
-                      AND NOT EXISTS (
-                        SELECT 1 FROM action_runs ar
-                        WHERE ar.action_id = a.id AND ar.status IN ('pending', 'running')
-                      )
-                    GROUP BY a.id
-                """)
-                rows = cur.fetchall()
+                cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+                all_users = cur.fetchall()
+
+                seen_orgs = set()
+                for user_id, org_id in all_users:
+                    if org_id in seen_orgs:
+                        continue
+                    seen_orgs.add(org_id)
+                    set_rls_context(cur, conn, user_id, log_prefix="[ActionScheduler]")
+                    cur.execute(_ACTIONS_QUERY)
+                    rows.extend(cur.fetchall())
     except Exception:
         logger.exception("[ActionScheduler] Failed to query scheduled actions")
         return

--- a/server/services/actions/scheduler.py
+++ b/server/services/actions/scheduler.py
@@ -52,7 +52,8 @@ def run_scheduled_actions():
                 )
                 org_reps = cur.fetchall()
                 for user_id, _org_id in org_reps:
-                    set_rls_context(cur, conn, user_id, log_prefix="[ActionScheduler]")
+                    if not set_rls_context(cur, conn, user_id, log_prefix="[ActionScheduler]"):
+                        continue
                     cur.execute(_ACTIONS_QUERY)
                     rows.extend(cur.fetchall())
     except Exception:

--- a/server/services/actions/scheduler.py
+++ b/server/services/actions/scheduler.py
@@ -45,14 +45,13 @@ def run_scheduled_actions():
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-                all_users = cur.fetchall()
-
-                seen_orgs = set()
-                for user_id, org_id in all_users:
-                    if org_id in seen_orgs:
-                        continue
-                    seen_orgs.add(org_id)
+                cur.execute(
+                    "SELECT DISTINCT ON (org_id) id, org_id "
+                    "FROM users WHERE org_id IS NOT NULL "
+                    "ORDER BY org_id, id"
+                )
+                org_reps = cur.fetchall()
+                for user_id, _org_id in org_reps:
                     set_rls_context(cur, conn, user_id, log_prefix="[ActionScheduler]")
                     cur.execute(_ACTIONS_QUERY)
                     rows.extend(cur.fetchall())

--- a/server/utils/aws/aws_sts_client.py
+++ b/server/utils/aws/aws_sts_client.py
@@ -84,7 +84,8 @@ class STSAssumeRoleClient:
         external_id: str,
         workspace_id: str,
         duration_seconds: int = 3600,
-        session_policy: Optional[str] = None
+        session_policy: Optional[str] = None,
+        user_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Assume a workspace role with ExternalId and return cached credentials.
@@ -115,7 +116,7 @@ class STSAssumeRoleClient:
         # SECURITY: Validate that external_id matches the workspace's expected external_id
         # This prevents attackers from using incorrect External IDs
         from utils.workspace.workspace_utils import get_workspace_by_id
-        workspace = get_workspace_by_id(workspace_id)
+        workspace = get_workspace_by_id(workspace_id, user_id=user_id)
         if not workspace:
             raise ValueError(f"Workspace {workspace_id} not found")
         
@@ -397,7 +398,8 @@ def assume_workspace_role(
     workspace_id: str,
     duration_seconds: int = 3600,
     region: str = "us-east-1",
-    session_policy: Optional[str] = None
+    session_policy: Optional[str] = None,
+    user_id: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Convenience function to assume a workspace role.
@@ -409,12 +411,13 @@ def assume_workspace_role(
         duration_seconds: Session duration
         region: AWS region
         session_policy: Optional session policy JSON to restrict permissions
+        user_id: User identifier (required in Celery/background context for RLS)
 
     Returns:
         AWS credentials dictionary
     """
     client = get_sts_client(region)
-    return client.assume_workspace_role(role_arn, external_id, workspace_id, duration_seconds, session_policy)
+    return client.assume_workspace_role(role_arn, external_id, workspace_id, duration_seconds, session_policy, user_id=user_id)
 
 
 def create_workspace_session(

--- a/server/utils/aws/credential_refresh.py
+++ b/server/utils/aws/credential_refresh.py
@@ -71,7 +71,7 @@ def refresh_aws_credentials():
         logger.error("Failed to query active AWS connections for refresh: %s", e)
         return {"refreshed": 0, "error": str(e)}
 
-    for _user_id, role_arn, region, workspace_id, external_id in rows:
+    for user_id, role_arn, region, workspace_id, external_id in rows:
         if role_arn not in expiring_role_arns:
             skipped += 1
             continue
@@ -82,6 +82,7 @@ def refresh_aws_credentials():
                 external_id=external_id,
                 workspace_id=workspace_id,
                 region=region,
+                user_id=user_id,
             )
             refreshed += 1
         except Exception as e:

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -168,12 +168,13 @@ def update_workspace_aws_role(
         raise
 
 
-def get_workspace_by_id(workspace_id: str) -> Optional[Dict[str, Any]]:
+def get_workspace_by_id(workspace_id: str, user_id: str = None) -> Optional[Dict[str, Any]]:
     """
     Get workspace by ID.
     
     Args:
         workspace_id: Workspace identifier
+        user_id: User identifier (required in background/Celery context for RLS)
         
     Returns:
         Workspace dictionary or None if not found
@@ -184,6 +185,10 @@ def get_workspace_by_id(workspace_id: str) -> Optional[Dict[str, Any]]:
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
+
+            if user_id:
+                from utils.auth.stateless_auth import set_rls_context
+                set_rls_context(cursor, conn, user_id, log_prefix="[Workspace:getById]")
             
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "
@@ -237,6 +242,9 @@ def get_user_workspaces(user_id: str) -> list:
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
+
+            from utils.auth.stateless_auth import set_rls_context
+            set_rls_context(cursor, conn, user_id, log_prefix="[Workspace:list]")
             
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "

--- a/server/utils/workspace/workspace_utils.py
+++ b/server/utils/workspace/workspace_utils.py
@@ -12,6 +12,14 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 
+def _has_request_context() -> bool:
+    try:
+        from flask import has_request_context
+        return has_request_context()
+    except ImportError:
+        return False
+
+
 def get_or_create_workspace(user_id: str, workspace_name: str = "default", org_id: Optional[str] = None) -> Dict[str, Any]:
     """
     Get existing workspace or create a new one for a user.
@@ -168,7 +176,7 @@ def update_workspace_aws_role(
         raise
 
 
-def get_workspace_by_id(workspace_id: str, user_id: str = None) -> Optional[Dict[str, Any]]:
+def get_workspace_by_id(workspace_id: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """
     Get workspace by ID.
     
@@ -186,7 +194,7 @@ def get_workspace_by_id(workspace_id: str, user_id: str = None) -> Optional[Dict
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
 
-            if user_id:
+            if user_id and not _has_request_context():
                 from utils.auth.stateless_auth import set_rls_context
                 set_rls_context(cursor, conn, user_id, log_prefix="[Workspace:getById]")
             
@@ -243,8 +251,9 @@ def get_user_workspaces(user_id: str) -> list:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
 
-            from utils.auth.stateless_auth import set_rls_context
-            set_rls_context(cursor, conn, user_id, log_prefix="[Workspace:list]")
+            if not _has_request_context():
+                from utils.auth.stateless_auth import set_rls_context
+                set_rls_context(cursor, conn, user_id, log_prefix="[Workspace:list]")
             
             cursor.execute(
                 "SELECT id, user_id, name, aws_external_id, aws_discovery_artifact_bucket, "


### PR DESCRIPTION
## Summary

- **Action scheduler** (`services/actions/scheduler.py`) was querying RLS-protected tables (`actions`, `action_runs`) without setting org context. This caused the scheduler to silently see 0 rows on every tick — scheduled actions were never dispatched for any org.
- **Workspace lookup** (`utils/workspace/workspace_utils.py:get_workspace_by_id`) opened its own DB connection without RLS context. When called from Celery workers (via `assume_workspace_role`), the workspace query returned `None`, causing all background AWS STS AssumeRole operations to fail with "Workspace not found".

Both bugs follow the same pattern: Celery tasks calling `get_admin_connection()` and querying FORCE ROW LEVEL SECURITY tables without first calling `set_rls_context()`.

## Changes

| File | Change |
|------|--------|
| `services/actions/scheduler.py` | Cross-org iteration: query `users` table first, then set RLS per org before querying `actions` |
| `utils/workspace/workspace_utils.py` | Add optional `user_id` param to `get_workspace_by_id` and `get_user_workspaces`; set RLS when provided |
| `utils/aws/aws_sts_client.py` | Add optional `user_id` param to `assume_workspace_role`; pass to `get_workspace_by_id` |
| `utils/aws/credential_refresh.py` | Pass `user_id` to `assume_workspace_role` |
| `chat/backend/agent/tools/cloud_exec_tool.py` | Pass `user_id` to both `assume_workspace_role` call sites |

## Impact

- Scheduled actions will now fire correctly for all orgs
- AWS discovery/prediscovery will successfully assume roles (previously returned 0 nodes for all AWS users)
- Proactive credential refresh will work for AWS connections
- No breaking changes — `user_id` params are optional with `None` default; Flask route callers are unaffected (RLS auto-set by connection pool in request context)

## Test plan

- [ ] Deploy to staging and verify `run_scheduled_actions` finds and dispatches due actions (check celery worker logs for `[ActionScheduler] Dispatched`)
- [ ] Verify AWS discovery returns >0 nodes for users with valid AWS connections
- [ ] Confirm no regression in Flask route behavior (AWS onboarding flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS credential handling to properly track user identity during workspace role assumption and credential refresh operations.
  * Enhanced scheduled action execution to maintain correct user and organization context when processing and dispatching due actions.
  * Improved workspace lookup authorization validation to ensure proper access control enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/398)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->