### PR TITLE
feat(helm): add per-service annotation support for ServiceAccounts

### DIFF
--- a/deploy/helm/aurora/templates/serviceaccount.yaml
+++ b/deploy/helm/aurora/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@
 # - Each service has its own ServiceAccount for identity separation
 # - automountServiceAccountToken: false by default (minimum access)
 # - Exception: server/chatbot need K8s API if ENABLE_POD_ISOLATION=true
-# - Annotations available for cloud Workload Identity if needed
+# - Per-service annotations support cloud Workload Identity (GKE/EKS)
 # ------------------------------------------------------------------------------
 
 # Server ServiceAccount
@@ -15,9 +15,12 @@ metadata:
   name: {{ include "aurora.fullname" . }}-server
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $shared := .Values.serviceAccount.annotations | default dict }}
+  {{- $svc := .Values.serviceAccount.server.annotations | default dict }}
+  {{- $merged := merge $svc $shared }}
+  {{- if $merged }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
   {{- end }}
 # Pod isolation requires K8s API access to create terminal pods
 automountServiceAccountToken: {{ eq .Values.config.ENABLE_POD_ISOLATION "true" }}
@@ -29,9 +32,12 @@ metadata:
   name: {{ include "aurora.fullname" . }}-chatbot
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $shared := .Values.serviceAccount.annotations | default dict }}
+  {{- $svc := .Values.serviceAccount.chatbot.annotations | default dict }}
+  {{- $merged := merge $svc $shared }}
+  {{- if $merged }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
   {{- end }}
 # Pod isolation requires K8s API access to create terminal pods
 automountServiceAccountToken: {{ eq .Values.config.ENABLE_POD_ISOLATION "true" }}
@@ -43,9 +49,12 @@ metadata:
   name: {{ include "aurora.fullname" . }}-mcp
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $shared := .Values.serviceAccount.annotations | default dict }}
+  {{- $svc := .Values.serviceAccount.mcp.annotations | default dict }}
+  {{- $merged := merge $svc $shared }}
+  {{- if $merged }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: false
 ---
@@ -56,9 +65,12 @@ metadata:
   name: {{ include "aurora.fullname" . }}-celery-worker
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $shared := .Values.serviceAccount.annotations | default dict }}
+  {{- $svc := .Values.serviceAccount.celeryWorker.annotations | default dict }}
+  {{- $merged := merge $svc $shared }}
+  {{- if $merged }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: false
 ---
@@ -69,9 +81,12 @@ metadata:
   name: {{ include "aurora.fullname" . }}-celery-beat
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $shared := .Values.serviceAccount.annotations | default dict }}
+  {{- $svc := .Values.serviceAccount.celeryBeat.annotations | default dict }}
+  {{- $merged := merge $svc $shared }}
+  {{- if $merged }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: false
 ---

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -56,9 +56,25 @@ services:
 #   annotations:
 #     eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<your-aurora-irsa-role>
 serviceAccount:
-  # Annotations applied to backend service accounts (server, chatbot, celery)
+  # Annotations applied to ALL backend service accounts (server, chatbot, celery, mcp)
   annotations: {}
-  
+
+  # Per-service annotation overrides (merged on top of shared annotations above)
+  # Example GKE Workload Identity:
+  #   chatbot:
+  #     annotations:
+  #       iam.gke.io/gcp-service-account: aurora-chatbot@your-project.iam.gserviceaccount.com
+  server:
+    annotations: {}
+  chatbot:
+    annotations: {}
+  celeryWorker:
+    annotations: {}
+  celeryBeat:
+    annotations: {}
+  mcp:
+    annotations: {}
+
   # Vault-specific ServiceAccount annotations (e.g., for cloud KMS auto-unseal)
   vault:
     annotations: {}


### PR DESCRIPTION
## Summary

- Adds per-service annotation overrides to ServiceAccount templates (merged on top of shared annotations)
- Enables individual services to have different Workload Identity bindings (e.g., chatbot using a different GSA than celery workers)
- Previously, only a single shared `serviceAccount.annotations` was supported — all services got the same annotation or none

## What changed

- `values.yaml`: Added `serviceAccount.{server,chatbot,celeryWorker,celeryBeat,mcp}.annotations` per-service fields
- `serviceaccount.yaml`: Uses `merge` to combine per-service annotations on top of shared ones, renders conditionally when non-empty

## Usage

```yaml
serviceAccount:
  annotations:
    # shared across all services
    iam.gke.io/gcp-service-account: default-sa@project.iam.gserviceaccount.com
  chatbot:
    annotations:
      # overrides shared for chatbot only
      iam.gke.io/gcp-service-account: chatbot-sa@project.iam.gserviceaccount.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)