### PR TITLE
fix: github diff tool showing wrong diff

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1427,7 +1427,10 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "Suggest a code fix for an identified issue during RCA. "
                     "Use this when you identify a specific code change that would fix the root cause. "
                     "The fix is stored for user review before being applied. "
-                    "Parameters: file_path (path in repo), suggested_content (complete fixed file), "
+                    "CRITICAL: suggested_content MUST be the ENTIRE file contents after your change is applied. "
+                    "Do NOT pass only the changed lines, a snippet, or a diff fragment — that will produce a broken diff in the UI. "
+                    "If the file is large, read the full file first, make your edit, then pass the complete result. "
+                    "Parameters: file_path (path in repo), suggested_content (COMPLETE file after fix — every line), "
                     "fix_description (what this fix does), root_cause_summary (why this change is needed). "
                     "Optional: repo (owner/repo format), commit_message, branch."
                 ),

--- a/server/chat/backend/agent/tools/github_fix_tool.py
+++ b/server/chat/backend/agent/tools/github_fix_tool.py
@@ -26,7 +26,12 @@ class GitHubFixArgs(BaseModel):
         description="Path to the file in the repository (e.g., 'config/deployment.yaml', 'src/app.py')"
     )
     suggested_content: str = Field(
-        description="The complete suggested file content with the fix applied. Must be the full file, not just the diff."
+        description=(
+            "The COMPLETE file contents after the fix is applied — every single line of the file. "
+            "NEVER pass only the changed lines, a code snippet, or a diff fragment. "
+            "If the original file is large, read it in full first, apply your change, "
+            "then pass the entire result here. Passing a partial file will produce a broken all-red diff in the UI."
+        )
     )
     fix_description: str = Field(
         description="Human-readable description of what this fix does (e.g., 'Increase memory limit from 256Mi to 512Mi')"
@@ -182,7 +187,12 @@ def github_fix(
     # Fetch original file content (optional - we proceed without it if unavailable)
     original_content = _get_file_content(owner, repo_name, file_path, branch, user_id)
     if original_content is None:
-        logger.warning(f"Could not fetch original content for {file_path}, proceeding without it")
+        logger.warning(f"[github_fix] Could not fetch original content for {file_path} — diff view will show all-green additions")
+    else:
+        logger.info(
+            f"[github_fix] original_content={len(original_content)} chars, "
+            f"suggested_content={len(suggested_content)} chars for {file_path}"
+        )
 
     # Generate commit message if not provided
     final_commit_message = commit_message or f"fix: {fix_description[:100]}"


### PR DESCRIPTION
The LLM was passing only changed lines instead of the complete file, causing the diff viewer to show everything as deleted. Strengthened the tool description to explicitly require the full file contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitHub fix tool to require complete file contents in fix suggestions instead of partial snippets, preventing UI and diff display breakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->