### PR TITLE
fix: use V2 signing for GCS S3-interop storage endpoint

### DIFF
--- a/server/utils/storage/storage.py
+++ b/server/utils/storage/storage.py
@@ -389,11 +389,23 @@ class S3Backend(StorageBackend):
             self._client = self._create_client()
         return self._client
 
+    def _is_gcs_endpoint(self) -> bool:
+        """Check if endpoint is Google Cloud Storage S3-compatible API."""
+        if not self._config.endpoint_url:
+            return False
+        from urllib.parse import urlparse
+        parsed = urlparse(self._config.endpoint_url)
+        return (parsed.hostname or "").lower() == "storage.googleapis.com"
+
     def _create_client(self):
         """Create boto3 S3 client with configuration."""
         try:
+            # GCS S3-interop requires V2 signatures; boto3's V4 chunked upload
+            # signing is incompatible with GCS's S3 endpoint for write operations.
+            sig_version = "s3" if self._is_gcs_endpoint() else "s3v4"
+
             client_config = Config(
-                signature_version="s3v4",
+                signature_version=sig_version,
                 retries={"max_attempts": 3, "mode": "standard"},
                 connect_timeout=10,
                 read_timeout=30,
@@ -421,7 +433,8 @@ class S3Backend(StorageBackend):
 
             endpoint_desc = self._config.endpoint_url or "AWS S3"
             logger.info(
-                f"S3 client initialized: endpoint={endpoint_desc}, bucket={self._config.bucket}"
+                "S3 client initialized: endpoint=%s, bucket=%s, signature=%s",
+                endpoint_desc, self._config.bucket, sig_version,
             )
 
             return client


### PR DESCRIPTION
## Summary

- **Bug**: boto3's V4 signature with chunked upload encoding (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`) is incompatible with GCS's S3-compatible endpoint for write operations. `PutObject` returns `SignatureDoesNotMatch: Invalid argument`, while read/list operations succeed.
- **Impact**: All storage writes fail on GKE deployments using `STORAGE_ENDPOINT_URL=https://storage.googleapis.com` with HMAC keys. This breaks:
  - Orchestrator sub-agent findings persistence (`write_findings`)
  - Knowledge Base document uploads
  - Terraform workspace file persistence
- **Fix**: Detect GCS endpoint and use V2 signing (`signature_version="s3"`) which works correctly for all operations. Non-GCS backends (AWS S3, MinIO, SeaweedFS) continue using V4.

## Verification

Tested directly on the staging cluster (GKE + GCS HMAC keys):

| Operation | V4 (s3v4) | V2 (s3) |
|-----------|-----------|---------|
| list_objects_v2 | Works | Works |
| put_object | SignatureDoesNotMatch | Works |
| upload_fileobj | SignatureDoesNotMatch | Works |

## Test plan

- [ ] Verify local dev (SeaweedFS) still works with V4 signing (endpoint is not storage.googleapis.com)
- [ ] Deploy to staging and confirm orchestrator write_findings succeeds
- [ ] Confirm Knowledge Base upload works on staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Google Cloud Storage by automatically detecting S3-compatible endpoints and applying appropriate signing configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/404)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->