### PR TITLE
RCA synthesis: inject main orchestrator thoughts to reduce hallucinations

### DIFF
--- a/server/chat/backend/agent/orchestrator/state_filter.py
+++ b/server/chat/backend/agent/orchestrator/state_filter.py
@@ -12,6 +12,7 @@ _EXCLUDED_STATE_KEYS = frozenset({
     "summarized_context",
     "triage_rationale",
     "synthesis_notes",
+    "synthesis_history",
     "rca_ui_updates",
 })
 

--- a/server/chat/backend/agent/orchestrator/synthesis.py
+++ b/server/chat/backend/agent/orchestrator/synthesis.py
@@ -26,6 +26,15 @@ logger = logging.getLogger(__name__)
 _MAX_SYNTHESIS_WAVES = 2
 _MAX_FOLLOWUPS = 6
 
+# Caps for orchestrator-context fields embedded in the synthesis prompt.
+# Findings themselves are already capped at 12000 chars; these are kept small
+# enough that the combined prompt comfortably fits inside the model window
+# while still surfacing the full alert + plan.
+_MAX_ORCH_QUESTION_CHARS = 4000
+_MAX_ORCH_ALERT_FIELD_CHARS = 600
+_MAX_ORCH_RATIONALE_CHARS = 800
+_MAX_ORCH_PURPOSE_CHARS = 500
+
 
 class SynthesisDecision(BaseModel):
     needs_more_research: bool = False
@@ -87,6 +96,9 @@ async def _synthesis(state: State) -> dict:
     finding_bodies: list[str] = []
     for row in finding_rows:
         header = f"## Wave {row.get('wave', '?')} | Agent: {row.get('agent_id')} ({row.get('role_name')})"
+        purpose = row.get("purpose")
+        if purpose:
+            header = f"{header}\nAssigned purpose: {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS)}"
         body = body_by_agent.get(row.get("agent_id"))
         if body:
             finding_bodies.append(f"{header}\n\n{body}")
@@ -133,7 +145,13 @@ async def _synthesis(state: State) -> dict:
         except Exception:
             available_roles = []
 
-        prompt = _build_synthesis_prompt(state, combined, current_wave, available_roles)
+        orchestrator_thoughts = _build_orchestrator_thoughts(state)
+        prompt = _build_synthesis_prompt(
+            state, combined, current_wave, available_roles, orchestrator_thoughts,
+        )
+        _log_orchestrator_context_injection(
+            inc_hash, target_wave, orchestrator_thoughts, prompt, len(finding_bodies),
+        )
         start_time = time.time()
         result = await structured.ainvoke(prompt)
 
@@ -206,6 +224,26 @@ async def _synthesis(state: State) -> dict:
     final_ai_msg = AIMessage(content=final_summary_text)
     new_messages = existing_messages + tool_messages + [final_ai_msg]
 
+    # Persist the orchestrator's own decision for this wave so subsequent
+    # synthesis waves can reason about what was already considered. This is
+    # the "main orchestrator thoughts" that must accompany the sub-agent tool
+    # output into later summarizations to prevent hallucinations.
+    history_entry = {
+        "wave": target_wave,
+        "rationale": (decision.rationale or "")[:_MAX_ORCH_RATIONALE_CHARS],
+        "needs_more_research": bool(decision.needs_more_research) and not is_terminal,
+        "follow_up_inputs": [
+            {
+                "agent_id": inp.agent_id,
+                "role_name": inp.role_name,
+                "purpose": (inp.purpose or "")[:_MAX_ORCH_PURPOSE_CHARS],
+            }
+            for inp in (decision.follow_up_inputs or [])
+        ],
+    }
+    existing_history = list(getattr(state, "synthesis_history", []) or [])
+    new_history = existing_history + [history_entry]
+
     if is_terminal:
         logger.info(
             "synthesis: incident=%s wave=%d cache_hits=%d",
@@ -215,12 +253,14 @@ async def _synthesis(state: State) -> dict:
             "synthesis_wave": new_wave,
             "subagent_inputs": [],
             "messages": new_messages,
+            "synthesis_history": new_history,
         }
 
     return {
         "synthesis_wave": new_wave,
         "subagent_inputs": [inp.model_dump() for inp in decision.follow_up_inputs],
         "messages": new_messages,
+        "synthesis_history": new_history,
     }
 
 
@@ -258,26 +298,35 @@ def _build_tool_messages(state: State, incident_id: str, target_wave: int) -> li
 
 
 def _build_synthesis_prompt(state: State, combined_findings: str, wave: int,
-                              available_roles: list) -> str:
+                              available_roles: list,
+                              orchestrator_thoughts: str) -> str:
     """Build the synthesis prompt.
 
     Findings are grouped by wave in `combined_findings`. The LLM judges
     `needs_more_research` from what the NEW wave (target_wave = wave+1) added,
     but writes the user-facing `summary` using full context across all waves.
+
+    `orchestrator_thoughts` carries the main orchestrator's grounding context
+    (alert details, triage rationale, sub-agent plan, prior wave decisions).
+    The summary must remain grounded in findings, but uses this context to
+    avoid hallucinating alert facts that the sub-agents did not re-state.
     """
-    incident_id = getattr(state, "incident_id", "unknown") or "unknown"
-    question = (getattr(state, "question", "") or "")[:500]
     target_wave = wave + 1
     role_lines = "\n".join(
         f"- {r.name}: {r.description}" for r in available_roles
     ) or "(none available)"
     return (
         f"You are an RCA orchestrator synthesizing parallel investigation findings.\n\n"
-        f"Incident: {incident_id}\nOriginal question: {question}\n"
         f"Most recent wave: {target_wave} (max {_MAX_SYNTHESIS_WAVES})\n\n"
+        f"{orchestrator_thoughts}\n\n"
         f"Available investigator roles for follow-up (use ONLY these role_name values):\n{role_lines}\n\n"
         f"=== SUB-AGENT FINDINGS (grouped by wave) ===\n\n{combined_findings[:12000]}\n\n"
         f"=== TASK ===\n"
+        f"Treat ORCHESTRATOR CONTEXT as ground-truth facts about the alert and "
+        f"the investigation plan. Treat SUB-AGENT FINDINGS as the only source "
+        f"of evidence for what was actually discovered. Do NOT invent findings, "
+        f"metrics, error messages, or root causes that are not present in the "
+        f"sub-agent findings; if a sub-agent did not investigate something, say so.\n\n"
         f"1) needs_more_research: judge based on what wave {target_wave} added. "
         f"If the new wave (or, on wave 1, the only wave) provides a clear root cause "
         f"with at least one strong/moderate-confidence finding, return false. "
@@ -288,6 +337,167 @@ def _build_synthesis_prompt(state: State, combined_findings: str, wave: int,
         f"across every wave shown above. Cover what was found, the most likely root cause(s), "
         f"and (if needs_more_research=true) what's being investigated next. Shown directly to the user.\n"
         f"3) rationale: brief reasoning for your decision."
+    )
+
+
+def _build_orchestrator_thoughts(state: State) -> str:
+    """Render the main orchestrator's grounding context as a prompt block.
+
+    Includes:
+    - The original RCA question / synthesized alert prompt header.
+    - Structured alert details from rca_context (title, severity, status,
+      message, service) — these come from the webhook/trigger payload and
+      are the authoritative description of what's being investigated.
+    - The triage decision rationale + the sub-agent assignments (agent_id ->
+      role + purpose) so the synthesizer can see what each sub-agent was
+      tasked with, not just what they returned.
+    - Prior wave synthesis rationales when running wave 2+ so the
+      orchestrator's previous reasoning is preserved across waves.
+
+    All fields are bounded to keep the prompt within model context.
+    """
+    incident_id = getattr(state, "incident_id", "unknown") or "unknown"
+    question = (getattr(state, "question", "") or "")[:_MAX_ORCH_QUESTION_CHARS]
+
+    lines: list[str] = [
+        "=== ORCHESTRATOR CONTEXT (grounding facts; NOT evidence) ===",
+        f"Incident: {incident_id}",
+    ]
+
+    rca_context = getattr(state, "rca_context", None) or {}
+    if isinstance(rca_context, dict):
+        alert_block = _format_rca_context(rca_context)
+        if alert_block:
+            lines.append("")
+            lines.append("Alert details (from trigger payload):")
+            lines.append(alert_block)
+
+    triage_block = _format_triage_decision(getattr(state, "triage_decision", None))
+    if triage_block:
+        lines.append("")
+        lines.append("Triage decision (main orchestrator reasoning):")
+        lines.append(triage_block)
+
+    history_block = _format_synthesis_history(getattr(state, "synthesis_history", None))
+    if history_block:
+        lines.append("")
+        lines.append("Prior synthesis decisions (orchestrator thoughts from earlier waves):")
+        lines.append(history_block)
+
+    if question:
+        lines.append("")
+        lines.append("Original RCA prompt (excerpt):")
+        lines.append(question)
+
+    return "\n".join(lines)
+
+
+def _trunc(value, limit: int) -> str:
+    s = "" if value is None else str(value)
+    return s if len(s) <= limit else s[:limit] + "...[truncated]"
+
+
+def _format_rca_context(rca_context: dict) -> str:
+    """Surface the alert facts the orchestrator was given. Pulls only fields
+    we know to be safe to embed (no secrets, no large blobs)."""
+    fields = [
+        ("title", "Title"),
+        ("severity", "Severity"),
+        ("status", "Status"),
+        ("source", "Source"),
+        ("service", "Service"),
+        ("message", "Message"),
+    ]
+    parts: list[str] = []
+    for key, label in fields:
+        val = rca_context.get(key)
+        if val:
+            parts.append(f"- {label}: {_trunc(val, _MAX_ORCH_ALERT_FIELD_CHARS)}")
+    providers = rca_context.get("providers")
+    if isinstance(providers, (list, tuple)) and providers:
+        parts.append(f"- Connected providers: {', '.join(str(p) for p in providers)}")
+    return "\n".join(parts)
+
+
+def _format_triage_decision(triage_decision) -> str:
+    """Render the triage rationale + the planned sub-agent assignments."""
+    if not triage_decision:
+        return ""
+    if isinstance(triage_decision, dict):
+        mode = triage_decision.get("mode")
+        rationale = triage_decision.get("rationale") or ""
+        inputs = triage_decision.get("inputs") or []
+    else:
+        mode = getattr(triage_decision, "mode", None)
+        rationale = getattr(triage_decision, "rationale", "") or ""
+        inputs = getattr(triage_decision, "inputs", []) or []
+
+    parts: list[str] = []
+    if mode:
+        parts.append(f"- Mode: {mode}")
+    if rationale:
+        parts.append(f"- Rationale: {_trunc(rationale, _MAX_ORCH_RATIONALE_CHARS)}")
+    if inputs:
+        parts.append("- Sub-agents dispatched:")
+        for inp in inputs:
+            if isinstance(inp, dict):
+                agent_id = inp.get("agent_id") or "?"
+                role = inp.get("role_name") or "?"
+                purpose = inp.get("purpose") or ""
+            else:
+                agent_id = getattr(inp, "agent_id", "?")
+                role = getattr(inp, "role_name", "?")
+                purpose = getattr(inp, "purpose", "")
+            parts.append(
+                f"  - {agent_id} ({role}): {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS)}"
+            )
+    return "\n".join(parts)
+
+
+def _format_synthesis_history(history) -> str:
+    if not history:
+        return ""
+    parts: list[str] = []
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        wave = entry.get("wave", "?")
+        rationale = _trunc(entry.get("rationale", ""), _MAX_ORCH_RATIONALE_CHARS)
+        needs_more = entry.get("needs_more_research")
+        parts.append(f"- Wave {wave}: needs_more_research={bool(needs_more)}")
+        if rationale:
+            parts.append(f"  rationale: {rationale}")
+        follow_ups = entry.get("follow_up_inputs") or []
+        for fu in follow_ups:
+            if not isinstance(fu, dict):
+                continue
+            agent_id = fu.get("agent_id") or "?"
+            role = fu.get("role_name") or "?"
+            purpose = _trunc(fu.get("purpose", ""), _MAX_ORCH_PURPOSE_CHARS)
+            parts.append(f"  follow-up {agent_id} ({role}): {purpose}")
+    return "\n".join(parts)
+
+
+def _log_orchestrator_context_injection(inc_hash: str, target_wave: int,
+                                          orchestrator_thoughts: str,
+                                          full_prompt: str,
+                                          findings_count: int) -> None:
+    """Emit an INFO log that proves orchestrator context was injected.
+
+    Counts the major context sections instead of dumping the prompt — keeps
+    logs grep-friendly and avoids leaking large alert bodies into log search.
+    """
+    sections = {
+        "alert_details": "Alert details (from trigger payload):" in orchestrator_thoughts,
+        "triage": "Triage decision (main orchestrator reasoning):" in orchestrator_thoughts,
+        "prior_synthesis": "Prior synthesis decisions" in orchestrator_thoughts,
+        "original_question": "Original RCA prompt (excerpt):" in orchestrator_thoughts,
+    }
+    logger.info(
+        "synthesis_node: orchestrator_context_injected incident=%s wave=%d "
+        "orch_chars=%d prompt_chars=%d findings=%d sections=%s",
+        inc_hash, target_wave, len(orchestrator_thoughts), len(full_prompt),
+        findings_count, sections,
     )
 
 
@@ -307,7 +517,7 @@ def _fetch_finding_rows(incident_id: str, user_id: str, max_wave: int) -> list:
                     return []
                 cur.execute(
                     """SELECT agent_id, role_name, storage_uri, status,
-                              self_assessed_strength, wave, error_message
+                              self_assessed_strength, wave, error_message, purpose
                        FROM rca_findings
                        WHERE incident_id = %s AND wave <= %s
                        ORDER BY wave ASC, started_at ASC""",

--- a/server/chat/backend/agent/orchestrator/synthesis.py
+++ b/server/chat/backend/agent/orchestrator/synthesis.py
@@ -25,11 +25,12 @@ logger = logging.getLogger(__name__)
 
 _MAX_SYNTHESIS_WAVES = 2
 _MAX_FOLLOWUPS = 6
+_MAX_FINDINGS_CHARS = 12000
 
 # Caps for orchestrator-context fields embedded in the synthesis prompt.
-# Findings themselves are already capped at 12000 chars; these are kept small
-# enough that the combined prompt comfortably fits inside the model window
-# while still surfacing the full alert + plan.
+# Findings themselves are already capped at _MAX_FINDINGS_CHARS; these are
+# kept small enough that the combined prompt comfortably fits inside the model
+# window while still surfacing the full alert + plan.
 _MAX_ORCH_QUESTION_CHARS = 4000
 _MAX_ORCH_ALERT_FIELD_CHARS = 600
 _MAX_ORCH_RATIONALE_CHARS = 800
@@ -98,7 +99,7 @@ async def _synthesis(state: State) -> dict:
         header = f"## Wave {row.get('wave', '?')} | Agent: {row.get('agent_id')} ({row.get('role_name')})"
         purpose = row.get("purpose")
         if purpose:
-            header = f"{header}\nAssigned purpose: {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS)}"
+            header = f"{header}\nAssigned purpose: {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS, 'finding_purpose')}"
         body = body_by_agent.get(row.get("agent_id"))
         if body:
             finding_bodies.append(f"{header}\n\n{body}")
@@ -315,12 +316,17 @@ def _build_synthesis_prompt(state: State, combined_findings: str, wave: int,
     role_lines = "\n".join(
         f"- {r.name}: {r.description}" for r in available_roles
     ) or "(none available)"
+    findings_len = len(combined_findings)
+    if findings_len > _MAX_FINDINGS_CHARS:
+        logger.info("synthesis: truncated combined_findings from %d to %d chars", findings_len, _MAX_FINDINGS_CHARS)
+        combined_findings = combined_findings[:_MAX_FINDINGS_CHARS]
+
     return (
         f"You are an RCA orchestrator synthesizing parallel investigation findings.\n\n"
         f"Most recent wave: {target_wave} (max {_MAX_SYNTHESIS_WAVES})\n\n"
         f"{orchestrator_thoughts}\n\n"
         f"Available investigator roles for follow-up (use ONLY these role_name values):\n{role_lines}\n\n"
-        f"=== SUB-AGENT FINDINGS (grouped by wave) ===\n\n{combined_findings[:12000]}\n\n"
+        f"=== SUB-AGENT FINDINGS (grouped by wave) ===\n\n{combined_findings}\n\n"
         f"=== TASK ===\n"
         f"Treat ORCHESTRATOR CONTEXT as ground-truth facts about the alert and "
         f"the investigation plan. Treat SUB-AGENT FINDINGS as the only source "
@@ -392,9 +398,12 @@ def _build_orchestrator_thoughts(state: State) -> str:
     return "\n".join(lines)
 
 
-def _trunc(value, limit: int) -> str:
+def _trunc(value, limit: int, field: str = "") -> str:
     s = "" if value is None else str(value)
-    return s if len(s) <= limit else s[:limit] + "...[truncated]"
+    if len(s) <= limit:
+        return s
+    logger.info("synthesis: truncated %s from %d to %d chars", field or "field", len(s), limit)
+    return s[:limit] + "...[truncated]"
 
 
 def _format_rca_context(rca_context: dict) -> str:
@@ -412,7 +421,7 @@ def _format_rca_context(rca_context: dict) -> str:
     for key, label in fields:
         val = rca_context.get(key)
         if val:
-            parts.append(f"- {label}: {_trunc(val, _MAX_ORCH_ALERT_FIELD_CHARS)}")
+            parts.append(f"- {label}: {_trunc(val, _MAX_ORCH_ALERT_FIELD_CHARS, label)}")
     providers = rca_context.get("providers")
     if isinstance(providers, (list, tuple)) and providers:
         parts.append(f"- Connected providers: {', '.join(str(p) for p in providers)}")
@@ -436,7 +445,7 @@ def _format_triage_decision(triage_decision) -> str:
     if mode:
         parts.append(f"- Mode: {mode}")
     if rationale:
-        parts.append(f"- Rationale: {_trunc(rationale, _MAX_ORCH_RATIONALE_CHARS)}")
+        parts.append(f"- Rationale: {_trunc(rationale, _MAX_ORCH_RATIONALE_CHARS, 'triage_rationale')}")
     if inputs:
         parts.append("- Sub-agents dispatched:")
         for inp in inputs:
@@ -449,7 +458,7 @@ def _format_triage_decision(triage_decision) -> str:
                 role = getattr(inp, "role_name", "?")
                 purpose = getattr(inp, "purpose", "")
             parts.append(
-                f"  - {agent_id} ({role}): {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS)}"
+                f"  - {agent_id} ({role}): {_trunc(purpose, _MAX_ORCH_PURPOSE_CHARS, 'purpose')}"
             )
     return "\n".join(parts)
 
@@ -462,7 +471,7 @@ def _format_synthesis_history(history) -> str:
         if not isinstance(entry, dict):
             continue
         wave = entry.get("wave", "?")
-        rationale = _trunc(entry.get("rationale", ""), _MAX_ORCH_RATIONALE_CHARS)
+        rationale = _trunc(entry.get("rationale", ""), _MAX_ORCH_RATIONALE_CHARS, "history_rationale")
         needs_more = entry.get("needs_more_research")
         parts.append(f"- Wave {wave}: needs_more_research={bool(needs_more)}")
         if rationale:
@@ -473,7 +482,7 @@ def _format_synthesis_history(history) -> str:
                 continue
             agent_id = fu.get("agent_id") or "?"
             role = fu.get("role_name") or "?"
-            purpose = _trunc(fu.get("purpose", ""), _MAX_ORCH_PURPOSE_CHARS)
+            purpose = _trunc(fu.get("purpose", ""), _MAX_ORCH_PURPOSE_CHARS, "history_purpose")
             parts.append(f"  follow-up {agent_id} ({role}): {purpose}")
     return "\n".join(parts)
 

--- a/server/chat/backend/agent/utils/state.py
+++ b/server/chat/backend/agent/utils/state.py
@@ -43,5 +43,10 @@ class State(BaseModel):
     subagent_inputs: List[Dict[str, Any]] = []
     finding_refs: Annotated[List[Dict[str, Any]], operator.add] = []
     synthesis_wave: int = 0
+    # Per-wave decisions from the synthesis node (rationale, follow-ups). Used
+    # to feed the orchestrator's own prior thoughts back into later synthesis
+    # waves so the summary is grounded in the full investigation arc, not just
+    # the most recent sub-agent findings.
+    synthesis_history: List[Dict[str, Any]] = []
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -241,12 +241,12 @@ If the correlated alerts are relevant, clearly indicate their relationship to th
         reasoning_block = ""
         if agent_reasoning and agent_reasoning.strip():
             reasoning_block = (
-                "\nAGENT REASONING & SYNTHESIS (the investigating agent's own thoughts "
-                "and any orchestrator synthesis summaries from this RCA):\n"
+                "\nAGENT REASONING (the investigating agent's own thoughts as shown "
+                "in the Thoughts panel — context, not direct evidence):\n"
                 f"{agent_reasoning}\n"
             )
 
-        prompt = f"""You are writing an incident report based on alert data, the investigating agent's reasoning, and forensic evidence.
+        prompt = f"""You are writing an incident report from alert data, the investigating agent's reasoning, and forensic evidence.
 
 ALERT INFORMATION:
 - Source: {source_type}
@@ -260,59 +260,38 @@ INVESTIGATION EVIDENCE (cite using [n] markers):
 
 Write a 2-3 paragraph incident report:
 
-PARAGRAPH 1 - What Happened:
-State what occurred, when it occurred, and what was affected, using only facts present in the alert, the agent reasoning, or the evidence. If a fact is not directly supported, do not state it. Write as if you're reporting a known fact rather than describing an investigation.
-Example (supported): "On [date], the data-processor service experienced OOMKilled events due to memory exhaustion [3, 5]."
+PARAGRAPH 1 — What Happened:
+State what occurred, when, and what was affected, using only facts present in the alert, agent reasoning, or evidence. Report as known facts, not as an investigation log.
 
-PARAGRAPH 2 - Root Cause:
-- If the evidence and agent reasoning together clearly support a specific root cause, state it and cite the supporting evidence.
+PARAGRAPH 2 — Root Cause:
+- If evidence and agent reasoning together clearly support a specific root cause, state it and cite the supporting evidence.
   Example: "The root cause was a ConfigMap change that increased BATCH_SIZE from 1000 to 10000 [7], causing memory usage to exceed the 128Mi limit [9, 11]."
-- If the evidence is missing, contradictory, or only consistent with the alert at a surface level, you MUST write a paragraph that begins with "Root cause undetermined." and then describe what is and isn't known. Do not invent a root cause to fill the paragraph. Do not present absence of data as evidence of a cause (e.g. "no logs were found" is not the same as "the service was not running").
+- Otherwise the paragraph MUST begin with "Root cause undetermined." and describe what is and isn't known. Do not invent a cause to fill the paragraph.
 
-PARAGRAPH 3 (if significant) - Impact & Timeline:
-Describe only the scope of impact and timeline details that are actually present in the alert, agent reasoning, or evidence.
+PARAGRAPH 3 (if significant) — Impact & Timeline:
+Only the scope and timeline actually present in the alert, agent reasoning, or evidence.
 
-CITATION RULES:
-- Cite specific evidence that supports factual claims.
-- Group related citations together [3, 5, 7].
-- Don't cite every detail — only key supporting evidence.
-- Never describe the investigation process or tools used.
-- Never say "Investigation revealed..." or "Attempts to..." — just state what is known.
+ANTI-HALLUCINATION RULES (non-negotiable):
+- Use only facts present in the alert, agent reasoning, or cited evidence — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
+- Empty or missing output from a generic probe is NOT evidence of a specific failure mode; never promote absence of data into a confident root cause.
+- Never fabricate a [n] citation — every marker MUST reference a real evidence row above.
+- Treat purely temporal correlations as correlations, not causations.
+- If the agent reasoning says the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
 
-ANTI-HALLUCINATION RULES (NON-NEGOTIABLE):
-- Do NOT introduce services, hosts, environments, configuration keys, user counts, time windows, error messages, or metrics that do not appear in the alert, agent reasoning, or evidence.
-- Do NOT promote weak signals (a single empty `ps`/`ls`, a missing file in a sandbox, an unreachable internal hostname) to "the auth/api/database service is down" or "the deployment failed". Empty/missing output from a generic command is NOT evidence of a specific failure mode.
-- Do NOT fabricate citations. Every [n] marker MUST refer to a real evidence row above; do not invent new numbers.
-- If the agent reasoning explicitly says the investigation was inconclusive, the report MUST reflect that — its Root Cause paragraph MUST start with "Root cause undetermined."
-- If the only correlation is temporal (e.g. "a release shipped ~30 minutes before symptoms"), say so explicitly as a correlation, not as causation.
+WRITING RULES:
+- Cite specific evidence that supports factual claims; group related citations [3, 5, 7]; cite only key supporting evidence.
+- Never describe investigation process or tool failures ("Investigation revealed...", "Attempts to query...", "The investigation was unable...").
+- Tone: professional, factual, incident-record style. Calibrated certainty: state facts where supported, state uncertainty where not.
 
-CRITICAL - DO NOT:
-- Describe investigation steps or what tools were run.
-- Say "Investigation revealed" or "Attempts to query" or "The investigation was unable".
-- Focus on tool failures or unavailable data.
-- Write about the RCA process itself.
-
-CRITICAL - DO:
-- Write as if reporting a completed incident, with calibrated certainty: state facts where supported, state uncertainty where not.
-- Focus on WHAT HAPPENED to the system, not HOW YOU FOUND OUT.
-- Use evidence citations to back up claims about system behavior.
-
-TONE: Professional, factual, incident-record style (not investigative process documentation).
-
-After the summary, add a separate paragraph titled "## Suggested Next Steps" that:
-- Lists 2-4 specific areas the SRE should investigate next.
-- When the root cause is undetermined, these next steps MUST be the concrete checks an engineer would run to determine the root cause (e.g. specific logs, metrics, configs to inspect), not generic advice.
-- References specific metrics, logs, or infrastructure components mentioned in the investigation when available.
-- Keep it concise and targeted.
+After the report, add a "## Suggested Next Steps" paragraph with 2-4 concrete diagnostic actions (specific logs/metrics/configs/components). When the root cause is undetermined, these MUST be the precise checks an engineer would run to determine it — not generic advice.
 """
     else:
-        # Fallback to transcript-based prompt
+        # Transcript fallback — same anti-hallucination contract.
         transcript = investigation_transcript or "[No transcript available]"
         reasoning_block = ""
         if agent_reasoning and agent_reasoning.strip():
             reasoning_block = (
-                "\nAGENT REASONING & SYNTHESIS (the investigating agent's own thoughts "
-                "and any orchestrator synthesis summaries):\n"
+                "\nAGENT REASONING (Thoughts-panel content — context, not direct evidence):\n"
                 f"{agent_reasoning}\n"
             )
         prompt = f"""
@@ -328,28 +307,17 @@ ALERT INFORMATION:
 INVESTIGATION TRANSCRIPT (chat log):
 {transcript}
 
-Write a concise 2–3 paragraph summary that:
-- Describes what triggered the alert.
-- States the severity and observed impact (only if explicitly present in the alert or transcript).
-- Identifies the affected service or component (only if explicitly named).
-- Summarizes investigation findings and best-known root cause ONLY if explicitly supported by the transcript or agent reasoning.
-- If the root cause is not explicit, the Root Cause paragraph MUST begin with "Root cause undetermined." and then describe what is and isn't known.
+Write a concise 2–3 paragraph summary covering what triggered the alert, the severity and observed impact (only if explicitly present), the affected service, and the best-known root cause. If the root cause is not explicit, the Root Cause paragraph MUST begin with "Root cause undetermined." and describe what is and isn't known.
 
-ANTI-HALLUCINATION RULES (NON-NEGOTIABLE):
-- Do NOT introduce services, hosts, configuration keys, user counts, error messages, or metrics that do not appear in the alert, agent reasoning, or transcript.
-- Do NOT promote absence of data (an empty command output, a missing file in a sandbox, an unreachable internal hostname) into a confident failure mode.
-- If the agent reasoning explicitly says the investigation was inconclusive, the report MUST reflect that.
+ANTI-HALLUCINATION RULES (non-negotiable):
+- Use only facts present in the alert, agent reasoning, or transcript — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
+- Empty or missing output from a generic probe is NOT evidence of a specific failure mode.
 - Treat purely temporal correlations as correlations, not causations.
+- If the agent reasoning says the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
 
-SUMMARY RULES:
-- Do NOT address any audience in the summary paragraphs.
-- Tone: neutral, factual, incident-record style.
-- Style: descriptive, not advisory.
+Tone: neutral, factual, incident-record style. Descriptive, not advisory. Do not address any audience.
 
-After the summary, add a separate paragraph titled "## Suggested Next Steps" that:
-- Lists 2-4 specific areas the SRE should investigate based on the findings.
-- When the root cause is undetermined, these next steps MUST be concrete diagnostic actions (specific logs, metrics, configs), not generic advice.
-- Keep it concise and targeted.
+After the summary, add a "## Suggested Next Steps" paragraph with 2-4 concrete diagnostic actions. When the root cause is undetermined, these MUST be the precise checks an engineer would run to determine it — not generic advice.
 """
     return prompt
 
@@ -397,56 +365,22 @@ def _fetch_incident_basics(incident_id: str, user_id: str) -> Optional[Dict[str,
         return None
 
 
-# Per-message and total caps for the agent-reasoning block. Sized so the block
-# carries the substantive intermediate thoughts (and the orchestrator's
-# synthesis summaries) without crowding out citations in the summary prompt.
-_REASONING_MAX_PER_MSG_CHARS = 1500
 _REASONING_MAX_TOTAL_CHARS = 8000
 
 
-def _extract_ai_text(content: Any) -> str:
-    """Pull plain text out of a serialized AIMessage `content` field.
+def _fetch_agent_reasoning(user_id: str, incident_id: str) -> str:
+    """Return the agent's reasoning for an incident — the same stream of
+    AI-authored text the UI's Thoughts panel renders.
 
-    LangChain serializes AIMessage content as either a string or a list of
-    typed blocks (`{"type": "text", "text": ...}`, plus thinking/reasoning
-    blocks on some providers). We keep only user-visible text — thinking
-    blocks are private chain-of-thought and stay private.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content.strip()
-    if isinstance(content, list):
-        parts: List[str] = []
-        for block in content:
-            if isinstance(block, dict):
-                btype = block.get("type", "")
-                if btype in ("thinking", "reasoning"):
-                    continue
-                text = block.get("text") or ""
-                if text:
-                    parts.append(str(text))
-            elif isinstance(block, str):
-                parts.append(block)
-        return "".join(parts).strip()
-    return str(content).strip()
+    Reading from `incident_thoughts` (instead of reconstructing reasoning from
+    `llm_context_history` AIMessages) is materially richer because thoughts are
+    streamed in token-by-token across single-agent, sub-agent, and synthesis
+    paths, while the checkpointer only persists the final-form messages.
 
-
-def _fetch_agent_reasoning(
-    user_id: str,
-    session_id: str,
-    max_per_msg: int = _REASONING_MAX_PER_MSG_CHARS,
-    max_total: int = _REASONING_MAX_TOTAL_CHARS,
-) -> str:
-    """Return the investigating agent's own text reasoning for a chat session.
-
-    Reads `llm_context_history` and concatenates every AIMessage's text content
-    (skipping AIMessages that only carry tool_calls and thinking/reasoning
-    blocks). This is the generic source of "agent thoughts" — in single-agent
-    mode it's the ReAct agent's intermediate analysis; in orchestrator mode it
-    additionally contains the synthesis_node's per-wave summaries. Without
-    this context the downstream summary LLM only sees raw tool outputs and
-    routinely fabricates root causes from absence of evidence.
+    `incident_thoughts` is not RLS-protected (it CASCADEs from `incidents`),
+    so we set RLS context on the connection and JOIN through `incidents` to
+    enforce the caller's tenant boundary. Truncated to a single budget so the
+    summary prompt stays inside the model context window.
     """
     try:
         with db_pool.get_admin_connection() as conn:
@@ -455,55 +389,29 @@ def _fetch_agent_reasoning(
                     return ""
                 cursor.execute(
                     """
-                    SELECT llm_context_history
-                    FROM chat_sessions
-                    WHERE id = %s AND user_id = %s
+                    SELECT it.content
+                    FROM incident_thoughts it
+                    JOIN incidents i ON i.id = it.incident_id
+                    WHERE it.incident_id = %s
+                    ORDER BY COALESCE(it.timestamp, it.created_at) ASC
                     """,
-                    (session_id, user_id),
+                    (incident_id,),
                 )
-                row = cursor.fetchone()
-                if not row or row[0] is None:
-                    return ""
-                history = row[0]
-                if isinstance(history, str):
-                    try:
-                        history = json.loads(history)
-                    except json.JSONDecodeError:
-                        return ""
-                if not isinstance(history, list):
-                    return ""
-
-        parts: List[str] = []
-        total = 0
-        msg_index = 0
-        for msg in history:
-            if not isinstance(msg, dict):
-                continue
-            if msg.get("role") != "ai":
-                continue
-            text = _extract_ai_text(msg.get("content"))
-            if not text:
-                continue
-            if len(text) > max_per_msg:
-                text = text[:max_per_msg] + "...[truncated]"
-            msg_index += 1
-            entry = f"[#{msg_index}] {text}"
-            if total + len(entry) > max_total:
-                remaining = max_total - total
-                if remaining > 200:
-                    parts.append(entry[:remaining] + "...[truncated]")
-                parts.append(
-                    "...[earlier agent reasoning truncated to fit prompt budget]"
-                )
-                break
-            parts.append(entry)
-            total += len(entry) + 1
-        return "\n\n".join(parts)
+                rows = cursor.fetchall()
     except Exception as e:
         logger.warning(
-            f"{_LOG_PREFIX} Failed to extract agent reasoning for session {session_id}: {e}"
+            f"{_LOG_PREFIX} Failed to read incident_thoughts for {incident_id}: {e}"
         )
         return ""
+
+    text = "\n\n".join(r[0] for r in rows if r and r[0])
+    if len(text) > _REASONING_MAX_TOTAL_CHARS:
+        # Keep the most recent reasoning — that's where the synthesis lands.
+        text = (
+            "...[earlier reasoning truncated to fit prompt budget]\n\n"
+            + text[-_REASONING_MAX_TOTAL_CHARS:]
+        )
+    return text
 
 
 def _fetch_chat_transcript(
@@ -748,14 +656,11 @@ def generate_incident_summary_from_chat(
         if not all_citations:
             transcript = _fetch_chat_transcript(user_id=user_id, session_id=session_id)
 
-        # The investigating agent's own reasoning (intermediate thoughts in
-        # single-agent mode + per-wave synthesis summaries in orchestrator
-        # mode) is the missing context that lets the summarizer ground its
-        # claims. Fetched generically so the same code path applies whether
-        # the workflow ran direct_react or the fan-out orchestrator.
-        agent_reasoning = _fetch_agent_reasoning(
-            user_id=user_id, session_id=session_id,
-        )
+        # Feed the same Thoughts-panel content the user sees back to the
+        # summarizer. Without it the LLM has only raw tool outputs and
+        # routinely promotes absence of evidence into a confident root cause.
+        # Same code path applies to both single-agent and orchestrator runs.
+        agent_reasoning = _fetch_agent_reasoning(user_id, incident_id)
 
         # Build prompt - uses citations if available, otherwise falls back to transcript
         prompt = _build_summary_prompt_with_chat(

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -189,11 +189,19 @@ def _build_summary_prompt_with_chat(
     investigation_transcript: Optional[str] = None,
     citations: Optional[List[Citation]] = None,
     correlated_alert_count: int = 0,
+    agent_reasoning: Optional[str] = None,
 ) -> str:
     """Build a concise summary prompt that incorporates RCA chat context.
 
     If citations are provided, uses citation-based prompt with [n] markers.
     Otherwise falls back to transcript-based summarization.
+
+    ``agent_reasoning`` carries the investigating agent's own thoughts and any
+    orchestrator synthesis summaries. It must be passed through whenever the
+    chat session has any AI-authored text — without it the summarizer only
+    sees raw tool outputs and routinely turns absence of evidence into
+    fabricated findings. Applies equally to single-agent and fan-out modes
+    because both paths emit AIMessage content during investigation.
     """
     triggered_line = f"- Triggered at: {triggered_at}" if triggered_at else ""
 
@@ -230,7 +238,15 @@ When writing your report, consider whether these correlated alerts contributed t
 If the correlated alerts are relevant, clearly indicate their relationship to the primary incident in your analysis.
 """
 
-        prompt = f"""You are writing an incident report based on alert data and forensic evidence.
+        reasoning_block = ""
+        if agent_reasoning and agent_reasoning.strip():
+            reasoning_block = (
+                "\nAGENT REASONING & SYNTHESIS (the investigating agent's own thoughts "
+                "and any orchestrator synthesis summaries from this RCA):\n"
+                f"{agent_reasoning}\n"
+            )
+
+        prompt = f"""You are writing an incident report based on alert data, the investigating agent's reasoning, and forensic evidence.
 
 ALERT INFORMATION:
 - Source: {source_type}
@@ -238,53 +254,67 @@ ALERT INFORMATION:
 - Severity: {severity}
 - Service: {service}
 {triggered_line}
-{correlated_note}
+{correlated_note}{reasoning_block}
 INVESTIGATION EVIDENCE (cite using [n] markers):
 {evidence_text}
 
 Write a 2-3 paragraph incident report:
 
 PARAGRAPH 1 - What Happened:
-State what occurred, when it occurred, and what was affected. Write as if you're reporting a known fact, not describing an investigation.
-Example: "On [date], the data-processor service experienced OOMKilled events due to memory exhaustion [3, 5]."
+State what occurred, when it occurred, and what was affected, using only facts present in the alert, the agent reasoning, or the evidence. If a fact is not directly supported, do not state it. Write as if you're reporting a known fact rather than describing an investigation.
+Example (supported): "On [date], the data-processor service experienced OOMKilled events due to memory exhaustion [3, 5]."
 
 PARAGRAPH 2 - Root Cause:
-Directly state the root cause and explain the causal chain. Use evidence to support claims.
-Example: "The root cause was a ConfigMap change that increased BATCH_SIZE from 1000 to 10000 [7], causing memory usage to exceed the 128Mi limit [9, 11]."
+- If the evidence and agent reasoning together clearly support a specific root cause, state it and cite the supporting evidence.
+  Example: "The root cause was a ConfigMap change that increased BATCH_SIZE from 1000 to 10000 [7], causing memory usage to exceed the 128Mi limit [9, 11]."
+- If the evidence is missing, contradictory, or only consistent with the alert at a surface level, you MUST write a paragraph that begins with "Root cause undetermined." and then describe what is and isn't known. Do not invent a root cause to fill the paragraph. Do not present absence of data as evidence of a cause (e.g. "no logs were found" is not the same as "the service was not running").
 
 PARAGRAPH 3 (if significant) - Impact & Timeline:
-Describe the scope of impact and any relevant timeline details.
+Describe only the scope of impact and timeline details that are actually present in the alert, agent reasoning, or evidence.
 
 CITATION RULES:
-- Cite specific evidence that supports factual claims
-- Group related citations together [3, 5, 7]
-- Don't cite every detail - only key supporting evidence
-- Never describe the investigation process or tools used
-- Never say "Investigation revealed..." or "Attempts to..." - just state what happened
+- Cite specific evidence that supports factual claims.
+- Group related citations together [3, 5, 7].
+- Don't cite every detail — only key supporting evidence.
+- Never describe the investigation process or tools used.
+- Never say "Investigation revealed..." or "Attempts to..." — just state what is known.
+
+ANTI-HALLUCINATION RULES (NON-NEGOTIABLE):
+- Do NOT introduce services, hosts, environments, configuration keys, user counts, time windows, error messages, or metrics that do not appear in the alert, agent reasoning, or evidence.
+- Do NOT promote weak signals (a single empty `ps`/`ls`, a missing file in a sandbox, an unreachable internal hostname) to "the auth/api/database service is down" or "the deployment failed". Empty/missing output from a generic command is NOT evidence of a specific failure mode.
+- Do NOT fabricate citations. Every [n] marker MUST refer to a real evidence row above; do not invent new numbers.
+- If the agent reasoning explicitly says the investigation was inconclusive, the report MUST reflect that — its Root Cause paragraph MUST start with "Root cause undetermined."
+- If the only correlation is temporal (e.g. "a release shipped ~30 minutes before symptoms"), say so explicitly as a correlation, not as causation.
 
 CRITICAL - DO NOT:
-- Describe investigation steps or what tools were run
-- Say "Investigation revealed" or "Attempts to query" or "The investigation was unable"
-- Focus on tool failures or unavailable data
-- Write about the RCA process itself
+- Describe investigation steps or what tools were run.
+- Say "Investigation revealed" or "Attempts to query" or "The investigation was unable".
+- Focus on tool failures or unavailable data.
+- Write about the RCA process itself.
 
 CRITICAL - DO:
-- Write as if reporting a completed incident with known facts
-- State the root cause directly in the first or second paragraph
-- Focus on WHAT HAPPENED to the system, not HOW YOU FOUND OUT
-- Use evidence citations to back up claims about system behavior
+- Write as if reporting a completed incident, with calibrated certainty: state facts where supported, state uncertainty where not.
+- Focus on WHAT HAPPENED to the system, not HOW YOU FOUND OUT.
+- Use evidence citations to back up claims about system behavior.
 
-TONE: Professional, factual, incident-record style (not investigative process documentation)
+TONE: Professional, factual, incident-record style (not investigative process documentation).
 
 After the summary, add a separate paragraph titled "## Suggested Next Steps" that:
-- Lists 2-4 specific areas the SRE should investigate based on the findings
-- Provides actionable guidance for further troubleshooting
-- References specific metrics, logs, or infrastructure components mentioned in the investigation
-- Keep it concise and targeted
+- Lists 2-4 specific areas the SRE should investigate next.
+- When the root cause is undetermined, these next steps MUST be the concrete checks an engineer would run to determine the root cause (e.g. specific logs, metrics, configs to inspect), not generic advice.
+- References specific metrics, logs, or infrastructure components mentioned in the investigation when available.
+- Keep it concise and targeted.
 """
     else:
         # Fallback to transcript-based prompt
         transcript = investigation_transcript or "[No transcript available]"
+        reasoning_block = ""
+        if agent_reasoning and agent_reasoning.strip():
+            reasoning_block = (
+                "\nAGENT REASONING & SYNTHESIS (the investigating agent's own thoughts "
+                "and any orchestrator synthesis summaries):\n"
+                f"{agent_reasoning}\n"
+            )
         prompt = f"""
 You are rewriting an alert plus the subsequent investigation transcript into a neutral incident summary.
 
@@ -294,27 +324,32 @@ ALERT INFORMATION:
 - Severity: {severity}
 - Service: {service}
 {triggered_line}
-
+{reasoning_block}
 INVESTIGATION TRANSCRIPT (chat log):
 {transcript}
 
 Write a concise 2–3 paragraph summary that:
-- Describes what triggered the alert
-- States the severity and observed impact (if explicitly present)
-- Identifies the affected service or component
-- Summarizes investigation findings and best-known root cause (only if explicitly stated)
-- If root cause is not explicit, state what is known and what is still uncertain
+- Describes what triggered the alert.
+- States the severity and observed impact (only if explicitly present in the alert or transcript).
+- Identifies the affected service or component (only if explicitly named).
+- Summarizes investigation findings and best-known root cause ONLY if explicitly supported by the transcript or agent reasoning.
+- If the root cause is not explicit, the Root Cause paragraph MUST begin with "Root cause undetermined." and then describe what is and isn't known.
+
+ANTI-HALLUCINATION RULES (NON-NEGOTIABLE):
+- Do NOT introduce services, hosts, configuration keys, user counts, error messages, or metrics that do not appear in the alert, agent reasoning, or transcript.
+- Do NOT promote absence of data (an empty command output, a missing file in a sandbox, an unreachable internal hostname) into a confident failure mode.
+- If the agent reasoning explicitly says the investigation was inconclusive, the report MUST reflect that.
+- Treat purely temporal correlations as correlations, not causations.
 
 SUMMARY RULES:
-- Do NOT address any audience in the summary paragraphs
-- Tone: neutral, factual, incident-record style
-- Style: descriptive, not advisory
+- Do NOT address any audience in the summary paragraphs.
+- Tone: neutral, factual, incident-record style.
+- Style: descriptive, not advisory.
 
 After the summary, add a separate paragraph titled "## Suggested Next Steps" that:
-- Lists 2-4 specific areas the SRE should investigate based on the findings
-- Provides actionable guidance for further troubleshooting
-- References specific metrics, logs, or infrastructure components mentioned in the investigation
-- Keep it concise and targeted
+- Lists 2-4 specific areas the SRE should investigate based on the findings.
+- When the root cause is undetermined, these next steps MUST be concrete diagnostic actions (specific logs, metrics, configs), not generic advice.
+- Keep it concise and targeted.
 """
     return prompt
 
@@ -360,6 +395,115 @@ def _fetch_incident_basics(incident_id: str, user_id: str) -> Optional[Dict[str,
             f"{_LOG_PREFIX} Failed to fetch incident basics for {incident_id}: {e}"
         )
         return None
+
+
+# Per-message and total caps for the agent-reasoning block. Sized so the block
+# carries the substantive intermediate thoughts (and the orchestrator's
+# synthesis summaries) without crowding out citations in the summary prompt.
+_REASONING_MAX_PER_MSG_CHARS = 1500
+_REASONING_MAX_TOTAL_CHARS = 8000
+
+
+def _extract_ai_text(content: Any) -> str:
+    """Pull plain text out of a serialized AIMessage `content` field.
+
+    LangChain serializes AIMessage content as either a string or a list of
+    typed blocks (`{"type": "text", "text": ...}`, plus thinking/reasoning
+    blocks on some providers). We keep only user-visible text — thinking
+    blocks are private chain-of-thought and stay private.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: List[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                btype = block.get("type", "")
+                if btype in ("thinking", "reasoning"):
+                    continue
+                text = block.get("text") or ""
+                if text:
+                    parts.append(str(text))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts).strip()
+    return str(content).strip()
+
+
+def _fetch_agent_reasoning(
+    user_id: str,
+    session_id: str,
+    max_per_msg: int = _REASONING_MAX_PER_MSG_CHARS,
+    max_total: int = _REASONING_MAX_TOTAL_CHARS,
+) -> str:
+    """Return the investigating agent's own text reasoning for a chat session.
+
+    Reads `llm_context_history` and concatenates every AIMessage's text content
+    (skipping AIMessages that only carry tool_calls and thinking/reasoning
+    blocks). This is the generic source of "agent thoughts" — in single-agent
+    mode it's the ReAct agent's intermediate analysis; in orchestrator mode it
+    additionally contains the synthesis_node's per-wave summaries. Without
+    this context the downstream summary LLM only sees raw tool outputs and
+    routinely fabricates root causes from absence of evidence.
+    """
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                if not set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX):
+                    return ""
+                cursor.execute(
+                    """
+                    SELECT llm_context_history
+                    FROM chat_sessions
+                    WHERE id = %s AND user_id = %s
+                    """,
+                    (session_id, user_id),
+                )
+                row = cursor.fetchone()
+                if not row or row[0] is None:
+                    return ""
+                history = row[0]
+                if isinstance(history, str):
+                    try:
+                        history = json.loads(history)
+                    except json.JSONDecodeError:
+                        return ""
+                if not isinstance(history, list):
+                    return ""
+
+        parts: List[str] = []
+        total = 0
+        msg_index = 0
+        for msg in history:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "ai":
+                continue
+            text = _extract_ai_text(msg.get("content"))
+            if not text:
+                continue
+            if len(text) > max_per_msg:
+                text = text[:max_per_msg] + "...[truncated]"
+            msg_index += 1
+            entry = f"[#{msg_index}] {text}"
+            if total + len(entry) > max_total:
+                remaining = max_total - total
+                if remaining > 200:
+                    parts.append(entry[:remaining] + "...[truncated]")
+                parts.append(
+                    "...[earlier agent reasoning truncated to fit prompt budget]"
+                )
+                break
+            parts.append(entry)
+            total += len(entry) + 1
+        return "\n\n".join(parts)
+    except Exception as e:
+        logger.warning(
+            f"{_LOG_PREFIX} Failed to extract agent reasoning for session {session_id}: {e}"
+        )
+        return ""
 
 
 def _fetch_chat_transcript(
@@ -604,6 +748,15 @@ def generate_incident_summary_from_chat(
         if not all_citations:
             transcript = _fetch_chat_transcript(user_id=user_id, session_id=session_id)
 
+        # The investigating agent's own reasoning (intermediate thoughts in
+        # single-agent mode + per-wave synthesis summaries in orchestrator
+        # mode) is the missing context that lets the summarizer ground its
+        # claims. Fetched generically so the same code path applies whether
+        # the workflow ran direct_react or the fan-out orchestrator.
+        agent_reasoning = _fetch_agent_reasoning(
+            user_id=user_id, session_id=session_id,
+        )
+
         # Build prompt - uses citations if available, otherwise falls back to transcript
         prompt = _build_summary_prompt_with_chat(
             source_type=basics["source_type"],
@@ -614,6 +767,15 @@ def generate_incident_summary_from_chat(
             investigation_transcript=transcript,
             citations=all_citations if all_citations else None,
             correlated_alert_count=basics.get("correlated_alert_count", 0),
+            agent_reasoning=agent_reasoning,
+        )
+
+        logger.info(
+            "%s incident_summary_prompt incident=%s citations=%d "
+            "agent_reasoning_chars=%d prompt_chars=%d transcript_fallback=%s",
+            _LOG_PREFIX, incident_id, len(all_citations),
+            len(agent_reasoning or ""), len(prompt),
+            "true" if transcript is not None else "false",
         )
 
         # Use centralized model config for email report generation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves DEV-1146. The post-RCA incident report
(`generate_incident_summary_from_chat`) is the user-facing summarizer
that hallucinates. It received only tool-call citations via
`CitationExtractor`; the agent's actual reasoning — the same content
the UI's Thoughts panel renders — was dropped before the prompt was
built. With only raw tool outputs to anchor it, the LLM routinely
promoted absence of evidence into a confident root cause (e.g. a
generic `ps`/`ls` returning empty in a sandbox became *"the auth
service was not deployed correctly, missing OAuth/OIDC environment
variables"*). This is the user-visible problem; the orchestrator
synthesis tweak alone did not solve it because the final report comes
from a different summarizer that runs in both single-agent and
fan-out modes.

## Changes

### `server/chat/background/summarization.py` (the fix)
- New 25-line `_fetch_agent_reasoning(user_id, incident_id)` reads from
  `incident_thoughts` — the canonical Thoughts-panel source, populated
  incrementally by `main_chatbot.save_incident_thought` during streaming.
  This captures sub-agent and synthesis text too, so it stays consistent
  with what the user sees and is materially richer than the LangChain
  checkpointer's final-form `llm_context_history` AIMessages (for the
  test incident: 90 rows / 19,299 chars vs 4 messages / 2,041 chars).
  RLS-scoped via the same `JOIN incidents` + `set_rls_context` pattern
  used by `monitor/fleet_routes.py`. Single 8000-char budget cap, keeps
  the most recent reasoning (where the synthesis lands).
- `_build_summary_prompt_with_chat` accepts `agent_reasoning` and renders
  it as an `AGENT REASONING` block alongside the existing alert details
  and citations. Both prompt branches (citation-based and transcript
  fallback) carry the new block.
- Prompt rewritten to forbid hallucination:
  - The Root Cause paragraph MUST start with `"Root cause undetermined."`
    when evidence is missing, contradictory, or only surface-consistent.
  - Use only facts present in alert / agent reasoning / cited evidence —
    do not introduce services, hosts, configs, error messages, or metrics
    that aren't there.
  - Empty/missing output from a generic probe is not evidence of a
    specific failure mode — never promote absence of data into a root
    cause.
  - Never fabricate a `[n]` citation.
  - Treat purely temporal correlations as correlations, not causations.
  - Suggested-next-steps must be concrete diagnostic actions when the
    cause is undetermined.
- Structured INFO log
  `[IncidentSummary] incident_summary_prompt incident=… citations=N agent_reasoning_chars=N prompt_chars=N transcript_fallback=…`
  proves agent reasoning was injected on every run.

### `server/chat/backend/agent/orchestrator/synthesis.py` (defense in depth)
- The orchestrator-thoughts injection in the synthesis prompt is retained
  from the earlier commit. It improves the synthesis-summary AIMessage
  text that streams into `incident_thoughts` and therefore back into the
  final report — a layered improvement that benefits the same single
  `_fetch_agent_reasoning` path.
- Adds `synthesis_history` to `State` so multi-wave runs preserve the
  orchestrator's per-wave rationale and follow-up plan.
- Each finding header carries the assigned `purpose` so the synthesizer
  sees what was asked vs. what was answered.

## Verification — same incident, before/after

Re-ran `generate_incident_summary_from_chat` against a real RCA chat
session whose previous report had hallucinated. Same evidence; only the
prompt builder + reasoning source changed.

Structured proof log shows the source switch took effect:

[incident_summary_prompt_proof_v2.log](https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincident_summary_prompt_proof_v2.log)

Before fix (fabricated narrative — no auth service, OAuth env, or hosts existed in the test environment):

[incident_summary_BEFORE_fix.txt](https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincident_summary_BEFORE_fix.txt)

After fix (Root Cause opens with "Root cause undetermined.", enumerates exactly which probes were run and which hypotheses remain uninvestigated):

[incident_summary_AFTER_fix_thoughts_panel_source.txt](https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincident_summary_AFTER_fix_thoughts_panel_source.txt)

UI confirmation:

[Final regenerated report on the incident page](https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsummary_after_fix_thoughts_panel_source.webp)

Synthesis-prompt orchestrator-context proof (waves 1 + 2):

[celery_synthesis_orchestrator_context.log](https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcelery_synthesis_orchestrator_context.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fab4dbe-acb1-485f-a79b-f363cb94367d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fab4dbe-acb1-485f-a79b-f363cb94367d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orchestrator context (alert details, triage decisions, prior investigation history) now enriches synthesis prompts for more informed analysis.
  * Agent reasoning and thoughts incorporated into incident summaries.
  * Investigation history persisted across multi-wave synthesis cycles for improved continuity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->