### PR TITLE
Fix: clean up Memgraph discovery nodes on provider disconnect

### DIFF
--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -304,11 +304,11 @@ def delete_connected_account(user_id, target_user_id, provider):
                 list_active_connections,
                 delete_connection_secret,
             )
-            
+
             active = list_active_connections(user_id)
             if not active:
                 logging.info("No active AWS connections found for user %s", user_id)
-            
+
             for conn in active:
                 acc_id = conn["account_id"]
                 _ok = delete_connection_secret(user_id, "aws", acc_id)
@@ -318,18 +318,39 @@ def delete_connected_account(user_id, target_user_id, provider):
                 except Exception:
                     pass
                 deletion_ok = deletion_ok and _ok
-            
+
+            # Clean up Memgraph discovery nodes for AWS before returning.
+            try:
+                from services.graph.memgraph_client import get_memgraph_client
+                get_memgraph_client().delete_services_for_provider(user_id, "aws")
+            except Exception as e:
+                logging.warning(
+                    "Failed to delete Memgraph nodes for user=%s provider=aws: %s",
+                    user_id, e,
+                )
+
             record_audit_event(org_id or "", user_id, "disconnect_provider", "connected_account", provider,
                                {"provider": provider}, request)
             return jsonify({"success": True, "message": "AWS connection(s) removed"}), 200
-        
+
+        # Clean up Memgraph discovery nodes for all other providers that reach this
+        # generic path (GCP, Azure, and any provider that uses Vault-backed tokens).
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_provider(user_id, provider_lc)
+        except Exception as e:
+            logging.warning(
+                "Failed to delete Memgraph nodes for user=%s provider=%s: %s",
+                user_id, provider_lc, e,
+            )
+
         # Idempotent behaviour: If there were no credentials stored in the first place
         # treat the request as successfully processed. This prevents unnecessary 404
         # errors that bubble up to the frontend when a user disconnects a provider
         # that was never connected (common after manual DB cleanup).
         if deleted == 0 and deletion_ok:
             return jsonify({"success": True, "message": "No tokens found for provider – nothing to delete"}), 200
-        
+
         if not deletion_ok:
             record_audit_event(org_id or "", user_id, "disconnect_provider", "connected_account", provider,
                                {"provider": provider, "partial": True}, request)

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -345,6 +345,13 @@ def workspace_cleanup(user_id, workspace_id):
             "You can now restart the onboarding flow from scratch."
         )
 
+        # Delete discovered infrastructure nodes from Memgraph
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_provider(user_id, "aws")
+        except Exception as e:
+            logger.warning("Failed to delete Memgraph nodes for user=%s provider=aws: %s", user_id, e)
+
         return jsonify({"success": True, "message": message})
 
     except Exception as e:
@@ -492,6 +499,13 @@ def delete_aws_account(user_id, workspace_id, account_id):
         from utils.db.connection_utils import delete_connection_secret
         success = delete_connection_secret(user_id, "aws", account_id)
         if success:
+            # Delete discovered infrastructure nodes scoped to this account only.
+            # Nodes for other AWS accounts still connected to this user are preserved.
+            try:
+                from services.graph.memgraph_client import get_memgraph_client
+                get_memgraph_client().delete_services_for_aws_account(user_id, account_id)
+            except Exception as e:
+                logger.warning("Failed to delete Memgraph nodes for user=%s aws account=%s: %s", user_id, account_id, e)
             return jsonify({"success": True, "message": f"Account {account_id} disconnected."})
         else:
             return jsonify({"error": "Account not found or already disconnected"}), 404

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -520,7 +520,7 @@ def delete_aws_account(user_id, workspace_id, account_id):
             return jsonify({"error": "Account not found or already disconnected"}), 404
 
     except Exception as e:
-        logger.error(
+        logger.exception(
             "Failed to delete AWS account %s for workspace %s: %s",
             sanitize(account_id),
             sanitize(workspace_id),

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -348,7 +348,10 @@ def workspace_cleanup(user_id, workspace_id):
         # Delete discovered infrastructure nodes from Memgraph
         try:
             from services.graph.memgraph_client import get_memgraph_client
-            get_memgraph_client().delete_services_for_provider(user_id, "aws")
+            if account_id:
+                get_memgraph_client().delete_services_for_aws_account(user_id, account_id)
+            else:
+                get_memgraph_client().delete_services_for_provider(user_id, "aws")
         except Exception as e:
             logger.warning(
                 "Failed to delete Memgraph nodes for user=%s provider=aws: %s",

--- a/server/routes/aws/onboarding.py
+++ b/server/routes/aws/onboarding.py
@@ -350,7 +350,11 @@ def workspace_cleanup(user_id, workspace_id):
             from services.graph.memgraph_client import get_memgraph_client
             get_memgraph_client().delete_services_for_provider(user_id, "aws")
         except Exception as e:
-            logger.warning("Failed to delete Memgraph nodes for user=%s provider=aws: %s", user_id, e)
+            logger.warning(
+                "Failed to delete Memgraph nodes for user=%s provider=aws: %s",
+                sanitize(user_id),
+                sanitize(str(e)),
+            )
 
         return jsonify({"success": True, "message": message})
 
@@ -505,13 +509,23 @@ def delete_aws_account(user_id, workspace_id, account_id):
                 from services.graph.memgraph_client import get_memgraph_client
                 get_memgraph_client().delete_services_for_aws_account(user_id, account_id)
             except Exception as e:
-                logger.warning("Failed to delete Memgraph nodes for user=%s aws account=%s: %s", user_id, account_id, e)
+                logger.warning(
+                    "Failed to delete Memgraph nodes for user=%s aws account=%s: %s",
+                    sanitize(user_id),
+                    sanitize(account_id),
+                    sanitize(str(e)),
+                )
             return jsonify({"success": True, "message": f"Account {account_id} disconnected."})
         else:
             return jsonify({"error": "Account not found or already disconnected"}), 404
 
     except Exception as e:
-        logger.error("Failed to delete AWS account %s for workspace %s: %s", account_id, workspace_id, e)
+        logger.error(
+            "Failed to delete AWS account %s for workspace %s: %s",
+            sanitize(account_id),
+            sanitize(workspace_id),
+            sanitize(str(e)),
+        )
         return jsonify({"error": "Internal server error"}), 500
 
 

--- a/server/routes/gcp/auth.py
+++ b/server/routes/gcp/auth.py
@@ -221,7 +221,14 @@ def force_disconnect_gcp(user_id):
             logging.info(f"Cleared secret cache for user {user_id}")
         except Exception as e:
             logging.warning(f"Failed to clear secret cache: {e}")
-    
+
+    # Delete discovered infrastructure nodes from Memgraph
+    try:
+        from services.graph.memgraph_client import get_memgraph_client
+        get_memgraph_client().delete_services_for_provider(user_id, "gcp")
+    except Exception as e:
+        logging.warning(f"Failed to delete Memgraph nodes for user={user_id} provider=gcp: {e}")
+
     logging.info(f"Successfully force disconnected GCP for user {user_id}")
     return jsonify({"success": True, "message": "GCP disconnected successfully"}), 200
 

--- a/server/routes/kubectl_token_routes.py
+++ b/server/routes/kubectl_token_routes.py
@@ -153,7 +153,14 @@ def disconnect_cluster(user_id, cluster_id):
         finally:
             conn.close()
         logger.info(f"Disconnected kubectl cluster {sanitize(cluster_id)} (revoked token) for user {sanitize(user_id)}")
-        
+
+        # Delete discovered infrastructure nodes from Memgraph for this cluster only
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_cluster(user_id, cluster_name)
+        except Exception as e:
+            logger.warning("Failed to delete Memgraph nodes for user=%s cluster=%s: %s", user_id, cluster_name, e)
+
         # Return command to delete agent from cluster (Helm deployment)
         delete_command = "helm uninstall aurora-kubectl-agent -n <your-namespace>"
         

--- a/server/routes/ovh/ovh_api_routes.py
+++ b/server/routes/ovh/ovh_api_routes.py
@@ -840,6 +840,13 @@ def ovh_disconnect(user_id):
         if account_id:
             set_connection_status(user_id, 'ovh', account_id, 'not_connected')
 
+        # Delete discovered infrastructure nodes from Memgraph
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_provider(user_id, "ovh")
+        except Exception as e:
+            logger.warning("Failed to delete Memgraph nodes for user=%s provider=ovh: %s", user_id, e)
+
         logger.info(f"Successfully disconnected OVH account for user: {user_id}")
         return jsonify({
             "status": "disconnected",

--- a/server/routes/scaleway/scaleway_routes.py
+++ b/server/routes/scaleway/scaleway_routes.py
@@ -289,7 +289,14 @@ def scaleway_disconnect(user_id):
         # Delete stored credentials
         delete_user_secret(user_id, "scaleway")
         set_connection_status(user_id, "scaleway", access_key, "disconnected")
-        
+
+        # Delete discovered infrastructure nodes from Memgraph
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_provider(user_id, "scaleway")
+        except Exception as e:
+            logger.warning("Failed to delete Memgraph nodes for user=%s provider=scaleway: %s", user_id, e)
+
         logger.info(f"Scaleway disconnected for user {user_id}")
         
         return jsonify({

--- a/server/routes/tailscale/tailscale_routes.py
+++ b/server/routes/tailscale/tailscale_routes.py
@@ -308,6 +308,13 @@ def tailscale_disconnect(user_id):
         finally:
             conn.close()
 
+        # Delete discovered infrastructure nodes from Memgraph
+        try:
+            from services.graph.memgraph_client import get_memgraph_client
+            get_memgraph_client().delete_services_for_provider(user_id, "tailscale")
+        except Exception as e:
+            logger.warning("Failed to delete Memgraph nodes for user=%s provider=tailscale: %s", user_id, e)
+
         logger.info(f"Tailscale disconnected for user {user_id}")
 
         return jsonify({

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -331,7 +331,7 @@ def mark_stale_services(self):
                 if deleted > 0:
                     logger.info(f"[Discovery Task] Deleted {deleted} stale services (>30d) for user {user_id}")
             except Exception as e:
-                logger.error(f"[Discovery Task] Stale deletion failed for user {user_id}: {e}")
+                logger.exception(f"[Discovery Task] Stale deletion failed for user {user_id}: {e}")
 
         logger.info(f"[Discovery Task] Stale detection complete: {total_marked} marked, {total_deleted} deleted")
         return {"status": "completed", "total_marked": total_marked, "total_deleted": total_deleted}

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -5,7 +5,7 @@ Celery tasks for scheduled infrastructure discovery.
 import logging
 
 from celery_config import celery_app
-from utils.auth.stateless_auth import set_rls_context
+from utils.auth.stateless_auth import set_rls_context, get_org_id_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -18,19 +18,24 @@ def _query_connected_providers(cur, user_id=None, conn=None):
     If user_id is given, returns just the provider names for that user.
     Otherwise returns (user_id, provider) rows for all users.
     Requires conn for cross-org queries to set RLS context per-org.
+
+    Includes org_id fallback so org-shared connections (e.g. AWS accounts
+    registered under the org rather than directly under the user) are picked
+    up the same way every other connection query in the codebase does.
     """
     if user_id is not None:
+        org_id = get_org_id_for_user(user_id)
         if conn:
             set_rls_context(cur, conn, user_id, log_prefix="[Discovery]")
         cur.execute("""
             SELECT DISTINCT provider FROM (
                 SELECT provider FROM user_connections
-                WHERE user_id = %s AND status = 'active' AND provider IN %s
+                WHERE (user_id = %s OR org_id = %s) AND status = 'active' AND provider IN %s
                 UNION
                 SELECT provider FROM user_tokens
                 WHERE user_id = %s AND is_active = true AND provider IN %s
             ) AS connected
-        """, (user_id, SUPPORTED_PROVIDERS, user_id, SUPPORTED_PROVIDERS))
+        """, (user_id, org_id, SUPPORTED_PROVIDERS, user_id, SUPPORTED_PROVIDERS))
         return [row[0] for row in cur.fetchall()]
     else:
         # No RLS needed — cross-org loop sets RLS per user
@@ -47,12 +52,12 @@ def _query_connected_providers(cur, user_id=None, conn=None):
             cur.execute("""
                 SELECT DISTINCT provider FROM (
                     SELECT provider FROM user_connections
-                    WHERE user_id = %s AND status = 'active' AND provider IN %s
+                    WHERE (user_id = %s OR org_id = %s) AND status = 'active' AND provider IN %s
                     UNION
                     SELECT provider FROM user_tokens
                     WHERE user_id = %s AND is_active = true AND provider IN %s
                 ) AS connected
-            """, (uid, SUPPORTED_PROVIDERS, uid, SUPPORTED_PROVIDERS))
+            """, (uid, org_id, SUPPORTED_PROVIDERS, uid, SUPPORTED_PROVIDERS))
             for row in cur.fetchall():
                 results.append((uid, row[0]))
         return results
@@ -291,7 +296,11 @@ def run_user_discovery(self, user_id):
 
 @celery_app.task(name="services.discovery.tasks.mark_stale_services", bind=True, max_retries=0, soft_time_limit=300, time_limit=600)
 def mark_stale_services(self):
-    """Mark services not updated in 7 days as stale. Runs daily at 3 AM."""
+    """Mark services not updated in 7 days as stale, and delete those older than 30 days.
+
+    Runs daily at 3 AM. The 30-day deletion acts as a safety net for nodes
+    that were never cleaned up by a disconnect event.
+    """
     from utils.db.db_utils import connect_to_db_as_admin
     from services.graph.memgraph_client import get_memgraph_client
 
@@ -307,6 +316,7 @@ def mark_stale_services(self):
 
         client = get_memgraph_client()
         total_marked = 0
+        total_deleted = 0
         for user_id in user_ids:
             try:
                 marked = client.mark_stale_services(user_id, stale_days=7)
@@ -315,9 +325,16 @@ def mark_stale_services(self):
                     logger.info(f"[Discovery Task] Marked {marked} stale services for user {user_id}")
             except Exception as e:
                 logger.error(f"[Discovery Task] Stale detection failed for user {user_id}: {e}")
+            try:
+                deleted = client.delete_stale_services(user_id, stale_days=30)
+                total_deleted += deleted
+                if deleted > 0:
+                    logger.info(f"[Discovery Task] Deleted {deleted} stale services (>30d) for user {user_id}")
+            except Exception as e:
+                logger.error(f"[Discovery Task] Stale deletion failed for user {user_id}: {e}")
 
-        logger.info(f"[Discovery Task] Stale detection complete: {total_marked} services marked")
-        return {"status": "completed", "total_marked": total_marked}
+        logger.info(f"[Discovery Task] Stale detection complete: {total_marked} marked, {total_deleted} deleted")
+        return {"status": "completed", "total_marked": total_marked, "total_deleted": total_deleted}
 
     except Exception as e:
         logger.error(f"[Discovery Task] Stale detection fatal error: {e}")

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -33,9 +33,9 @@ def _query_connected_providers(cur, user_id=None, conn=None):
                 WHERE (user_id = %s OR org_id = %s) AND status = 'active' AND provider IN %s
                 UNION
                 SELECT provider FROM user_tokens
-                WHERE user_id = %s AND is_active = true AND provider IN %s
+                WHERE (user_id = %s OR org_id = %s) AND is_active = true AND provider IN %s
             ) AS connected
-        """, (user_id, org_id, SUPPORTED_PROVIDERS, user_id, SUPPORTED_PROVIDERS))
+        """, (user_id, org_id, SUPPORTED_PROVIDERS, user_id, org_id, SUPPORTED_PROVIDERS))
         return [row[0] for row in cur.fetchall()]
     else:
         # No RLS needed — cross-org loop sets RLS per user
@@ -55,9 +55,9 @@ def _query_connected_providers(cur, user_id=None, conn=None):
                     WHERE (user_id = %s OR org_id = %s) AND status = 'active' AND provider IN %s
                     UNION
                     SELECT provider FROM user_tokens
-                    WHERE user_id = %s AND is_active = true AND provider IN %s
+                    WHERE (user_id = %s OR org_id = %s) AND is_active = true AND provider IN %s
                 ) AS connected
-            """, (uid, org_id, SUPPORTED_PROVIDERS, uid, SUPPORTED_PROVIDERS))
+            """, (uid, org_id, SUPPORTED_PROVIDERS, uid, org_id, SUPPORTED_PROVIDERS))
             for row in cur.fetchall():
                 results.append((uid, row[0]))
         return results

--- a/server/services/graph/memgraph_client.py
+++ b/server/services/graph/memgraph_client.py
@@ -781,12 +781,11 @@ class MemgraphClient:
         """
         query = """
         MATCH (s:Service {user_id: $user_id, provider: $provider})
-        WITH s, count(s) AS deleted
         DETACH DELETE s
-        RETURN deleted;
+        RETURN count(s) AS deleted;
         """
         results = self._execute(query, {"user_id": user_id, "provider": provider})
-        deleted = sum(r["deleted"] for r in results) if results else 0
+        deleted = results[0]["deleted"] if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s provider=%s",
             deleted, sanitize(user_id), sanitize(provider),
@@ -801,12 +800,11 @@ class MemgraphClient:
         """
         query = """
         MATCH (s:Service {user_id: $user_id, provider: "kubectl", cluster_name: $cluster_name})
-        WITH s, count(s) AS deleted
         DETACH DELETE s
-        RETURN deleted;
+        RETURN count(s) AS deleted;
         """
         results = self._execute(query, {"user_id": user_id, "cluster_name": cluster_name})
-        deleted = sum(r["deleted"] for r in results) if results else 0
+        deleted = results[0]["deleted"] if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s cluster=%s",
             deleted, sanitize(user_id), sanitize(cluster_name),
@@ -821,12 +819,11 @@ class MemgraphClient:
         """
         query = """
         MATCH (s:Service {user_id: $user_id, provider: "aws", aws_account_id: $aws_account_id})
-        WITH s, count(s) AS deleted
         DETACH DELETE s
-        RETURN deleted;
+        RETURN count(s) AS deleted;
         """
         results = self._execute(query, {"user_id": user_id, "aws_account_id": aws_account_id})
-        deleted = sum(r["deleted"] for r in results) if results else 0
+        deleted = results[0]["deleted"] if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s aws_account=%s",
             deleted, sanitize(user_id), sanitize(aws_account_id),
@@ -854,12 +851,11 @@ class MemgraphClient:
         query = """
         MATCH (s:Service {user_id: $user_id, stale: true})
         WHERE s.updated_at < localDateTime() - duration({days: $days})
-        WITH s, count(s) AS deleted
         DETACH DELETE s
-        RETURN deleted;
+        RETURN count(s) AS deleted;
         """
         results = self._execute(query, {"user_id": user_id, "days": stale_days})
-        deleted = sum(r["deleted"] for r in results) if results else 0
+        deleted = results[0]["deleted"] if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d stale Service nodes (>%dd) for user=%s",
             deleted, stale_days, sanitize(user_id),

--- a/server/services/graph/memgraph_client.py
+++ b/server/services/graph/memgraph_client.py
@@ -773,6 +773,66 @@ class MemgraphClient:
     # Stale Service Management
     # =========================================================================
 
+    def delete_services_for_provider(self, user_id, provider):
+        """Delete all Service nodes (and their edges) for a user/provider pair.
+
+        Called immediately when a cloud provider is disconnected so that
+        stale infrastructure nodes are not left behind in the graph.
+        """
+        query = """
+        MATCH (s:Service {user_id: $user_id, provider: $provider})
+        WITH s, count(s) AS deleted
+        DETACH DELETE s
+        RETURN deleted;
+        """
+        results = self._execute(query, {"user_id": user_id, "provider": provider})
+        deleted = sum(r["deleted"] for r in results) if results else 0
+        logger.info(
+            "[MemgraphClient] Deleted %d Service nodes for user=%s provider=%s",
+            deleted, user_id, provider,
+        )
+        return deleted
+
+    def delete_services_for_cluster(self, user_id, cluster_name):
+        """Delete all Service nodes (and their edges) for a specific kubectl cluster.
+
+        Used when a single cluster is disconnected so that only its nodes are
+        removed, leaving other clusters' nodes intact.
+        """
+        query = """
+        MATCH (s:Service {user_id: $user_id, provider: "kubectl", cluster_name: $cluster_name})
+        WITH s, count(s) AS deleted
+        DETACH DELETE s
+        RETURN deleted;
+        """
+        results = self._execute(query, {"user_id": user_id, "cluster_name": cluster_name})
+        deleted = sum(r["deleted"] for r in results) if results else 0
+        logger.info(
+            "[MemgraphClient] Deleted %d Service nodes for user=%s cluster=%s",
+            deleted, user_id, cluster_name,
+        )
+        return deleted
+
+    def delete_services_for_aws_account(self, user_id, aws_account_id):
+        """Delete Service nodes for a single AWS account, leaving other accounts intact.
+
+        Uses the aws_account_id property set during discovery rather than the
+        provider field, so only the disconnected account's nodes are removed.
+        """
+        query = """
+        MATCH (s:Service {user_id: $user_id, provider: "aws", aws_account_id: $aws_account_id})
+        WITH s, count(s) AS deleted
+        DETACH DELETE s
+        RETURN deleted;
+        """
+        results = self._execute(query, {"user_id": user_id, "aws_account_id": aws_account_id})
+        deleted = sum(r["deleted"] for r in results) if results else 0
+        logger.info(
+            "[MemgraphClient] Deleted %d Service nodes for user=%s aws_account=%s",
+            deleted, user_id, aws_account_id,
+        )
+        return deleted
+
     def mark_stale_services(self, user_id, stale_days=7):
         """Mark services not updated in N days as stale."""
         query = """
@@ -783,6 +843,28 @@ class MemgraphClient:
         """
         results = self._execute(query, {"user_id": user_id, "days": stale_days})
         return results[0]["marked"] if results else 0
+
+    def delete_stale_services(self, user_id, stale_days=30):
+        """Delete Service nodes already marked stale and not updated in stale_days.
+
+        Only deletes nodes where stale=true to avoid removing nodes that are
+        actively updated but happen to be old (e.g. long-lived services). Acts
+        as a safety net for nodes never cleaned up by a disconnect event.
+        """
+        query = """
+        MATCH (s:Service {user_id: $user_id, stale: true})
+        WHERE s.updated_at < localDateTime() - duration({days: $days})
+        WITH s, count(s) AS deleted
+        DETACH DELETE s
+        RETURN deleted;
+        """
+        results = self._execute(query, {"user_id": user_id, "days": stale_days})
+        deleted = sum(r["deleted"] for r in results) if results else 0
+        logger.info(
+            "[MemgraphClient] Deleted %d stale Service nodes (>%dd) for user=%s",
+            deleted, stale_days, user_id,
+        )
+        return deleted
 
     # =========================================================================
     # Helpers

--- a/server/services/graph/memgraph_client.py
+++ b/server/services/graph/memgraph_client.py
@@ -789,7 +789,7 @@ class MemgraphClient:
         deleted = sum(r["deleted"] for r in results) if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s provider=%s",
-            deleted, user_id, provider,
+            deleted, sanitize(user_id), sanitize(provider),
         )
         return deleted
 
@@ -809,7 +809,7 @@ class MemgraphClient:
         deleted = sum(r["deleted"] for r in results) if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s cluster=%s",
-            deleted, user_id, cluster_name,
+            deleted, sanitize(user_id), sanitize(cluster_name),
         )
         return deleted
 
@@ -829,7 +829,7 @@ class MemgraphClient:
         deleted = sum(r["deleted"] for r in results) if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d Service nodes for user=%s aws_account=%s",
-            deleted, user_id, aws_account_id,
+            deleted, sanitize(user_id), sanitize(aws_account_id),
         )
         return deleted
 
@@ -862,7 +862,7 @@ class MemgraphClient:
         deleted = sum(r["deleted"] for r in results) if results else 0
         logger.info(
             "[MemgraphClient] Deleted %d stale Service nodes (>%dd) for user=%s",
-            deleted, stale_days, user_id,
+            deleted, stale_days, sanitize(user_id),
         )
         return deleted
 


### PR DESCRIPTION
Fixes stale infrastructure nodes persisting in Memgraph after a cloud provider is disconnected. Adds delete_services_for_provider, delete_services_for_cluster, and delete_services_for_aws_account methods to MemgraphClient and calls them from all disconnect endpoints (GCP, AWS, Azure, OVH, Scaleway, Tailscale, kubectl). Also adds a delete_stale_services safety net to the daily stale task that hard-deletes nodes flagged stale for 30+ days. Fixes a pre-existing bug where _query_connected_providers was missing the OR org_id = %s fallback, causing org-shared AWS connections to be silently skipped during discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-level connections now supported for discovery operations.

* **Improvements**
  * Disconnecting cloud providers and clusters now triggers automatic cleanup of discovered infrastructure entries (AWS, GCP, OVH, Scaleway, Tailscale, Kubernetes), with failures logged but not blocking disconnects.
  * Stale infrastructure data older than 30 days is now automatically removed to improve performance and hygiene.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/402)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->