### PR TITLE
rca: structured-output via function_calling across providers

### DIFF
--- a/server/chat/backend/agent/llm.py
+++ b/server/chat/backend/agent/llm.py
@@ -225,7 +225,7 @@ class LLMManager:
         try:
             if output_struct:
                 raw_result = model.with_structured_output(
-                    schema=output_struct, include_raw=True
+                    schema=output_struct, include_raw=True, method="function_calling"
                 ).invoke(prompt)
                 llm_response = raw_result.get("raw")
                 parsed = raw_result.get("parsed")

--- a/server/chat/backend/agent/orchestrator/synthesis.py
+++ b/server/chat/backend/agent/orchestrator/synthesis.py
@@ -123,7 +123,12 @@ async def _synthesis(state: State) -> dict:
         # The user-facing summary is appended below as an AIMessage that the
         # existing chat pipeline handles.
         llm = create_chat_model(model=ModelConfig.RCA_ORCHESTRATOR_MODEL, streaming=False)
-        structured = llm.with_structured_output(SynthesisDecision, include_raw=True)
+        # method="function_calling" — Bedrock-routed Anthropic models (Opus via
+        # OpenRouter) reject the OpenAI json_schema response_format
+        # (output_config.format). Tool calling is supported across all providers.
+        structured = llm.with_structured_output(
+            SynthesisDecision, include_raw=True, method="function_calling"
+        )
 
         # Pass available role names to constrain follow-up dispatch — prevents
         # the LLM from hallucinating role names that aren't in the registry.

--- a/server/chat/backend/agent/orchestrator/synthesis.py
+++ b/server/chat/backend/agent/orchestrator/synthesis.py
@@ -123,9 +123,6 @@ async def _synthesis(state: State) -> dict:
         # The user-facing summary is appended below as an AIMessage that the
         # existing chat pipeline handles.
         llm = create_chat_model(model=ModelConfig.RCA_ORCHESTRATOR_MODEL, streaming=False)
-        # method="function_calling" — Bedrock-routed Anthropic models (Opus via
-        # OpenRouter) reject the OpenAI json_schema response_format
-        # (output_config.format). Tool calling is supported across all providers.
         structured = llm.with_structured_output(
             SynthesisDecision, include_raw=True, method="function_calling"
         )

--- a/server/chat/backend/agent/orchestrator/triage.py
+++ b/server/chat/backend/agent/orchestrator/triage.py
@@ -120,7 +120,12 @@ async def _triage(state: State) -> TriageDecision:
         # Non-streaming: triage's structured output is internal — must not
         # leak token chunks into the user-facing chat stream.
         llm = create_chat_model(model=ModelConfig.RCA_ORCHESTRATOR_MODEL, streaming=False)
-        structured = llm.with_structured_output(TriageDecision, include_raw=True)
+        # method="function_calling" — Bedrock-routed Anthropic models (Opus via
+        # OpenRouter) reject the OpenAI json_schema response_format
+        # (output_config.format). Tool calling is supported across all providers.
+        structured = llm.with_structured_output(
+            TriageDecision, include_raw=True, method="function_calling"
+        )
 
         incident_summary = await _build_triage_prompt(state, available_roles)
         start_time = time.time()

--- a/server/chat/backend/agent/orchestrator/triage.py
+++ b/server/chat/backend/agent/orchestrator/triage.py
@@ -120,9 +120,6 @@ async def _triage(state: State) -> TriageDecision:
         # Non-streaming: triage's structured output is internal — must not
         # leak token chunks into the user-facing chat stream.
         llm = create_chat_model(model=ModelConfig.RCA_ORCHESTRATOR_MODEL, streaming=False)
-        # method="function_calling" — Bedrock-routed Anthropic models (Opus via
-        # OpenRouter) reject the OpenAI json_schema response_format
-        # (output_config.format). Tool calling is supported across all providers.
         structured = llm.with_structured_output(
             TriageDecision, include_raw=True, method="function_calling"
         )

--- a/server/chat/background/visualization_extractor.py
+++ b/server/chat/background/visualization_extractor.py
@@ -66,7 +66,9 @@ class VisualizationExtractor:
         import time as _time
         start_time = _time.time()
         try:
-            extractor = self.llm.with_structured_output(VisualizationData, include_raw=True)
+            extractor = self.llm.with_structured_output(
+                VisualizationData, include_raw=True, method="function_calling"
+            )
             result = extractor.invoke(prompt)
             new_viz = result["parsed"]
             raw_response = result.get("raw")

--- a/server/utils/security/command_safety.py
+++ b/server/utils/security/command_safety.py
@@ -220,7 +220,7 @@ def _create_safety_llm():
         temperature=0.0,
         streaming=False,
     )
-    return base.with_structured_output(SafetyVerdict)
+    return base.with_structured_output(SafetyVerdict, method="function_calling")
 
 
 # Pool is deliberately generous: future.result(timeout=...) frees the waiter


### PR DESCRIPTION
## Summary
- Switched `with_structured_output(...)` to `method="function_calling"` at all orchestrator + agent call sites (triage, synthesis, generic agent llm, visualization extractor, command-safety verdict). Previous default (`json_schema`) sent `response_format` / `output_config.format`, which non-OpenAI upstreams via OpenRouter (notably Bedrock-routed Anthropic) reject with HTTP 400. Tool-calling is universally supported across OpenAI, Anthropic, and Google.

## Test plan
End-to-end live RCAs run through the multi-agent orchestrator pipeline against each combination below. Triage call, fan-out, sub-agent execution, synthesis, and final summary verified per run.

| Run | Orchestrator (triage + synthesis) | Sub-agents | Result |
| --- | --- | --- | --- |
| 1 | `anthropic/claude-opus-4.7` | `anthropic/claude-sonnet-4.6` | Pipeline healthy end-to-end (×2 runs) |
| 2 | `openai/gpt-5.5` | `anthropic/claude-sonnet-4.6` | Pipeline healthy end-to-end |
| 3 | `google/gemini-3.1-pro-preview` | `anthropic/claude-sonnet-4.6` | Triage + fan-out + sub-agents healthy |

Also exercised `with_structured_output(method="function_calling")` against the four models directly through the same `create_chat_model` factory path used by the orchestrator:

- [x] `anthropic/claude-opus-4.7`
- [x] `anthropic/claude-sonnet-4.6`
- [x] `openai/gpt-5.5`
- [x] `google/gemini-3.1-pro-preview`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with multiple LLM providers and services by refining how structured outputs are handled throughout core system components including agent orchestration, decision synthesis, triage routing, visualization extraction, and safety verification, reducing formatting errors and improving system stability and reliability across different LLM backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->