### PR TITLE
Fix: scope kubernetes to org instead of user

### DIFF
--- a/server/chat/backend/agent/skills/registry.py
+++ b/server/chat/backend/agent/skills/registry.py
@@ -505,8 +505,9 @@ class SkillRegistry:
         """Fetch connected on-prem cluster names and IDs for template rendering."""
         try:
             from utils.db.connection_pool import db_pool
-            from utils.auth.stateless_auth import set_rls_context
+            from utils.auth.stateless_auth import set_rls_context, resolve_org_id
 
+            org_id = resolve_org_id(user_id)
             with db_pool.get_user_connection() as conn:
                 with conn.cursor() as cur:
                     set_rls_context(cur, conn, user_id, log_prefix="[SkillRegistry:kubectl]")
@@ -514,9 +515,9 @@ class SkillRegistry:
                         """SELECT c.cluster_id, t.cluster_name
                            FROM active_kubectl_connections c
                            JOIN kubectl_agent_tokens t ON c.token = t.token
-                           WHERE t.user_id = %s AND c.status = 'active'
+                           WHERE (t.user_id = %s OR t.org_id = %s) AND c.status = 'active'
                            ORDER BY t.cluster_name""",
-                        (user_id,),
+                        (user_id, org_id),
                     )
                     rows = cur.fetchall()
 

--- a/server/chat/backend/agent/tools/kubectl_onprem_tool.py
+++ b/server/chat/backend/agent/tools/kubectl_onprem_tool.py
@@ -141,21 +141,22 @@ def on_prem_kubectl(
 
 
 def is_kubectl_onprem_connected(user_id: str) -> bool:
-    """Check if user has active on-prem kubectl connections."""
+    """Check if the org has active on-prem kubectl connections."""
     if not user_id:
         return False
     try:
         from utils.db.connection_pool import db_pool
-        from utils.auth.stateless_auth import set_rls_context
+        from utils.auth.stateless_auth import set_rls_context, resolve_org_id
 
+        org_id = resolve_org_id(user_id)
         with db_pool.get_user_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[KubectlOnprem:check]")
                 cursor.execute(
                     """SELECT COUNT(*) FROM active_kubectl_connections c
                        JOIN kubectl_agent_tokens t ON c.token = t.token
-                       WHERE t.user_id = %s AND c.status = 'active'""",
-                    (user_id,),
+                       WHERE (t.user_id = %s OR t.org_id = %s) AND c.status = 'active'""",
+                    (user_id, org_id),
                 )
                 count = cursor.fetchone()[0]
                 return count > 0

--- a/server/chat/background/rca_prompt_builder.py
+++ b/server/chat/background/rca_prompt_builder.py
@@ -362,32 +362,6 @@ def get_user_providers(user_id: str) -> List[str]:
     return result
 
 
-def _has_onprem_clusters(user_id: Optional[str]) -> bool:
-    """Check if user has active on-prem kubectl connections."""
-    if not user_id:
-        return False
-    try:
-        from utils.db.db_adapters import connect_to_db_as_user
-        from utils.auth.stateless_auth import set_rls_context
-        conn = connect_to_db_as_user()
-        try:
-            cursor = conn.cursor()
-            set_rls_context(cursor, conn, user_id, log_prefix="[RCAPrompt:onprem]")
-            cursor.execute("""
-                SELECT COUNT(*) FROM active_kubectl_connections c
-                JOIN kubectl_agent_tokens t ON c.token = t.token
-                WHERE t.user_id = %s AND c.status = 'active'
-            """, (user_id,))
-            count = cursor.fetchone()[0]
-            cursor.close()
-            return count > 0
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.warning(f"Error checking on-prem clusters: {e}")
-        return False
-
-
 def _build_provider_investigation_section(providers: List[str], user_id: Optional[str] = None) -> str:
     """Provider investigation now loaded from skills/rca/ files."""
     return ""

--- a/server/routes/kubectl_token_routes.py
+++ b/server/routes/kubectl_token_routes.py
@@ -12,6 +12,8 @@ from utils.web.limiter_ext import limiter
 logger = logging.getLogger(__name__)
 kubectl_token_bp = Blueprint('kubectl_token', __name__)
 
+_ORG_CONTEXT_REQUIRED = 'Organization context required'
+
 def generate_token():
     return f"aurora_kubectl_{secrets.token_urlsafe(48)}"
 
@@ -74,7 +76,7 @@ def list_tokens(user_id):
             cursor = conn.cursor(cursor_factory=RealDictCursor)
             org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_tokens]")
             if not org_id:
-                return jsonify({'error': 'Organization context required'}), 400
+                return jsonify({'error': _ORG_CONTEXT_REQUIRED}), 400
             cursor.execute("""
                 SELECT id, cluster_name, cluster_id, created_at, last_connected_at, expires_at, status, notes,
                        CONCAT(SUBSTRING(token, 1, 20), '...') as token_preview
@@ -104,7 +106,7 @@ def list_connections(user_id):
             cursor = conn.cursor(cursor_factory=RealDictCursor)
             org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_connections]")
             if not org_id:
-                return jsonify({'error': 'Organization context required'}), 400
+                return jsonify({'error': _ORG_CONTEXT_REQUIRED}), 400
             cursor.execute("UPDATE active_kubectl_connections SET status = 'stale' WHERE last_heartbeat < NOW() - INTERVAL '3 minutes'")
             cursor.execute("UPDATE active_kubectl_connections SET status = 'active' WHERE last_heartbeat >= NOW() - INTERVAL '3 minutes'")
             conn.commit()
@@ -134,7 +136,7 @@ def disconnect_cluster(user_id, cluster_id):
             cursor = conn.cursor(cursor_factory=RealDictCursor)
             org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:disconnect_cluster]")
             if not org_id:
-                return jsonify({'error': 'Organization context required'}), 400
+                return jsonify({'error': _ORG_CONTEXT_REQUIRED}), 400
             cursor.execute("""
                 SELECT c.token, t.cluster_name FROM active_kubectl_connections c
                 JOIN kubectl_agent_tokens t ON c.token = t.token

--- a/server/routes/kubectl_token_routes.py
+++ b/server/routes/kubectl_token_routes.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, jsonify, request
 from psycopg2.extras import RealDictCursor
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import resolve_org_id, set_rls_context
 from utils.db.db_adapters import connect_to_db_as_user
 from utils.log_sanitizer import sanitize
 from utils.web.limiter_ext import limiter
@@ -34,7 +34,7 @@ def create_token(user_id):
         expires_days = data.get('expires_days')
         token = generate_token()
         expires_at = datetime.now() + timedelta(days=expires_days) if expires_days else None
-        org_id = get_org_id_from_request()
+        org_id = resolve_org_id(user_id)
         if not org_id:
             return jsonify({'error': 'Organization context required to create kubectl tokens'}), 400
         conn = connect_to_db_as_user()
@@ -72,12 +72,14 @@ def list_tokens(user_id):
         conn = connect_to_db_as_user()
         try:
             cursor = conn.cursor(cursor_factory=RealDictCursor)
-            set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_tokens]")
+            org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_tokens]")
+            if not org_id:
+                return jsonify({'error': 'Organization context required'}), 400
             cursor.execute("""
                 SELECT id, cluster_name, cluster_id, created_at, last_connected_at, expires_at, status, notes,
                        CONCAT(SUBSTRING(token, 1, 20), '...') as token_preview
-                FROM kubectl_agent_tokens WHERE user_id = %s ORDER BY created_at DESC
-            """, (user_id,))
+                FROM kubectl_agent_tokens WHERE org_id = %s ORDER BY created_at DESC
+            """, (org_id,))
             tokens = cursor.fetchall()
             cursor.close()
         finally:
@@ -100,14 +102,16 @@ def list_connections(user_id):
         conn = connect_to_db_as_user()
         try:
             cursor = conn.cursor(cursor_factory=RealDictCursor)
-            set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_connections]")
+            org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:list_connections]")
+            if not org_id:
+                return jsonify({'error': 'Organization context required'}), 400
             cursor.execute("UPDATE active_kubectl_connections SET status = 'stale' WHERE last_heartbeat < NOW() - INTERVAL '3 minutes'")
             cursor.execute("UPDATE active_kubectl_connections SET status = 'active' WHERE last_heartbeat >= NOW() - INTERVAL '3 minutes'")
             conn.commit()
             query = """SELECT c.cluster_id, c.connected_at, c.last_heartbeat, c.agent_version, c.status, t.cluster_name
                        FROM active_kubectl_connections c JOIN kubectl_agent_tokens t ON c.token = t.token
-                       WHERE t.user_id = %s""" + (" AND c.token = %s" if token_filter else "") + " ORDER BY c.connected_at DESC"
-            cursor.execute(query, (user_id, token_filter) if token_filter else (user_id,))
+                       WHERE t.org_id = %s""" + (" AND c.token = %s" if token_filter else "") + " ORDER BY c.connected_at DESC"
+            cursor.execute(query, (org_id, token_filter) if token_filter else (org_id,))
             connections = cursor.fetchall()
             cursor.close()
         finally:
@@ -128,12 +132,14 @@ def disconnect_cluster(user_id, cluster_id):
         conn = connect_to_db_as_user()
         try:
             cursor = conn.cursor(cursor_factory=RealDictCursor)
-            set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:disconnect_cluster]")
+            org_id = set_rls_context(cursor, conn, user_id, log_prefix="[kubectl_token:disconnect_cluster]")
+            if not org_id:
+                return jsonify({'error': 'Organization context required'}), 400
             cursor.execute("""
                 SELECT c.token, t.cluster_name FROM active_kubectl_connections c
                 JOIN kubectl_agent_tokens t ON c.token = t.token
-                WHERE c.cluster_id = %s AND t.user_id = %s
-            """, (cluster_id, user_id))
+                WHERE c.cluster_id = %s AND t.org_id = %s
+            """, (cluster_id, org_id))
             
             result = cursor.fetchone()
             if not result:

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -9,7 +9,11 @@ from utils.auth.stateless_auth import set_rls_context, get_org_id_for_user
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_PROVIDERS = ('gcp', 'aws', 'azure', 'ovh', 'scaleway', 'tailscale', 'kubectl')
+# Providers whose connections are stored in user_connections / user_tokens.
+# kubectl is intentionally excluded: its connections live in the separate
+# kubectl_agent_tokens / active_kubectl_connections tables and are picked up
+# by the explicit kubectl queries in run_full_discovery / run_user_discovery.
+SUPPORTED_PROVIDERS = ('gcp', 'aws', 'azure', 'ovh', 'scaleway', 'tailscale')
 
 
 def _query_connected_providers(cur, user_id=None, conn=None):
@@ -165,7 +169,7 @@ def _reset_provider_failure(user_id: str, provider: str) -> None:
 def _mark_provider_inactive(user_id: str, provider: str) -> None:
     """Mark all active connections for (user_id, provider) as inactive.
 
-    Covers both user_connections (AWS/kubectl/OVH/Scaleway/Tailscale) and
+    Covers both user_connections (AWS/OVH/Scaleway/Tailscale) and
     user_tokens (GCP/Azure and other OAuth-backed providers).  Deactivates
     both user-scoped and org-scoped rows so org-shared connections are also
     cleaned up.
@@ -460,6 +464,9 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
 
     Returns None when the org has no usable providers and should be skipped.
     """
+    from utils.db.db_utils import connect_to_db_as_admin
+    from utils.auth.stateless_auth import set_rls_context
+
     user_id = org_info["rep"]
     # Build provider credentials dict, embedding the per-provider owner so
     # discovery_service._setup_provider_env authenticates against the correct
@@ -471,6 +478,38 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
 
     if "gcp" in providers:
         _resolve_gcp_provider(user_id, org_id, providers, get_owner)
+
+    # Query active kubectl clusters for this org.
+    if "kubectl" in providers:
+        try:
+            conn = connect_to_db_as_admin()
+            with conn.cursor() as cur:
+                rls_org_id = set_rls_context(cur, conn, user_id, log_prefix="[Discovery Task]")
+                cur.execute(
+                    """SELECT c.cluster_id, t.cluster_name
+                       FROM active_kubectl_connections c
+                       JOIN kubectl_agent_tokens t ON c.token = t.token
+                       WHERE (t.user_id = %s OR t.org_id = %s)
+                         AND t.status = 'active' AND c.status = 'active'""",
+                    (user_id, rls_org_id),
+                )
+                kubectl_rows = cur.fetchall()
+            conn.close()
+            if kubectl_rows:
+                clusters = [
+                    {"cluster_id": row[0], "cluster_name": row[1] or row[0]}
+                    for row in kubectl_rows
+                ]
+                providers["kubectl"] = {"clusters": clusters}
+                logger.info(
+                    "[Discovery Task] Found %d active kubectl cluster(s) for org=%s",
+                    len(clusters), org_id,
+                )
+            else:
+                del providers["kubectl"]
+        except Exception as e:
+            logger.warning("[Discovery Task] kubectl cluster query failed for org=%s: %s", org_id, e)
+            del providers["kubectl"]
 
     if not providers:
         logger.info("[Discovery Task] No valid providers for org=%s, skipping", org_id)
@@ -509,12 +548,21 @@ def run_full_discovery(self):
         conn = connect_to_db_as_admin()
         cur = conn.cursor()  # No RLS needed — cross-org loop, sets RLS per user inside
         rows = _query_connected_providers(cur, conn=conn)
+
+        # kubectl on-prem connections live in active_kubectl_connections /
+        # kubectl_agent_tokens — never in user_connections / user_tokens — so
+        # _query_connected_providers misses them entirely.  kubectl_agent_tokens
+        # is not RLS-protected, so a plain admin query finds all active orgs.
+        cur.execute(
+            """SELECT DISTINCT t.org_id, t.user_id
+               FROM kubectl_agent_tokens t
+               JOIN active_kubectl_connections c ON t.token = c.token
+               WHERE t.status = 'active' AND c.status = 'active'"""
+        )
+        kubectl_org_rows = cur.fetchall()
+
         cur.close()
         conn.close()
-
-        if not rows:
-            logger.info("[Discovery Task] No orgs with connected cloud providers")
-            return {"status": "no_users", "users_processed": 0}
 
         # Deduplicate by org: collect the union of active providers per org.
         # Record the connector owner per provider (the user_id from each row IS
@@ -527,6 +575,17 @@ def run_full_discovery(self):
             if org_id not in orgs:
                 orgs[org_id] = {"rep": user_id, "providers": {}}
             orgs[org_id]["providers"][provider] = {"owner_id": user_id}
+
+        # Add any kubectl-only orgs (not found via cloud provider query above).
+        # Mark kubectl as a provider so _process_org will query the cluster list.
+        for org_id, kubectl_user_id in kubectl_org_rows:
+            if org_id not in orgs:
+                orgs[org_id] = {"rep": kubectl_user_id, "providers": {}}
+            orgs[org_id]["providers"].setdefault("kubectl", {"owner_id": kubectl_user_id})
+
+        if not orgs:
+            logger.info("[Discovery Task] No orgs with connected cloud providers")
+            return {"status": "no_users", "users_processed": 0}
 
         logger.info("[Discovery Task] Processing %d org(s)", len(orgs))
 
@@ -571,10 +630,21 @@ def run_user_discovery(self, user_id):
     try:
         conn = connect_to_db_as_admin()
         cur = conn.cursor()
-        set_rls_context(cur, conn, user_id, log_prefix="[Discovery Task]")
+        org_id = set_rls_context(cur, conn, user_id, log_prefix="[Discovery Task]")
         provider_names = _query_connected_providers(cur, user_id, conn=conn)
 
-        if not provider_names:
+        # Query active kubectl clusters for this org before the early-return
+        # check — kubectl connections live in their own tables and are never
+        # returned by _query_connected_providers.
+        cur.execute("""
+            SELECT c.cluster_id, t.cluster_name
+            FROM active_kubectl_connections c
+            JOIN kubectl_agent_tokens t ON c.token = t.token
+            WHERE (t.user_id = %s OR t.org_id = %s) AND t.status = 'active' AND c.status = 'active'
+        """, (user_id, org_id))
+        kubectl_rows = cur.fetchall()
+
+        if not provider_names and not kubectl_rows:
             cur.close()
             conn.close()
             return {"status": "no_providers", "user_id": user_id}
@@ -587,15 +657,6 @@ def run_user_discovery(self, user_id):
             from utils.auth.stateless_auth import get_user_preference
             root_project = get_user_preference(user_id, 'gcp_root_project')
 
-        # Query active kubectl clusters for this user
-        cur.execute("""
-            SELECT c.cluster_id, t.cluster_name
-            FROM active_kubectl_connections c
-            JOIN kubectl_agent_tokens t ON c.token = t.token
-            WHERE t.user_id = %s AND t.status = 'active' AND c.status = 'active'
-        """, (user_id,))
-        kubectl_rows = cur.fetchall()
-
         # Close DB connection BEFORE calling setup functions that also use the pool
         cur.close()
         conn.close()
@@ -607,7 +668,7 @@ def run_user_discovery(self, user_id):
                 for row in kubectl_rows
             ]
             providers["kubectl"] = {"clusters": clusters}
-            logger.info(f"[Discovery Task] Found {len(clusters)} active kubectl clusters for user {user_id}")
+            logger.info(f"[Discovery Task] Found {len(clusters)} active kubectl clusters for org {org_id}")
 
         if "gcp" in providers:
             # Wait for GCP post-auth setup to finish (API enablement, SA propagation)

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -558,8 +558,7 @@ def run_full_discovery(self):
     logger.info("[Discovery Task] Starting full discovery run")
 
     try:
-        conn = connect_to_db_as_admin()
-        try:
+        with connect_to_db_as_admin() as conn:
             with conn.cursor() as cur:
                 rows = _query_connected_providers(cur)
 
@@ -567,8 +566,6 @@ def run_full_discovery(self):
                 # not user_connections / user_tokens, so _query_connected_providers misses them.
                 # _query_kubectl_orgs handles this with a single aggregated JOIN query.
                 kubectl_org_rows = _query_kubectl_orgs(cur)
-        finally:
-            conn.close()
 
         # Deduplicate by org: collect the union of active providers per org.
         # Record the connector owner per provider (the user_id from each row IS
@@ -717,12 +714,9 @@ def mark_stale_services(self):
     logger.info("[Discovery Task] Starting stale service detection")
 
     try:
-        conn = connect_to_db_as_admin()
-        try:
+        with connect_to_db_as_admin() as conn:
             with conn.cursor() as cur:
                 rows = _query_connected_providers(cur)
-        finally:
-            conn.close()
         # Deduplicate by org: one representative user per org is sufficient
         # since graph data is written per org credential owner.
         user_ids = list({org_id: user_id for user_id, org_id, _provider in rows}.values())

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -16,6 +16,33 @@ logger = logging.getLogger(__name__)
 SUPPORTED_PROVIDERS = ('gcp', 'aws', 'azure', 'ovh', 'scaleway', 'tailscale')
 
 
+def _query_kubectl_orgs(cur, conn):
+    """Return list of (org_id, user_id) pairs that have at least one active kubectl cluster.
+
+    kubectl_agent_tokens is RLS-protected, so this mirrors the pattern used by
+    _query_connected_providers: enumerate orgs from the non-RLS users table first,
+    then set RLS context per org before querying kubectl_agent_tokens.
+    """
+    cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+    all_users = cur.fetchall()
+    result = []
+    for uid, org_id in all_users:
+        cur.execute("SET myapp.current_user_id = %s;", (uid,))
+        cur.execute("SET myapp.current_org_id = %s;", (org_id,))
+        conn.commit()
+        cur.execute(
+            """SELECT 1 FROM kubectl_agent_tokens t
+               JOIN active_kubectl_connections c ON t.token = c.token
+               WHERE (t.user_id = %s OR t.org_id = %s)
+                 AND t.status = 'active' AND c.status = 'active'
+               LIMIT 1""",
+            (uid, org_id),
+        )
+        if cur.fetchone():
+            result.append((org_id, uid))
+    return result
+
+
 def _query_connected_providers(cur, user_id=None, conn=None):
     """Query active cloud provider connections.
 
@@ -555,26 +582,9 @@ def run_full_discovery(self):
         # kubectl on-prem connections live in active_kubectl_connections /
         # kubectl_agent_tokens — never in user_connections / user_tokens — so
         # _query_connected_providers misses them entirely.
-        # kubectl_agent_tokens IS RLS-protected, so we must mirror the pattern
-        # used by _query_connected_providers: enumerate orgs via the non-RLS
-        # users table first, then set RLS context per org before querying.
-        cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-        all_users = cur.fetchall()
-        kubectl_org_rows = []
-        for uid, org_id in all_users:
-            cur.execute("SET myapp.current_user_id = %s;", (uid,))
-            cur.execute("SET myapp.current_org_id = %s;", (org_id,))
-            conn.commit()
-            cur.execute(
-                """SELECT %s, %s FROM kubectl_agent_tokens t
-                   JOIN active_kubectl_connections c ON t.token = c.token
-                   WHERE (t.user_id = %s OR t.org_id = %s)
-                     AND t.status = 'active' AND c.status = 'active'
-                   LIMIT 1""",
-                (org_id, uid, uid, org_id),
-            )
-            if cur.fetchone():
-                kubectl_org_rows.append((org_id, uid))
+        # kubectl_agent_tokens IS RLS-protected; _query_kubectl_orgs mirrors
+        # _query_connected_providers and sets RLS context per org before querying.
+        kubectl_org_rows = _query_kubectl_orgs(cur, conn)
 
         cur.close()
         conn.close()

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -481,6 +481,7 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
 
     # Query active kubectl clusters for this org.
     if "kubectl" in providers:
+        conn = None
         try:
             conn = connect_to_db_as_admin()
             with conn.cursor() as cur:
@@ -494,7 +495,6 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
                     (user_id, rls_org_id),
                 )
                 kubectl_rows = cur.fetchall()
-            conn.close()
             if kubectl_rows:
                 clusters = [
                     {"cluster_id": row[0], "cluster_name": row[1] or row[0]}
@@ -510,6 +510,9 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
         except Exception as e:
             logger.warning("[Discovery Task] kubectl cluster query failed for org=%s: %s", org_id, e)
             del providers["kubectl"]
+        finally:
+            if conn:
+                conn.close()
 
     if not providers:
         logger.info("[Discovery Task] No valid providers for org=%s, skipping", org_id)
@@ -551,15 +554,27 @@ def run_full_discovery(self):
 
         # kubectl on-prem connections live in active_kubectl_connections /
         # kubectl_agent_tokens — never in user_connections / user_tokens — so
-        # _query_connected_providers misses them entirely.  kubectl_agent_tokens
-        # is not RLS-protected, so a plain admin query finds all active orgs.
-        cur.execute(
-            """SELECT DISTINCT t.org_id, t.user_id
-               FROM kubectl_agent_tokens t
-               JOIN active_kubectl_connections c ON t.token = c.token
-               WHERE t.status = 'active' AND c.status = 'active'"""
-        )
-        kubectl_org_rows = cur.fetchall()
+        # _query_connected_providers misses them entirely.
+        # kubectl_agent_tokens IS RLS-protected, so we must mirror the pattern
+        # used by _query_connected_providers: enumerate orgs via the non-RLS
+        # users table first, then set RLS context per org before querying.
+        cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
+        all_users = cur.fetchall()
+        kubectl_org_rows = []
+        for uid, org_id in all_users:
+            cur.execute("SET myapp.current_user_id = %s;", (uid,))
+            cur.execute("SET myapp.current_org_id = %s;", (org_id,))
+            conn.commit()
+            cur.execute(
+                """SELECT %s, %s FROM kubectl_agent_tokens t
+                   JOIN active_kubectl_connections c ON t.token = c.token
+                   WHERE (t.user_id = %s OR t.org_id = %s)
+                     AND t.status = 'active' AND c.status = 'active'
+                   LIMIT 1""",
+                (org_id, uid, uid, org_id),
+            )
+            if cur.fetchone():
+                kubectl_org_rows.append((org_id, uid))
 
         cur.close()
         conn.close()

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -16,40 +16,46 @@ logger = logging.getLogger(__name__)
 SUPPORTED_PROVIDERS = ('gcp', 'aws', 'azure', 'ovh', 'scaleway', 'tailscale')
 
 
-def _query_kubectl_orgs(cur, conn):
-    """Return list of (org_id, user_id) pairs that have at least one active kubectl cluster.
+def _query_kubectl_orgs(cur):
+    """Return dict of org_id -> {user_id, clusters} for orgs with active kubectl clusters.
 
-    kubectl_agent_tokens is RLS-protected, so this mirrors the pattern used by
-    _query_connected_providers: enumerate orgs from the non-RLS users table first,
-    then set RLS context per org before querying kubectl_agent_tokens.
+    Uses a single query joining kubectl_agent_tokens and active_kubectl_connections
+    directly against the users table so no per-user RLS iteration is needed.
+    kubectl_agent_tokens has FORCE RLS; we opt in to the permissive
+    select_by_token_resolve policy (same pattern as agent_ws_handler) so the
+    cross-org scan can see all tokens without setting org context per row.
     """
-    cur.execute("SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL")
-    all_users = cur.fetchall()
-    result = []
-    for uid, org_id in all_users:
-        cur.execute("SET myapp.current_user_id = %s;", (uid,))
-        cur.execute("SET myapp.current_org_id = %s;", (org_id,))
-        conn.commit()
-        cur.execute(
-            """SELECT 1 FROM kubectl_agent_tokens t
-               JOIN active_kubectl_connections c ON t.token = c.token
-               WHERE (t.user_id = %s OR t.org_id = %s)
-                 AND t.status = 'active' AND c.status = 'active'
-               LIMIT 1""",
-            (uid, org_id),
+    cur.execute("SET LOCAL myapp.kubectl_token_resolve = 'true'")
+    cur.execute("""
+        SELECT t.org_id, MIN(u.id) AS user_id, c.cluster_id, t.cluster_name
+        FROM kubectl_agent_tokens t
+        JOIN active_kubectl_connections c ON c.token = t.token
+        JOIN users u ON u.org_id = t.org_id
+        WHERE t.status = 'active' AND c.status = 'active'
+          AND t.org_id IS NOT NULL
+        GROUP BY t.org_id, c.cluster_id, t.cluster_name
+        ORDER BY t.org_id
+    """)
+    rows = cur.fetchall()
+
+    orgs: dict = {}
+    for org_id, user_id, cluster_id, cluster_name in rows:
+        if org_id not in orgs:
+            orgs[org_id] = {"user_id": user_id, "clusters": []}
+        orgs[org_id]["clusters"].append(
+            {"cluster_id": cluster_id, "cluster_name": cluster_name or cluster_id}
         )
-        if cur.fetchone():
-            result.append((org_id, uid))
-    return result
+    return orgs
 
 
 def _query_connected_providers(cur, user_id=None, conn=None):
     """Query active cloud provider connections.
 
-    If user_id is given, returns just the provider name strings for that user.
-    Otherwise returns (user_id, org_id, provider) rows for all users so the
-    caller can deduplicate at the org level.
-    Requires conn for cross-org queries to set RLS context per-org.
+    If user_id is given, returns just the provider name strings for that user
+    (requires conn to set RLS context).
+    Otherwise issues a single aggregated query returning (user_id, org_id, provider)
+    rows — one row per (org, provider) pair with a representative user_id — so
+    callers never need to iterate per-user or set RLS context themselves.
 
     Includes org_id fallback so org-shared connections (e.g. AWS accounts
     registered under the org rather than directly under the user) are picked
@@ -70,30 +76,32 @@ def _query_connected_providers(cur, user_id=None, conn=None):
             """, (user_id, org_id, org_id, SUPPORTED_PROVIDERS, user_id, org_id, org_id, SUPPORTED_PROVIDERS))
         return [row[0] for row in cur.fetchall()]
     else:
-        # No RLS needed — cross-org loop sets RLS per user.
-        # Returns (user_id, org_id, provider) so callers can group by org.
-        cur.execute(
-            "SELECT DISTINCT id, org_id FROM users WHERE org_id IS NOT NULL"
-        )
-        all_users = cur.fetchall()
-        results = []
-        for uid, org_id in all_users:
-            cur.execute("SET myapp.current_user_id = %s;", (uid,))
-            cur.execute("SET myapp.current_org_id = %s;", (org_id,))
-            if conn:
-                conn.commit()
-            cur.execute("""
-                SELECT DISTINCT provider FROM (
-                    SELECT provider FROM user_connections
-                    WHERE (user_id = %s OR org_id = %s) AND status = 'active' AND provider IN %s
-                    UNION
-                    SELECT provider FROM user_tokens
-                    WHERE (user_id = %s OR org_id = %s) AND is_active = true AND provider IN %s
-                ) AS connected
-            """, (uid, org_id, SUPPORTED_PROVIDERS, uid, org_id, SUPPORTED_PROVIDERS))
-            for row in cur.fetchall():
-                results.append((uid, org_id, row[0]))
-        return results
+        # Single query: for each (org_id, provider) pair pick one representative
+        # user_id via MIN so the caller can route Vault / token lookups.
+        # user_connections / user_tokens are NOT RLS-protected when queried
+        # through an admin connection, so no per-user SET myapp.* is needed.
+        cur.execute("""
+            SELECT MIN(u.id) AS user_id, u.org_id, c.provider
+            FROM users u
+            JOIN user_connections c
+              ON (c.user_id = u.id OR c.org_id = u.org_id)
+             AND c.status = 'active'
+             AND c.provider = ANY(%s)
+            WHERE u.org_id IS NOT NULL
+            GROUP BY u.org_id, c.provider
+
+            UNION
+
+            SELECT MIN(u.id) AS user_id, u.org_id, t.provider
+            FROM users u
+            JOIN user_tokens t
+              ON (t.user_id = u.id OR t.org_id = u.org_id)
+             AND t.is_active = true
+             AND t.provider = ANY(%s)
+            WHERE u.org_id IS NOT NULL
+            GROUP BY u.org_id, t.provider
+        """, (list(SUPPORTED_PROVIDERS), list(SUPPORTED_PROVIDERS)))
+        return cur.fetchall()
 
 
 def _clear_discovery_lock(user_id):
@@ -491,15 +499,14 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
 
     Returns None when the org has no usable providers and should be skipped.
     """
-    from utils.db.db_utils import connect_to_db_as_admin
-    from utils.auth.stateless_auth import set_rls_context
 
     user_id = org_info["rep"]
     # Build provider credentials dict, embedding the per-provider owner so
     # discovery_service._setup_provider_env authenticates against the correct
-    # Vault secret path for each connector.
+    # Vault secret path for each connector.  Preserve any extra keys (e.g.
+    # pre-fetched "clusters" for kubectl) so downstream code can skip re-querying.
     providers = {
-        pname: {"owner_id": pdata.get("owner_id", user_id)}
+        pname: {**pdata, "owner_id": pdata.get("owner_id", user_id)}
         for pname, pdata in org_info["providers"].items()
     }
 
@@ -508,38 +515,14 @@ def _process_org(org_id, org_info, get_owner, run_discovery):
 
     # Query active kubectl clusters for this org.
     if "kubectl" in providers:
-        conn = None
-        try:
-            conn = connect_to_db_as_admin()
-            with conn.cursor() as cur:
-                rls_org_id = set_rls_context(cur, conn, user_id, log_prefix="[Discovery Task]")
-                cur.execute(
-                    """SELECT c.cluster_id, t.cluster_name
-                       FROM active_kubectl_connections c
-                       JOIN kubectl_agent_tokens t ON c.token = t.token
-                       WHERE (t.user_id = %s OR t.org_id = %s)
-                         AND t.status = 'active' AND c.status = 'active'""",
-                    (user_id, rls_org_id),
-                )
-                kubectl_rows = cur.fetchall()
-            if kubectl_rows:
-                clusters = [
-                    {"cluster_id": row[0], "cluster_name": row[1] or row[0]}
-                    for row in kubectl_rows
-                ]
-                providers["kubectl"] = {"clusters": clusters}
-                logger.info(
-                    "[Discovery Task] Found %d active kubectl cluster(s) for org=%s",
-                    len(clusters), org_id,
-                )
-            else:
-                del providers["kubectl"]
-        except Exception as e:
-            logger.warning("[Discovery Task] kubectl cluster query failed for org=%s: %s", org_id, e)
+        clusters = providers["kubectl"].get("clusters", [])
+        if clusters:
+            logger.info(
+                "[Discovery Task] Using %d pre-fetched kubectl cluster(s) for org=%s",
+                len(clusters), org_id,
+            )
+        else:
             del providers["kubectl"]
-        finally:
-            if conn:
-                conn.close()
 
     if not providers:
         logger.info("[Discovery Task] No valid providers for org=%s, skipping", org_id)
@@ -576,15 +559,13 @@ def run_full_discovery(self):
 
     try:
         conn = connect_to_db_as_admin()
-        cur = conn.cursor()  # No RLS needed — cross-org loop, sets RLS per user inside
-        rows = _query_connected_providers(cur, conn=conn)
+        cur = conn.cursor()
+        rows = _query_connected_providers(cur)
 
-        # kubectl on-prem connections live in active_kubectl_connections /
-        # kubectl_agent_tokens — never in user_connections / user_tokens — so
-        # _query_connected_providers misses them entirely.
-        # kubectl_agent_tokens IS RLS-protected; _query_kubectl_orgs mirrors
-        # _query_connected_providers and sets RLS context per org before querying.
-        kubectl_org_rows = _query_kubectl_orgs(cur, conn)
+        # kubectl connections live in active_kubectl_connections / kubectl_agent_tokens,
+        # not user_connections / user_tokens, so _query_connected_providers misses them.
+        # _query_kubectl_orgs handles this with a single aggregated JOIN query.
+        kubectl_org_rows = _query_kubectl_orgs(cur)
 
         cur.close()
         conn.close()
@@ -602,11 +583,15 @@ def run_full_discovery(self):
             orgs[org_id]["providers"][provider] = {"owner_id": user_id}
 
         # Add any kubectl-only orgs (not found via cloud provider query above).
-        # Mark kubectl as a provider so _process_org will query the cluster list.
-        for org_id, kubectl_user_id in kubectl_org_rows:
+        # Embed the cluster list directly so _process_org skips the re-query.
+        for org_id, kubectl_info in kubectl_org_rows.items():
+            kubectl_user_id = kubectl_info["user_id"]
             if org_id not in orgs:
                 orgs[org_id] = {"rep": kubectl_user_id, "providers": {}}
-            orgs[org_id]["providers"].setdefault("kubectl", {"owner_id": kubectl_user_id})
+            orgs[org_id]["providers"].setdefault(
+                "kubectl",
+                {"owner_id": kubectl_user_id, "clusters": kubectl_info["clusters"]},
+            )
 
         if not orgs:
             logger.info("[Discovery Task] No orgs with connected cloud providers")
@@ -733,8 +718,8 @@ def mark_stale_services(self):
 
     try:
         conn = connect_to_db_as_admin()
-        cur = conn.cursor()  # No RLS needed — cross-org loop, sets RLS per user inside
-        rows = _query_connected_providers(cur, conn=conn)
+        cur = conn.cursor()
+        rows = _query_connected_providers(cur)
         cur.close()
         conn.close()
         # Deduplicate by org: one representative user per org is sufficient

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -559,16 +559,16 @@ def run_full_discovery(self):
 
     try:
         conn = connect_to_db_as_admin()
-        cur = conn.cursor()
-        rows = _query_connected_providers(cur)
+        try:
+            with conn.cursor() as cur:
+                rows = _query_connected_providers(cur)
 
-        # kubectl connections live in active_kubectl_connections / kubectl_agent_tokens,
-        # not user_connections / user_tokens, so _query_connected_providers misses them.
-        # _query_kubectl_orgs handles this with a single aggregated JOIN query.
-        kubectl_org_rows = _query_kubectl_orgs(cur)
-
-        cur.close()
-        conn.close()
+                # kubectl connections live in active_kubectl_connections / kubectl_agent_tokens,
+                # not user_connections / user_tokens, so _query_connected_providers misses them.
+                # _query_kubectl_orgs handles this with a single aggregated JOIN query.
+                kubectl_org_rows = _query_kubectl_orgs(cur)
+        finally:
+            conn.close()
 
         # Deduplicate by org: collect the union of active providers per org.
         # Record the connector owner per provider (the user_id from each row IS
@@ -678,7 +678,7 @@ def run_user_discovery(self, user_id):
                 for row in kubectl_rows
             ]
             providers["kubectl"] = {"clusters": clusters}
-            logger.info(f"[Discovery Task] Found {len(clusters)} active kubectl clusters for org {org_id}")
+            logger.info("[Discovery Task] Found %d active kubectl clusters for org %s", len(clusters), org_id)
 
         if "gcp" in providers:
             # Wait for GCP post-auth setup to finish (API enablement, SA propagation)
@@ -718,10 +718,11 @@ def mark_stale_services(self):
 
     try:
         conn = connect_to_db_as_admin()
-        cur = conn.cursor()
-        rows = _query_connected_providers(cur)
-        cur.close()
-        conn.close()
+        try:
+            with conn.cursor() as cur:
+                rows = _query_connected_providers(cur)
+        finally:
+            conn.close()
         # Deduplicate by org: one representative user per org is sufficient
         # since graph data is written per org credential owner.
         user_ids = list({org_id: user_id for user_id, org_id, _provider in rows}.values())

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1023,7 +1023,6 @@ def initialize_tables():
                     );
 
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_user ON kubectl_agent_tokens(user_id);
-                    CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_org ON kubectl_agent_tokens(org_id);
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_token ON kubectl_agent_tokens(token);
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_status ON kubectl_agent_tokens(status);
                 """,
@@ -2564,19 +2563,6 @@ def initialize_tables():
             logging.info("Added kubectl token resolve RLS policies on kubectl_agent_tokens.")
 
             conn.commit()
-
-            # Migration: add org_id index on kubectl_agent_tokens to support
-            # org-scoped cluster queries introduced with org-sharing fix.
-            try:
-                cursor.execute("SAVEPOINT sp_kubectl_org_idx")
-                cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_org ON kubectl_agent_tokens(org_id);"
-                )
-                cursor.execute("RELEASE SAVEPOINT sp_kubectl_org_idx")
-                logging.info("Added idx_kubectl_tokens_org index on kubectl_agent_tokens(org_id).")
-            except Exception as e:
-                logging.warning(f"Error adding org_id index to kubectl_agent_tokens: {e}")
-                cursor.execute("ROLLBACK TO SAVEPOINT sp_kubectl_org_idx")
 
             # Migration: Add role column to users table for RBAC
             try:

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1023,6 +1023,7 @@ def initialize_tables():
                     );
 
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_user ON kubectl_agent_tokens(user_id);
+                    CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_org ON kubectl_agent_tokens(org_id);
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_token ON kubectl_agent_tokens(token);
                     CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_status ON kubectl_agent_tokens(status);
                 """,
@@ -2563,6 +2564,19 @@ def initialize_tables():
             logging.info("Added kubectl token resolve RLS policies on kubectl_agent_tokens.")
 
             conn.commit()
+
+            # Migration: add org_id index on kubectl_agent_tokens to support
+            # org-scoped cluster queries introduced with org-sharing fix.
+            try:
+                cursor.execute("SAVEPOINT sp_kubectl_org_idx")
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_kubectl_tokens_org ON kubectl_agent_tokens(org_id);"
+                )
+                cursor.execute("RELEASE SAVEPOINT sp_kubectl_org_idx")
+                logging.info("Added idx_kubectl_tokens_org index on kubectl_agent_tokens(org_id).")
+            except Exception as e:
+                logging.warning(f"Error adding org_id index to kubectl_agent_tokens: {e}")
+                cursor.execute("ROLLBACK TO SAVEPOINT sp_kubectl_org_idx")
 
             # Migration: Add role column to users table for RBAC
             try:

--- a/server/utils/kubectl/agent_ws_handler.py
+++ b/server/utils/kubectl/agent_ws_handler.py
@@ -32,7 +32,7 @@ def get_agent_websocket_by_cluster(user_id: str, cluster_identifier: str):
     Get websocket for cluster by cluster_id.
     
     Args:
-        user_id: User ID for ownership verification
+        user_id: User ID for org membership verification
         cluster_identifier: The cluster_id
     
     Returns:
@@ -41,10 +41,11 @@ def get_agent_websocket_by_cluster(user_id: str, cluster_identifier: str):
     conn = connect_to_db_as_admin()
     try:
         cursor = conn.cursor()
-        from utils.auth.stateless_auth import set_rls_context
+        from utils.auth.stateless_auth import set_rls_context, resolve_org_id
         set_rls_context(cursor, conn, user_id, log_prefix="[KubectlWS:resolve]")
+        org_id = resolve_org_id(user_id)
         cursor.execute("""
-            SELECT c.cluster_id, t.user_id
+            SELECT c.cluster_id, t.org_id
             FROM active_kubectl_connections c
             JOIN kubectl_agent_tokens t ON c.token = t.token
             WHERE c.cluster_id = %s AND c.status = 'active'
@@ -55,9 +56,9 @@ def get_agent_websocket_by_cluster(user_id: str, cluster_identifier: str):
             logger.warning(f"No active cluster found for identifier: {cluster_identifier}")
             return None
             
-        cluster_id, owner_id = result
-        if owner_id != user_id:
-            logger.warning(f"Unauthorized cluster access attempt by {user_id} for cluster {cluster_id}")
+        cluster_id, owner_org_id = result
+        if owner_org_id != org_id:
+            logger.warning(f"Unauthorized cluster access attempt by user {user_id} (org {org_id}) for cluster {cluster_id} (org {owner_org_id})")
             return None
         
         with _ws_lock:


### PR DESCRIPTION
Switch all kubectl token/connection queries from user_id-scoped to org_id-scoped so any member of an org can see and use clusters registered by teammates
Replace get_org_id_from_request() with resolve_org_id(user_id) in kubectl_token_routes.py to correctly resolve org context outside request headers
Fix cluster authorization in agent_ws_handler.py to verify org membership rather than exact user ownership
Fix the discovery pipeline (tasks.py) to query kubectl_agent_tokens / active_kubectl_connections directly (since kubectl connections never appear in user_connections) and include kubectl-only orgs in the full discovery loop
Remove kubectl from SUPPORTED_PROVIDERS to prevent the standard provider query from incorrectly handling it
Add idx_kubectl_tokens_org index on kubectl_agent_tokens(org_id) with a safe migration savepoint for existing deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-premises Kubernetes connections are now scoped at the organization level, allowing multiple organization members to access shared cluster credentials and connections.

* **Updates**
  * Kubernetes connection discovery and authorization logic now operates at the organization level rather than the individual user level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->