### PR TITLE
fix(mcp): add missing aurora_mcp package to Dockerfile prod stage

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -260,6 +260,7 @@ RUN useradd -m -u 1000 -s /bin/bash app && \
 
 # Copy project sources with root:root ownership + world-read so the `app`
 # user can read+execute but cannot self-modify the image contents.
+COPY --chmod=0555 ./aurora_mcp /app/aurora_mcp/
 COPY --chmod=0555 ./chat /app/chat/
 COPY --chmod=0555 ./config /app/config/
 COPY --chmod=0555 ./connectors /app/connectors/


### PR DESCRIPTION
## Summary
- PR #395 added server/aurora_mcp/ (the tiered MCP tool surface package) and rewired mcp_server.py to import from it, but the Dockerfile prod stage was never updated with a COPY directive for the new directory.
- This causes the MCP container to immediately crash with ModuleNotFoundError in all non-dev deployments (K8s staging/prod, docker-compose.prod-local.yml, airtight mode).
- The staging terraform apply CI run is currently failing because of this — Helm times out after 15 minutes waiting for the MCP pod to become ready.

## Fix
Single line: COPY --chmod=0555 ./aurora_mcp /app/aurora_mcp/ in the prod stage, alongside the other directory COPY directives.

Local dev is unaffected (volume-mounts the entire ./server directory).

## Test plan
- [ ] docker build --target prod && verify aurora_mcp importable
- [ ] After merge + CI image build, re-run staging deploy — MCP pod should start cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image build configuration to include application components with restricted file permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->