### PR TITLE
fix: actions bypass orchestrator sub-agents

### DIFF
--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -156,11 +156,15 @@ class Workflow:
         workflow.add_node("synthesis", synthesis_node)
 
         # Only background RCA sessions enter the orchestrator. Foreground chats
-        # bypass triage so they don't pay the role-discovery + LLM call cost.
+        # and actions bypass triage entirely.
         def _route_start(state) -> str:
             is_bg = getattr(state, "is_background", False)
+            rca_ctx = getattr(state, "rca_context", None)
             if isinstance(state, dict):
                 is_bg = state.get("is_background", False)
+                rca_ctx = state.get("rca_context")
+            if (rca_ctx or {}).get("source") == "action":
+                return "direct_react"
             return "triage" if is_bg else "direct_react"
 
         workflow.add_conditional_edges(


### PR DESCRIPTION
## Summary
- Actions (scheduled and on-incident) were being routed through the multi-agent orchestrator, causing sub-agents to timeout or complete without producing findings.
- The orchestrator's triage node is designed for incident RCA — it fans out specialist sub-agents for cross-system correlation. Actions are user-defined tasks that should run as a single agent.
- This fix checks `rca_context.source` in the workflow's `_route_start` function and sends action-sourced sessions directly to `direct_react`, bypassing triage/dispatch/sub-agent/synthesis entirely.

## Root cause
When `ORCHESTRATOR_ENABLED=true` (default), all `is_background=True` sessions were routed to triage. Since `"action"` is in `_RCA_SOURCES`, actions got `rca_context` set, and the triage LLM would decide to fan out — spawning sub-agents that either timed out (600s) or completed without calling `write_findings`.

## Test plan
- [x] Triggered an action locally — confirmed it goes through `direct_react` and completes in ~18s
- [ ] Verify incident-triggered RCA still routes through orchestrator (unaffected — `rca_context.source` will be `pagerduty`/`grafana`/etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated request routing logic to refine how action-based interactions and background sessions are processed through the workflow system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->