### PR TITLE
fix: add deployment verification guidance to RCA GitHub investigation

### DIFF
--- a/server/chat/backend/agent/orchestrator/roles/recent_change_investigator.md
+++ b/server/chat/backend/agent/orchestrator/roles/recent_change_investigator.md
@@ -12,10 +12,12 @@ You are a change-correlation investigator. Your scope is deployments, commits, C
 
 Search the version-control and CI/CD systems for commits merged and deployments completed in the relevant time window. Correlate timing of changes with the incident onset. Identify the specific commit or pipeline that is the most likely candidate.
 
+**Important: Merged != Deployed.** A commit merged to main is not necessarily deployed to production. When attributing an incident to a code change, check whether a deployment workflow ran after the commit. If deployment status is unclear, qualify your finding (e.g. "likely cause if deployed").
+
 **You must NOT:**
 - Call any tool that writes code, opens pull requests, or triggers deployments.
 - Speculate about causation without a concrete change event to anchor it.
 
 **Reading scope:** Limit reading to changed files and their immediate dependencies (imports/includes) and the commit message; only expand to other files if the change purpose remains unclear.
 
-**Findings structure:** Cite specific commit SHAs, pipeline run IDs, or deployment identifiers in `citations`. If no change correlates within the window, document that explicitly and mark `inconclusive`. Suggest a `runtime_state_investigator` follow-up if change correlation is weak.
+**Findings structure:** Cite specific commit SHAs, pipeline run IDs, or deployment identifiers in `citations`. If no change correlates within the window, document that explicitly and mark `inconclusive`. If changes exist but deployment cannot be confirmed, note that in your findings. Suggest a `runtime_state_investigator` follow-up if change correlation is weak.

--- a/server/chat/backend/agent/skills/integrations/github/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/github/SKILL.md
@@ -56,14 +56,15 @@ Connected account: {username}
 - All MCP tools require `owner` and `repo` parameters (split from 'owner/repo').
 
 ### RCA Investigation Workflow
-Code changes are the most common root cause of incidents.
-Investigate GitHub BEFORE deep-diving into infrastructure.
+Code changes are a common root cause of incidents. Investigate GitHub early in the process.
+
+**Important: Merged does not always mean deployed.** Many teams have separate CI (build) and CD (deploy) steps. When concluding that a commit caused an incident, check whether it was actually deployed. If deployment status cannot be confirmed, qualify your conclusion (e.g. "this commit is the likely cause if it was deployed").
 
 **Step 1 — Discover repos:**
 `get_connected_repos()` — returns all connected repos with descriptions.
 Read the descriptions to pick the repo most relevant to the alert.
 
-**Step 2 — Check deployments (did something just ship?):**
+**Step 2 — Check deployments (did something ship?):**
 `github_rca(repo='owner/repo', action='deployment_check', incident_time='<ISO8601>')`
 Finds failed workflow runs and runs completed within 2 hours of the incident.
 
@@ -88,3 +89,4 @@ Suggests a fix stored for user review. User can approve, then `github_apply_fix`
 - Use `time_window_hours` (default 24) to widen/narrow the search.
 - Repos are REMOTE — use MCP tools (`get_file_contents`) to read files, never local shell commands.
 - Look for: config changes, k8s manifests, Terraform, dependency updates.
+- When concluding a commit is the root cause, check if deployment_check confirms it was deployed. If not, qualify with "likely cause if deployed" rather than stating it definitively.

--- a/server/chat/backend/agent/skills/rca/segments/what_to_investigate.md
+++ b/server/chat/backend/agent/skills/rca/segments/what_to_investigate.md
@@ -5,4 +5,4 @@
 - CONFIGURATIONS for misconfigurations or invalid values
 - EVENTS for recent state changes
 - DEPENDENCIES for cascading failures
-- RECENT CHANGES or deployments that correlate with the issue
+- RECENT DEPLOYMENTS (not just commits) that correlate with the issue — verify the change reached production before blaming it


### PR DESCRIPTION
## Summary
- Adds merged != deployed guidance to the GitHub RCA skill and the recent_change_investigator role
- When the agent finds recent commits correlated with an incident, it now qualifies conclusions with deployment status rather than stating causation definitively
- Addresses issue where the agent would blame the most recent merge to main even when those changes had not been deployed to production

## Changes
- SKILL.md (GitHub integration): adds note that merged commits should be verified as deployed before concluding causation
- recent_change_investigator.md: qualifies findings when deployment cannot be confirmed
- what_to_investigate.md: recent deployments rather than recent changes

## Test plan
- [ ] Trigger an RCA with a GitHub-connected user where recent commits exist but no deployment workflow ran -- agent should qualify its conclusion
- [ ] Verify agent still investigates code changes and flags suspicious commits normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Root Cause Analysis investigation guidance to clarify that merged code is not necessarily deployed
  * Updated RCA workflow with explicit deployment verification requirement before attributing incidents to commits
  * Reinforced investigation checklist to confirm changes reached production before drawing conclusions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->