### PR TITLE
fix: add wait-with-timeout to DB connection pool to prevent exhaustion under concurrent load

### DIFF
--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 # How long to wait for a connection before giving up (seconds)
-_POOL_WAIT_TIMEOUT = float(os.getenv('DB_POOL_WAIT_TIMEOUT', '5.0'))
+_POOL_WAIT_TIMEOUT = 5.0
 
 
 class DatabaseConnectionPool:

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -2,6 +2,7 @@ import psycopg2
 import psycopg2.pool
 import logging
 import os
+import time
 import threading
 from dotenv import load_dotenv
 from contextlib import contextmanager
@@ -12,6 +13,10 @@ load_dotenv()
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+# How long to wait for a connection before giving up (seconds)
+_POOL_WAIT_TIMEOUT = float(os.getenv('DB_POOL_WAIT_TIMEOUT', '5.0'))
+
 
 class DatabaseConnectionPool:
     """Centralized database connection pool manager."""
@@ -54,15 +59,18 @@ class DatabaseConnectionPool:
         # Track which PID created the pool so we can detect post-fork reuse
         self._pool_pid: Optional[int] = None
 
+        # Condition variable for waiting when pool is exhausted
+        self._pool_available = threading.Condition(threading.Lock())
+
         # Initialize pool on first access
         self._pool_lock = threading.Lock()
         self._initialized = True
 
         logger.info("DatabaseConnectionPool initialized")
-    
+
     def _get_pool(self) -> psycopg2.pool.ThreadedConnectionPool:
         """Get or create the connection pool.
-        
+
         Detects process forks (e.g. Gunicorn with --preload) and recreates
         the pool in child workers. psycopg2 connections are not fork-safe.
         """
@@ -96,11 +104,43 @@ class DatabaseConnectionPool:
                         logger.error(f"Failed to create connection pool: {e}")
                         raise
         return self._pool
-    
+
+    def _getconn_with_retry(self, pool):
+        """Get a connection, waiting up to _POOL_WAIT_TIMEOUT if exhausted.
+
+        psycopg2's ThreadedConnectionPool raises PoolError immediately when
+        all connections are checked out. This wrapper retries with backoff so
+        that short-lived queries (sub-agents, tool callbacks) don't fail just
+        because they collided at the same instant.
+        """
+        deadline = time.monotonic() + _POOL_WAIT_TIMEOUT
+        attempt = 0
+        while True:
+            try:
+                return pool.getconn()
+            except psycopg2.pool.PoolError:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise
+                attempt += 1
+                if attempt == 1:
+                    logger.warning(
+                        "Connection pool exhausted — waiting up to %.1fs for a free connection",
+                        remaining,
+                    )
+                with self._pool_available:
+                    self._pool_available.wait(timeout=min(0.1, remaining))
+
+    def _putconn_notify(self, pool, connection):
+        """Return a connection to the pool and notify waiters."""
+        pool.putconn(connection)
+        with self._pool_available:
+            self._pool_available.notify()
+
     @contextmanager
     def get_connection(self):
         """Get a connection from the pool with automatic cleanup.
-        
+
         Automatically sets RLS session variables (myapp.current_user_id,
         myapp.current_org_id) from the Flask request context when available.
         This ensures all queries on RLS-protected tables work correctly
@@ -109,7 +149,7 @@ class DatabaseConnectionPool:
         pool = self._get_pool()
         connection = None
         try:
-            connection = pool.getconn()
+            connection = self._getconn_with_retry(pool)
             if connection:
                 connection.autocommit = False
                 self._set_rls_vars(connection)
@@ -137,7 +177,7 @@ class DatabaseConnectionPool:
                 except Exception as e:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
                 try:
-                    pool.putconn(connection)
+                    self._putconn_notify(pool, connection)
                 except Exception as e:
                     logger.error("Error returning connection to pool: %s", e)
 
@@ -172,7 +212,7 @@ class DatabaseConnectionPool:
     def get_admin_connection(self):
         """Alias for get_connection() - kept for backward compatibility."""
         return self.get_connection()
-    
+
     def get_pool_status(self) -> dict:
         """Get status information about the connection pool."""
         status = {'pool': None}
@@ -209,4 +249,4 @@ class DatabaseConnectionPool:
                 logger.info("Connection pool closed")
 
 # Global instance
-db_pool = DatabaseConnectionPool() 
+db_pool = DatabaseConnectionPool()


### PR DESCRIPTION
## Summary
- Adds a wait-with-timeout mechanism to the DB connection pool instead of failing immediately when exhausted
- When all connections are checked out, callers now wait up to 5s (configurable via `DB_POOL_WAIT_TIMEOUT`) for one to be returned
- Uses a condition variable so returning a connection immediately wakes a waiter

## Root cause
psycopg2's `ThreadedConnectionPool.getconn()` raises `PoolError("connection pool exhausted")` **instantly** when max connections are checked out. It doesn't queue or wait.

During multi-agent RCA (6 sub-agents in a wave), brief contention spikes cause all 20 connections to be momentarily checked out. Even though each query finishes in <100ms, any request that arrives during that spike gets an immediate failure — cascading into gunicorn worker timeouts and 500s on unrelated API calls.

## Fix
Wrap `getconn()` in a retry loop backed by a `threading.Condition`:
- On `PoolError`, wait up to 5s (polling every 100ms)
- `putconn()` now calls `condition.notify()` to wake waiters immediately
- If 5s pass with no free connection, raise the original error (preserves fail-fast for actual leaks)

This means transient spikes are absorbed (sub-agents finishing their queries free up connections within milliseconds), while actual pool leaks still surface as errors after the timeout.

## Test plan
- [ ] Deploy to staging, trigger multi-agent RCA with 6+ sub-agents while using the UI
- [ ] Verify GET /chat-sessions no longer 500s during RCA waves
- [ ] Verify the warning log "Connection pool exhausted — waiting..." appears briefly then resolves
- [ ] Verify actual pool leaks still raise after 5s (not masked indefinitely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connection pool management to handle high-load scenarios more gracefully. Implemented retry logic that allows requests to wait for available database connections instead of immediately failing when resources are exhausted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->