### PR TITLE
fix: skip input guardrail for prediscovery (no untrusted input)

### DIFF
--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -1028,7 +1028,7 @@ class Workflow:
         self._history_prefix_len = history_prefix_len
 
         # --- Input rail: check user message for prompt injection ---
-        from guardrails.input_rail import check_input
+        from guardrails.input_rail import check_input, InputRailResult
         last_msg = input_state.messages[-1] if input_state.messages else None
         if last_msg and hasattr(last_msg, "type") and last_msg.type == "human":
             # Skip persistence for scaffold messages (background prompts, not user input)
@@ -1041,7 +1041,12 @@ class Workflow:
                 getattr(input_state, "question", None),
                 last_msg.content,
             )
-            rail_result = await check_input(msg_text)
+            # Skip rail when there is no untrusted text to evaluate (e.g.
+            # prediscovery prompts are entirely system-authored).
+            if not msg_text:
+                rail_result = InputRailResult(blocked=False)
+            else:
+                rail_result = await check_input(msg_text)
             if rail_result.blocked:
                 emit_block_event(
                     user_id=getattr(input_state, "user_id", "") or "",

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -214,6 +214,7 @@ def run_prediscovery(
             trigger_metadata=trigger_metadata,
             provider_preference=providers,
             mode="prediscovery",
+            rail_text="",
         ))
 
         from chat.background.task import _update_session_status

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1176,7 +1176,7 @@ async def _execute_background_chat(
         # user input and would produce false positives. Callers pass rail_text
         # for that case; fall back to initial_message to preserve legacy
         # semantics for triggers that forward a raw user question.
-        rail_question = rail_text if rail_text else initial_message
+        rail_question = rail_text if rail_text is not None else initial_message
 
         # State.incident_id is read-only context for downstream nodes (triage
         # uses it to look up prior findings, prompt_builder for RCA scaffolding).


### PR DESCRIPTION
## Summary
- Prediscovery prompts are entirely system-authored with zero user/webhook input, but the NeMo input rail was evaluating the full 4700-char instruction scaffold as "user input" and blocking every single run on prod (confirmed via `kubectl logs` — all 5 runs in the last 24h were blocked)
- Pass `rail_text=""` from prediscovery to explicitly signal "nothing to check", fix the truthiness check so empty string is respected, and skip the NeMo call when `msg_text` is empty
- RCA still correctly evaluates webhook-authored alert fields; foreground chats are unaffected

## Test plan
- [x] Triggered prediscovery locally via celery-beat schedule — 4 orgs completed successfully (1.5-3 min each, actually calling tools)
- [x] Triggered prediscovery manually via frontend button — agent ran, called GCP/Splunk tools (failed on creds as expected locally, but passed guardrails)
- [x] Confirmed no `InputRail BLOCKED` logs for prediscovery sessions
- [x] Verified RCA background chats still invoke NeMo on their `rail_text` (other background tasks ran concurrently with NeMo logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation to properly handle edge cases where extracted text is empty or missing.
  * Enhanced consistency in guardrail text processing during background operations, ensuring correct fallback behavior.
  * Fixed handling of empty text parameters in prediscovery sessions to maintain proper validation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->