### PR TITLE
fix: decouple postmortem from incident resolve (DEV-1150)

### DIFF
--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -175,8 +175,8 @@ function ActionsListView({ actions, onSelect, onCreate }: {
         <StatCard label="Total Runs" value={String(totalRuns)} icon={Play} />
       </div>
 
-      <Panel title="Configured Actions" subtitle="Background agent tasks that follow your instructions">
-        {actions.length === 0 ? (
+      {actions.length === 0 ? (
+        <Panel title="Configured Actions" subtitle="Background agent tasks that follow your instructions">
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <Workflow className="h-8 w-8 text-zinc-700 mb-3" />
             <p className="text-sm text-zinc-500">No actions yet</p>
@@ -185,65 +185,49 @@ function ActionsListView({ actions, onSelect, onCreate }: {
               <Plus className="h-3.5 w-3.5 mr-1.5" /> Create Action
             </Button>
           </div>
-        ) : (
-          <div className="overflow-hidden rounded-lg border border-zinc-800/60">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-zinc-800/60 text-zinc-500 text-xs uppercase tracking-wider">
-                  <th className="text-left px-4 py-2.5 font-medium">Name</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Trigger</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Mode</th>
-                  <th className="text-right px-4 py-2.5 font-medium">Runs</th>
-                  <th className="text-left px-4 py-2.5 font-medium">Last Run</th>
-                  <th className="text-left px-4 py-2.5 font-medium w-8"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {actions.map((action) => (
-                  <tr
-                    key={action.id}
-                    onClick={() => onSelect(action)}
-                    className="border-b border-zinc-800/40 hover:bg-zinc-800/20 transition-colors duration-150 cursor-pointer"
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className="text-zinc-200 font-medium text-sm">{action.name}</span>
-                        {action.is_system && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">System</span>
-                        )}
-                        {!action.enabled && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-800 text-zinc-500">OFF</span>
-                        )}
+        </Panel>
+      ) : (
+        <div className="space-y-3">
+          {actions.map((action) => (
+            <div
+              key={action.id}
+              onClick={() => onSelect(action)}
+              className="group bg-zinc-900/60 border border-zinc-800/80 rounded-xl p-5 cursor-pointer hover:border-zinc-700/80 hover:bg-zinc-800/40 transition-all duration-200"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2.5 mb-1">
+                    <h3 className="text-sm font-medium text-zinc-100">{action.name}</h3>
+                    {action.is_system && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">System</span>
+                    )}
+                    {!action.enabled && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-800 text-zinc-500">Disabled</span>
+                    )}
+                  </div>
+                  {action.description && (
+                    <p className="text-xs text-zinc-500 leading-relaxed">{action.description}</p>
+                  )}
+                  <div className="flex items-center gap-3 mt-3">
+                    <TriggerBadge type={action.trigger_type} />
+                    <ModeBadge mode={action.mode} />
+                    {action.last_run_at && (
+                      <div className="flex items-center gap-1.5">
+                        <StatusDot status={action.last_run_status || 'pending'} />
+                        <span className="text-xs text-zinc-500">{formatTimeAgo(action.last_run_at)}</span>
                       </div>
-                      {action.description && (
-                        <p className="text-xs text-zinc-600 mt-0.5 truncate max-w-md">{action.description}</p>
-                      )}
-                    </td>
-                    <td className="px-4 py-3"><TriggerBadge type={action.trigger_type} /></td>
-                    <td className="px-4 py-3"><ModeBadge mode={action.mode} /></td>
-                    <td className="px-4 py-3 text-right text-zinc-400 text-sm" style={{ fontVariantNumeric: 'tabular-nums' }}>
-                      {action.run_count || 0}
-                    </td>
-                    <td className="px-4 py-3">
-                      {action.last_run_at ? (
-                        <div className="flex items-center gap-1.5">
-                          <StatusDot status={action.last_run_status || 'pending'} />
-                          <span className="text-xs text-zinc-500">{formatTimeAgo(action.last_run_at)}</span>
-                        </div>
-                      ) : (
-                        <span className="text-xs text-zinc-600">Never</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3">
-                      <ChevronRight className="h-3.5 w-3.5 text-zinc-600" />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Panel>
+                    )}
+                    {action.run_count > 0 && (
+                      <span className="text-xs text-zinc-600">{action.run_count} {action.run_count === 1 ? 'run' : 'runs'}</span>
+                    )}
+                  </div>
+                </div>
+                <ChevronRight className="h-4 w-4 text-zinc-700 group-hover:text-zinc-400 transition-colors mt-0.5 flex-shrink-0" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -191,7 +191,10 @@ function ActionsListView({ actions, onSelect, onCreate }: {
           {actions.map((action) => (
             <div
               key={action.id}
+              role="button"
+              tabIndex={0}
               onClick={() => onSelect(action)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(action); } }}
               className="group bg-zinc-900/60 border border-zinc-800/80 rounded-xl p-5 cursor-pointer hover:border-zinc-700/80 hover:bg-zinc-800/40 transition-all duration-200"
             >
               <div className="flex items-start justify-between gap-4">

--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -189,13 +189,11 @@ function ActionsListView({ actions, onSelect, onCreate }: {
       ) : (
         <div className="space-y-3">
           {actions.map((action) => (
-            <div
+            <button
               key={action.id}
-              role="button"
-              tabIndex={0}
+              type="button"
               onClick={() => onSelect(action)}
-              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(action); } }}
-              className="group bg-zinc-900/60 border border-zinc-800/80 rounded-xl p-5 cursor-pointer hover:border-zinc-700/80 hover:bg-zinc-800/40 transition-all duration-200"
+              className="group w-full text-left bg-zinc-900/60 border border-zinc-800/80 rounded-xl p-5 cursor-pointer hover:border-zinc-700/80 hover:bg-zinc-800/40 transition-all duration-200"
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
@@ -227,7 +225,7 @@ function ActionsListView({ actions, onSelect, onCreate }: {
                 </div>
                 <ChevronRight className="h-4 w-4 text-zinc-700 group-hover:text-zinc-400 transition-colors mt-0.5 flex-shrink-0" />
               </div>
-            </div>
+            </button>
           ))}
         </div>
       )}

--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -286,7 +286,12 @@ function ActionDetailView({ actionId, onBack, onEdit }: { readonly actionId: str
 
   const handleRunNow = useCallback(async () => {
     try {
-      await fetchR(`/api/actions/${actionId}/run`, { method: 'POST' });
+      const res = await fetchR(`/api/actions/${actionId}/run`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        toast({ title: 'Failed to trigger action', description: body.error || res.statusText, variant: 'destructive' });
+        return;
+      }
       toast({ title: 'Action triggered', description: 'Background task started.' });
       mutate();
     } catch {
@@ -346,9 +351,11 @@ function ActionDetailView({ actionId, onBack, onEdit }: { readonly actionId: str
               <span className="text-xs text-zinc-500">Enabled</span>
               <Switch checked={action.enabled} onCheckedChange={handleToggle} />
             </div>
-            <button onClick={handleRunNow} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 border border-zinc-700/50 text-xs font-medium text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700/80 transition-all">
-              <Play className="h-3 w-3" /> Run Now
-            </button>
+            {action.trigger_type !== 'on_incident' && (
+              <button onClick={handleRunNow} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 border border-zinc-700/50 text-xs font-medium text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700/80 transition-all">
+                <Play className="h-3 w-3" /> Run Now
+              </button>
+            )}
             <button onClick={onEdit} className="px-3 py-1.5 rounded-lg bg-zinc-800 border border-zinc-700/50 text-xs font-medium text-zinc-300 hover:text-zinc-100 hover:bg-zinc-700/80 transition-all">
               Edit
             </button>

--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -345,6 +345,9 @@ function ActionDetailView({ actionId, onBack, onEdit }: { readonly actionId: str
               )}
             </div>
             {action.description && <p className="text-sm text-zinc-500 mt-0.5">{action.description}</p>}
+            {action.trigger_type === 'on_incident' && (
+              <p className="text-xs text-zinc-600 mt-1">Triggered automatically when an incident is resolved from the Incidents page.</p>
+            )}
           </div>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -127,7 +127,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
     setResolvingIncident(true);
     try {
       await incidentsService.resolveIncident(incident.id);
-      toast({ title: 'Incident resolved', description: 'You can now generate a postmortem from the Postmortem panel.' });
+      toast({ title: 'Incident resolved', description: 'Postmortem is being generated in the background.' });
       onRefresh?.();
     } catch (e) {
       console.error('Failed to resolve incident:', e);

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -123,11 +123,15 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
   const showSeverity = (alert.severity && (alert.severity as string) !== 'unknown') || incident.status === 'analyzed';
   const sourceIconSrc = alert.source === 'chat' ? null : `/${alert.source}.svg`;
 
+  const [justResolved, setJustResolved] = useState(false);
+
   const handleResolveIncident = async () => {
     setResolvingIncident(true);
     try {
       await incidentsService.resolveIncident(incident.id);
       toast({ title: 'Incident resolved', description: 'Postmortem is being generated in the background.' });
+      setJustResolved(true);
+      setShowPostmortem(true);
       onRefresh?.();
     } catch (e) {
       console.error('Failed to resolve incident:', e);
@@ -764,6 +768,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
         incidentTitle={incident.alert.title}
         isVisible={showPostmortem}
         onClose={() => setShowPostmortem(false)}
+        justResolved={justResolved}
       />
 
       {/* Infrastructure Visualization */}

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -127,7 +127,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
     setResolvingIncident(true);
     try {
       await incidentsService.resolveIncident(incident.id);
-      toast({ title: 'Incident resolved', description: 'Postmortem generation has started.' });
+      toast({ title: 'Incident resolved', description: 'You can now generate a postmortem from the Postmortem panel.' });
       onRefresh?.();
     } catch (e) {
       console.error('Failed to resolve incident:', e);

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -123,14 +123,11 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
   const showSeverity = (alert.severity && (alert.severity as string) !== 'unknown') || incident.status === 'analyzed';
   const sourceIconSrc = alert.source === 'chat' ? null : `/${alert.source}.svg`;
 
-  const [justResolved, setJustResolved] = useState(false);
-
   const handleResolveIncident = async () => {
     setResolvingIncident(true);
     try {
       await incidentsService.resolveIncident(incident.id);
       toast({ title: 'Incident resolved', description: 'Postmortem is being generated in the background.' });
-      setJustResolved(true);
       setShowPostmortem(true);
       onRefresh?.();
     } catch (e) {
@@ -768,7 +765,6 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
         incidentTitle={incident.alert.title}
         isVisible={showPostmortem}
         onClose={() => setShowPostmortem(false)}
-        justResolved={justResolved}
       />
 
       {/* Infrastructure Visualization */}

--- a/client/src/app/incidents/components/PostmortemPanel.tsx
+++ b/client/src/app/incidents/components/PostmortemPanel.tsx
@@ -18,11 +18,12 @@ interface PostmortemPanelProps {
   incidentTitle: string;
   isVisible: boolean;
   onClose: () => void;
+  justResolved?: boolean;
 }
 
 
 
-export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, onClose }: PostmortemPanelProps) {
+export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, onClose, justResolved }: PostmortemPanelProps) {
   const [postmortem, setPostmortem] = useState<PostmortemData | null>(null);
   const [postmortemNotFound, setPostmortemNotFound] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -42,6 +43,8 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
   const [currentVersionId, setCurrentVersionId] = useState<string | null>(null);
   const [loadingVersions, setLoadingVersions] = useState(false);
 
+  const notFoundCountRef = useRef(0);
+
   const loadPostmortem = useCallback(async () => {
     const result = await postmortemService.getPostmortem(incidentId);
     if (result.error) {
@@ -53,13 +56,20 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
       setEditContent(result.data.content);
       setPostmortemNotFound(false);
       setRegenerating(false);
+      notFoundCountRef.current = 0;
     } else if (result.generating) {
       setPostmortemNotFound(false);
       setRegenerating(true);
+      notFoundCountRef.current = 0;
     } else if (!regenerating) {
-      setPostmortemNotFound(true);
+      notFoundCountRef.current += 1;
+      if (justResolved && notFoundCountRef.current < 5) {
+        setRegenerating(true);
+      } else {
+        setPostmortemNotFound(true);
+      }
     }
-  }, [incidentId, regenerating]);
+  }, [incidentId, regenerating, justResolved]);
 
   useEffect(() => {
     if (isVisible) {

--- a/client/src/app/incidents/components/PostmortemPanel.tsx
+++ b/client/src/app/incidents/components/PostmortemPanel.tsx
@@ -18,12 +18,11 @@ interface PostmortemPanelProps {
   incidentTitle: string;
   isVisible: boolean;
   onClose: () => void;
-  justResolved?: boolean;
 }
 
 
 
-export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, onClose, justResolved }: PostmortemPanelProps) {
+export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, onClose }: PostmortemPanelProps) {
   const [postmortem, setPostmortem] = useState<PostmortemData | null>(null);
   const [postmortemNotFound, setPostmortemNotFound] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -43,8 +42,6 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
   const [currentVersionId, setCurrentVersionId] = useState<string | null>(null);
   const [loadingVersions, setLoadingVersions] = useState(false);
 
-  const notFoundCountRef = useRef(0);
-
   const loadPostmortem = useCallback(async () => {
     const result = await postmortemService.getPostmortem(incidentId);
     if (result.error) {
@@ -56,20 +53,13 @@ export default function PostmortemPanel({ incidentId, incidentTitle, isVisible, 
       setEditContent(result.data.content);
       setPostmortemNotFound(false);
       setRegenerating(false);
-      notFoundCountRef.current = 0;
     } else if (result.generating) {
       setPostmortemNotFound(false);
       setRegenerating(true);
-      notFoundCountRef.current = 0;
     } else if (!regenerating) {
-      notFoundCountRef.current += 1;
-      if (justResolved && notFoundCountRef.current < 5) {
-        setRegenerating(true);
-      } else {
-        setPostmortemNotFound(true);
-      }
+      setPostmortemNotFound(true);
     }
-  }, [incidentId, regenerating, justResolved]);
+  }, [incidentId, regenerating]);
 
   useEffect(() => {
     if (isVisible) {

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -6,7 +6,8 @@ logger = logging.getLogger(__name__)
 
 # Reduce verbosity of specific noisy loggers
 logging.getLogger("langchain").setLevel(logging.WARNING)
-logging.getLogger("websockets").setLevel(logging.WARNING)  
+logging.getLogger("websockets").setLevel(logging.WARNING)
+logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
 logging.getLogger("weaviate").setLevel(logging.WARNING)
 logging.getLogger("redis").setLevel(logging.WARNING)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -1644,7 +1645,8 @@ async def main():
         ping_interval=20,  # Send ping every 20 seconds
         ping_timeout=10,   # Wait 10 seconds for pong response
         max_size=10 * 1024 * 1024,  # 10MB max message size
-        compression=None   # Disable compression to avoid frame issues
+        compression=None,  # Disable compression to avoid frame issues
+        logger=logging.getLogger("websockets.server"),
     ):
         logger.info(f"WebSocket server listening on port {WS_PORT}")
         await asyncio.Future()

--- a/server/routes/actions/actions_routes.py
+++ b/server/routes/actions/actions_routes.py
@@ -428,7 +428,7 @@ def trigger_action(user_id, action_id):
                 if row and row[0] == "on_incident" and not trigger_context.get("incident_id"):
                     return jsonify({"error": "This action requires an incident. Trigger it from an incident page instead."}), 400
     except Exception:
-        pass
+        logger.debug("Failed to verify on_incident precondition, proceeding to dispatch")
 
     try:
         from services.actions.executor import dispatch_action

--- a/server/routes/actions/actions_routes.py
+++ b/server/routes/actions/actions_routes.py
@@ -428,7 +428,8 @@ def trigger_action(user_id, action_id):
                 if row and row[0] == "on_incident" and not trigger_context.get("incident_id"):
                     return jsonify({"error": "This action requires an incident. Trigger it from an incident page instead."}), 400
     except Exception:
-        logger.debug("Failed to verify on_incident precondition, proceeding to dispatch")
+        logger.exception("Failed to verify on_incident precondition")
+        return jsonify({"error": "Unable to validate action context. Please retry."}), 503
 
     try:
         from services.actions.executor import dispatch_action

--- a/server/routes/actions/actions_routes.py
+++ b/server/routes/actions/actions_routes.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from flask import jsonify, request
 from utils.db.connection_pool import db_pool
 from utils.auth.rbac_decorators import require_permission
+from utils.auth.stateless_auth import set_rls_context
 from services.actions.system_actions import seed_system_actions, SYSTEM_ACTIONS
 
 _UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I)
@@ -413,6 +414,21 @@ def trigger_action(user_id, action_id):
         trigger_context["incident_id"] = body["incident_id"]
     if body.get("trigger_label"):
         trigger_context["trigger_label"] = body["trigger_label"]
+
+    # on_incident actions (like postmortem) require an incident_id
+    try:
+        with db_pool.get_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Actions:trigger]")
+                cur.execute(
+                    "SELECT trigger_type FROM actions WHERE id = %s",
+                    (action_id,),
+                )
+                row = cur.fetchone()
+                if row and row[0] == "on_incident" and not trigger_context.get("incident_id"):
+                    return jsonify({"error": "This action requires an incident. Trigger it from an incident page instead."}), 400
+    except Exception:
+        pass
 
     try:
         from services.actions.executor import dispatch_action

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -108,11 +108,7 @@ def dispatch_action(
 
 
 def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "immediate") -> None:
-    """Dispatch enabled on_incident actions matching the given timing. Fire-and-forget.
-
-    Note: generate_postmortem is skipped here — users trigger it explicitly
-    from the incident's Postmortem panel.
-    """
+    """Dispatch enabled on_incident actions matching the given timing. Fire-and-forget."""
     with db_pool.get_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[Actions:on_incident]")
@@ -128,17 +124,26 @@ def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "
         if action_timing != timing:
             continue
 
-        if system_key == "generate_postmortem":
-            continue
-
         try:
-            dispatch_action(
-                action_id=str(action_id),
-                user_id=user_id,
-                trigger_context={"source": "on_incident", "incident_id": incident_id},
-            )
+            if system_key == "generate_postmortem":
+                _dispatch_postmortem_via_action(user_id, incident_id)
+            else:
+                dispatch_action(
+                    action_id=str(action_id),
+                    user_id=user_id,
+                    trigger_context={"source": "on_incident", "incident_id": incident_id},
+                )
         except Exception:
             logger.debug("[Actions] Failed to dispatch on_incident action %s", action_id)
+
+
+def _dispatch_postmortem_via_action(user_id: str, incident_id: str) -> None:
+    """Dispatch the postmortem system action with its special pre-reserve logic."""
+    from services.actions.postmortem_action import dispatch_postmortem_action
+    try:
+        dispatch_postmortem_action(user_id, incident_id)
+    except ValueError:
+        logger.info("[Actions] Postmortem action skipped for incident")
 
 
 def build_action_prompt(

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -97,7 +97,7 @@ def dispatch_action(
             mode=action["mode"],
             rail_text=rail_text,
             send_notifications=False,
-            incident_id=None,
+            incident_id=trigger_context.get("incident_id"),
         )
     except Exception as e:
         _update_run(run_id, user_id, status="error", error=f"Failed to enqueue: {e}")
@@ -108,7 +108,11 @@ def dispatch_action(
 
 
 def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "immediate") -> None:
-    """Dispatch enabled on_incident actions matching the given timing. Fire-and-forget."""
+    """Dispatch enabled on_incident actions matching the given timing. Fire-and-forget.
+
+    Note: generate_postmortem is skipped here — users trigger it explicitly
+    from the incident's Postmortem panel.
+    """
     with db_pool.get_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[Actions:on_incident]")
@@ -124,26 +128,17 @@ def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "
         if action_timing != timing:
             continue
 
+        if system_key == "generate_postmortem":
+            continue
+
         try:
-            if system_key == "generate_postmortem":
-                _dispatch_postmortem_via_action(user_id, incident_id)
-            else:
-                dispatch_action(
-                    action_id=str(action_id),
-                    user_id=user_id,
-                    trigger_context={"source": "on_incident", "incident_id": incident_id},
-                )
+            dispatch_action(
+                action_id=str(action_id),
+                user_id=user_id,
+                trigger_context={"source": "on_incident", "incident_id": incident_id},
+            )
         except Exception:
             logger.debug("[Actions] Failed to dispatch on_incident action %s", action_id)
-
-
-def _dispatch_postmortem_via_action(user_id: str, incident_id: str) -> None:
-    """Dispatch the postmortem system action with its special pre-reserve logic."""
-    from services.actions.postmortem_action import dispatch_postmortem_action
-    try:
-        dispatch_postmortem_action(user_id, incident_id)
-    except ValueError:
-        logger.info("[Actions] Postmortem action skipped for incident")
 
 
 def build_action_prompt(


### PR DESCRIPTION
## Summary
- Postmortem no longer auto-triggers when resolving an incident — users explicitly generate it from the Postmortem panel
- "Run Now" button hidden for on_incident actions (like postmortem) on the Actions page since they require incident context
- Manual trigger API now returns a clear error for on_incident actions without an incident_id
- `incident_id` correctly passed through to background chat when triggering actions with incident context

## Test plan
- [ ] Resolve an incident → verify no postmortem auto-generates, toast says "You can now generate a postmortem from the Postmortem panel"
- [ ] Click Postmortem button on resolved incident → see "Generate Postmortem" button → click it → postmortem generates
- [ ] Open Actions page → verify "Run Now" is hidden for the Generate Postmortem action
- [ ] Trigger a non-postmortem action from Actions page → verify it still works

Closes DEV-1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Triggering actions now surfaces server error messages to users and blocks invalid triggers for incident-linked actions.

* **Improvements**
  * “Run Now” is hidden for incident-triggered actions and an explanatory header line is shown.
  * Incident resolution toast updated to reference postmortem generation.
  * Background action runs are correctly associated with incidents.
  * Actions list now uses a card-style view; postmortem panel retries briefly after resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->