### PR TITLE
fix(helm): add PodDisruptionBudgets to prevent session drops during Autopilot evictions

### DIFF
--- a/deploy/helm/aurora/templates/pdb.yaml
+++ b/deploy/helm/aurora/templates/pdb.yaml
@@ -1,0 +1,46 @@
+# PodDisruptionBudgets — prevent Autopilot from evicting all replicas
+# simultaneously, which drops active WebSocket sessions and API requests.
+{{- if ge (int .Values.replicaCounts.server) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aurora.fullname" . }}-server
+  labels:
+    {{- include "aurora.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aurora.name" . }}-server
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+---
+{{- if ge (int .Values.replicaCounts.chatbot) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aurora.fullname" . }}-chatbot
+  labels:
+    {{- include "aurora.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aurora.name" . }}-chatbot
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+---
+{{- if ge (int .Values.replicaCounts.celeryWorker) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aurora.fullname" . }}-celery-worker
+  labels:
+    {{- include "aurora.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aurora.name" . }}-celery-worker
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
## Summary

- GKE Autopilot evicts pods during node scale-down, which severs active WebSocket sessions (chatbot) and in-flight API requests (server)
- This was triggering the "Container restarts > 3 in 10 min" alert — technically restarts, but not crashes (exit code 0)
- PDBs ensure at least 1 replica remains available during voluntary disruptions
- Only created when `replicaCount >= 2` (a PDB on a single replica would block all node maintenance)

## What changed

- New `deploy/helm/aurora/templates/pdb.yaml` with PDBs for server, chatbot, and celery-worker
- Each uses `minAvailable: 1` so Autopilot must keep one pod running when evicting others

## Also done (outside this PR)

- Updated GCP Monitoring alert "Pod Restart Rate" to exclude kubectl-agent and raise threshold to 5
- Created new log-based metric `aurora_container_crash` and alert that only fires on actual fatal errors (tracebacks, panics, non-zero exits)
- Enabled control plane logging (API_SERVER, SCHEDULER, CONTROLLER_MANAGER) on the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced service resilience by implementing safeguards that prevent simultaneous disruption of all instances for server, chatbot, and worker components during infrastructure maintenance, ensuring continued availability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->