### PR TITLE
fix(rca/github): resolve relation rename, snippet wipe, missing incident_start_time

### DIFF
--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -138,18 +138,37 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
     }
   };
 
-  // Extract significant words (length > 3) from text for matching
+  // Extract significant words (length > 3) from text for matching.
+  // Splits on every non-word run AND on underscores, so path-y tokens like
+  // `server/routes/health_routes.py` become ['server', 'routes', 'health',
+  // 'routes', 'py'] instead of one un-splittable blob. Without this, file
+  // paths in bullets never overlap with file paths in fix-suggestion titles.
   const extractSignificantWords = useCallback((text: string): string[] => {
-    const normalized = text.toLowerCase().replace(/[^\w\s]/g, '');
-    return normalized.split(/\s+/).filter(word => word.length > 3);
+    return text
+      .toLowerCase()
+      .split(/[\W_]+/)
+      .filter(word => word.length > 3);
+  }, []);
+
+  // Pull the bare filename out of a path so we can do a strong "file mentioned
+  // in this bullet?" check for fix-type suggestions independent of word overlap.
+  const fileBasename = useCallback((filePath?: string): string | null => {
+    if (!filePath) return null;
+    const trimmed = filePath.trim();
+    if (!trimmed) return null;
+    const parts = trimmed.split(/[\\/]/);
+    const base = parts[parts.length - 1] || trimmed;
+    return base.toLowerCase();
   }, []);
 
   // Matches summary list items to suggestions by comparing significant words
-  // Returns the suggestion with the BEST match (most matching words), not just the first match
+  // Returns the suggestion with the BEST match (most matching words), not just the first match.
+  // For fix-type suggestions, a basename mention in the bullet is also a strong match signal.
   const findMatchingSuggestion = useCallback((text: string): Suggestion | null => {
     if (!incident.suggestions?.length) return null;
 
     const textWords = extractSignificantWords(text);
+    const lowerText = text.toLowerCase();
     const normalizedText = text.toLowerCase().replace(/[^\w\s]/g, '');
 
     let bestMatch: Suggestion | null = null;
@@ -158,12 +177,25 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
     for (const suggestion of incident.suggestions) {
       // Match by title word overlap (at least 2 significant words in common)
       const titleWords = extractSignificantWords(suggestion.title);
-      const matchingWordCount = titleWords.filter(word => textWords.includes(word)).length;
+      const textWordSet = new Set(textWords);
+      const matchingWordCount = titleWords.filter(word => textWordSet.has(word)).length;
 
       // Keep track of the best match (most words in common)
       if (matchingWordCount >= 2 && matchingWordCount > bestMatchCount) {
         bestMatch = suggestion;
         bestMatchCount = matchingWordCount;
+      }
+
+      // For fix-type suggestions, also match if the bullet text mentions the
+      // target filename. Bullets like "Audit `server/routes/health_routes.py`"
+      // are a clear pointer to a fix on that file even when the prose vocab
+      // doesn't otherwise overlap with the fix title.
+      if (suggestion.type === 'fix') {
+        const base = fileBasename(suggestion.filePath);
+        if (base && lowerText.includes(base) && bestMatchCount < 3) {
+          bestMatch = suggestion;
+          bestMatchCount = 3; // beat any 2-word overlap; lose to richer overlap
+        }
       }
 
       // Match by description prefix overlap (only if no better title match)
@@ -178,7 +210,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
       }
     }
     return bestMatch;
-  }, [incident.suggestions, extractSignificantWords]);
+  }, [incident.suggestions, extractSignificantWords, fileBasename]);
 
   // Function to render text with citation badges
   const renderTextWithCitations = useCallback((text: string): React.ReactNode => {

--- a/server/chat/backend/agent/orchestrator/dispatcher.py
+++ b/server/chat/backend/agent/orchestrator/dispatcher.py
@@ -239,6 +239,7 @@ def _build_sends(state: State) -> list:
         return []
 
     incident_id = getattr(state, "incident_id", None)
+    incident_start_time = getattr(state, "incident_start_time", None)
     user_id = getattr(state, "user_id", None)
     org_id = getattr(state, "org_id", None)
     parent_session_id = getattr(state, "session_id", None)
@@ -269,6 +270,7 @@ def _build_sends(state: State) -> list:
         payload = {
             **inp.model_dump(),
             "parent_incident_id": incident_id,
+            "parent_incident_start_time": incident_start_time,
             "parent_user_id": user_id,
             "parent_org_id": org_id,
             "parent_session_id": parent_session_id,

--- a/server/chat/backend/agent/orchestrator/select_skills.py
+++ b/server/chat/backend/agent/orchestrator/select_skills.py
@@ -47,7 +47,7 @@ _TOOL_METADATA: dict = {
     # Write tools — excluded from sub-agents
     "github_commit": {"capability_tags": ["source_control_write"], "mutates": True, "cacheable": False},
     "github_fix": {"capability_tags": ["source_control_write"], "mutates": True, "cacheable": False},
-    "github_apply_fix": {"capability_tags": ["source_control_write"], "mutates": True, "cacheable": False},
+    # github_apply_fix is NOT exposed to agents — see note in cloud_tools.py.
     "iac_tool": {"capability_tags": ["iac"], "mutates": True, "cacheable": False},
     # Runbooks + knowledge base
     "confluence_runbook_parse": {"capability_tags": ["runbooks", "knowledge_base"], "mutates": False, "cacheable": True},

--- a/server/chat/backend/agent/orchestrator/sub_agent.py
+++ b/server/chat/backend/agent/orchestrator/sub_agent.py
@@ -541,6 +541,7 @@ async def _run(input_dict: dict) -> FindingRef:
             user_id=user_id,
             session_id=child_session_id,
             incident_id=incident_id,
+            incident_start_time=input_dict.get("parent_incident_start_time"),
             org_id=org_id,
             is_background=True,
             mode="ask",

--- a/server/chat/backend/agent/skills/integrations/github/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/github/SKILL.md
@@ -42,7 +42,7 @@ Connected account: {username}
    - `diff` (requires `commit_sha`) — File-level changes for a specific commit
    - `pull_requests` — Merged PRs in the time window
    - Pass `incident_time` (ISO 8601) for automatic time window correlation
-3. `github_fix(file_path=..., suggested_content=..., fix_description=..., root_cause_summary=...)` — Suggest a code fix (stored for user review, not auto-applied)
+3. `github_fix(file_path=..., edits=[{old_string, new_string, replace_all?}, ...], fix_description=..., root_cause_summary=...)` — Suggest a code fix via anchored search-and-replace edits (stored for user review, not auto-applied). First call `get_file_contents` to read the current file so you can copy the exact `old_string` (with enough surrounding context to be unique).
 4. `github_apply_fix(suggestion_id=...)` — Create a PR from an approved fix (only after user reviews)
 5. `github_commit(repo=..., commit_message=...)` — Push Terraform files to GitHub
 
@@ -81,8 +81,9 @@ Shows file-level additions/deletions. Prioritize config/infra files (.yaml, .env
 Finds PRs merged in the time window; recently merged PRs are flagged.
 
 **Step 6 — Suggest fix:**
-`github_fix(file_path=..., suggested_content=..., fix_description=..., root_cause_summary=...)`
-Suggests a fix stored for user review. User can approve, then `github_apply_fix` creates a PR.
+First read the file with `get_file_contents(owner, repo, path)`. Then:
+`github_fix(file_path=..., edits=[{old_string: "...", new_string: "..."}], fix_description=..., root_cause_summary=...)`
+`old_string` must match the current file exactly (include 1–3 lines of surrounding context so the match is unique). Indentation counts. **Keep `old_string` narrow** — just the lines you're changing plus a little surrounding context. Do NOT pass the whole file as `old_string`; if a single edit covers more than ~half the file Aurora will reject it. For multi-section changes, send multiple smaller edits. Use `replace_all: true` only when `old_string` matches the file byte-for-byte and you want every occurrence touched. Aurora applies the edits server-side and stores the result for user review; `github_apply_fix` then creates the PR.
 
 ### Important Rules
 - Pass `incident_time` on every github_rca call for automatic time correlation.

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -47,7 +47,10 @@ _viz_triggers: TTLCache = TTLCache(maxsize=100, ttl=3600)  # 1 hour TTL
 # Strong references for fire-and-forget tasks so they aren't GC'd before completion.
 _background_tasks: "set[asyncio.Task]" = set()
 from chat.backend.constants import MAX_TOOL_OUTPUT_CHARS
-from .github_apply_fix_tool import github_apply_fix, GitHubApplyFixArgs
+# github_apply_fix is intentionally NOT exposed as an LLM-callable tool — it
+# creates a PR and must require explicit user approval via the Incidents UI's
+# "Create Pull Request" button. The route handler in incidents_routes.py
+# imports github_apply_fix directly.
 from .gitlab_tool import gitlab_tool, GitLabToolArgs
 from routes.gitlab.gitlab_api_utils import is_gitlab_connected
 from .cloud_exec_tool import cloud_exec
@@ -1296,7 +1299,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         (jenkins_rca, "jenkins_rca"),
         (cloudbees_rca, "cloudbees_rca"),
         (spinnaker_rca, "spinnaker_rca"),
-        (github_apply_fix, "github_apply_fix"),
         (cloud_exec_wrapper, "cloud_exec"),
         (terminal_exec, "terminal_exec"),
         (tailscale_ssh, "tailscale_ssh"),
@@ -1364,7 +1366,7 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
             effective_func = _github_rca_pinned
 
         # Apply forced context wrapper for critical tools that should never have parameters mixed up
-        if name in ['iac_tool', 'github_commit', 'github_fix', 'github_apply_fix']:
+        if name in ['iac_tool', 'github_commit', 'github_fix']:
             context_wrapped = with_forced_context(effective_func)
             logging.info(f"Applied with_forced_context decorator to {name}")
         else:
@@ -1496,19 +1498,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "Use during RCA to check if deployments correlate with incidents."
                 ),
                 args_schema=SpinnakerRCAArgs
-            )
-        elif name == 'github_apply_fix':
-            tool = StructuredTool.from_function(
-                func=final_func,
-                name=name,
-                description=(
-                    "Apply an approved fix suggestion by creating a branch and PR. "
-                    "Use this after the user has reviewed and approved a fix suggestion. "
-                    "Parameters: suggestion_id (ID of the fix suggestion to apply), "
-                    "use_edited_content (boolean, default true - use user-edited content if available), "
-                    "target_branch (optional base branch for PR, defaults to main)."
-                ),
-                args_schema=GitHubApplyFixArgs
             )
         elif name == 'trigger_rca':
             tool = StructuredTool.from_function(

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1428,8 +1428,9 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "Use this when you identify a specific code change that would fix the root cause. "
                     "The fix is stored for user review before being applied. "
                     "Parameters: file_path (path in repo), "
-                    "suggested_content (the ENTIRE updated file body — every line of the file, "
-                    "not just the changed lines; Aurora overwrites the whole file with this string), "
+                    "edits (list of anchored search-and-replace edits: each has old_string + new_string; "
+                    "old_string must match the current file exactly, with enough surrounding context to be unique; "
+                    "set replace_all=true if you want every occurrence replaced), "
                     "fix_description (what this fix does), root_cause_summary (why this change is needed). "
                     "Optional: repo (owner/repo format), commit_message, branch."
                 ),

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1427,7 +1427,9 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "Suggest a code fix for an identified issue during RCA. "
                     "Use this when you identify a specific code change that would fix the root cause. "
                     "The fix is stored for user review before being applied. "
-                    "Parameters: file_path (path in repo), suggested_content (complete fixed file), "
+                    "Parameters: file_path (path in repo), "
+                    "suggested_content (the ENTIRE updated file body — every line of the file, "
+                    "not just the changed lines; Aurora overwrites the whole file with this string), "
                     "fix_description (what this fix does), root_cause_summary (why this change is needed). "
                     "Optional: repo (owner/repo format), commit_message, branch."
                 ),

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -1,13 +1,17 @@
 """
 GitHub Fix Tool - Suggest code fixes during RCA.
 
-This tool allows the RCA agent to suggest code fixes when it identifies
-a code issue that caused an incident. The fix is stored as a suggestion
-for user review before being applied.
+The LLM proposes one or more anchored search-and-replace edits. The server
+fetches the current file from GitHub, applies the edits, stores the resulting
+full file body as the suggestion, and the user reviews + creates the PR from
+the UI.
+
+Replacer chain (exact → fuzzier) is ported from opencode/cline/gemini-cli
+edit tools to absorb common LLM whitespace/indent drift.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Callable, Generator
 from pydantic import BaseModel, Field
 
 from .github_mcp_utils import (
@@ -19,10 +23,29 @@ from .github_mcp_utils import (
 
 logger = logging.getLogger(__name__)
 
-# Reject suggested_content much smaller than the original — likely a snippet
-# rather than the full file body push_files will overwrite with.
-MIN_FILE_SIZE_FOR_TRUNCATION_CHECK = 500
-MIN_CONTENT_RATIO_THRESHOLD = 0.4
+
+# ---------------------------------------------------------------------------
+# Args schema
+# ---------------------------------------------------------------------------
+
+
+class FixEdit(BaseModel):
+    """A single anchored search-and-replace edit."""
+    old_string: str = Field(
+        description=(
+            "Exact text to match in the current file. Include enough surrounding "
+            "context (typically 1–3 lines above and below the change) to make the "
+            "match unique. Whitespace counts; if you copy from get_file_contents "
+            "the indentation will be right."
+        )
+    )
+    new_string: str = Field(
+        description="Replacement text. Indentation must match what belongs at that location."
+    )
+    replace_all: bool = Field(
+        default=False,
+        description="Replace every occurrence of old_string. Default False requires exactly one match.",
+    )
 
 
 class GitHubFixArgs(BaseModel):
@@ -30,25 +53,23 @@ class GitHubFixArgs(BaseModel):
     file_path: str = Field(
         description="Path to the file in the repository (e.g., 'config/deployment.yaml', 'src/app.py')"
     )
-    suggested_content: str = Field(
+    edits: list[FixEdit] = Field(
+        min_length=1,
         description=(
-            "COMPLETE updated file body with your fix applied — every line of "
-            "the file from first to last, not a snippet, not a diff, not just "
-            "the changed section. If the original file is 800 lines, your "
-            "suggested_content should also be ~800 lines (give or take the "
-            "lines you added/removed). Aurora overwrites the entire file with "
-            "this string, so any line you omit will be deleted."
-        )
+            "One or more anchored search-and-replace edits applied sequentially. "
+            "Each edit's old_string must match the file exactly once "
+            "(unless replace_all=true). Edits operate on the result of prior edits."
+        ),
     )
     fix_description: str = Field(
-        description="Human-readable description of what this fix does (e.g., 'Increase memory limit from 256Mi to 512Mi')"
+        description="Human-readable description of what this fix does."
     )
     root_cause_summary: str = Field(
-        description="Summary of why this change is needed - what root cause does it address"
+        description="Summary of why this change is needed - what root cause it addresses."
     )
     commit_message: Optional[str] = Field(
         default=None,
-        description="Suggested commit message for this fix. If not provided, one will be generated."
+        description="Suggested commit message. If not provided, one is generated."
     )
     repo: Optional[str] = Field(
         default=None,
@@ -56,29 +77,448 @@ class GitHubFixArgs(BaseModel):
     )
     branch: Optional[str] = Field(
         default=None,
-        description="Target branch for the fix. Defaults to repository's default branch."
+        description="Target branch for the fix. Defaults to the repository's default branch."
     )
+
+
+# ---------------------------------------------------------------------------
+# Line-ending helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_lf(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
+def _detect_line_ending(text: str) -> str:
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def _restore_line_ending(text: str, ending: str) -> str:
+    return text if ending == "\n" else text.replace("\n", "\r\n")
+
+
+# ---------------------------------------------------------------------------
+# Levenshtein (for BlockAnchorReplacer similarity scoring)
+# ---------------------------------------------------------------------------
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if not a or not b:
+        return max(len(a), len(b))
+    prev = list(range(len(b) + 1))
+    curr = [0] * (len(b) + 1)
+    for i in range(1, len(a) + 1):
+        curr[0] = i
+        for j in range(1, len(b) + 1):
+            cost = 0 if a[i - 1] == b[j - 1] else 1
+            curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+        prev, curr = curr, prev
+    return prev[len(b)]
+
+
+# ---------------------------------------------------------------------------
+# Replacers — each yields candidate substrings of `content` that should be
+# treated as a match for `find`. The driver picks the unique match (or all
+# matches, for replace_all) and performs the actual replacement.
+# ---------------------------------------------------------------------------
+
+
+Replacer = Callable[[str, str], Generator[str, None, None]]
+
+
+def _simple_replacer(content: str, find: str) -> Generator[str, None, None]:
+    if find and find in content:
+        yield find
+
+
+def _line_trimmed_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Match per-line modulo leading/trailing whitespace per line."""
+    original_lines = content.split("\n")
+    search_lines = find.split("\n")
+    if search_lines and search_lines[-1] == "":
+        search_lines.pop()
+    if not search_lines:
+        return
+
+    for i in range(len(original_lines) - len(search_lines) + 1):
+        ok = True
+        for j, sline in enumerate(search_lines):
+            if original_lines[i + j].strip() != sline.strip():
+                ok = False
+                break
+        if not ok:
+            continue
+        # Reconstruct exact substring of `content` that spans these lines
+        start = sum(len(original_lines[k]) + 1 for k in range(i))
+        end = start
+        for k in range(len(search_lines)):
+            end += len(original_lines[i + k])
+            if k < len(search_lines) - 1:
+                end += 1  # newline
+        yield content[start:end]
+
+
+_SINGLE_CANDIDATE_SIMILARITY = 0.5
+_MULTIPLE_CANDIDATES_SIMILARITY = 0.5
+
+
+def _block_anchor_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Match blocks whose first and last (trimmed) lines anchor, with middle
+    judged by average Levenshtein similarity. Requires ≥3 lines. To avoid
+    swallowing extra lines when the candidate block is much larger than the
+    search block, candidates with very different line counts are skipped."""
+    original_lines = content.split("\n")
+    search_lines = find.split("\n")
+    if search_lines and search_lines[-1] == "":
+        search_lines.pop()
+    if len(search_lines) < 3:
+        return
+
+    first = search_lines[0].strip()
+    last = search_lines[-1].strip()
+    search_size = len(search_lines)
+
+    candidates: list[tuple[int, int]] = []
+    for i, line in enumerate(original_lines):
+        if line.strip() != first:
+            continue
+        for j in range(i + 2, len(original_lines)):
+            if original_lines[j].strip() == last:
+                candidates.append((i, j))
+                break  # take first matching closer
+
+    if not candidates:
+        return
+
+    def _emit(start_line: int, end_line: int) -> str:
+        start = sum(len(original_lines[k]) + 1 for k in range(start_line))
+        end = start
+        for k in range(start_line, end_line + 1):
+            end += len(original_lines[k])
+            if k < end_line:
+                end += 1
+        return content[start:end]
+
+    def _similarity(start_line: int, end_line: int) -> float:
+        """Average per-line similarity across ALL middle lines on BOTH sides.
+        Missing lines (when sizes differ) score as 0 so a too-long candidate
+        can't get a free pass on its untested tail."""
+        actual_size = end_line - start_line + 1
+        s_middle = max(search_size - 2, 0)
+        a_middle = max(actual_size - 2, 0)
+        if s_middle == 0 and a_middle == 0:
+            return 1.0
+        denom = max(s_middle, a_middle)
+        score = 0.0
+        for k in range(1, denom + 1):
+            orig = original_lines[start_line + k].strip() if k < actual_size - 1 else ""
+            srch = search_lines[k].strip() if k < search_size - 1 else ""
+            max_len = max(len(orig), len(srch))
+            if max_len == 0:
+                # Both lines empty → exact match
+                score += 1.0
+                continue
+            score += 1 - _levenshtein(orig, srch) / max_len
+        return score / denom
+
+    if len(candidates) == 1:
+        s, e = candidates[0]
+        if _similarity(s, e) >= _SINGLE_CANDIDATE_SIMILARITY:
+            yield _emit(s, e)
+        return
+
+    best: Optional[tuple[int, int]] = None
+    best_score = -1.0
+    for s, e in candidates:
+        sc = _similarity(s, e)
+        if sc > best_score:
+            best_score = sc
+            best = (s, e)
+    if best is not None and best_score >= _MULTIPLE_CANDIDATES_SIMILARITY:
+        yield _emit(*best)
+
+
+def _whitespace_normalized_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Match where all runs of whitespace collapse to a single space."""
+    import re
+
+    def normalize(t: str) -> str:
+        return re.sub(r"\s+", " ", t).strip()
+
+    norm_find = normalize(find)
+    if not norm_find:
+        return
+
+    lines = content.split("\n")
+    for line in lines:
+        if normalize(line) == norm_find:
+            yield line
+        else:
+            if norm_find in normalize(line):
+                words = find.strip().split()
+                if words:
+                    pattern = r"\s+".join(re.escape(w) for w in words)
+                    try:
+                        m = re.search(pattern, line)
+                        if m:
+                            yield m.group(0)
+                    except re.error:
+                        pass
+
+    find_lines = find.split("\n")
+    if len(find_lines) > 1:
+        for i in range(len(lines) - len(find_lines) + 1):
+            block = "\n".join(lines[i:i + len(find_lines)])
+            if normalize(block) == norm_find:
+                yield block
+
+
+def _indentation_flexible_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Strip common minimum indentation from both sides and compare."""
+    def strip_min_indent(t: str) -> str:
+        ls = t.split("\n")
+        non_empty = [l for l in ls if l.strip()]
+        if not non_empty:
+            return t
+        min_indent = min(len(l) - len(l.lstrip(" \t")) for l in non_empty)
+        return "\n".join(l if not l.strip() else l[min_indent:] for l in ls)
+
+    norm_find = strip_min_indent(find)
+    content_lines = content.split("\n")
+    find_lines = find.split("\n")
+    for i in range(len(content_lines) - len(find_lines) + 1):
+        block = "\n".join(content_lines[i:i + len(find_lines)])
+        if strip_min_indent(block) == norm_find:
+            yield block
+
+
+def _unescape_string(s: str) -> str:
+    """Convert backslash-escape sequences (\\n, \\t, \\", \\\\, ...) to their literal forms."""
+    import re
+    return re.sub(
+        r'\\(n|t|r|\'|"|`|\\|\n|\$)',
+        lambda m: {
+            "n": "\n", "t": "\t", "r": "\r", "'": "'", '"': '"',
+            "`": "`", "\\": "\\", "\n": "\n", "$": "$",
+        }.get(m.group(1), m.group(0)),
+        s,
+    )
+
+
+def _escape_normalized_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Treat backslash-escapes (\\n, \\t, \\\", etc.) in find as their literal.
+    Skipped when find contains no escape sequences (would duplicate _simple_replacer)."""
+    unesc_find = _unescape_string(find)
+    if unesc_find == find:
+        # No escapes present — nothing this replacer adds over _simple_replacer.
+        return
+    if unesc_find and unesc_find in content:
+        yield unesc_find
+
+    lines = content.split("\n")
+    find_lines = unesc_find.split("\n")
+    for i in range(len(lines) - len(find_lines) + 1):
+        block = "\n".join(lines[i:i + len(find_lines)])
+        if _unescape_string(block) == unesc_find:
+            yield block
+
+
+def _trimmed_boundary_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Try matching with leading/trailing whitespace stripped from find."""
+    trimmed = find.strip()
+    if trimmed == find:
+        return
+    if trimmed and trimmed in content:
+        yield trimmed
+    lines = content.split("\n")
+    find_lines = find.split("\n")
+    for i in range(len(lines) - len(find_lines) + 1):
+        block = "\n".join(lines[i:i + len(find_lines)])
+        if block.strip() == trimmed:
+            yield block
+
+
+def _context_aware_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Block-anchor variant requiring same line count and ≥50% trimmed-line match."""
+    find_lines = find.split("\n")
+    if find_lines and find_lines[-1] == "":
+        find_lines.pop()
+    if len(find_lines) < 3:
+        return
+
+    content_lines = content.split("\n")
+    first = find_lines[0].strip()
+    last = find_lines[-1].strip()
+
+    for i, line in enumerate(content_lines):
+        if line.strip() != first:
+            continue
+        for j in range(i + 2, len(content_lines)):
+            if content_lines[j].strip() != last:
+                continue
+            block_lines = content_lines[i:j + 1]
+            if len(block_lines) != len(find_lines):
+                break
+            matching = 0
+            total = 0
+            for k in range(1, len(block_lines) - 1):
+                bl = block_lines[k].strip()
+                fl = find_lines[k].strip()
+                if bl or fl:
+                    total += 1
+                    if bl == fl:
+                        matching += 1
+            if total == 0 or matching / total >= 0.5:
+                yield "\n".join(block_lines)
+            break
+
+
+def _multi_occurrence_replacer(content: str, find: str) -> Generator[str, None, None]:
+    """Yield every exact occurrence of find. Used with replace_all."""
+    if not find:
+        return
+    start = 0
+    while True:
+        idx = content.find(find, start)
+        if idx == -1:
+            break
+        yield find
+        start = idx + len(find)
+
+
+_REPLACERS: list[tuple[str, Replacer]] = [
+    ("simple", _simple_replacer),
+    ("line_trimmed", _line_trimmed_replacer),
+    ("block_anchor", _block_anchor_replacer),
+    ("whitespace_normalized", _whitespace_normalized_replacer),
+    ("indentation_flexible", _indentation_flexible_replacer),
+    ("escape_normalized", _escape_normalized_replacer),
+    ("trimmed_boundary", _trimmed_boundary_replacer),
+    ("context_aware", _context_aware_replacer),
+    ("multi_occurrence", _multi_occurrence_replacer),
+]
+
+# Only these replacers preserve byte-equality with old_string, so str.replace
+# can safely apply the same edit to every occurrence under replace_all.
+_REPLACE_ALL_SAFE = {"simple", "multi_occurrence"}
+
+
+def _replace_with_chain(content: str, old: str, new: str, replace_all: bool) -> tuple[Optional[str], Optional[str]]:
+    """Try each replacer until one yields a usable match. Returns (new_content, error)."""
+    if old == new:
+        return None, "old_string and new_string are identical (no-op)"
+    if not old:
+        return None, "old_string is empty"
+
+    found_any = False
+    fuzzy_only = False  # True iff every match so far came from a fuzzy replacer
+    for name, replacer in _REPLACERS:
+        for candidate in replacer(content, old):
+            idx = content.find(candidate)
+            if idx == -1:
+                continue
+            found_any = True
+
+            if replace_all:
+                if name not in _REPLACE_ALL_SAFE:
+                    # Fuzzy match + replace_all would only touch this one
+                    # variant — other occurrences with different whitespace /
+                    # indentation / escapes would be silently skipped. Refuse.
+                    fuzzy_only = True
+                    continue
+                return content.replace(candidate, new), None
+
+            last_idx = content.rfind(candidate)
+            if idx != last_idx:
+                # multiple matches via this replacer — keep trying.
+                continue
+
+            # If the escape-normalized replacer is what made this match, the
+            # LLM's new_string is probably escaped the same way — unescape it
+            # too so the file gets real newlines/tabs instead of backslash-n.
+            effective_new = _unescape_string(new) if name == "escape_normalized" else new
+            return content[:idx] + effective_new + content[idx + len(candidate):], None
+
+    if not found_any:
+        return None, (
+            "old_string not found in the current file (tried exact, line-trimmed, "
+            "block-anchor, whitespace-normalized, indentation-flexible, escape-"
+            "normalized, trimmed-boundary, and context-aware matching). Re-fetch "
+            "the file with get_file_contents and copy the exact text to replace."
+        )
+    if replace_all and fuzzy_only:
+        return None, (
+            "replace_all=true requires old_string to match the file exactly. "
+            "Fix the whitespace/indentation in old_string to match the file, "
+            "or split into individual edits with replace_all=false."
+        )
+    return None, (
+        "old_string matches multiple places in the file. Add more surrounding "
+        "context to make it unique, or set replace_all=true."
+    )
+
+
+# An anchored edit should target a small window around the change, not the
+# whole file. If old_string covers more than this fraction of the original,
+# the LLM is doing a whole-file rewrite under the guise of an edit — refuse.
+_MAX_OLD_STRING_RATIO = 0.5
+_OLD_STRING_RATIO_MIN_FILE = 500  # don't enforce on tiny files
+
+
+def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:
+    """Apply edits sequentially. Returns (new_content, error)."""
+    line_ending = _detect_line_ending(original)
+    content = _normalize_lf(original)
+    orig_lf_len = len(content)
+
+    for i, raw in enumerate(edits, 1):
+        if isinstance(raw, dict):
+            old = raw.get("old_string", "")
+            new = raw.get("new_string", "")
+            replace_all = bool(raw.get("replace_all", False))
+        else:
+            old = getattr(raw, "old_string", "")
+            new = getattr(raw, "new_string", "")
+            replace_all = bool(getattr(raw, "replace_all", False))
+
+        old_lf = _normalize_lf(old)
+        new_lf = _normalize_lf(new)
+
+        if orig_lf_len > _OLD_STRING_RATIO_MIN_FILE and len(old_lf) > _MAX_OLD_STRING_RATIO * orig_lf_len:
+            return None, (
+                f"edit {i}: old_string is {len(old_lf)/orig_lf_len:.0%} of the "
+                f"file ({len(old_lf)} of {orig_lf_len} chars). An anchored edit "
+                "should target a narrow window around the change — usually 1–3 "
+                "lines of context above and below. Break this into smaller "
+                "targeted edits instead of regenerating the whole file."
+            )
+
+        new_content, err = _replace_with_chain(content, old_lf, new_lf, replace_all)
+        if err is not None or new_content is None:
+            return None, f"edit {i}: {err}"
+        content = new_content
+
+    return _restore_line_ending(content, line_ending), None
+
+
+# ---------------------------------------------------------------------------
+# GitHub + DB plumbing (unchanged from prior version)
+# ---------------------------------------------------------------------------
 
 
 def _resolve_repository(
     user_id: str,
     explicit_repo: Optional[str] = None
 ) -> tuple[Optional[str], Optional[str], str]:
-    """
-    Resolve repository using the same logic as github_rca_tool.
-    Imported from github_rca_tool to maintain consistency.
-    """
     from .github_rca_tool import _resolve_repository as rca_resolve_repo
     return rca_resolve_repo(user_id, explicit_repo)
 
 
 def _get_file_content(owner: str, repo: str, path: str, branch: Optional[str], user_id: str) -> Optional[str]:
-    """Fetch current file content from GitHub using MCP."""
     args = {"owner": owner, "repo": repo, "path": path}
     if branch:
-        # GitHub MCP uses 'ref' parameter, not 'branch'
         args["ref"] = f"refs/heads/{branch}"
-
     result = call_github_mcp_sync("get_file_contents", args, user_id)
     return parse_file_content_response(result)
 
@@ -94,13 +534,11 @@ def _save_fix_suggestion(
     repository: str,
     commit_message: Optional[str],
 ) -> Optional[int]:
-    """Save fix suggestion to database."""
     from utils.db.connection_pool import db_pool
 
     try:
         with db_pool.get_admin_connection() as conn:
             cursor = conn.cursor()
-            # No RLS needed — incident_suggestions not RLS-protected
             cursor.execute(
                 """
                 INSERT INTO incident_suggestions
@@ -113,13 +551,13 @@ def _save_fix_suggestion(
                     incident_id,
                     title,
                     description,
-                    "fix",  # type
-                    "medium",  # risk - code changes are medium risk
+                    "fix",
+                    "medium",
                     file_path,
                     original_content,
                     suggested_content,
                     repository,
-                    commit_message,  # Store commit message in command field for now
+                    commit_message,
                 )
             )
             result = cursor.fetchone()
@@ -134,7 +572,6 @@ def _save_fix_suggestion(
 
 
 def _build_title(file_path: str, fix_description: str) -> str:
-    """Build a concise title from file path and description."""
     filename = file_path.split('/')[-1]
     truncated_desc = fix_description[:50]
     suffix = "..." if len(fix_description) > 50 else ""
@@ -143,7 +580,7 @@ def _build_title(file_path: str, fix_description: str) -> str:
 
 def github_fix(
     file_path: str,
-    suggested_content: str,
+    edits: list,
     fix_description: str,
     root_cause_summary: str,
     commit_message: Optional[str] = None,
@@ -153,82 +590,52 @@ def github_fix(
     incident_id: Optional[str] = None,
     **kwargs,
 ) -> str:
-    """
-    Suggest a code fix for an identified issue during RCA.
-
-    Creates an incident_suggestion with type='fix' that stores the proposed
-    change for user review. The user can then edit the suggestion and create
-    a PR when ready.
-
-    Args:
-        file_path: Path to the file in the repository
-        suggested_content: Complete fixed file content
-        fix_description: What this fix does
-        root_cause_summary: Why this change is needed
-        commit_message: Optional commit message
-        repo: Optional repository in 'owner/repo' format
-        branch: Optional target branch
-        user_id: User ID (injected by tool wrapper)
-        incident_id: Incident ID (injected by tool wrapper)
-
-    Returns:
-        JSON string with result status and details
-    """
+    """Suggest a code fix via anchored multi-edit applied server-side."""
     if not user_id:
         return build_error_response("User ID is required")
-
     if not incident_id:
         return build_error_response("Incident ID is required. This tool should be used during RCA.")
+    if not edits:
+        return build_error_response("edits must contain at least one entry")
 
-    # Resolve repository
     owner, repo_name, source = _resolve_repository(user_id, repo)
     if not owner or not repo_name:
         return build_error_response(
-            "Could not resolve repository. Please specify repo parameter "
-            "(e.g., repo='owner/repo') or add repository info to Knowledge Base."
+            "Could not resolve repository. Please specify repo='owner/repo' or add repo info to Knowledge Base."
         )
 
     full_repo = f"{owner}/{repo_name}"
     logger.info(f"[github_fix] Using repository {full_repo} (resolved from {source})")
 
-    # Fetch original file content (optional - we proceed without it if unavailable)
     original_content = _get_file_content(owner, repo_name, file_path, branch, user_id)
     if original_content is None:
-        logger.warning(f"Could not fetch original content for {file_path}, proceeding without it")
-    else:
-        orig_lines = original_content.count("\n") + 1
-        sugg_lines = suggested_content.count("\n") + 1
-        orig_len = len(original_content)
-        sugg_len = len(suggested_content)
-        if orig_len > MIN_FILE_SIZE_FOR_TRUNCATION_CHECK and (
-            sugg_len < MIN_CONTENT_RATIO_THRESHOLD * orig_len
-            or sugg_lines < MIN_CONTENT_RATIO_THRESHOLD * orig_lines
-        ):
-            logger.warning(
-                "[github_fix] Rejecting suggested_content for %s as likely truncated: "
-                "original %d lines / %d chars, suggested %d lines / %d chars "
-                "(threshold ratio=%.2f)",
-                file_path, orig_lines, orig_len, sugg_lines, sugg_len,
-                MIN_CONTENT_RATIO_THRESHOLD,
-            )
-            return build_error_response(
-                f"suggested_content for {file_path} is much smaller than the "
-                f"original (original {orig_lines} lines / {orig_len} chars, "
-                f"you sent {sugg_lines} lines / {sugg_len} chars). If you "
-                "intended a large deletion, that's fine — re-send the COMPLETE "
-                "new file body so push_files writes the file you mean. If you "
-                "only sent the changed snippet, expand it to the full file with "
-                "your targeted change applied and re-call github_fix."
-            )
+        return build_error_response(
+            f"Could not fetch current contents of {file_path} from {full_repo}. "
+            "Verify the path and branch, then retry."
+        )
 
-    # Generate commit message if not provided
+    suggested_content, apply_err = _apply_edits(original_content, edits)
+    if apply_err or suggested_content is None:
+        logger.warning("[github_fix] edit application failed for %s: %s", file_path, apply_err)
+        return build_error_response(apply_err or "edit application failed")
+
+    if suggested_content == original_content:
+        return build_error_response(
+            "Applied edits produced no change to the file. Double-check old_string/new_string."
+        )
+    if not suggested_content.strip():
+        # An edit that empties the entire file is almost always a mistake and
+        # push_files would silently truncate the file. Reject explicitly.
+        return build_error_response(
+            "Applied edits produced an empty (or whitespace-only) file. If you "
+            "really intend to empty this file, do it manually — github_fix is "
+            "for targeted code changes."
+        )
+
     final_commit_message = commit_message or f"fix: {fix_description[:100]}"
-
-    # Build title and description
     title = _build_title(file_path, fix_description)
     description = f"{fix_description}\n\n**Root Cause:** {root_cause_summary}"
 
-    # Save to database
     suggestion_id = _save_fix_suggestion(
         incident_id=incident_id,
         user_id=user_id,
@@ -249,6 +656,6 @@ def github_fix(
         suggestion_id=suggestion_id,
         repository=full_repo,
         file_path=file_path,
-        has_original_content=original_content is not None,
+        edits_applied=len(edits),
         next_steps="The user can review and edit the suggested fix in the Incidents UI, then create a PR when ready."
     )

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -6,8 +6,13 @@ fetches the current file from GitHub, applies the edits, stores the resulting
 full file body as the suggestion, and the user reviews + creates the PR from
 the UI.
 
-Replacer chain (exact → fuzzier) is ported from opencode/cline/gemini-cli
-edit tools to absorb common LLM whitespace/indent drift.
+Replacer chain (exact → fuzzier) is ported from opencode's edit tool, which
+in turn credits cline and gemini-cli. Original source:
+    https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/tool/edit.ts
+Licensed under MIT — see opencode's LICENSE for terms. This file ports the
+replacer algorithms (LineTrimmed, BlockAnchor, WhitespaceNormalized,
+IndentationFlexible, EscapeNormalized, TrimmedBoundary, ContextAware,
+MultiOccurrence) and the Levenshtein-based similarity scoring to Python.
 """
 
 import logging
@@ -171,8 +176,10 @@ def _line_trimmed_replacer(content: str, find: str) -> Generator[str, None, None
         yield content[start:end]
 
 
-_SINGLE_CANDIDATE_SIMILARITY = 0.5
-_MULTIPLE_CANDIDATES_SIMILARITY = 0.5
+# Match opencode's battle-tested thresholds. Anchors plus the per-edit length
+# check (above) keep these from accepting wildly-different middle content.
+_SINGLE_CANDIDATE_SIMILARITY = 0.0
+_MULTIPLE_CANDIDATES_SIMILARITY = 0.3
 
 
 def _block_anchor_replacer(content: str, find: str) -> Generator[str, None, None]:
@@ -420,15 +427,66 @@ _REPLACERS: list[tuple[str, Replacer]] = [
 _REPLACE_ALL_SAFE = {"simple", "multi_occurrence"}
 
 
-def _replace_with_chain(content: str, old: str, new: str, replace_all: bool) -> tuple[Optional[str], Optional[str]]:
-    """Try each replacer until one yields a usable match. Returns (new_content, error)."""
+def _find_closest_lines(content: str, find: str, max_results: int = 3) -> list[tuple[int, str]]:
+    """Return up to ``max_results`` (1-based line_no, line) pairs from ``content``
+    most similar to the most distinctive (longest non-empty) line of ``find``.
+    Used to give the LLM concrete "did you mean this line?" hints."""
+    find_lines = [l for l in find.split("\n") if l.strip()]
+    if not find_lines:
+        return []
+    anchor = max(find_lines, key=len).strip()
+    if not anchor:
+        return []
+    scored: list[tuple[float, int, str]] = []
+    for i, line in enumerate(content.split("\n")):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        max_len = max(len(stripped), len(anchor))
+        sim = 1.0 - _levenshtein(stripped, anchor) / max_len
+        if sim > 0.3:
+            scored.append((sim, i + 1, line))
+    scored.sort(key=lambda t: -t[0])
+    return [(ln, line) for _sim, ln, line in scored[:max_results]]
+
+
+def _find_all_match_lines(content: str, needle: str, max_results: int = 10) -> list[int]:
+    """Return up to ``max_results`` distinct 1-based line numbers where
+    ``needle`` appears in ``content``. Multiple matches on the same line
+    collapse to one entry so the LLM doesn't see ``L5, L5, L5``."""
+    if not needle:
+        return []
+    seen: list[int] = []
+    start = 0
+    while len(seen) < max_results:
+        idx = content.find(needle, start)
+        if idx == -1:
+            break
+        ln = content.count("\n", 0, idx) + 1
+        if ln not in seen:
+            seen.append(ln)
+        start = idx + max(len(needle), 1)
+    return seen
+
+
+def _locate_with_chain(
+    content: str, old: str, new: str, replace_all: bool
+) -> tuple[list[tuple[int, int, str]], Optional[str]]:
+    """Find match spans for `old` in `content` via the replacer chain.
+
+    Returns (list of (start, end, replacement_text), error). Pure-locate
+    function; does NOT modify content. Callers apply spans atomically so
+    that a multi-edit batch can't have later edits accidentally match text
+    inserted by earlier ones — every edit anchors to the ORIGINAL file.
+    """
     if old == new:
-        return None, "old_string and new_string are identical (no-op)"
+        return [], "old_string and new_string are identical (no-op)"
     if not old:
-        return None, "old_string is empty"
+        return [], "old_string is empty"
 
     found_any = False
-    fuzzy_only = False  # True iff every match so far came from a fuzzy replacer
+    fuzzy_only = False
+    multi_match_candidate: Optional[str] = None
     for name, replacer in _REPLACERS:
         for candidate in replacer(content, old):
             idx = content.find(candidate)
@@ -438,40 +496,59 @@ def _replace_with_chain(content: str, old: str, new: str, replace_all: bool) -> 
 
             if replace_all:
                 if name not in _REPLACE_ALL_SAFE:
-                    # Fuzzy match + replace_all would only touch this one
-                    # variant — other occurrences with different whitespace /
-                    # indentation / escapes would be silently skipped. Refuse.
                     fuzzy_only = True
                     continue
-                return content.replace(candidate, new), None
+                spans: list[tuple[int, int, str]] = []
+                pos = 0
+                while True:
+                    p = content.find(candidate, pos)
+                    if p == -1:
+                        break
+                    spans.append((p, p + len(candidate), new))
+                    pos = p + len(candidate)
+                return spans, None
 
             last_idx = content.rfind(candidate)
             if idx != last_idx:
-                # multiple matches via this replacer — keep trying.
+                if multi_match_candidate is None:
+                    multi_match_candidate = candidate
                 continue
 
-            # If the escape-normalized replacer is what made this match, the
-            # LLM's new_string is probably escaped the same way — unescape it
-            # too so the file gets real newlines/tabs instead of backslash-n.
-            effective_new = _unescape_string(new) if name == "escape_normalized" else new
-            return content[:idx] + effective_new + content[idx + len(candidate):], None
+            return [(idx, idx + len(candidate), new)], None
 
     if not found_any:
-        return None, (
+        hints = _find_closest_lines(content, old)
+        if hints:
+            hint_block = "\nClosest lines in the file (copy verbatim — keep quotes, whitespace, indent):\n"
+            for ln, line in hints:
+                hint_block += f"  L{ln}: {line!r}\n"
+            hint_block += (
+                "Pick the right one and include 1–3 surrounding lines as anchor context so "
+                "the match is unique. Then re-call github_fix."
+            )
+        else:
+            hint_block = (
+                " Call get_file_contents for this file first, then copy old_string byte-for-byte "
+                "from the response and retry."
+            )
+        return [], (
             "old_string not found in the current file (tried exact, line-trimmed, "
             "block-anchor, whitespace-normalized, indentation-flexible, escape-"
-            "normalized, trimmed-boundary, and context-aware matching). Re-fetch "
-            "the file with get_file_contents and copy the exact text to replace."
+            "normalized, trimmed-boundary, and context-aware matching)." + hint_block
         )
     if replace_all and fuzzy_only:
-        return None, (
+        return [], (
             "replace_all=true requires old_string to match the file exactly. "
             "Fix the whitespace/indentation in old_string to match the file, "
             "or split into individual edits with replace_all=false."
         )
-    return None, (
-        "old_string matches multiple places in the file. Add more surrounding "
-        "context to make it unique, or set replace_all=true."
+    match_lines = _find_all_match_lines(content, multi_match_candidate or old)
+    locs = ", ".join(f"L{n}" for n in match_lines) if match_lines else "multiple places"
+    return [], (
+        f"old_string matches {len(match_lines) or 'multiple'} places in the file "
+        f"({locs}). Extend old_string with 1–3 unique surrounding lines as anchor "
+        "context (e.g. the function header above, the closing brace below) and "
+        "retry. Use replace_all=true only if you want every occurrence replaced."
     )
 
 
@@ -483,7 +560,12 @@ _OLD_STRING_RATIO_MIN_FILE = 500  # don't enforce on tiny files
 
 
 def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:
-    """Apply edits sequentially. Returns (new_content, error)."""
+    """Apply edits atomically against the original buffer.
+
+    Each edit is located independently in the ORIGINAL content (not the
+    running content), so edit N can never silently match text that edit
+    N-1 inserted. Overlapping spans across edits are rejected.
+    """
     if _has_mixed_line_endings(original):
         return None, (
             "file has mixed CRLF and LF line endings — refusing to apply edits "
@@ -493,6 +575,9 @@ def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[st
     line_ending = _detect_line_ending(original)
     content = _normalize_lf(original)
     orig_lf_len = len(content)
+
+    all_spans: list[tuple[int, int, str]] = []
+    span_owner: dict[int, int] = {}  # span start → edit index, for overlap errors
 
     for i, raw in enumerate(edits, 1):
         if isinstance(raw, dict):
@@ -516,12 +601,33 @@ def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[st
                 "targeted edits instead of regenerating the whole file."
             )
 
-        new_content, err = _replace_with_chain(content, old_lf, new_lf, replace_all)
-        if err is not None or new_content is None:
+        spans, err = _locate_with_chain(content, old_lf, new_lf, replace_all)
+        if err is not None:
             return None, f"edit {i}: {err}"
-        content = new_content
 
-    return _restore_line_ending(content, line_ending), None
+        for s, e, replacement in spans:
+            for ps, pe, _existing in all_spans:
+                if s < pe and e > ps:
+                    return None, (
+                        f"edit {i}: target region [{s}:{e}] overlaps a region "
+                        f"already claimed by edit {span_owner.get(ps, '?')}. "
+                        "Each edit must anchor to a distinct slice of the "
+                        "original file — combine them into one edit or rework "
+                        "the anchors."
+                    )
+            span_owner[s] = i
+            all_spans.append((s, e, replacement))
+
+    all_spans.sort(key=lambda t: t[0])
+    parts: list[str] = []
+    cursor = 0
+    for s, e, replacement in all_spans:
+        parts.append(content[cursor:s])
+        parts.append(replacement)
+        cursor = e
+    parts.append(content[cursor:])
+
+    return _restore_line_ending("".join(parts), line_ending), None
 
 
 # ---------------------------------------------------------------------------

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -39,7 +39,7 @@ class FixEdit(BaseModel):
     old_string: str = Field(
         description=(
             "Exact text to match in the current file. Include enough surrounding "
-            "context (typically 1–3 lines above and below the change) to make the "
+            "context (typically 1-3 lines above and below the change) to make the "
             "match unique. Whitespace counts; if you copy from get_file_contents "
             "the indentation will be right."
         )
@@ -523,7 +523,7 @@ def _locate_with_chain(
             for ln, line in hints:
                 hint_block += f"  L{ln}: {line!r}\n"
             hint_block += (
-                "Pick the right one and include 1–3 surrounding lines as anchor context so "
+                "Pick the right one and include 1-3 surrounding lines as anchor context so "
                 "the match is unique. Then re-call github_fix."
             )
         else:
@@ -546,7 +546,7 @@ def _locate_with_chain(
     locs = ", ".join(f"L{n}" for n in match_lines) if match_lines else "multiple places"
     return [], (
         f"old_string matches {len(match_lines) or 'multiple'} places in the file "
-        f"({locs}). Extend old_string with 1–3 unique surrounding lines as anchor "
+        f"({locs}). Extend old_string with 1-3 unique surrounding lines as anchor "
         "context (e.g. the function header above, the closing brace below) and "
         "retry. Use replace_all=true only if you want every occurrence replaced."
     )
@@ -596,7 +596,7 @@ def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[st
             return None, (
                 f"edit {i}: old_string is {len(old_lf)/orig_lf_len:.0%} of the "
                 f"file ({len(old_lf)} of {orig_lf_len} chars). An anchored edit "
-                "should target a narrow window around the change — usually 1–3 "
+                "should target a narrow window around the change - usually 1-3 "
                 "lines of context above and below. Break this into smaller "
                 "targeted edits instead of regenerating the whole file."
             )

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -19,6 +19,11 @@ from .github_mcp_utils import (
 
 logger = logging.getLogger(__name__)
 
+# Reject suggested_content much smaller than the original — likely a snippet
+# rather than the full file body push_files will overwrite with.
+MIN_FILE_SIZE_FOR_TRUNCATION_CHECK = 500
+MIN_CONTENT_RATIO_THRESHOLD = 0.4
+
 
 class GitHubFixArgs(BaseModel):
     """Arguments for github_fix tool."""
@@ -191,26 +196,29 @@ def github_fix(
     if original_content is None:
         logger.warning(f"Could not fetch original content for {file_path}, proceeding without it")
     else:
-        # Guard against the LLM passing only a snippet of the change instead of
-        # the complete file. push_files overwrites the entire file with whatever
-        # we hand it, so a snippet here silently deletes the rest of the file.
         orig_lines = original_content.count("\n") + 1
         sugg_lines = suggested_content.count("\n") + 1
         orig_len = len(original_content)
         sugg_len = len(suggested_content)
-        if orig_len > 500 and (sugg_len < 0.4 * orig_len or sugg_lines < 0.4 * orig_lines):
+        if orig_len > MIN_FILE_SIZE_FOR_TRUNCATION_CHECK and (
+            sugg_len < MIN_CONTENT_RATIO_THRESHOLD * orig_len
+            or sugg_lines < MIN_CONTENT_RATIO_THRESHOLD * orig_lines
+        ):
             logger.warning(
-                "[github_fix] Rejecting truncated suggestion for %s: "
-                "original %d lines / %d chars, suggested %d lines / %d chars",
+                "[github_fix] Rejecting suggested_content for %s as likely truncated: "
+                "original %d lines / %d chars, suggested %d lines / %d chars "
+                "(threshold ratio=%.2f)",
                 file_path, orig_lines, orig_len, sugg_lines, sugg_len,
+                MIN_CONTENT_RATIO_THRESHOLD,
             )
             return build_error_response(
-                f"suggested_content is too short to be the full {file_path} "
-                f"(original is {orig_lines} lines / {orig_len} chars, "
-                f"you sent {sugg_lines} lines / {sugg_len} chars). "
-                "You must pass the COMPLETE updated file contents, not just "
-                "the changed lines. Re-call github_fix with the full file body "
-                "containing your targeted change applied."
+                f"suggested_content for {file_path} is much smaller than the "
+                f"original (original {orig_lines} lines / {orig_len} chars, "
+                f"you sent {sugg_lines} lines / {sugg_len} chars). If you "
+                "intended a large deletion, that's fine — re-send the COMPLETE "
+                "new file body so push_files writes the file you mean. If you "
+                "only sent the changed snippet, expand it to the full file with "
+                "your targeted change applied and re-call github_fix."
             )
 
     # Generate commit message if not provided

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -263,8 +263,8 @@ def _whitespace_normalized_replacer(content: str, find: str) -> Generator[str, N
                         m = re.search(pattern, line)
                         if m:
                             yield m.group(0)
-                    except re.error:
-                        pass
+                    except re.error as exc:
+                        logger.debug("Skipping invalid regex pattern in whitespace-normalized replacer: %s", exc)
 
     find_lines = find.split("\n")
     if len(find_lines) > 1:

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -26,7 +26,14 @@ class GitHubFixArgs(BaseModel):
         description="Path to the file in the repository (e.g., 'config/deployment.yaml', 'src/app.py')"
     )
     suggested_content: str = Field(
-        description="The complete suggested file content with the fix applied. Must be the full file, not just the diff."
+        description=(
+            "COMPLETE updated file body with your fix applied — every line of "
+            "the file from first to last, not a snippet, not a diff, not just "
+            "the changed section. If the original file is 800 lines, your "
+            "suggested_content should also be ~800 lines (give or take the "
+            "lines you added/removed). Aurora overwrites the entire file with "
+            "this string, so any line you omit will be deleted."
+        )
     )
     fix_description: str = Field(
         description="Human-readable description of what this fix does (e.g., 'Increase memory limit from 256Mi to 512Mi')"
@@ -183,6 +190,28 @@ def github_fix(
     original_content = _get_file_content(owner, repo_name, file_path, branch, user_id)
     if original_content is None:
         logger.warning(f"Could not fetch original content for {file_path}, proceeding without it")
+    else:
+        # Guard against the LLM passing only a snippet of the change instead of
+        # the complete file. push_files overwrites the entire file with whatever
+        # we hand it, so a snippet here silently deletes the rest of the file.
+        orig_lines = original_content.count("\n") + 1
+        sugg_lines = suggested_content.count("\n") + 1
+        orig_len = len(original_content)
+        sugg_len = len(suggested_content)
+        if orig_len > 500 and (sugg_len < 0.4 * orig_len or sugg_lines < 0.4 * orig_lines):
+            logger.warning(
+                "[github_fix] Rejecting truncated suggestion for %s: "
+                "original %d lines / %d chars, suggested %d lines / %d chars",
+                file_path, orig_lines, orig_len, sugg_lines, sugg_len,
+            )
+            return build_error_response(
+                f"suggested_content is too short to be the full {file_path} "
+                f"(original is {orig_lines} lines / {orig_len} chars, "
+                f"you sent {sugg_lines} lines / {sugg_len} chars). "
+                "You must pass the COMPLETE updated file contents, not just "
+                "the changed lines. Re-call github_fix with the full file body "
+                "containing your targeted change applied."
+            )
 
     # Generate commit message if not provided
     final_commit_message = commit_message or f"fix: {fix_description[:100]}"

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -98,6 +98,18 @@ def _restore_line_ending(text: str, ending: str) -> str:
     return text if ending == "\n" else text.replace("\n", "\r\n")
 
 
+def _has_mixed_line_endings(text: str) -> bool:
+    """True iff `text` contains both CRLF and standalone LF.
+
+    Normalizing a mixed-ending file to LF and restoring as CRLF (or vice versa)
+    would rewrite every line terminator and produce a giant diff for what
+    should be a tiny edit — so callers should refuse mixed input instead.
+    """
+    if "\r\n" not in text:
+        return False
+    return "\n" in text.replace("\r\n", "")
+
+
 # ---------------------------------------------------------------------------
 # Levenshtein (for BlockAnchorReplacer similarity scoring)
 # ---------------------------------------------------------------------------
@@ -183,10 +195,12 @@ def _block_anchor_replacer(content: str, find: str) -> Generator[str, None, None
     for i, line in enumerate(original_lines):
         if line.strip() != first:
             continue
+        # Don't break on the first matching closer — repeated closers (e.g.
+        # multiple `}` after one opener) mean the correct end may be further
+        # out. Collect every (open, close) pair and let _similarity rank them.
         for j in range(i + 2, len(original_lines)):
             if original_lines[j].strip() == last:
                 candidates.append((i, j))
-                break  # take first matching closer
 
     if not candidates:
         return
@@ -354,12 +368,15 @@ def _context_aware_replacer(content: str, find: str) -> Generator[str, None, Non
     for i, line in enumerate(content_lines):
         if line.strip() != first:
             continue
+        # Scan every matching closer; a closer further out may be the right
+        # one when there are repeated trailing anchors. The driver dedupes
+        # identical yields and detects multi-match ambiguity.
         for j in range(i + 2, len(content_lines)):
             if content_lines[j].strip() != last:
                 continue
             block_lines = content_lines[i:j + 1]
             if len(block_lines) != len(find_lines):
-                break
+                continue
             matching = 0
             total = 0
             for k in range(1, len(block_lines) - 1):
@@ -371,7 +388,6 @@ def _context_aware_replacer(content: str, find: str) -> Generator[str, None, Non
                         matching += 1
             if total == 0 or matching / total >= 0.5:
                 yield "\n".join(block_lines)
-            break
 
 
 def _multi_occurrence_replacer(content: str, find: str) -> Generator[str, None, None]:
@@ -468,6 +484,12 @@ _OLD_STRING_RATIO_MIN_FILE = 500  # don't enforce on tiny files
 
 def _apply_edits(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:
     """Apply edits sequentially. Returns (new_content, error)."""
+    if _has_mixed_line_endings(original):
+        return None, (
+            "file has mixed CRLF and LF line endings — refusing to apply edits "
+            "because normalizing the buffer would rewrite every line terminator "
+            "and produce a huge diff. Normalize the file's line endings first."
+        )
     line_ending = _detect_line_ending(original)
     content = _normalize_lf(original)
     orig_lf_len = len(content)

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1548,6 +1548,29 @@ async def handle_connection(websocket) -> None:
             # Resolve incident_id — reuse result from RBAC check to avoid duplicate query
             _incident_id = _rbac_incident_id
 
+            # Fetch the authoritative incident start time so github_rca (and any
+            # other time-sensitive tool) doesn't fail-closed in this code path.
+            # Mirrors the fetch in server/chat/background/task.py.
+            _incident_start_time = None
+            if _incident_id:
+                try:
+                    from datetime import timezone as _tz
+                    with db_pool.get_admin_connection() as _conn:
+                        with _conn.cursor() as _cur:
+                            set_rls_context(_cur, _conn, user_id, log_prefix="[Chatbot:StartTime]")
+                            _cur.execute(
+                                "SELECT started_at FROM incidents WHERE id = %s",
+                                (_incident_id,),
+                            )
+                            _row = _cur.fetchone()
+                            if _row and _row[0]:
+                                _started_at = _row[0]
+                                if _started_at.tzinfo is None:
+                                    _started_at = _started_at.replace(tzinfo=_tz.utc)
+                                _incident_start_time = _started_at.astimezone(_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                except Exception as _e:
+                    logger.warning("[Chatbot] Could not fetch incident started_at for %s: %s", _incident_id, _e)
+
             # Fetch org tool permissions for gate bypass
             _permitted_tools = None
             try:
@@ -1566,6 +1589,7 @@ async def handle_connection(websocket) -> None:
                 user_id=user_id,
                 session_id=session_id,
                 incident_id=_incident_id,
+                incident_start_time=_incident_start_time,
                 org_id=org_id,
                 provider_preference=provider_preference,
                 selected_project_id=selected_project_id,

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1548,28 +1548,10 @@ async def handle_connection(websocket) -> None:
             # Resolve incident_id — reuse result from RBAC check to avoid duplicate query
             _incident_id = _rbac_incident_id
 
-            # Fetch the authoritative incident start time so github_rca (and any
-            # other time-sensitive tool) doesn't fail-closed in this code path.
-            # Mirrors the fetch in server/chat/background/task.py.
-            _incident_start_time = None
-            if _incident_id:
-                try:
-                    from datetime import timezone as _tz
-                    with db_pool.get_admin_connection() as _conn:
-                        with _conn.cursor() as _cur:
-                            set_rls_context(_cur, _conn, user_id, log_prefix="[Chatbot:StartTime]")
-                            _cur.execute(
-                                "SELECT started_at FROM incidents WHERE id = %s",
-                                (_incident_id,),
-                            )
-                            _row = _cur.fetchone()
-                            if _row and _row[0]:
-                                _started_at = _row[0]
-                                if _started_at.tzinfo is None:
-                                    _started_at = _started_at.replace(tzinfo=_tz.utc)
-                                _incident_start_time = _started_at.astimezone(_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-                except Exception as _e:
-                    logger.warning("[Chatbot] Could not fetch incident started_at for %s: %s", _incident_id, _e)
+            from utils.incidents import fetch_incident_start_time
+            _incident_start_time = fetch_incident_start_time(
+                user_id, _incident_id, log_prefix="[Chatbot:StartTime]"
+            )
 
             # Fetch org tool permissions for gate bypass
             _permitted_tools = None

--- a/server/routes/github/github_app.py
+++ b/server/routes/github/github_app.py
@@ -265,7 +265,7 @@ def _reconcile_user_installations(user_id: str) -> None:
                         (user_id, stale),
                     )
                     cur.execute(
-                        """UPDATE github_connected_repos
+                        """UPDATE connected_repos
                               SET installation_id = NULL,
                                   updated_at = NOW()
                             WHERE user_id = %s
@@ -880,7 +880,7 @@ def github_app_unlink_installation(user_id, installation_id):
                     log_prefix="[GITHUB-APP-UNLINK]",
                 )
                 cur.execute(
-                    """UPDATE github_connected_repos
+                    """UPDATE connected_repos
                           SET installation_id = NULL,
                               updated_at = NOW()
                         WHERE user_id = %s
@@ -1068,7 +1068,7 @@ def github_disconnect(user_id):
                         log_prefix="[GITHUB-DISCONNECT]",
                     )
                     cur.execute(
-                        """UPDATE github_connected_repos
+                        """UPDATE connected_repos
                               SET installation_id = NULL,
                                   updated_at = NOW()
                             WHERE user_id = %s

--- a/server/tasks/github_webhook_tasks.py
+++ b/server/tasks/github_webhook_tasks.py
@@ -184,7 +184,7 @@ def _handle_installation_event(
           (key by ``installation_id``).
         * ``deleted``: DELETE row by ``installation_id``. The
           ``user_github_installations`` join is cleared by ON DELETE
-          CASCADE. ``github_connected_repos.installation_id`` rows are
+          CASCADE. ``connected_repos.installation_id`` rows are
           intentionally NOT touched here — see Task 9 lazy cleanup in
           the auth router.
         * ``suspend``: ``UPDATE suspended_at = NOW()``.
@@ -278,7 +278,7 @@ def _handle_installation_event(
 
                 # Drop the parent row first. ``user_github_installations``
                 # has ``ON DELETE CASCADE`` so the user-link rows go with
-                # it. ``github_connected_repos.installation_id`` is a plain
+                # it. ``connected_repos.installation_id`` is a plain
                 # column with no FK, so we null it explicitly below to
                 # avoid leaving dangling references that would surface as
                 # "App-bound repo with no install" in the picker.
@@ -304,7 +304,7 @@ def _handle_installation_event(
                         )
                         continue
                     cur.execute(
-                        """UPDATE github_connected_repos
+                        """UPDATE connected_repos
                               SET installation_id = NULL,
                                   updated_at = NOW()
                             WHERE installation_id = %s
@@ -429,14 +429,14 @@ def _handle_installation_repositories_event(
     """Apply an ``installation_repositories.<action>`` webhook.
 
     Supported actions:
-        * ``added``: **NO-OP**. Aurora populates ``github_connected_repos``
+        * ``added``: **NO-OP**. Aurora populates ``connected_repos``
           lazily when a user fetches their installation's repos via the
           auth router (Task 9). Eagerly inserting per-user rows here
           would require iterating ``user_github_installations`` for every
           linked user, which is wasteful for installations with no
           active Aurora users yet.
         * ``removed``: DELETE matching rows from
-          ``github_connected_repos`` for ALL users that have this
+          ``connected_repos`` for ALL users that have this
           ``(installation_id, repo_full_name)`` pair. Multi-user
           installations exist; we must clean every user's view.
 
@@ -477,7 +477,7 @@ def _handle_installation_repositories_event(
                     if isinstance(full_name, str) and full_name:
                         repo_full_names.append(full_name)
 
-        # github_connected_repos is RLS-protected; the Celery worker has
+        # connected_repos is RLS-protected; the Celery worker has
         # no Flask request context so RLS vars are unset by default. Set
         # the RLS context per-user before DELETE so FORCE RLS doesn't
         # silently no-op the cleanup. An installation can be linked by
@@ -512,7 +512,7 @@ def _handle_installation_repositories_event(
                             )
                             continue
                         cur.execute(
-                            """DELETE FROM github_connected_repos
+                            """DELETE FROM connected_repos
                                 WHERE installation_id = %s
                                   AND repo_full_name = ANY(%s)""",
                             (installation_id, repo_full_names),

--- a/server/utils/auth/github_auth_router.py
+++ b/server/utils/auth/github_auth_router.py
@@ -7,7 +7,7 @@ Routing rules
 -------------
 For each call to :func:`get_auth_for_user_repo`:
 
-1. Look up the ``github_connected_repos`` row for ``(user_id,
+1. Look up the ``connected_repos`` row for ``(user_id,
    repo_full_name)``, joining ``user_github_installations`` and
    ``github_installations`` so we know in one round-trip whether the
    user still links a non-suspended installation for that repo.
@@ -106,7 +106,7 @@ def _lookup_repo_installation(
 
     A LEFT JOIN means a missing user link → ``has_active=False``, which
     sends the caller down the ``NoGitHubAuthError`` path. Returns
-    ``(None, False)`` when no ``github_connected_repos`` row exists for
+    ``(None, False)`` when no ``connected_repos`` row exists for
     this user/repo at all.
     """
 
@@ -119,7 +119,7 @@ def _lookup_repo_installation(
                 AND i.installation_id IS NOT NULL
                 AND i.suspended_at IS NULL
             ) AS has_active_installation
-        FROM github_connected_repos r
+        FROM connected_repos r
         LEFT JOIN user_github_installations u
             ON u.installation_id = r.installation_id
             AND u.user_id = r.user_id
@@ -131,7 +131,7 @@ def _lookup_repo_installation(
 
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cursor:
-            # ``github_connected_repos`` (the leading table in this join)
+            # ``connected_repos`` (the leading table in this join)
             # is RLS-protected; the auth router can be called from Celery
             # tasks where the connection pool's request-context RLS vars
             # never fired. Resolving + setting org_id explicitly keeps
@@ -263,7 +263,7 @@ def _backfill_repo_installation(
                 ):
                     return
                 cur.execute(
-                    """UPDATE github_connected_repos
+                    """UPDATE connected_repos
                           SET installation_id = %s,
                               updated_at = NOW()
                         WHERE user_id = %s
@@ -363,7 +363,7 @@ def get_any_auth_for_user(user_id: str) -> AuthResult:
 
     - ``get_auth_for_user_repo`` looks up the App installation tied to
       ONE specific ``(user_id, repo_full_name)`` pair via
-      ``github_connected_repos.installation_id``.
+      ``connected_repos.installation_id``.
     - ``get_any_auth_for_user`` looks up the FIRST non-suspended App
       installation linked to the user via ``user_github_installations``,
       regardless of repo.

--- a/server/utils/incidents.py
+++ b/server/utils/incidents.py
@@ -1,0 +1,38 @@
+"""Helpers for reading incident state from the DB."""
+
+import logging
+from datetime import timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_incident_start_time(user_id: str, incident_id: Optional[str], log_prefix: str = "[incidents]") -> Optional[str]:
+    """Return the incident's ``started_at`` as an ISO 8601 UTC string, or None.
+
+    Sets RLS context with ``user_id`` before reading the RLS-protected
+    ``incidents`` table. Returns None on missing incident, missing
+    ``started_at``, or any error (logged at warning level).
+    """
+    if not incident_id:
+        return None
+    try:
+        from utils.db.connection_pool import db_pool
+        from utils.auth.stateless_auth import set_rls_context
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix=log_prefix)
+                cur.execute(
+                    "SELECT started_at FROM incidents WHERE id = %s",
+                    (incident_id,),
+                )
+                row = cur.fetchone()
+                if not row or not row[0]:
+                    return None
+                started_at = row[0]
+                if started_at.tzinfo is None:
+                    started_at = started_at.replace(tzinfo=timezone.utc)
+                return started_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception as exc:
+        logger.warning("%s Could not fetch incident started_at for %s: %s", log_prefix, incident_id, exc)
+        return None


### PR DESCRIPTION
## Summary
- **GitHub tool auth failure** — auth router/webhook/disconnect SQL still queried the legacy `github_connected_repos`; live DB only has `connected_repos`. Every `github_*` tool call returned `relation does not exist`.
- **PR diff wiped the file** — LLM was passing only the changed snippet as `suggested_content`; `push_files` overwrote the whole file. Added a length-ratio guard against the fetched original and tightened the tool/field descriptions.
- **`github_rca` failed-closed inside sub-agents** — dispatcher's `Send` payload never forwarded `incident_start_time`, and `sub_agent_node` rebuilt a fresh `State` without it, clobbering the parent's contextvar via `agentic_tool_flow → set_user_context(state=sub_state)`. Now forwarded end-to-end.
- **Incident-chat textbox also missed the timestamp** — `main_chatbot.py` built State with `incident_id` but never fetched `incidents.started_at`; added the same fetch used by the background-RCA path.

## Test plan
- [ ] Rebuild + roll `server`, `chatbot`, `celery_worker`
- [ ] Auto-RCA on a fresh incident → sub-agents call `github_rca` successfully (no `pinned timestamp` error)
- [ ] Type a follow-up in the incident chat → `github_rca` from chat works
- [ ] Approve a fix suggestion that touches a real multi-hundred-line file → PR diff shows only the targeted change, not whole-file deletion (or the LLM gets the new "too short" error and retries)
- [ ] Connect/disconnect GitHub App → no `relation "github_connected_repos" does not exist` errors in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagate incident start time through agent orchestration and sub-agent flows.
  * New anchored search-and-replace fix workflow: submit edits (old/new/replace_all) and have the server apply and save suggested fixes.
  * GitHub integration now targets the consolidated connected_repos records for repo-linkage operations.

* **Bug Fixes**
  * Reject ambiguous, empty, no-op, overlapping, or mixed-encoding edits to prevent unsafe or ineffective fixes.

* **Documentation**
  * Updated guidance for crafting and submitting code-fix edits and tool usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->