### PR TITLE
feat: move Actions from settings modal to main sidebar (DEV-1175)

### DIFF
--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -706,7 +706,11 @@ export function ActionsContent() {
 // -- Page (redirects to settings) --
 
 export default function ActionsPage() {
-  return <ActionsContent />;
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-4">
+      <ActionsContent />
+    </div>
+  );
 }
 
 function EditActionWrapper({ actionId, onBack, onSaved }: { readonly actionId: string; readonly onBack: () => void; readonly onSaved: () => void }) {

--- a/client/src/app/actions/page.tsx
+++ b/client/src/app/actions/page.tsx
@@ -703,7 +703,6 @@ export function ActionsContent() {
   );
 }
 
-// -- Page (redirects to settings) --
 
 export default function ActionsPage() {
   return (

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { Settings, User, BookOpen, FileText, Building2, Shield, Workflow } from "lucide-react";
+import { Settings, User, BookOpen, FileText, Building2, Shield } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { GeneralSettings } from "@/components/GeneralSettings";
 import { ProfileSettings } from "@/components/ProfileSettings";
@@ -11,7 +11,6 @@ import { KnowledgeBaseSettings } from "@/components/KnowledgeBaseSettings";
 import { PostmortemsSettings } from "@/components/PostmortemsSettings";
 import { OrgSettings } from "@/components/OrgSettings";
 import { SecuritySettings } from "@/components/SecuritySettings";
-import { ActionsContent } from "@/app/actions/page";
 import { useUser } from "@/hooks/useAuthHooks";
 
 
@@ -20,7 +19,7 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-type SettingsTab = 'organization' | 'general' | 'profile' | 'knowledge-base' | 'postmortems' | 'security' | 'actions';
+type SettingsTab = 'organization' | 'general' | 'profile' | 'knowledge-base' | 'postmortems' | 'security';
 
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>('organization');
@@ -62,12 +61,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       label: 'Security',
       icon: Shield,
       description: 'Agent command policies'
-    },
-    {
-      id: 'actions' as SettingsTab,
-      label: 'Actions',
-      icon: Workflow,
-      description: 'Background agent automations'
     },
   ];
 
@@ -123,13 +116,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         return (
           <div className="p-6 h-full overflow-y-auto">
             <SecuritySettings />
-          </div>
-        );
-
-      case 'actions':
-        return (
-          <div className="p-6 h-full overflow-y-auto">
-            <ActionsContent />
           </div>
         );
 

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { ChevronLeft, Settings, LogOut, User, Zap, Plug, Gauge, SquarePen } from "lucide-react"
+import { ChevronLeft, Settings, LogOut, User, Zap, Plug, Gauge, SquarePen, Workflow } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import ChatHistory from "@/components/ChatHistory"
@@ -220,6 +220,24 @@ export default function Navigation({
               <div className="flex items-center">
                 <Plug size={16} />
                 <span className="ml-2">Connectors</span>
+              </div>
+            </Link>
+          </li>
+
+          {/* Actions Navigation Item */}
+          <li>
+            <Link
+              href="/actions"
+              className={cn(
+                "w-full flex items-center justify-between px-2.5 py-1.5 rounded-md hover:bg-primary/10 transition-colors text-sm border border-transparent hover:border-border/50",
+                pathname?.startsWith("/actions")
+                  ? "bg-card rounded-lg border border-border shadow-sm"
+                  : "text-muted-foreground"
+              )}
+            >
+              <div className="flex items-center">
+                <Workflow size={16} />
+                <span className="ml-2">Actions</span>
               </div>
             </Link>
           </li>


### PR DESCRIPTION
## Summary
- Moves Actions from a tab inside the Settings modal to a top-level item in the main sidebar navigation
- Adds proper page container (`max-w-4xl`) to the `/actions` route so content doesn't stretch full-width
- Removes Actions tab, render case, and related imports from `SettingsModal.tsx`

## Test plan
- [ ] Verify Actions appears in the sidebar with the Workflow icon
- [ ] Clicking it navigates to `/actions` with proper layout
- [ ] Actions CRUD (create, edit, enable/disable, run) still works as before
- [ ] Settings modal no longer shows the Actions tab

Resolves DEV-1175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Actions" menu item to the main navigation sidebar for direct access

* **Refactor**
  * Removed the "Actions" tab from the Settings modal to streamline the interface
  * Improved the Actions page layout with centered content and better spacing
  * Updated the Actions navigation item icon for clearer visual recognition

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->