### PR TITLE
fix: include org_id in all INSERT statements to RLS-protected tables

### DIFF
--- a/server/chat/backend/agent/utils/persistence/context_manager.py
+++ b/server/chat/backend/agent/utils/persistence/context_manager.py
@@ -175,11 +175,12 @@ class ContextManager:
             with db_pool.get_user_connection() as conn:
                 cursor = conn.cursor()
                 from utils.auth.stateless_auth import set_rls_context
-                if not set_rls_context(cursor, conn, user_id, log_prefix="[ContextManager]"):
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ContextManager]")
+                if not org_id:
                     return False
                 
                 result = self._upsert_session(
-                    cursor, conn, session_id, user_id,
+                    cursor, conn, session_id, user_id, org_id,
                     json.dumps(serialized_messages), datetime.now(),
                 )
                 if result is not None:
@@ -239,7 +240,7 @@ class ContextManager:
         return serialized
 
     @staticmethod
-    def _upsert_session(cursor, conn, session_id, user_id, context_json, now):
+    def _upsert_session(cursor, conn, session_id, user_id, org_id, context_json, now):
         """Try UPDATE, then INSERT if the session doesn't exist. Returns bool or None (updated OK, continue)."""
         cursor.execute("""
             UPDATE chat_sessions 
@@ -261,9 +262,9 @@ class ContextManager:
         try:
             logger.info(f"Session {session_id} not found - creating it automatically")
             cursor.execute("""
-                INSERT INTO chat_sessions (id, user_id, title, messages, ui_state, llm_context_history, created_at, updated_at, is_active)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            """, (session_id, user_id, "New Chat", json.dumps([]), json.dumps({}), context_json, now, now, True))
+                INSERT INTO chat_sessions (id, user_id, org_id, title, messages, ui_state, llm_context_history, created_at, updated_at, is_active)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """, (session_id, user_id, org_id, "New Chat", json.dumps([]), json.dumps({}), context_json, now, now, True))
             conn.commit()
             logger.info(f"Auto-created session {session_id} and saved context")
             return True

--- a/server/chat/backend/agent/utils/persistence/context_manager.py
+++ b/server/chat/backend/agent/utils/persistence/context_manager.py
@@ -240,7 +240,7 @@ class ContextManager:
         return serialized
 
     @staticmethod
-    def _upsert_session(cursor, conn, session_id, user_id, org_id, context_json, now):
+    def _upsert_session(cursor, conn, session_id, user_id, org_id, context_json, now) -> "bool | None":
         """Try UPDATE, then INSERT if the session doesn't exist. Returns bool or None (updated OK, continue)."""
         cursor.execute("""
             UPDATE chat_sessions 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -461,7 +461,8 @@ def run_background_chat(
             try:
                 with db_pool.get_admin_connection() as conn:
                     with conn.cursor() as cursor:
-                        if not set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat]"):
+                        rls_org_id = set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat]")
+                        if not rls_org_id:
                             logger.error("[BackgroundChat] Cannot resolve org_id for user %s, skipping incident linking", user_id)
                             raise ValueError(f"Missing org_id for user {user_id}")
                     # Ensure chat_sessions.incident_id is set (single source of truth)
@@ -536,7 +537,7 @@ def run_background_chat(
                                 """INSERT INTO incident_lifecycle_events
                                    (incident_id, user_id, org_id, event_type, new_value)
                                    VALUES (%s, %s, %s, %s, %s)""",
-                                (incident_id, user_id, get_org_id_for_user(user_id), 'rca_started', 'running')
+                                (incident_id, user_id, rls_org_id, 'rca_started', 'running')
                             )
                             conn.commit()
                             logger.info(f"[BackgroundChat] Recorded lifecycle event 'rca_started' for incident {incident_id}")

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -536,7 +536,7 @@ def run_background_chat(
                                 """INSERT INTO incident_lifecycle_events
                                    (incident_id, user_id, org_id, event_type, new_value)
                                    VALUES (%s, %s, %s, %s, %s)""",
-                                (incident_id, user_id, None, 'rca_started', 'running')
+                                (incident_id, user_id, get_org_id_for_user(user_id), 'rca_started', 'running')
                             )
                             conn.commit()
                             logger.info(f"[BackgroundChat] Recorded lifecycle event 'rca_started' for incident {incident_id}")
@@ -2222,12 +2222,14 @@ def create_background_chat_session(
 def _record_rca_error(cursor, incident_id: str, user_id: str) -> None:
     """Write an rca_error lifecycle event, wrapped in a savepoint to avoid aborting the caller."""
     try:
+        from utils.auth.stateless_auth import get_org_id_for_user
+        org_id = get_org_id_for_user(user_id)
         cursor.execute("SAVEPOINT sp_rca_err")
         cursor.execute(
             """INSERT INTO incident_lifecycle_events
                (incident_id, user_id, org_id, event_type, new_value)
                VALUES (%s, %s, %s, %s, %s)""",
-            (incident_id, user_id, None, 'rca_error', 'error')
+            (incident_id, user_id, org_id, 'rca_error', 'error')
         )
         cursor.execute("RELEASE SAVEPOINT sp_rca_err")
     except Exception as e:


### PR DESCRIPTION
## Summary

- Three code paths were inserting rows into RLS-protected tables (`chat_sessions`, `incident_lifecycle_events`) with `org_id = NULL`, causing those rows to become **permanently invisible** on prod/staging where RLS is enforced (policy requires `org_id IS NOT NULL`).
- `context_manager.py`: `_upsert_session` fallback INSERT now passes the `org_id` already resolved by `set_rls_context`
- `task.py`: `_record_rca_error` and the `rca_started` lifecycle event INSERT now resolve `org_id` via `get_org_id_for_user` instead of hardcoding `None`

## Root Cause

The RLS policy on these tables requires:
```sql
org_id IS NOT NULL
AND org_id = current_setting('myapp.current_org_id')::text
```

On localhost this was invisible because the Postgres user is a superuser (bypasses RLS). On prod/staging, any row with `org_id = NULL` is permanently hidden from all queries.

## Impact

- Chat sessions auto-created by the context manager (fallback path when UPDATE finds no matching row) would have NULL org_id
- RCA error/started lifecycle events were always inserted with NULL org_id
- These rows are silently invisible on prod — no error, just missing data on refresh

## Test plan

- [x] Verified locally with non-superuser DB role (`appuser`) that RLS correctly hides NULL org_id rows
- [x] Verified all other INSERT paths into RLS-protected tables already include org_id
- [ ] Deploy to staging and confirm chat sessions persist across page refresh
- [ ] Trigger an RCA and verify `incident_lifecycle_events` has correct org_id

Fixes DEV-1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Corrected organization context tracking in chat sessions, ensuring user sessions are accurately attributed to the correct organization for improved data consistency
- Enhanced background chat operations by properly capturing organization information in incident lifecycle events and error logs for better system reliability and tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->