### PR TITLE
fix(agent): route chat follow-ups to direct_react, not orchestrator

### DIFF
--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -155,8 +155,9 @@ class Workflow:
         workflow.add_node("sub_agent", sub_agent_node)
         workflow.add_node("synthesis", synthesis_node)
 
-        # Only background RCA sessions enter the orchestrator. Foreground chats
-        # and actions bypass triage entirely.
+        # Only background RCA sessions WITH an rca_context enter the
+        # orchestrator. Foreground chats, actions, and follow-up messages
+        # (which are background but lack rca_context) use direct_react.
         def _route_start(state) -> str:
             is_bg = getattr(state, "is_background", False)
             rca_ctx = getattr(state, "rca_context", None)
@@ -165,7 +166,7 @@ class Workflow:
                 rca_ctx = state.get("rca_context")
             if (rca_ctx or {}).get("source") == "action":
                 return "direct_react"
-            return "triage" if is_bg else "direct_react"
+            return "triage" if (is_bg and rca_ctx) else "direct_react"
 
         workflow.add_conditional_edges(
             START, _route_start, {"triage": "triage", "direct_react": "direct_react"}


### PR DESCRIPTION
## Summary
- Chat messages from the UI trigger `run_background_chat` which always sets `is_background=True`
- `_route_start` previously checked only `is_background` to route to the orchestrator/triage path
- This caused regular chat follow-ups to enter the RCA pipeline, where sub-agents fail to produce findings → "Sub-agents completed but no findings were available to synthesize"
- Fix: require **both** `is_background` AND `rca_context` to enter triage routing

## Test plan
- [x] Sent chat message via `/chat_api/sessions/<id>/messages` with `mode: chat`
- [x] Verified celery worker logs show `rca=False` in tool cache key and `name=model` (direct_react node) starting immediately
- [x] Confirmed no triage/orchestrator/synthesis nodes were invoked
- [x] LLM streamed a response directly ("Hello! I'm Aurora...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)