### PR TITLE
Fix: gate save_postmortem to postmortem action sessions only

### DIFF
--- a/server/chat/backend/agent/skills/integrations/postmortem/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/postmortem/SKILL.md
@@ -7,7 +7,6 @@ connection_check:
   method: always
 tools:
   - get_postmortem
-  - save_postmortem
 index: "Incident postmortem management -- read, write, version postmortem documents"
 rca_priority: 90
 metadata:
@@ -18,7 +17,7 @@ metadata:
 # Postmortem Tools
 
 ## Overview
-Core tools for reading and writing postmortem documents. Always available. Used by the built-in "Generate Postmortem" action and accessible during interactive chat for postmortem-related tasks.
+Core tools for reading postmortem documents during investigation, and writing them during the dedicated "Generate Postmortem" action. `get_postmortem` is available in all sessions. `save_postmortem` is only available during the "Generate Postmortem" action — not during RCA.
 
 ## Tools
 
@@ -26,7 +25,7 @@ Core tools for reading and writing postmortem documents. Always available. Used 
 Read the current postmortem for an incident. Returns markdown content, generated_at, and updated_at timestamps. Returns `status: "not_found"` if no postmortem exists yet. Only the latest version is returned; historical versions are browsable in the UI but not via this tool.
 
 ### `save_postmortem(incident_id, content)`
-Write or update a postmortem. Each save automatically snapshots the previous content as a version for history tracking. Content must be complete markdown — partial updates are not supported. Max 100,000 characters.
+Write or update a postmortem. **Only available during the "Generate Postmortem" action — not during RCA.** Each save automatically snapshots the previous content as a version for history tracking. Content must be complete markdown — partial updates are not supported. Max 100,000 characters.
 
 ## Workflow
 

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1314,10 +1314,8 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     if _action_id:
         tool_functions.append((trigger_action, "trigger_action"))
 
-    # Postmortem tools: save_postmortem is write-only and must not be exposed to
-    # the RCA agent — it has no Aurora incident UUID and may pass ULIDs or
-    # hallucinated strings, causing UUID type errors in PostgreSQL.
-    # get_postmortem is read-only and safe to expose in all contexts.
+    # get_postmortem is always available (read-only).
+    # save_postmortem is restricted to the dedicated postmortem generation action.
     try:
         from .postmortem_tool import get_postmortem, save_postmortem
         tool_functions.append((get_postmortem, "get_postmortem"))

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1006,10 +1006,11 @@ def get_cloud_tools():
     #   session gets its own wrapped functions that close over the *right* capture instance.
     rca_flag = getattr(state_context, 'trigger_rca_requested', False) if state_context else False
     is_background = getattr(state_context, 'is_background', False) if state_context else False
+    is_postmortem_action = getattr(state_context, 'is_postmortem_action', False) if state_context else False
     if tool_capture is None:
-        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}"
+        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
     else:
-        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}"
+        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
     
     if user_id:
         current_time = time.time()
@@ -1313,11 +1314,15 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     if _action_id:
         tool_functions.append((trigger_action, "trigger_action"))
 
-    # Postmortem tools (always available)
+    # Postmortem tools: save_postmortem is write-only and must not be exposed to
+    # the RCA agent — it has no Aurora incident UUID and may pass ULIDs or
+    # hallucinated strings, causing UUID type errors in PostgreSQL.
+    # get_postmortem is read-only and safe to expose in all contexts.
     try:
         from .postmortem_tool import get_postmortem, save_postmortem
         tool_functions.append((get_postmortem, "get_postmortem"))
-        tool_functions.append((save_postmortem, "save_postmortem"))
+        if is_postmortem_action:
+            tool_functions.append((save_postmortem, "save_postmortem"))
     except ImportError:
         logger.warning("Postmortem tools not available — import failed")
 

--- a/server/chat/backend/agent/tools/postmortem_tool.py
+++ b/server/chat/backend/agent/tools/postmortem_tool.py
@@ -8,10 +8,20 @@ during regular chat for postmortem-related queries.
 
 import json
 import logging
+import uuid as _uuid_mod
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+
+def _is_valid_uuid(value: str) -> bool:
+    """Return True only if value is a well-formed UUID string."""
+    try:
+        _uuid_mod.UUID(value)
+        return True
+    except (ValueError, AttributeError):
+        return False
 
 
 class GetPostmortemArgs(BaseModel):
@@ -35,6 +45,19 @@ def get_postmortem(
 
     if not incident_id:
         return json.dumps({"error": "incident_id is required."})
+
+    if not _is_valid_uuid(incident_id):
+        logger.warning(
+            "[PostmortemTool] get_postmortem called with non-UUID incident_id=%r — rejecting",
+            incident_id,
+        )
+        return json.dumps({
+            "error": (
+                "incident_id must be the Aurora internal UUID (e.g. the id from the "
+                "incidents table).  You may have passed an external identifier such as "
+                "an incident.io ULID.  Check the incident context for the correct UUID."
+            )
+        })
 
     try:
         from utils.db.connection_pool import db_pool
@@ -83,6 +106,20 @@ def save_postmortem(
 
     if not incident_id:
         return json.dumps({"error": "incident_id is required."})
+
+    if not _is_valid_uuid(incident_id):
+        logger.warning(
+            "[PostmortemTool] save_postmortem called with non-UUID incident_id=%r — rejecting",
+            incident_id,
+        )
+        return json.dumps({
+            "error": (
+                "incident_id must be the Aurora internal UUID (e.g. the id from the "
+                "incidents table).  You may have passed an external identifier such as "
+                "an incident.io ULID or a descriptive string.  Check the incident "
+                "context for the correct UUID before retrying."
+            )
+        })
 
     if not content or not content.strip():
         return json.dumps({"error": "content cannot be empty."})

--- a/server/chat/backend/agent/utils/state.py
+++ b/server/chat/backend/agent/utils/state.py
@@ -23,6 +23,9 @@ class State(BaseModel):
     is_background: bool = (
         False  # True for background chats (webhook-triggered, no user interaction)
     )
+    is_postmortem_action: bool = (
+        False  # True only when the session is the dedicated "Generate Postmortem" action
+    )
     rca_context: Optional[Dict[str, Any]] = (
         None  # RCA-specific context (source, providers) - used by prompt_builder
     )

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1099,6 +1099,23 @@ async def _run_jira_action(
     logger.info(f"[JiraAction] Completed for {session_id}")
 
 
+def _action_is_generate_postmortem(action_id: Optional[str]) -> bool:
+    """Return True when action_id belongs to the built-in 'generate_postmortem' system action."""
+    if not action_id:
+        return False
+    try:
+        with db_pool.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM actions WHERE id = %s AND system_key = 'generate_postmortem'",
+                    (action_id,),
+                )
+                return cur.fetchone() is not None
+    except Exception as e:
+        logger.warning("[BackgroundChat] _action_is_generate_postmortem lookup failed: %s", e)
+        return False
+
+
 async def _execute_background_chat(
     user_id: str,
     session_id: str,
@@ -1213,6 +1230,22 @@ async def _execute_background_chat(
                 logger.warning(f"[BackgroundChat] Could not fetch incident started_at: {_e}")
         logger.info("[BackgroundChat] incident_start_time=%r for incident %s", incident_start_time, context_incident_id)
 
+        # Determine whether this session is the dedicated postmortem generation action.
+        # The postmortem action sets source="postmortem_generation" (or overrides to
+        # source="action" when an action_id is found in the DB, but always includes
+        # the original "postmortem_generation" context via action_id).  No RCA or
+        # webhook source ever uses "postmortem_generation", so this flag is exclusive.
+        _tm_source = (trigger_metadata or {}).get("source", "")
+        _is_postmortem_action = _tm_source == "postmortem_generation" or (
+            _tm_source == "action"
+            and (trigger_metadata or {}).get("action_id") is not None
+            # Distinguish postmortem actions from other /action-triggered chats by
+            # checking whether the action's system_key is generate_postmortem.  We
+            # look this up lazily only when source=="action" to avoid a DB round-trip
+            # on every RCA background chat.
+            and _action_is_generate_postmortem((trigger_metadata or {}).get("action_id"))
+        )
+
         # Create state with is_background=True and rca_context for system prompt
         # Use centralized model configuration for RCA with provider mode awareness
         state = State(
@@ -1227,10 +1260,14 @@ async def _execute_background_chat(
             model=ModelConfig.RCA_MODEL,
             mode=mode,
             is_background=True,
+            is_postmortem_action=_is_postmortem_action,
             rca_context=rca_context,
             permitted_tools=_resolve_permitted_tools(user_id),
         )
-        logger.info(f"[BackgroundChat] Created state with is_background=True, mode={mode}, model={state.model}, rca_context={'set' if rca_context else 'None'}, context_incident_id={context_incident_id}")
+        logger.info(
+            f"[BackgroundChat] Created state with is_background=True, is_postmortem_action={_is_postmortem_action}, "
+            f"mode={mode}, model={state.model}, rca_context={'set' if rca_context else 'None'}, context_incident_id={context_incident_id}"
+        )
         
         # Set user context for tools (AFTER state is created so we can pass it)
         set_user_context(

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1230,19 +1230,11 @@ async def _execute_background_chat(
                 logger.warning(f"[BackgroundChat] Could not fetch incident started_at: {_e}")
         logger.info("[BackgroundChat] incident_start_time=%r for incident %s", incident_start_time, context_incident_id)
 
-        # Determine whether this session is the dedicated postmortem generation action.
-        # The postmortem action sets source="postmortem_generation" (or overrides to
-        # source="action" when an action_id is found in the DB, but always includes
-        # the original "postmortem_generation" context via action_id).  No RCA or
-        # webhook source ever uses "postmortem_generation", so this flag is exclusive.
+        # True when triggered by the "Generate Postmortem" action; gates save_postmortem.
+        # source is "postmortem_generation" when no action_id exists, "action" otherwise.
         _tm_source = (trigger_metadata or {}).get("source", "")
         _is_postmortem_action = _tm_source == "postmortem_generation" or (
             _tm_source == "action"
-            and (trigger_metadata or {}).get("action_id") is not None
-            # Distinguish postmortem actions from other /action-triggered chats by
-            # checking whether the action's system_key is generate_postmortem.  We
-            # look this up lazily only when source=="action" to avoid a DB round-trip
-            # on every RCA background chat.
             and _action_is_generate_postmortem((trigger_metadata or {}).get("action_id"))
         )
 


### PR DESCRIPTION
Remove save_postmortem from the RCA agent's tool list — it is now only injected when the session is the dedicated "Generate Postmortem" action
Add is_postmortem_action flag to State, set in task.py by inspecting trigger_metadata.source and a lazy DB lookup on actions.system_key
Update tool cache key to include the new flag so RCA and postmortem sessions never share a cached tool set
Add UUID validation in postmortem_tool.py as a defense-in-depth guard against ULIDs or hallucinated strings reaching PostgreSQL
Update SKILL.md to reflect that save_postmortem is not available during RCA