### PR TITLE
fix(docker): add missing tasks/ directory to prod stage COPY

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -267,6 +267,7 @@ COPY --chmod=0555 ./connectors /app/connectors/
 COPY --chmod=0555 ./guardrails /app/guardrails/
 COPY --chmod=0555 ./routes /app/routes/
 COPY --chmod=0555 ./services /app/services/
+COPY --chmod=0555 ./tasks /app/tasks/
 COPY --chmod=0555 ./utils /app/utils/
 COPY --chmod=0444 ./celery_config.py /app/celery_config.py
 COPY --chmod=0444 ./main_chatbot.py /app/main_chatbot.py


### PR DESCRIPTION
## Summary
- Adds `COPY --chmod=0555 ./tasks /app/tasks/` to the Dockerfile prod stage
- Fixes Celery worker crash-looping in staging/prod with `ModuleNotFoundError: No module named 'tasks'`

## Root Cause
PR #371 introduced `server/tasks/github_webhook_tasks.py` and registered it in `celery_config.py`, but didn't add the `tasks/` directory to the Dockerfile's COPY commands. The module exists in the dev stage (which copies everything) but is missing from the prod stage (which copies directories explicitly).

## Test plan
- [x] Verified `server/tasks/__init__.py` and `server/tasks/github_webhook_tasks.py` exist on main
- [ ] Deploy to staging after merge — Celery worker should start without `ModuleNotFoundError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to include necessary task resources with appropriate security permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->