### PR TITLE
fix: provider-specific tool_choice format in ForceToolChoice middleware

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -576,10 +576,11 @@ class Agent:
             # ContextSafetyMiddleware is a lightweight safety net that also injects
             # correlated RCA context updates into background sessions.
             middlewares = [ContextTrimMiddleware(model_name=model_name)]
+            tool_choice_provider = detected_provider if _use_direct else "openrouter"
             if getattr(state, "trigger_action_id", None):
-                middlewares.insert(0, _ForceToolChoice("trigger_action"))
+                middlewares.insert(0, _ForceToolChoice("trigger_action", provider=tool_choice_provider))
             elif getattr(state, "trigger_rca_requested", False):
-                middlewares.insert(0, _ForceToolChoice("trigger_rca"))
+                middlewares.insert(0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider))
 
             agent_graph = create_agent(
                 model=streaming_llm,

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -578,9 +578,13 @@ class Agent:
             middlewares = [ContextTrimMiddleware(model_name=model_name)]
             tool_choice_provider = detected_provider if _use_direct else "openrouter"
             if getattr(state, "trigger_action_id", None):
-                middlewares.insert(0, _ForceToolChoice("trigger_action", provider=tool_choice_provider))
+                middlewares.insert(
+                    0, _ForceToolChoice("trigger_action", provider=tool_choice_provider)
+                )
             elif getattr(state, "trigger_rca_requested", False):
-                middlewares.insert(0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider))
+                middlewares.insert(
+                    0, _ForceToolChoice("trigger_rca", provider=tool_choice_provider)
+                )
 
             agent_graph = create_agent(
                 model=streaming_llm,

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest
 
 
+# (module_substring, class_name, llm_type_substring, provider_key)
+# OpenRouter uses ChatOpenAI with a custom base URL — the "openai" match
+# is intentional: OpenRouter's API is OpenAI-shaped so tool_choice format
+# is identical.
 _PROVIDER_SIGNATURES: list[tuple[str, str, str, str]] = [
     ("langchain_anthropic", "chatanthropic", "anthropic", "anthropic"),
+    ("langchain_google_vertexai", "chatvertexai", "vertexai", "vertex"),
     ("langchain_google", "chatgooglegenerativeai", "google", "google"),
     ("langchain_openai", "chatopenai", "openai", "openai"),
 ]
@@ -32,11 +38,16 @@ class ForceToolChoice(AgentMiddleware):
 
     @staticmethod
     def _infer_provider(model: Any) -> str | None:
+        """Best-effort provider detection from a LangChain model instance.
+
+        This is a fallback — agent.py always passes provider= explicitly.
+        When the explicit provider is set, this method is never called.
+        """
         seen: set[int] = set()
-        candidates = [model]
+        candidates: deque[Any] = deque([model])
 
         while candidates:
-            candidate = candidates.pop(0)
+            candidate = candidates.popleft()
             if candidate is None or id(candidate) in seen:
                 continue
             seen.add(id(candidate))

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest
 
@@ -9,25 +11,63 @@ from langchain.agents.middleware.types import ModelRequest
 class ForceToolChoice(AgentMiddleware):
     """Set tool_choice on the first model invocation, then step aside."""
 
-    def __init__(self, tool_name: str):
+    def __init__(self, tool_name: str, provider: str | None = None):
         self._tool_name = tool_name
+        self._provider = provider
         self._fired = False
 
-    def _tool_choice_for(self, model) -> object:
-        """Return the provider-native `tool_choice` value forcing a single tool.
+    @staticmethod
+    def _infer_provider(model: Any) -> str | None:
+        seen: set[int] = set()
+        candidates = [model]
 
-        Direct providers each use their own shape; LLM_PROVIDER_MODE=openrouter
-        is OpenAI-compatible so the OpenAI shape works universally there.
-        """
-        llm_type = getattr(model, "_llm_type", "") or ""
-        # Unwrap RunnableBinding / similar (request.model may be wrapped)
-        inner = getattr(model, "bound", None)
-        if inner is not None and not llm_type:
-            llm_type = getattr(inner, "_llm_type", "") or ""
+        while candidates:
+            candidate = candidates.pop(0)
+            if candidate is None or id(candidate) in seen:
+                continue
+            seen.add(id(candidate))
 
-        if "anthropic" in llm_type:
+            module = candidate.__class__.__module__.lower()
+            name = candidate.__class__.__name__.lower()
+            llm_type = str(getattr(candidate, "_llm_type", "")).lower()
+
+            if (
+                "langchain_anthropic" in module
+                or name == "chatanthropic"
+                or "anthropic" in llm_type
+            ):
+                return "anthropic"
+            if (
+                "langchain_google" in module
+                or name == "chatgooglegenerativeai"
+                or "google" in llm_type
+            ):
+                return "google"
+            if (
+                "langchain_openai" in module
+                or name == "chatopenai"
+                or "openai" in llm_type
+            ):
+                return "openai"
+
+            for attr in ("bound", "model", "runnable"):
+                nested = getattr(candidate, attr, None)
+                if nested is not candidate:
+                    candidates.append(nested)
+
+        return None
+
+    def _tool_choice(self, request: ModelRequest):
+        provider = (
+            self._provider
+            or self._infer_provider(getattr(request, "model", None))
+            or ""
+        ).lower()
+
+        if provider == "anthropic":
             return {"type": "tool", "name": self._tool_name}
-        # OpenAI (direct + openrouter), default for unknown providers.
+        if provider in {"google", "vertex"}:
+            return self._tool_name
         return {
             "type": "function",
             "function": {"name": self._tool_name},
@@ -36,7 +76,11 @@ class ForceToolChoice(AgentMiddleware):
     def _patch(self, request: ModelRequest) -> ModelRequest:
         if not self._fired:
             self._fired = True
-            request.tool_choice = self._tool_choice_for(request.model)
+            tool_choice = self._tool_choice(request)
+            override = getattr(request, "override", None)
+            if callable(override):
+                return override(tool_choice=tool_choice)
+            request.tool_choice = tool_choice
         return request
 
     def wrap_model_call(self, request, call_next):

--- a/server/chat/backend/agent/middleware/force_tool.py
+++ b/server/chat/backend/agent/middleware/force_tool.py
@@ -8,6 +8,13 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest
 
 
+_PROVIDER_SIGNATURES: list[tuple[str, str, str, str]] = [
+    ("langchain_anthropic", "chatanthropic", "anthropic", "anthropic"),
+    ("langchain_google", "chatgooglegenerativeai", "google", "google"),
+    ("langchain_openai", "chatopenai", "openai", "openai"),
+]
+
+
 class ForceToolChoice(AgentMiddleware):
     """Set tool_choice on the first model invocation, then step aside."""
 
@@ -15,6 +22,13 @@ class ForceToolChoice(AgentMiddleware):
         self._tool_name = tool_name
         self._provider = provider
         self._fired = False
+
+    @staticmethod
+    def _match_provider(module: str, name: str, llm_type: str) -> str | None:
+        for mod_key, cls_key, type_key, provider in _PROVIDER_SIGNATURES:
+            if mod_key in module or name == cls_key or type_key in llm_type:
+                return provider
+        return None
 
     @staticmethod
     def _infer_provider(model: Any) -> str | None:
@@ -31,24 +45,9 @@ class ForceToolChoice(AgentMiddleware):
             name = candidate.__class__.__name__.lower()
             llm_type = str(getattr(candidate, "_llm_type", "")).lower()
 
-            if (
-                "langchain_anthropic" in module
-                or name == "chatanthropic"
-                or "anthropic" in llm_type
-            ):
-                return "anthropic"
-            if (
-                "langchain_google" in module
-                or name == "chatgooglegenerativeai"
-                or "google" in llm_type
-            ):
-                return "google"
-            if (
-                "langchain_openai" in module
-                or name == "chatopenai"
-                or "openai" in llm_type
-            ):
-                return "openai"
+            matched = ForceToolChoice._match_provider(module, name, llm_type)
+            if matched:
+                return matched
 
             for attr in ("bound", "model", "runnable"):
                 nested = getattr(candidate, attr, None)

--- a/server/chat/backend/agent/providers/openai_provider.py
+++ b/server/chat/backend/agent/providers/openai_provider.py
@@ -80,6 +80,7 @@ class OpenAIProvider(BaseLLMProvider):
                 f"Enabled reasoning=high+summary=auto + use_responses_api=True for {native_model}"
             )
 
+
         config.update(kwargs)
 
         return ChatOpenAI(**config)

--- a/server/tests/chat/test_force_tool_choice.py
+++ b/server/tests/chat/test_force_tool_choice.py
@@ -117,3 +117,19 @@ def test_forces_only_first_model_call(force_tool_module):
 
     assert first.tool_choice == {"type": "tool", "name": "trigger_rca"}
     assert second.tool_choice is None
+
+
+def test_uses_model_request_override_when_available(force_tool_module):
+    class Request(SimpleNamespace):
+        def override(self, **kwargs):
+            return Request(**{**self.__dict__, **kwargs})
+
+    request = Request(model=None, tool_choice=None)
+
+    patched = force_tool_module.ForceToolChoice("trigger_rca", provider="google")._patch(
+        request
+    )
+
+    assert patched is not request
+    assert patched.tool_choice == "trigger_rca"
+    assert request.tool_choice is None

--- a/server/tests/chat/test_force_tool_choice.py
+++ b/server/tests/chat/test_force_tool_choice.py
@@ -1,0 +1,119 @@
+"""Provider-specific forced tool choice formatting."""
+
+import importlib.util
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+_SERVER_DIR = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+_FORCE_TOOL_PATH = os.path.join(
+    _SERVER_DIR, "chat", "backend", "agent", "middleware", "force_tool.py"
+)
+
+
+@pytest.fixture()
+def force_tool_module(monkeypatch):
+    """Load the middleware with minimal LangChain stubs for focused tests."""
+    langchain = types.ModuleType("langchain")
+    agents = types.ModuleType("langchain.agents")
+    middleware = types.ModuleType("langchain.agents.middleware")
+    middleware_types = types.ModuleType("langchain.agents.middleware.types")
+
+    class AgentMiddleware:
+        pass
+
+    class ModelRequest:
+        pass
+
+    middleware.AgentMiddleware = AgentMiddleware
+    middleware_types.ModelRequest = ModelRequest
+
+    monkeypatch.setitem(sys.modules, "langchain", langchain)
+    monkeypatch.setitem(sys.modules, "langchain.agents", agents)
+    monkeypatch.setitem(sys.modules, "langchain.agents.middleware", middleware)
+    monkeypatch.setitem(sys.modules, "langchain.agents.middleware.types", middleware_types)
+
+    spec = importlib.util.spec_from_file_location(
+        "_force_tool_under_test", _FORCE_TOOL_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _request(model=None):
+    return SimpleNamespace(model=model, tool_choice=None)
+
+
+def _model(class_name: str, module: str, **attrs):
+    cls = type(class_name, (), {})
+    cls.__module__ = module
+    instance = cls()
+    for key, value in attrs.items():
+        setattr(instance, key, value)
+    return instance
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("openrouter", {"type": "function", "function": {"name": "trigger_rca"}}),
+        ("openai", {"type": "function", "function": {"name": "trigger_rca"}}),
+        ("anthropic", {"type": "tool", "name": "trigger_rca"}),
+        ("google", "trigger_rca"),
+        ("vertex", "trigger_rca"),
+        (None, {"type": "function", "function": {"name": "trigger_rca"}}),
+    ],
+)
+def test_formats_tool_choice_for_transport_provider(force_tool_module, provider, expected):
+    request = _request()
+
+    force_tool_module.ForceToolChoice("trigger_rca", provider=provider)._patch(request)
+
+    assert request.tool_choice == expected
+
+
+def test_infers_openai_shape_from_chat_openai_for_openrouter_model(force_tool_module):
+    model = _model(
+        "ChatOpenAI",
+        "langchain_openai.chat_models.base",
+        model_name="anthropic/claude-sonnet-4.5",
+    )
+    request = _request(model=model)
+
+    force_tool_module.ForceToolChoice("trigger_rca")._patch(request)
+
+    assert request.tool_choice == {
+        "type": "function",
+        "function": {"name": "trigger_rca"},
+    }
+
+
+def test_infers_google_shape_through_wrapped_model(force_tool_module):
+    google_model = _model(
+        "ChatGoogleGenerativeAI",
+        "langchain_google_genai.chat_models",
+    )
+    wrapper = SimpleNamespace(bound=google_model)
+    request = _request(model=wrapper)
+
+    force_tool_module.ForceToolChoice("trigger_rca")._patch(request)
+
+    assert request.tool_choice == "trigger_rca"
+
+
+def test_forces_only_first_model_call(force_tool_module):
+    middleware = force_tool_module.ForceToolChoice("trigger_rca", provider="anthropic")
+    first = _request()
+    second = _request()
+
+    middleware._patch(first)
+    middleware._patch(second)
+
+    assert first.tool_choice == {"type": "tool", "name": "trigger_rca"}
+    assert second.tool_choice is None

--- a/server/tests/chat/test_openai_provider.py
+++ b/server/tests/chat/test_openai_provider.py
@@ -38,7 +38,7 @@ def openai_provider_module(monkeypatch):
 
     class BaseLLMProvider:
         def __init__(self):
-            pass
+            pass  # Stub — real implementation lives in base_provider.py
 
     base_provider.BaseLLMProvider = BaseLLMProvider
 

--- a/server/tests/chat/test_openai_provider.py
+++ b/server/tests/chat/test_openai_provider.py
@@ -1,0 +1,93 @@
+"""OpenAI direct provider compatibility tests."""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+
+_SERVER_DIR = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+_PROVIDER_PATH = os.path.join(
+    _SERVER_DIR, "chat", "backend", "agent", "providers", "openai_provider.py"
+)
+
+
+@pytest.fixture()
+def openai_provider_module(monkeypatch):
+    """Load the provider with minimal dependency stubs."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    langchain_openai = types.ModuleType("langchain_openai")
+    langchain_core = types.ModuleType("langchain_core")
+    language_models = types.ModuleType("langchain_core.language_models")
+    chat_models = types.ModuleType("langchain_core.language_models.chat_models")
+
+    class ChatOpenAI:
+        def __init__(self, **config):
+            self.config = config
+
+    class BaseChatModel:
+        pass
+
+    langchain_openai.ChatOpenAI = ChatOpenAI
+    chat_models.BaseChatModel = BaseChatModel
+
+    base_provider = types.ModuleType("chat.backend.agent.providers.base_provider")
+
+    class BaseLLMProvider:
+        def __init__(self):
+            pass
+
+    base_provider.BaseLLMProvider = BaseLLMProvider
+
+    model_mapper = types.ModuleType("chat.backend.agent.model_mapper")
+
+    class ModelMapper:
+        @staticmethod
+        def get_native_name(model_name, target_provider):
+            assert target_provider == "openai"
+            return model_name.split("/", 1)[1] if "/" in model_name else model_name
+
+        @staticmethod
+        def is_model_supported_by_provider(model_name, provider):
+            return provider == "openai" and model_name.startswith("gpt-")
+
+        @staticmethod
+        def get_supported_models_for_provider(provider):
+            return ["openai/gpt-5.5"] if provider == "openai" else []
+
+    model_mapper.ModelMapper = ModelMapper
+
+    monkeypatch.setitem(sys.modules, "langchain_openai", langchain_openai)
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.language_models", language_models)
+    monkeypatch.setitem(
+        sys.modules, "langchain_core.language_models.chat_models", chat_models
+    )
+    monkeypatch.setitem(
+        sys.modules, "chat.backend.agent.providers.base_provider", base_provider
+    )
+    monkeypatch.setitem(sys.modules, "chat.backend.agent.model_mapper", model_mapper)
+
+    spec = importlib.util.spec_from_file_location(
+        "chat.backend.agent.providers.openai_provider", _PROVIDER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_reasoning_model_uses_responses_api(openai_provider_module):
+    provider = openai_provider_module.OpenAIProvider()
+
+    model = provider.get_chat_model("openai/gpt-5.5", streaming=True)
+
+    assert model.config["model"] == "gpt-5.5"
+    assert model.config["streaming"] is True
+    assert "reasoning_effort" not in model.config
+    assert model.config["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert model.config["use_responses_api"] is True
+    assert "temperature" not in model.config


### PR DESCRIPTION
## Summary

- **ForceToolChoice middleware** hardcoded OpenAI's `tool_choice` format (`{"type": "function", "function": {"name": "..."}}`), causing 400 errors when using `LLM_PROVIDER_MODE=direct` with Anthropic or Google
- Added provider-aware `_tool_choice()` that emits the correct format per provider:
  - **OpenRouter/OpenAI**: `{"type": "function", "function": {"name": "..."}}`
  - **Anthropic**: `{"type": "tool", "name": "..."}`
  - **Google/Vertex**: just the string tool name
- Added `_infer_provider()` for automatic detection from LangChain model class when provider isn't explicitly passed
- `agent.py` now passes the detected provider to the middleware constructor

Closes DEV-1113

Based on @damianloch's work on `damianloch/fix-provider-tool-choice-2956`, rebased onto main and resolved conflicts with the Responses API reasoning config.

## Test plan

- [x] All 11 unit tests passing (6 provider format tests, inference tests, fire-once, override)
- [ ] Verify RCA trigger works with Anthropic direct (`LLM_PROVIDER_MODE=direct`)
- [ ] Verify RCA trigger works with OpenRouter (default)
- [ ] Verify action trigger works with forced tool choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved provider detection and made middleware emit provider-compatible tool-choice payloads on first invocation.

* **Tests**
  * Added tests covering provider inference, provider-specific tool-choice formatting, statefulness of forced tool application, request-level override behavior, and OpenAI provider model configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/400)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->