### PR TITLE
Add email notifications on action completion

### DIFF
--- a/client/src/components/RCASettings.tsx
+++ b/client/src/components/RCASettings.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { Bell, Plus, Trash2, Check, Clock, RefreshCw, Mail } from "lucide-react";
+import { Bell, Plus, Trash2, Check, Clock, RefreshCw, Mail, Zap } from "lucide-react";
 import { useAuth, useUser } from "@/hooks/useAuthHooks";
 import {
   Dialog,
@@ -37,16 +37,16 @@ export function RCASettings() {
   });
   const [savingPreferences, setSavingPreferences] = useState<Record<string, boolean>>({});
   const [isLoadingNotificationPref, setIsLoadingNotificationPref] = useState(true);
-  
+
   const [primaryEmail, setPrimaryEmail] = useState<string>("");
   const [additionalEmails, setAdditionalEmails] = useState<RCAEmail[]>([]);
   const [isLoadingEmails, setIsLoadingEmails] = useState(true);
-  
+
   // Add email state
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [newEmail, setNewEmail] = useState("");
   const [isAddingEmail, setIsAddingEmail] = useState(false);
-  
+
   // Verification dialog state
   const [isVerifyDialogOpen, setIsVerifyDialogOpen] = useState(false);
   const [verifyingEmail, setVerifyingEmail] = useState("");
@@ -54,16 +54,15 @@ export function RCASettings() {
   const [isVerifying, setIsVerifying] = useState(false);
   const [isResending, setIsResending] = useState(false);
   const [resendCooldown, setResendCooldown] = useState(0);
-  
+
   const { toast } = useToast();
   const { userId } = useAuth();
   const { user } = useUser();
 
-  // Load notification preferences
   useEffect(() => {
     const loadNotificationPreferences = async () => {
       if (!userId) return;
-      
+
       try {
         const keys = ['rca_email_notifications', 'rca_email_start_notifications', 'action_email_notifications'];
         const loaded: Record<string, boolean> = {};
@@ -93,19 +92,16 @@ export function RCASettings() {
     loadNotificationPreferences();
   }, [userId]);
 
-  // Load email list
   useEffect(() => {
     loadEmails();
   }, [userId]);
 
-  // Set primary email from authenticated user
   useEffect(() => {
     if (user?.emailAddresses?.[0]?.emailAddress) {
       setPrimaryEmail(user.emailAddresses[0].emailAddress);
     }
   }, [user]);
 
-  // Resend cooldown timer
   useEffect(() => {
     if (resendCooldown > 0) {
       const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
@@ -113,9 +109,9 @@ export function RCASettings() {
     }
   }, [resendCooldown]);
 
-  const loadEmails = async () => {
+  const loadEmails = useCallback(async () => {
     if (!userId) return;
-    
+
     try {
       setIsLoadingEmails(true);
       const data = await listRCAEmails();
@@ -131,12 +127,11 @@ export function RCASettings() {
     } finally {
       setIsLoadingEmails(false);
     }
-  };
+  }, [userId, toast]);
 
-  const handlePreferenceChange = async (key: string, enabled: boolean, label: string) => {
+  const handlePreferenceChange = async (key: string, enabled: boolean) => {
     if (!userId) return;
-    
-    // Optimistic update for smoother UI
+
     setPreferences(prev => ({ ...prev, [key]: enabled }));
     setSavingPreferences(prev => ({ ...prev, [key]: true }));
 
@@ -145,13 +140,8 @@ export function RCASettings() {
         `/api/proxy/user-preferences`,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            key,
-            value: enabled,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key, value: enabled }),
         }
       );
 
@@ -160,7 +150,6 @@ export function RCASettings() {
       }
     } catch (error) {
       console.error(`Error saving ${key} preference:`, error);
-      // Revert on error
       setPreferences(prev => ({ ...prev, [key]: !enabled }));
       toast({
         title: "Error",
@@ -175,50 +164,30 @@ export function RCASettings() {
   const handleAddEmail = async () => {
     if (!userId) return;
     if (!newEmail.trim()) {
-      toast({
-        title: "Error",
-        description: "Please enter an email address",
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: "Please enter an email address", variant: "destructive" });
       return;
     }
 
-    // Simple email validation (length-capped per RFC 5321; `.` excluded from the middle class to avoid backtracking).
     const emailRegex = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
     if (newEmail.length > 320 || !emailRegex.test(newEmail)) {
-      toast({
-        title: "Error",
-        description: "Please enter a valid email address",
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: "Please enter a valid email address", variant: "destructive" });
       return;
     }
 
     try {
       setIsAddingEmail(true);
       await addRCAEmail(newEmail.trim().toLowerCase());
-      
-      toast({
-        title: "Verification Code Sent",
-        description: `A verification code has been sent to ${newEmail}`,
-        variant: "default",
-      });
-      
-      // Close add dialog and open verify dialog
+
+      toast({ title: "Verification Code Sent", description: `A verification code has been sent to ${newEmail}` });
+
       setIsAddDialogOpen(false);
       setVerifyingEmail(newEmail.trim().toLowerCase());
       setIsVerifyDialogOpen(true);
       setNewEmail("");
-      
-      // Reload email list
+
       await loadEmails();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to add email";
-      toast({
-        title: "Error",
-        description: errorMessage,
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: error instanceof Error ? error.message : "Failed to add email", variant: "destructive" });
     } finally {
       setIsAddingEmail(false);
     }
@@ -227,37 +196,22 @@ export function RCASettings() {
   const handleVerifyEmail = async () => {
     if (!userId) return;
     if (!verificationCode.trim() || verificationCode.trim().length !== 6) {
-      toast({
-        title: "Error",
-        description: "Please enter a valid 6-digit code",
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: "Please enter a valid 6-digit code", variant: "destructive" });
       return;
     }
 
     try {
       setIsVerifying(true);
       await verifyRCAEmail(verifyingEmail, verificationCode.trim());
-      
-      toast({
-        title: "Email Verified",
-        description: "Your email has been verified successfully",
-        variant: "default",
-      });
-      
+
+      toast({ title: "Email Verified", description: "Your email has been verified successfully" });
+
       setIsVerifyDialogOpen(false);
       setVerificationCode("");
       setVerifyingEmail("");
-      
-      // Reload email list
       await loadEmails();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to verify email";
-      toast({
-        title: "Error",
-        description: errorMessage,
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: error instanceof Error ? error.message : "Failed to verify email", variant: "destructive" });
     } finally {
       setIsVerifying(false);
     }
@@ -270,21 +224,10 @@ export function RCASettings() {
     try {
       setIsResending(true);
       await resendVerificationCode(verifyingEmail);
-      
-      toast({
-        title: "Code Resent",
-        description: "A new verification code has been sent",
-        variant: "default",
-      });
-      
+      toast({ title: "Code Resent", description: "A new verification code has been sent" });
       setResendCooldown(60);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to resend code";
-      toast({
-        title: "Error",
-        description: errorMessage,
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: error instanceof Error ? error.message : "Failed to resend code", variant: "destructive" });
     } finally {
       setIsResending(false);
     }
@@ -295,50 +238,26 @@ export function RCASettings() {
 
     try {
       await toggleRCAEmail(emailId, !currentStatus);
-      
       toast({
         title: !currentStatus ? "Email Enabled" : "Email Disabled",
-        description: `${emailAddress} will ${!currentStatus ? 'now' : 'no longer'} receive RCA notifications`,
-        variant: "default",
+        description: `${emailAddress} will ${!currentStatus ? 'now' : 'no longer'} receive notifications`,
       });
-      
-      // Reload email list
       await loadEmails();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to toggle email";
-      toast({
-        title: "Error",
-        description: errorMessage,
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: error instanceof Error ? error.message : "Failed to toggle email", variant: "destructive" });
     }
   };
 
   const handleRemoveEmail = async (emailId: number, emailAddress: string) => {
     if (!userId) return;
-    
-    if (!confirm(`Remove ${emailAddress} from RCA notifications?`)) {
-      return;
-    }
+    if (!confirm(`Remove ${emailAddress} from notifications?`)) return;
 
     try {
       await removeRCAEmail(emailId);
-      
-      toast({
-        title: "Email Removed",
-        description: "Email address has been removed",
-        variant: "default",
-      });
-      
-      // Reload email list
+      toast({ title: "Email Removed", description: "Email address has been removed" });
       await loadEmails();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to remove email";
-      toast({
-        title: "Error",
-        description: errorMessage,
-        variant: "destructive",
-      });
+      toast({ title: "Error", description: error instanceof Error ? error.message : "Failed to remove email", variant: "destructive" });
     }
   };
 
@@ -350,12 +269,15 @@ export function RCASettings() {
 
   return (
     <div className="space-y-6 min-h-0">
-      {/* RCA Notifications Card */}
+      {/* Email Recipients Card */}
       <Card>
         <CardHeader>
-          <CardTitle>RCA Notifications</CardTitle>
+          <CardTitle className="flex items-center gap-2">
+            <Mail className="h-5 w-5" />
+            Notification Recipients
+          </CardTitle>
           <CardDescription>
-            Manage how you receive root cause analysis notifications
+            Manage who receives email notifications for investigations and actions
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -376,48 +298,13 @@ export function RCASettings() {
             </p>
           </div>
 
-          {/* Notification Toggles */}
-          <NotificationToggle
-            title="Email Notifications"
-            description="Receive email notifications when Aurora completes root cause analysis investigations"
-            icon={<Bell className="h-4 w-4" />}
-            checked={preferences.rca_email_notifications}
-            onChange={(checked) => handlePreferenceChange('rca_email_notifications', checked, 'RCA email notifications')}
-            isLoading={isLoadingNotificationPref || savingPreferences.rca_email_notifications}
-          />
-          
-          <NotificationToggle
-            title="Investigation Start Email Notifications"
-            description="Also receive an email when Aurora begins an investigation"
-            icon={<Bell className="h-4 w-4" />}
-            checked={preferences.rca_email_start_notifications}
-            onChange={(checked) => handlePreferenceChange('rca_email_start_notifications', checked, 'RCA investigation start notifications')}
-            isLoading={isLoadingNotificationPref || savingPreferences.rca_email_start_notifications}
-            disabled={!preferences.rca_email_notifications}
-          />
-
-          <NotificationToggle
-            title="Action Completion Email Notifications"
-            description="Receive an email when Aurora Actions finish running (success or failure)"
-            icon={<Bell className="h-4 w-4" />}
-            checked={preferences.action_email_notifications}
-            onChange={(checked) => handlePreferenceChange('action_email_notifications', checked, 'Action completion notifications')}
-            isLoading={isLoadingNotificationPref || savingPreferences.action_email_notifications}
-          />
-
-          {/* Divider */}
-          <div className="border-t my-4" />
-
           {/* Additional Email Recipients */}
-          <div className="space-y-4">
+          <div className="space-y-4 pt-2">
             <div className="flex items-center justify-between">
               <div>
-                <h4 className="font-medium flex items-center gap-2">
-                  <Mail className="h-4 w-4" />
-                  Additional Email Recipients
-                </h4>
-                <p className="text-sm text-muted-foreground">
-                  Add other email addresses to receive RCA notifications
+                <h4 className="font-medium text-sm">Additional Recipients</h4>
+                <p className="text-xs text-muted-foreground">
+                  These recipients receive all enabled notification types
                 </p>
               </div>
               <Button
@@ -431,11 +318,12 @@ export function RCASettings() {
               </Button>
             </div>
 
-            {/* Email List */}
             {isLoadingEmails ? (
-              <div className="text-sm text-muted-foreground">Loading...</div>
+              <div className="flex items-center justify-center p-6">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+              </div>
             ) : additionalEmails.length === 0 ? (
-              <div className="text-sm text-muted-foreground p-4 border rounded-lg text-center">
+              <div className="text-sm text-muted-foreground p-4 border border-dashed rounded-lg text-center">
                 No additional email addresses added
               </div>
             ) : (
@@ -443,45 +331,35 @@ export function RCASettings() {
                 {additionalEmails.map((email) => (
                   <div
                     key={email.id}
-                    className="flex items-center justify-between p-3 border rounded-lg"
+                    className="flex items-center justify-between p-3 border rounded-lg transition-colors hover:bg-muted/50"
                   >
-                    <div className="flex items-center gap-3 flex-1">
-                      <span className="text-sm">{email.email}</span>
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                      <span className="text-sm truncate">{email.email}</span>
                       {email.is_verified ? (
-                        <Badge variant="default" className="bg-green-500 flex items-center gap-1">
+                        <Badge variant="default" className="bg-green-600 shrink-0 flex items-center gap-1">
                           <Check className="h-3 w-3" />
                           Verified
                         </Badge>
                       ) : (
-                        <Badge variant="secondary" className="flex items-center gap-1">
+                        <Badge variant="secondary" className="shrink-0 flex items-center gap-1">
                           <Clock className="h-3 w-3" />
                           Pending
                         </Badge>
                       )}
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 shrink-0">
                       {email.is_verified && (
-                        <div className="flex items-center gap-2 px-2">
-                          <Switch
-                            checked={email.is_enabled}
-                            onCheckedChange={() => handleToggleEmail(email.id, email.is_enabled, email.email)}
-                          />
-                        </div>
+                        <Switch
+                          checked={email.is_enabled}
+                          onCheckedChange={() => handleToggleEmail(email.id, email.is_enabled, email.email)}
+                        />
                       )}
                       {!email.is_verified && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => openVerifyDialog(email.email)}
-                        >
+                        <Button variant="ghost" size="sm" onClick={() => openVerifyDialog(email.email)}>
                           Verify
                         </Button>
                       )}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleRemoveEmail(email.id, email.email)}
-                      >
+                      <Button variant="ghost" size="sm" onClick={() => handleRemoveEmail(email.id, email.email)}>
                         <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
                     </div>
@@ -493,13 +371,69 @@ export function RCASettings() {
         </CardContent>
       </Card>
 
+      {/* RCA Investigation Notifications */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bell className="h-5 w-5" />
+            Investigation Notifications
+          </CardTitle>
+          <CardDescription>
+            Get notified when Aurora completes root cause analysis investigations
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <NotificationToggle
+            title="Investigation Complete"
+            description="Receive an email when Aurora finishes an RCA investigation"
+            icon={<Bell className="h-4 w-4" />}
+            checked={preferences.rca_email_notifications}
+            onChange={(checked) => handlePreferenceChange('rca_email_notifications', checked)}
+            isLoading={isLoadingNotificationPref || savingPreferences.rca_email_notifications}
+          />
+
+          <NotificationToggle
+            title="Investigation Started"
+            description="Also receive an email when Aurora begins an investigation"
+            icon={<Bell className="h-4 w-4" />}
+            checked={preferences.rca_email_start_notifications}
+            onChange={(checked) => handlePreferenceChange('rca_email_start_notifications', checked)}
+            isLoading={isLoadingNotificationPref || savingPreferences.rca_email_start_notifications}
+            disabled={!preferences.rca_email_notifications}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Action Notifications */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5" />
+            Action Notifications
+          </CardTitle>
+          <CardDescription>
+            Get notified when automated actions complete or fail
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <NotificationToggle
+            title="Action Complete"
+            description="Receive an email when an Aurora Action finishes running"
+            icon={<Zap className="h-4 w-4" />}
+            checked={preferences.action_email_notifications}
+            onChange={(checked) => handlePreferenceChange('action_email_notifications', checked)}
+            isLoading={isLoadingNotificationPref || savingPreferences.action_email_notifications}
+          />
+        </CardContent>
+      </Card>
+
       {/* Add Email Dialog */}
       <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add Email Address</DialogTitle>
+            <DialogTitle>Add Email Recipient</DialogTitle>
             <DialogDescription>
-              Enter an email address to receive RCA notifications. We'll send a verification code to confirm.
+              Add an email address to receive notifications. A verification code will be sent to confirm.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
@@ -589,4 +523,3 @@ export function RCASettings() {
     </div>
   );
 }
-

--- a/client/src/components/RCASettings.tsx
+++ b/client/src/components/RCASettings.tsx
@@ -33,6 +33,7 @@ export function RCASettings() {
   const [preferences, setPreferences] = useState({
     rca_email_notifications: false,
     rca_email_start_notifications: false,
+    action_email_notifications: false,
   });
   const [savingPreferences, setSavingPreferences] = useState<Record<string, boolean>>({});
   const [isLoadingNotificationPref, setIsLoadingNotificationPref] = useState(true);
@@ -64,7 +65,7 @@ export function RCASettings() {
       if (!userId) return;
       
       try {
-        const keys = ['rca_email_notifications', 'rca_email_start_notifications'];
+        const keys = ['rca_email_notifications', 'rca_email_start_notifications', 'action_email_notifications'];
         const loaded: Record<string, boolean> = {};
 
         await Promise.all(keys.map(async (key) => {
@@ -393,6 +394,15 @@ export function RCASettings() {
             onChange={(checked) => handlePreferenceChange('rca_email_start_notifications', checked, 'RCA investigation start notifications')}
             isLoading={isLoadingNotificationPref || savingPreferences.rca_email_start_notifications}
             disabled={!preferences.rca_email_notifications}
+          />
+
+          <NotificationToggle
+            title="Action Completion Email Notifications"
+            description="Receive an email when Aurora Actions finish running (success or failure)"
+            icon={<Bell className="h-4 w-4" />}
+            checked={preferences.action_email_notifications}
+            onChange={(checked) => handlePreferenceChange('action_email_notifications', checked, 'Action completion notifications')}
+            isLoading={isLoadingNotificationPref || savingPreferences.action_email_notifications}
           />
 
           {/* Divider */}

--- a/client/src/components/RCASettings.tsx
+++ b/client/src/components/RCASettings.tsx
@@ -7,7 +7,8 @@ import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
 import { Bell, Plus, Trash2, Check, Clock, RefreshCw, Mail, Zap } from "lucide-react";
-import { useAuth, useUser } from "@/hooks/useAuthHooks";
+import { useAuth } from "@/hooks/useAuthHooks";
+import { canWrite } from "@/lib/roles";
 import {
   Dialog,
   DialogContent,
@@ -38,8 +39,7 @@ export function RCASettings() {
   const [savingPreferences, setSavingPreferences] = useState<Record<string, boolean>>({});
   const [isLoadingNotificationPref, setIsLoadingNotificationPref] = useState(true);
 
-  const [primaryEmail, setPrimaryEmail] = useState<string>("");
-  const [additionalEmails, setAdditionalEmails] = useState<RCAEmail[]>([]);
+  const [orgEmails, setOrgEmails] = useState<RCAEmail[]>([]);
   const [isLoadingEmails, setIsLoadingEmails] = useState(true);
 
   // Add email state
@@ -56,8 +56,8 @@ export function RCASettings() {
   const [resendCooldown, setResendCooldown] = useState(0);
 
   const { toast } = useToast();
-  const { userId } = useAuth();
-  const { user } = useUser();
+  const { userId, role } = useAuth();
+  const canEditNotifications = canWrite(role);
 
   useEffect(() => {
     const loadNotificationPreferences = async () => {
@@ -97,12 +97,6 @@ export function RCASettings() {
   }, [userId]);
 
   useEffect(() => {
-    if (user?.emailAddresses?.[0]?.emailAddress) {
-      setPrimaryEmail(user.emailAddresses[0].emailAddress);
-    }
-  }, [user]);
-
-  useEffect(() => {
     if (resendCooldown > 0) {
       const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
       return () => clearTimeout(timer);
@@ -115,8 +109,7 @@ export function RCASettings() {
     try {
       setIsLoadingEmails(true);
       const data = await listRCAEmails();
-      setPrimaryEmail(data.primary_email || "");
-      setAdditionalEmails(data.additional_emails);
+      setOrgEmails(data.emails);
     } catch (error) {
       console.error("Error loading emails:", error);
       toast({
@@ -281,37 +274,17 @@ export function RCASettings() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Primary Email */}
-          <div className="space-y-2">
-            <Label htmlFor="primary-email" className="text-sm font-medium">
-              Primary Email
-            </Label>
-            <Input
-              id="primary-email"
-              type="email"
-              value={primaryEmail}
-              disabled
-              className="bg-muted"
-            />
-            <p className="text-xs text-muted-foreground">
-              Your primary email from your account
-            </p>
-          </div>
-
-          {/* Additional Email Recipients */}
-          <div className="space-y-4 pt-2">
+          <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div>
-                <h4 className="font-medium text-sm">Additional Recipients</h4>
-                <p className="text-xs text-muted-foreground">
-                  These recipients receive all enabled notification types
-                </p>
-              </div>
+              <p className="text-xs text-muted-foreground">
+                All org members who trigger actions or investigations will notify these recipients
+              </p>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setIsAddDialogOpen(true)}
                 className="flex items-center gap-2"
+                disabled={!canEditNotifications}
               >
                 <Plus className="h-4 w-4" />
                 Add Email
@@ -322,13 +295,13 @@ export function RCASettings() {
               <div className="flex items-center justify-center p-6">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
               </div>
-            ) : additionalEmails.length === 0 ? (
+            ) : orgEmails.length === 0 ? (
               <div className="text-sm text-muted-foreground p-4 border border-dashed rounded-lg text-center">
                 No additional email addresses added
               </div>
             ) : (
               <div className="space-y-2">
-                {additionalEmails.map((email) => (
+                {orgEmails.map((email) => (
                   <div
                     key={email.id}
                     className="flex items-center justify-between p-3 border rounded-lg transition-colors hover:bg-muted/50"
@@ -352,16 +325,19 @@ export function RCASettings() {
                         <Switch
                           checked={email.is_enabled}
                           onCheckedChange={() => handleToggleEmail(email.id, email.is_enabled, email.email)}
+                          disabled={!canEditNotifications}
                         />
                       )}
-                      {!email.is_verified && (
+                      {!email.is_verified && canEditNotifications && (
                         <Button variant="ghost" size="sm" onClick={() => openVerifyDialog(email.email)}>
                           Verify
                         </Button>
                       )}
-                      <Button variant="ghost" size="sm" onClick={() => handleRemoveEmail(email.id, email.email)}>
-                        <Trash2 className="h-4 w-4 text-destructive" />
-                      </Button>
+                      {canEditNotifications && (
+                        <Button variant="ghost" size="sm" onClick={() => handleRemoveEmail(email.id, email.email)}>
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      )}
                     </div>
                   </div>
                 ))}
@@ -390,6 +366,7 @@ export function RCASettings() {
             checked={preferences.rca_email_notifications}
             onChange={(checked) => handlePreferenceChange('rca_email_notifications', checked)}
             isLoading={isLoadingNotificationPref || savingPreferences.rca_email_notifications}
+            disabled={!canEditNotifications}
           />
 
           <NotificationToggle
@@ -399,7 +376,7 @@ export function RCASettings() {
             checked={preferences.rca_email_start_notifications}
             onChange={(checked) => handlePreferenceChange('rca_email_start_notifications', checked)}
             isLoading={isLoadingNotificationPref || savingPreferences.rca_email_start_notifications}
-            disabled={!preferences.rca_email_notifications}
+            disabled={!canEditNotifications}
           />
         </CardContent>
       </Card>
@@ -423,6 +400,7 @@ export function RCASettings() {
             checked={preferences.action_email_notifications}
             onChange={(checked) => handlePreferenceChange('action_email_notifications', checked)}
             isLoading={isLoadingNotificationPref || savingPreferences.action_email_notifications}
+            disabled={!canEditNotifications}
           />
         </CardContent>
       </Card>

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -77,8 +77,9 @@ export function SentryWebhookStep({
             <ol className="space-y-1 list-decimal list-inside">
               <li>Open your <strong>Aurora</strong> Internal Integration in Sentry (<strong>Settings &rarr; Custom Integrations</strong>).</li>
               <li>Confirm the <strong>Webhook URL</strong> field matches the URL above exactly.</li>
-              <li>Confirm <code>issue</code> and <code>error</code> are checked under <strong>Webhooks</strong>.</li>
-              <li>Save the integration. Aurora will start receiving alerts on the next event.</li>
+              <li>Under <strong>Webhooks</strong>, check <code>issue</code> to receive issue state changes.</li>
+              <li>To also receive individual error/exception events, check <code>error</code> under Webhooks (requires Sentry Business or Enterprise plan).</li>
+              <li>Save the integration. Aurora will start receiving alerts and triggering RCA on the next event.</li>
             </ol>
           </div>
 

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -77,9 +77,8 @@ export function SentryWebhookStep({
             <ol className="space-y-1 list-decimal list-inside">
               <li>Open your <strong>Aurora</strong> Internal Integration in Sentry (<strong>Settings &rarr; Custom Integrations</strong>).</li>
               <li>Confirm the <strong>Webhook URL</strong> field matches the URL above exactly.</li>
-              <li>Under <strong>Webhooks</strong>, check <code>issue</code> to receive issue state changes.</li>
-              <li>To also receive individual error/exception events, check <code>error</code> under Webhooks (requires Sentry Business or Enterprise plan).</li>
-              <li>Save the integration. Aurora will start receiving alerts and triggering RCA on the next event.</li>
+              <li>Confirm <code>issue</code> and <code>error</code> are checked under <strong>Webhooks</strong>.</li>
+              <li>Save the integration. Aurora will start receiving alerts on the next event.</li>
             </ol>
           </div>
 

--- a/client/src/lib/services/rcaEmails.ts
+++ b/client/src/lib/services/rcaEmails.ts
@@ -13,8 +13,7 @@ export interface RCAEmail {
 }
 
 export interface RCAEmailsResponse {
-  primary_email: string;
-  additional_emails: RCAEmail[];
+  emails: RCAEmail[];
 }
 
 /**

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -18,7 +18,7 @@ from langchain_core.messages import HumanMessage
 from utils.cache.redis_client import get_redis_client
 from utils.log_sanitizer import sanitize
 from utils.notifications.email_service import get_email_service
-from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user
+from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_user_preference
 from utils.notifications.slack_notification_service import (
     send_slack_investigation_started_notification,
     send_slack_investigation_completed_notification,
@@ -693,6 +693,8 @@ def run_background_chat(
                 logger.error(f"[BackgroundChat] Failed to send response to Google Chat: {e}", exc_info=True)
         
         if trigger_metadata and trigger_metadata.get('source') == 'action':
+            action_status = None
+            action_error_msg = None
             try:
                 from services.actions.executor import update_action_run_status
                 if result.get("guardrail_blocked"):
@@ -701,12 +703,19 @@ def run_background_chat(
                         run_id=trigger_metadata['run_id'], status='error',
                         user_id=user_id, error_message='Action blocked by safety guardrails',
                     )
-                    _send_action_completion_notification(user_id, trigger_metadata, session_id, status='error', error_message='Action blocked by safety guardrails')
+                    action_status = 'error'
+                    action_error_msg = 'Action blocked by safety guardrails'
                 else:
                     update_action_run_status(run_id=trigger_metadata['run_id'], status='success', user_id=user_id)
-                    _send_action_completion_notification(user_id, trigger_metadata, session_id, status='success')
+                    action_status = 'success'
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to update action run status: {e}")
+
+            if action_status:
+                try:
+                    _send_action_completion_notification(user_id, trigger_metadata, session_id, status=action_status, error_message=action_error_msg)
+                except Exception as e:
+                    logger.warning(f"[BackgroundChat] Failed to send action notification email: {e}")
 
         # Dispatch on_incident actions configured for after_rca timing
         if incident_id and trigger_metadata and trigger_metadata.get('source') != 'action':
@@ -1877,7 +1886,7 @@ def _send_action_completion_notification(
 ) -> None:
     """Send email notification when an action completes (success or error)."""
     try:
-        if not _is_action_email_notification_enabled(user_id):
+        if not get_user_preference(user_id, 'action_email_notifications', default=False):
             return
 
         user_email = get_user_email(user_id)
@@ -1944,22 +1953,6 @@ def _send_action_completion_notification(
         logger.error("[ActionNotification] Error sending action completion notification: %s", e)
 
 
-def _is_action_email_notification_enabled(user_id: str) -> bool:
-    """Check if user has action completion email notifications enabled."""
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cur:
-                set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:PrefCheck]")
-                cur.execute(
-                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'action_email_notifications'",
-                    (user_id,),
-                )
-                result = cur.fetchone()
-                if result and isinstance(result[0], bool):
-                    return result[0]
-        return False
-    except Exception:
-        return False
 
 
 def _send_rca_notification(user_id: str, incident_id: str, event_type: str, email_enabled: bool = False, slack_enabled: bool = False, google_chat_enabled: bool = False, session_id: Optional[str] = None) -> None:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1885,7 +1885,6 @@ def _send_action_completion_notification(
             logger.warning("[ActionNotification] No email found for user %s", user_id)
             return
 
-        action_id = trigger_metadata.get('action_id')
         run_id = trigger_metadata.get('run_id')
 
         action_name = "Unknown Action"
@@ -1930,8 +1929,8 @@ def _send_action_completion_notification(
                         (user_id,),
                     )
                     all_emails += [r[0] for r in cur.fetchall()]
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("[ActionNotification] Failed to fetch additional recipients for user %s: %s", user_id, e)
 
         email_service = get_email_service()
         for recipient in all_emails:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1905,7 +1905,7 @@ def _send_action_completion_notification(
                         row = cur.fetchone()
                         if row:
                             action_name = row[0]
-                            started_at = row[1]
+                            started_at = row[1].replace(tzinfo=timezone.utc) if row[1] else None
             except Exception as e:
                 logger.warning("[ActionNotification] Failed to fetch action run details: %s", e)
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -701,8 +701,10 @@ def run_background_chat(
                         run_id=trigger_metadata['run_id'], status='error',
                         user_id=user_id, error_message='Action blocked by safety guardrails',
                     )
+                    _send_action_completion_notification(user_id, trigger_metadata, session_id, status='error', error_message='Action blocked by safety guardrails')
                 else:
                     update_action_run_status(run_id=trigger_metadata['run_id'], status='success', user_id=user_id)
+                    _send_action_completion_notification(user_id, trigger_metadata, session_id, status='success')
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to update action run status: {e}")
 
@@ -729,6 +731,7 @@ def run_background_chat(
                 from services.actions.executor import update_action_run_status
                 update_action_run_status(run_id=trigger_metadata['run_id'], status='error',
                                          error_message='Background chat exceeded 30 minute timeout', user_id=user_id)
+                _send_action_completion_notification(user_id, trigger_metadata, session_id, status='error', error_message='Background chat exceeded 30 minute timeout')
             except Exception:
                 logger.debug("Failed to update action run status after timeout")
         return {
@@ -748,6 +751,7 @@ def run_background_chat(
                 from services.actions.executor import update_action_run_status
                 update_action_run_status(run_id=trigger_metadata['run_id'], status='error',
                                          error_message=str(e), user_id=user_id)
+                _send_action_completion_notification(user_id, trigger_metadata, session_id, status='error', error_message=str(e))
             except Exception:
                 logger.debug("Failed to update action run status during error handling")
         return {
@@ -1862,6 +1866,101 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
     except Exception as e:
         logger.error(f"[EmailNotification] Error fetching incident data: {e}")
         return None
+
+
+def _send_action_completion_notification(
+    user_id: str,
+    trigger_metadata: Dict[str, Any],
+    session_id: str,
+    status: str = 'success',
+    error_message: Optional[str] = None,
+) -> None:
+    """Send email notification when an action completes (success or error)."""
+    try:
+        if not _is_action_email_notification_enabled(user_id):
+            return
+
+        user_email = get_user_email(user_id)
+        if not user_email:
+            logger.warning("[ActionNotification] No email found for user %s", user_id)
+            return
+
+        action_id = trigger_metadata.get('action_id')
+        run_id = trigger_metadata.get('run_id')
+
+        action_name = "Unknown Action"
+        started_at = None
+        if run_id:
+            try:
+                with db_pool.get_admin_connection() as conn:
+                    with conn.cursor() as cur:
+                        set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification]")
+                        cur.execute(
+                            """SELECT a.name, ar.started_at
+                               FROM action_runs ar
+                               JOIN actions a ON a.id = ar.action_id
+                               WHERE ar.id = %s""",
+                            (run_id,),
+                        )
+                        row = cur.fetchone()
+                        if row:
+                            action_name = row[0]
+                            started_at = row[1]
+            except Exception as e:
+                logger.warning("[ActionNotification] Failed to fetch action run details: %s", e)
+
+        action_data = {
+            'action_name': action_name,
+            'run_id': run_id,
+            'status': status,
+            'error': error_message,
+            'started_at': started_at,
+            'completed_at': datetime.now(timezone.utc),
+            'session_id': session_id,
+        }
+
+        # Send to primary + verified additional emails
+        all_emails = [user_email]
+        try:
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cur:
+                    set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:Emails]")
+                    cur.execute(
+                        "SELECT email FROM rca_notification_emails WHERE user_id = %s AND is_verified = TRUE AND is_enabled = TRUE",
+                        (user_id,),
+                    )
+                    all_emails += [r[0] for r in cur.fetchall()]
+        except Exception:
+            pass
+
+        email_service = get_email_service()
+        for recipient in all_emails:
+            try:
+                email_service.send_action_completed_email(recipient, action_data)
+            except Exception as e:
+                logger.warning("[ActionNotification] Failed to send to %s: %s", recipient, e)
+
+        logger.info("[ActionNotification] Sent %s notification for action '%s' to %d recipient(s)", status, action_name, len(all_emails))
+    except Exception as e:
+        logger.error("[ActionNotification] Error sending action completion notification: %s", e)
+
+
+def _is_action_email_notification_enabled(user_id: str) -> bool:
+    """Check if user has action completion email notifications enabled."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:PrefCheck]")
+                cur.execute(
+                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'action_email_notifications'",
+                    (user_id,),
+                )
+                result = cur.fetchone()
+                if result and isinstance(result[0], bool):
+                    return result[0]
+        return False
+    except Exception:
+        return False
 
 
 def _send_rca_notification(user_id: str, incident_id: str, event_type: str, email_enabled: bool = False, slack_enabled: bool = False, google_chat_enabled: bool = False, session_id: Optional[str] = None) -> None:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -18,7 +18,7 @@ from langchain_core.messages import HumanMessage
 from utils.cache.redis_client import get_redis_client
 from utils.log_sanitizer import sanitize
 from utils.notifications.email_service import get_email_service
-from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_user_preference
+from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_user_preference, get_org_preference
 from utils.notifications.slack_notification_service import (
     send_slack_investigation_started_notification,
     send_slack_investigation_completed_notification,
@@ -1735,38 +1735,12 @@ def _update_incident_status(incident_id: str, status: str, user_id: str) -> None
 
 
 def _is_rca_email_notification_enabled(user_id: str) -> bool:
-    """Check if user has RCA email notifications enabled.
-    
-    Args:
-        user_id: The user ID
-        
-    Returns:
-        True if email notifications are enabled, False otherwise
-    """
+    """Check if the org has RCA email notifications enabled."""
     try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:RCAEmailNotifCheck]")
-                cursor.execute(
-                    """
-                    SELECT preference_value 
-                    FROM user_preferences 
-                    WHERE user_id = %s AND preference_key = 'rca_email_notifications'
-                    """,
-                    (user_id,)
-                )
-                result = cursor.fetchone()
-                if result and result[0] is not None:
-                    value = result[0]
-                    # preference_value is JSONB, stored as boolean from frontend
-                    if isinstance(value, bool):
-                        return value
-                    # Unexpected format - log and default to False
-                    logger.warning(f"[EmailNotification] Unexpected preference format for rca_email_notifications: {type(value).__name__}, expected bool")
-        
-        # Default: notifications disabled (opt-in)
-        return False
-        
+        org_id = get_org_id_for_user(user_id)
+        if not org_id:
+            return False
+        return bool(get_org_preference(org_id, 'rca_email_notifications', default=False))
     except Exception as e:
         logger.error(f"[EmailNotification] Error checking notification preference: {e}")
         return False
@@ -1786,42 +1760,12 @@ def _has_google_chat_connected(user_id: str) -> bool:
 
 
 def _is_rca_email_start_notification_enabled(user_id: str) -> bool:
-    """Check if user has RCA investigation start email notifications enabled.
-    
-    This is a separate preference from the general RCA email notifications, allowing users
-    to receive completion emails without being notified when investigations start.
-    
-    Args:
-        user_id: The user ID
-        
-    Returns:
-        True if email start notifications are enabled, False otherwise (default: False)
-    """
-    
+    """Check if the org has RCA investigation start email notifications enabled."""
     try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:RCAEmailStartNotifCheck]")
-                cursor.execute(
-                    """
-                    SELECT preference_value 
-                    FROM user_preferences 
-                    WHERE user_id = %s AND preference_key = 'rca_email_start_notifications'
-                    """,
-                    (user_id,)
-                )
-                result = cursor.fetchone()
-                if result and result[0] is not None:
-                    value = result[0]
-                    # preference_value is JSONB, stored as boolean from frontend
-                    if isinstance(value, bool):
-                        return value
-                    # Unexpected format - log and default to False
-                    logger.warning(f"[EmailNotification] Unexpected preference format for rca_email_start_notifications: {type(value).__name__}, expected bool")
-        
-        # Default: start notifications DISABLED (opt-in)
-        return False
-        
+        org_id = get_org_id_for_user(user_id)
+        if not org_id:
+            return False
+        return bool(get_org_preference(org_id, 'rca_email_start_notifications', default=False))
     except Exception as e:
         logger.error(f"[EmailNotification] Error checking start notification preference: {e}")
         return False
@@ -1886,12 +1830,10 @@ def _send_action_completion_notification(
 ) -> None:
     """Send email notification when an action completes (success or error)."""
     try:
-        if not get_user_preference(user_id, 'action_email_notifications', default=False):
+        org_id = get_org_id_for_user(user_id)
+        if not org_id:
             return
-
-        user_email = get_user_email(user_id)
-        if not user_email:
-            logger.warning("[ActionNotification] No email found for user %s", user_id)
+        if not get_org_preference(org_id, 'action_email_notifications', default=False):
             return
 
         run_id = trigger_metadata.get('run_id')
@@ -1927,23 +1869,23 @@ def _send_action_completion_notification(
             'session_id': session_id,
         }
 
-        # Send to primary email + org-wide notification recipients
-        all_emails = [user_email]
+        # Send to org-wide configured notification recipients only
+        all_emails = []
         try:
-            org_id = get_org_id_for_user(user_id)
-            if org_id:
-                with db_pool.get_admin_connection() as conn:
-                    with conn.cursor() as cur:
-                        set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:Emails]")
-                        cur.execute(
-                            "SELECT email FROM rca_notification_emails WHERE org_id = %s AND is_verified = TRUE AND is_enabled = TRUE",
-                            (org_id,),
-                        )
-                        all_emails += [r[0] for r in cur.fetchall()]
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cur:
+                    set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:Emails]")
+                    cur.execute(
+                        "SELECT email FROM rca_notification_emails WHERE org_id = %s AND is_verified = TRUE AND is_enabled = TRUE",
+                        (org_id,),
+                    )
+                    all_emails = [r[0] for r in cur.fetchall()]
         except Exception as e:
-            logger.warning("[ActionNotification] Failed to fetch additional recipients for org: %s", e)
+            logger.warning("[ActionNotification] Failed to fetch recipients for org: %s", e)
 
-        all_emails = list(dict.fromkeys(all_emails))
+        if not all_emails:
+            logger.info("[ActionNotification] No configured recipients for org %s, skipping", org_id)
+            return
 
         email_service = get_email_service()
         for recipient in all_emails:
@@ -2011,13 +1953,9 @@ def _send_rca_notification(user_id: str, incident_id: str, event_type: str, emai
     # --- EMAIL NOTIFICATIONS ---
     if email_enabled:
         try:
-            # Get primary email
-            user_email = get_user_email(user_id)
-            if not user_email:
-                logger.warning(f"[EmailNotification] No email found for user {user_id}")
-            else:
-                # Get all verified additional emails
-                additional_emails = []
+            org_id = get_org_id_for_user(user_id)
+            all_emails = []
+            if org_id:
                 try:
                     with db_pool.get_admin_connection() as conn:
                         with conn.cursor() as cursor:
@@ -2025,18 +1963,18 @@ def _send_rca_notification(user_id: str, incident_id: str, event_type: str, emai
                             cursor.execute(
                                 """
                                 SELECT email FROM rca_notification_emails
-                                WHERE user_id = %s AND is_verified = TRUE AND is_enabled = TRUE
+                                WHERE org_id = %s AND is_verified = TRUE AND is_enabled = TRUE
                                 ORDER BY verified_at ASC
                                 """,
-                                (user_id,)
+                                (org_id,)
                             )
-                            rows = cursor.fetchall()
-                            additional_emails = [row[0] for row in rows]
+                            all_emails = [row[0] for row in cursor.fetchall()]
                 except Exception as e:
-                    logger.error(f"[EmailNotification] Failed to fetch additional emails for user {user_id}: {e}")
-                
-                # Combine all recipient emails
-                all_emails = [user_email] + additional_emails
+                    logger.error(f"[EmailNotification] Failed to fetch notification emails for org: {e}")
+
+            if not all_emails:
+                logger.info(f"[EmailNotification] No configured recipients for org, skipping email")
+            else:
                 logger.info(f"[EmailNotification] Sending {event_type} notification to {len(all_emails)} email(s): {', '.join(all_emails)}")
                 
                 # Send appropriate email to all recipients

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -18,7 +18,7 @@ from langchain_core.messages import HumanMessage
 from utils.cache.redis_client import get_redis_client
 from utils.log_sanitizer import sanitize
 from utils.notifications.email_service import get_email_service
-from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_org_preference
+from utils.auth.stateless_auth import get_credentials_from_db, set_rls_context, get_org_id_for_user, get_org_preference
 from utils.notifications.slack_notification_service import (
     send_slack_investigation_started_notification,
     send_slack_investigation_completed_notification,

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1927,19 +1927,23 @@ def _send_action_completion_notification(
             'session_id': session_id,
         }
 
-        # Send to primary + verified additional emails
+        # Send to primary email + org-wide notification recipients
         all_emails = [user_email]
         try:
-            with db_pool.get_admin_connection() as conn:
-                with conn.cursor() as cur:
-                    set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:Emails]")
-                    cur.execute(
-                        "SELECT email FROM rca_notification_emails WHERE user_id = %s AND is_verified = TRUE AND is_enabled = TRUE",
-                        (user_id,),
-                    )
-                    all_emails += [r[0] for r in cur.fetchall()]
+            org_id = get_org_id_for_user(user_id)
+            if org_id:
+                with db_pool.get_admin_connection() as conn:
+                    with conn.cursor() as cur:
+                        set_rls_context(cur, conn, user_id, log_prefix="[ActionNotification:Emails]")
+                        cur.execute(
+                            "SELECT email FROM rca_notification_emails WHERE org_id = %s AND is_verified = TRUE AND is_enabled = TRUE",
+                            (org_id,),
+                        )
+                        all_emails += [r[0] for r in cur.fetchall()]
         except Exception as e:
-            logger.warning("[ActionNotification] Failed to fetch additional recipients for user %s: %s", user_id, e)
+            logger.warning("[ActionNotification] Failed to fetch additional recipients for org: %s", e)
+
+        all_emails = list(dict.fromkeys(all_emails))
 
         email_service = get_email_service()
         for recipient in all_emails:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -18,7 +18,7 @@ from langchain_core.messages import HumanMessage
 from utils.cache.redis_client import get_redis_client
 from utils.log_sanitizer import sanitize
 from utils.notifications.email_service import get_email_service
-from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_user_preference, get_org_preference
+from utils.auth.stateless_auth import get_user_email, get_credentials_from_db, set_rls_context, get_org_id_for_user, get_org_preference
 from utils.notifications.slack_notification_service import (
     send_slack_investigation_started_notification,
     send_slack_investigation_completed_notification,

--- a/server/routes/rca_emails.py
+++ b/server/routes/rca_emails.py
@@ -144,7 +144,7 @@ def add_rca_email(user_id):
             logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
 
-        logger.info(f"{_LOG_PREFIX} Verification code sent to {email} for org {org_id}")
+        logger.info("%s Verification code sent to %s for org %s", _LOG_PREFIX, email, org_id)
         record_audit_event("", user_id, "add_notification_email", "rca_email", email, {"email": email}, request)
         return jsonify({"status": "success", "message": "Verification code sent to email"})
 
@@ -211,7 +211,7 @@ def verify_rca_email(user_id):
                 )
                 conn.commit()
 
-        logger.info(f"{_LOG_PREFIX} Email {email} verified for org {org_id}")
+        logger.info("%s Email %s verified for org %s", _LOG_PREFIX, email, org_id)
         record_audit_event("", user_id, "verify_notification_email", "rca_email", email, {"email": email}, request)
         return jsonify({"status": "success", "message": "Email verified successfully"})
 
@@ -276,7 +276,7 @@ def resend_verification_code(user_id):
             logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
 
-        logger.info(f"{_LOG_PREFIX} Verification code resent to {email} for org {org_id}")
+        logger.info("%s Verification code resent to %s for org %s", _LOG_PREFIX, email, org_id)
         return jsonify({"status": "success", "message": "Verification code resent"})
 
     except Exception as e:
@@ -315,7 +315,7 @@ def toggle_rca_email(user_id, email_id: int):
                     return jsonify({"error": "Email not found or not verified"}), 404
                 conn.commit()
 
-        logger.info(f"{_LOG_PREFIX} Email ID {email_id} toggled to {is_enabled} for org {org_id}")
+        logger.info("%s Email ID %s toggled to %s for org %s", _LOG_PREFIX, email_id, is_enabled, org_id)
         record_audit_event("", user_id, "toggle_notification_email", "rca_email", str(email_id),
                            {"is_enabled": is_enabled}, request)
         return jsonify({"status": "success"})
@@ -346,7 +346,7 @@ def remove_rca_email(user_id, email_id: int):
                     return jsonify({"error": "Email not found"}), 404
                 conn.commit()
 
-        logger.info(f"{_LOG_PREFIX} Email ID {email_id} removed for org {org_id}")
+        logger.info("%s Email ID %s removed for org %s", _LOG_PREFIX, email_id, org_id)
         record_audit_event("", user_id, "remove_notification_email", "rca_email", str(email_id), {}, request)
         return jsonify({"status": "success"})
 

--- a/server/routes/rca_emails.py
+++ b/server/routes/rca_emails.py
@@ -144,7 +144,7 @@ def add_rca_email(user_id):
             logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
 
-        logger.info("%s Verification code sent to %s for org %s", _LOG_PREFIX, email, org_id)
+        logger.info("%s Verification code sent", _LOG_PREFIX)
         record_audit_event("", user_id, "add_notification_email", "rca_email", email, {"email": email}, request)
         return jsonify({"status": "success", "message": "Verification code sent to email"})
 
@@ -211,7 +211,7 @@ def verify_rca_email(user_id):
                 )
                 conn.commit()
 
-        logger.info("%s Email %s verified for org %s", _LOG_PREFIX, email, org_id)
+        logger.info("%s Email verified", _LOG_PREFIX)
         record_audit_event("", user_id, "verify_notification_email", "rca_email", email, {"email": email}, request)
         return jsonify({"status": "success", "message": "Email verified successfully"})
 
@@ -276,7 +276,7 @@ def resend_verification_code(user_id):
             logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
 
-        logger.info("%s Verification code resent to %s for org %s", _LOG_PREFIX, email, org_id)
+        logger.info("%s Verification code resent", _LOG_PREFIX)
         return jsonify({"status": "success", "message": "Verification code resent"})
 
     except Exception as e:
@@ -315,7 +315,7 @@ def toggle_rca_email(user_id, email_id: int):
                     return jsonify({"error": "Email not found or not verified"}), 404
                 conn.commit()
 
-        logger.info("%s Email ID %s toggled to %s for org %s", _LOG_PREFIX, email_id, is_enabled, org_id)
+        logger.info("%s Email toggled", _LOG_PREFIX)
         record_audit_event("", user_id, "toggle_notification_email", "rca_email", str(email_id),
                            {"is_enabled": is_enabled}, request)
         return jsonify({"status": "success"})
@@ -346,7 +346,7 @@ def remove_rca_email(user_id, email_id: int):
                     return jsonify({"error": "Email not found"}), 404
                 conn.commit()
 
-        logger.info("%s Email ID %s removed for org %s", _LOG_PREFIX, email_id, org_id)
+        logger.info("%s Email removed", _LOG_PREFIX)
         record_audit_event("", user_id, "remove_notification_email", "rca_email", str(email_id), {}, request)
         return jsonify({"status": "success"})
 

--- a/server/routes/rca_emails.py
+++ b/server/routes/rca_emails.py
@@ -1,10 +1,10 @@
-"""RCA notification email management API routes."""
+"""RCA notification email management API routes (org-scoped)."""
 import logging
 import secrets
 import re
 from datetime import datetime, timedelta
 from flask import Blueprint, request, jsonify
-from utils.auth.stateless_auth import get_user_email, set_rls_context
+from utils.auth.stateless_auth import set_rls_context, get_org_id_from_request
 from utils.auth.rbac_decorators import require_permission
 from utils.db.connection_pool import db_pool
 from utils.notifications.email_service import get_email_service
@@ -15,70 +15,38 @@ logger = logging.getLogger(__name__)
 rca_emails_bp = Blueprint('rca_emails', __name__)
 _LOG_PREFIX = "[RCAEmails]"
 
-# Email validation regex
 EMAIL_REGEX = re.compile(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
 
-# Rate limiting constants
-MAX_VERIFICATION_ATTEMPTS = 3
 MAX_RESEND_PER_HOUR = 5
 CODE_EXPIRATION_MINUTES = 15
 
 
 def _validate_email(email: str) -> bool:
-    """Validate email format."""
     return bool(EMAIL_REGEX.match(email))
 
 
 def _generate_verification_code() -> str:
-    """Generate a random 6-digit verification code."""
     return f"{secrets.randbelow(1000000):06d}"
 
 
-def _check_rate_limit(user_id: str, email: str, action: str) -> tuple[bool, str]:
-    """
-    Check rate limits for verification actions.
-    
-    Args:
-        user_id: User ID
-        email: Email address
-        action: 'add' or 'resend'
-    
-    Returns:
-        Tuple of (is_allowed, error_message)
-    """
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                if action == 'resend':
-                    # Check resend rate limit (5 per hour)
-                    one_hour_ago = datetime.now() - timedelta(hours=1)
-                    cursor.execute(
-                        """
-                        SELECT COUNT(*) FROM rca_notification_emails
-                        WHERE user_id = %s AND email = %s AND created_at > %s
-                        """,
-                        (user_id, email, one_hour_ago)
-                    )
-                    count = cursor.fetchone()[0]
-                    if count >= MAX_RESEND_PER_HOUR:
-                        return False, "Too many verification attempts. Please wait an hour."
-                
-                return True, ""
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error checking rate limit: {e}")
-        return True, ""  # Allow on error to avoid blocking legitimate users
+def _get_org_id(user_id: str) -> str | None:
+    """Resolve org_id from request header or DB lookup."""
+    org_id = get_org_id_from_request()
+    if org_id:
+        return org_id
+    from utils.auth.stateless_auth import get_org_id_for_user
+    return get_org_id_for_user(user_id)
 
 
 @rca_emails_bp.route('/api/rca-emails', methods=['GET'])
 @require_permission("rca_emails", "read")
 def list_rca_emails(user_id):
-    """List all emails for user (primary + additional)."""
+    """List all notification recipient emails for the org."""
     try:
-        # Get primary email from Auth.js or database
-        primary_email = get_user_email(user_id)
-        
-        # Get additional emails from database
+        org_id = _get_org_id(user_id)
+        if not org_id:
+            return jsonify({"error": "Could not resolve organization"}), 400
+
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
@@ -86,14 +54,14 @@ def list_rca_emails(user_id):
                     """
                     SELECT id, email, is_verified, created_at, verified_at, is_enabled
                     FROM rca_notification_emails
-                    WHERE user_id = %s
+                    WHERE org_id = %s
                     ORDER BY created_at DESC
                     """,
-                    (user_id,)
+                    (org_id,)
                 )
                 rows = cursor.fetchall()
-                
-                additional_emails = [
+
+                emails = [
                     {
                         "id": row[0],
                         "email": row[1],
@@ -104,104 +72,85 @@ def list_rca_emails(user_id):
                     }
                     for row in rows
                 ]
-        
-        return jsonify({
-            "primary_email": primary_email,
-            "additional_emails": additional_emails
-        })
-    
+
+        return jsonify({"emails": emails})
+
     except Exception as e:
-        logger.error(f"[RCAEmails] Error listing emails for user {user_id}: {e}")
+        logger.error(f"{_LOG_PREFIX} Error listing emails for org: {e}")
         return jsonify({"error": "Failed to retrieve emails"}), 500
 
 
 @rca_emails_bp.route('/api/rca-emails/add', methods=['POST'])
 @require_permission("rca_emails", "write")
 def add_rca_email(user_id):
-    """Add a new email and send verification code."""
+    """Add a new notification recipient email for the org."""
     data = request.get_json()
     email = data.get('email', '').strip().lower()
-    
+
     if not email:
         return jsonify({"error": "Email is required"}), 400
-    
+
     if not _validate_email(email):
         return jsonify({"error": "Invalid email format"}), 400
-    
-    # Check rate limit
-    is_allowed, error_msg = _check_rate_limit(user_id, email, 'add')
-    if not is_allowed:
-        return jsonify({"error": error_msg}), 429
-    
+
+    org_id = _get_org_id(user_id)
+    if not org_id:
+        return jsonify({"error": "Could not resolve organization"}), 400
+
     try:
-        # Check if user already has this email
-        primary_email = get_user_email(user_id)
-        if email == primary_email:
-            return jsonify({"error": "This is your primary email. It already receives notifications."}), 400
-        
-        # Generate verification code
         verification_code = _generate_verification_code()
         expires_at = datetime.now() + timedelta(minutes=CODE_EXPIRATION_MINUTES)
-        
+
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                
-                # Check if email already exists for this user
+
                 cursor.execute(
-                    "SELECT id, is_verified FROM rca_notification_emails WHERE user_id = %s AND email = %s",
-                    (user_id, email)
+                    "SELECT id, is_verified FROM rca_notification_emails WHERE org_id = %s AND email = %s",
+                    (org_id, email)
                 )
                 existing = cursor.fetchone()
-                
+
                 if existing:
-                    if existing[1]:  # is_verified
-                        return jsonify({"error": "This email is already verified"}), 400
-                    
-                    # Update existing unverified email with new code
+                    if existing[1]:
+                        return jsonify({"error": "This email is already configured and verified"}), 400
+
                     cursor.execute(
                         """
                         UPDATE rca_notification_emails
                         SET verification_code = %s, verification_code_expires_at = %s, created_at = %s
-                        WHERE user_id = %s AND email = %s
+                        WHERE org_id = %s AND email = %s
                         """,
-                        (verification_code, expires_at, datetime.now(), user_id, email)
+                        (verification_code, expires_at, datetime.now(), org_id, email)
                     )
                 else:
-                    # Insert new email
                     cursor.execute(
                         """
-                        INSERT INTO rca_notification_emails 
-                        (user_id, email, verification_code, verification_code_expires_at)
-                        VALUES (%s, %s, %s, %s)
+                        INSERT INTO rca_notification_emails
+                        (user_id, org_id, email, verification_code, verification_code_expires_at)
+                        VALUES (%s, %s, %s, %s, %s)
                         """,
-                        (user_id, email, verification_code, expires_at)
+                        (user_id, org_id, email, verification_code, expires_at)
                     )
-                
+
                 conn.commit()
-        
-        # Send verification email
+
         try:
             email_service = get_email_service()
             success = email_service.send_verification_code_email(email, verification_code)
             if not success:
-                logger.warning(f"[RCAEmails] Failed to send verification email to {email}")
                 return jsonify({"error": "Failed to send verification email"}), 500
         except ValueError as e:
-            logger.error(f"[RCAEmails] Email service not configured: {e}")
+            logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
-        
-        logger.info(f"[RCAEmails] Verification code sent to {email} for user {user_id}")
-        record_audit_event("", user_id, "add_notification_email", "rca_email", email, {"email": email}, request)
-        return jsonify({
-            "status": "success",
-            "message": "Verification code sent to email"
-        })
-    
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error adding email for user {user_id}: {e}", exc_info=True)
-        return jsonify({"error": "Failed to add email"}), 500
 
+        logger.info(f"{_LOG_PREFIX} Verification code sent to {email} for org {org_id}")
+        record_audit_event("", user_id, "add_notification_email", "rca_email", email, {"email": email}, request)
+        return jsonify({"status": "success", "message": "Verification code sent to email"})
+
+    except Exception as e:
+        logger.error(f"{_LOG_PREFIX} Error adding email: {e}", exc_info=True)
+        return jsonify({"error": "Failed to add email"}), 500
 
 
 @rca_emails_bp.route('/api/rca-emails/verify', methods=['POST'])
@@ -211,68 +160,64 @@ def verify_rca_email(user_id):
     data = request.get_json()
     email = data.get('email', '').strip().lower()
     code = data.get('code', '').strip()
-    
+
     if not email or not code:
         return jsonify({"error": "Email and code are required"}), 400
-    
+
     if len(code) != 6 or not code.isdigit():
         return jsonify({"error": "Invalid verification code format"}), 400
-    
+
+    org_id = _get_org_id(user_id)
+    if not org_id:
+        return jsonify({"error": "Could not resolve organization"}), 400
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                
-                # Get email record
+
                 cursor.execute(
                     """
                     SELECT id, verification_code, verification_code_expires_at, is_verified
                     FROM rca_notification_emails
-                    WHERE user_id = %s AND email = %s
+                    WHERE org_id = %s AND email = %s
                     """,
-                    (user_id, email)
+                    (org_id, email)
                 )
                 row = cursor.fetchone()
-                
+
                 if not row:
                     return jsonify({"error": "Email not found"}), 404
-                
+
                 email_id, stored_code, expires_at, is_verified = row
-                
+
                 if is_verified:
                     return jsonify({"error": "Email is already verified"}), 400
-                
-                # Check if code expired
+
                 if expires_at and datetime.now() > expires_at:
                     return jsonify({"error": "Verification code has expired"}), 400
-                
-                # Verify code
+
                 if stored_code != code:
                     return jsonify({"error": "Invalid verification code"}), 400
-                
-                # Mark as verified
+
                 cursor.execute(
                     """
                     UPDATE rca_notification_emails
-                    SET is_verified = TRUE, verified_at = %s, 
+                    SET is_verified = TRUE, verified_at = %s,
                         verification_code = NULL, verification_code_expires_at = NULL
                     WHERE id = %s
                     """,
                     (datetime.now(), email_id)
                 )
                 conn.commit()
-        
-        logger.info(f"[RCAEmails] Email {email} verified for user {user_id}")
-        record_audit_event("", user_id, "verify_notification_email", "rca_email", email, {"email": email}, request)
-        return jsonify({
-            "status": "success",
-            "message": "Email verified successfully"
-        })
-    
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error verifying email for user {user_id}: {e}")
-        return jsonify({"error": "Failed to verify email"}), 500
 
+        logger.info(f"{_LOG_PREFIX} Email {email} verified for org {org_id}")
+        record_audit_event("", user_id, "verify_notification_email", "rca_email", email, {"email": email}, request)
+        return jsonify({"status": "success", "message": "Email verified successfully"})
+
+    except Exception as e:
+        logger.error(f"{_LOG_PREFIX} Error verifying email: {e}")
+        return jsonify({"error": "Failed to verify email"}), 500
 
 
 @rca_emails_bp.route('/api/rca-emails/resend', methods=['POST'])
@@ -281,71 +226,62 @@ def resend_verification_code(user_id):
     """Resend verification code to an email."""
     data = request.get_json()
     email = data.get('email', '').strip().lower()
-    
+
     if not email:
         return jsonify({"error": "Email is required"}), 400
-    
-    # Check rate limit
-    is_allowed, error_msg = _check_rate_limit(user_id, email, 'resend')
-    if not is_allowed:
-        return jsonify({"error": error_msg}), 429
-    
+
+    org_id = _get_org_id(user_id)
+    if not org_id:
+        return jsonify({"error": "Could not resolve organization"}), 400
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                
-                # Check if email exists and is not verified
+
                 cursor.execute(
                     """
                     SELECT id, is_verified FROM rca_notification_emails
-                    WHERE user_id = %s AND email = %s
+                    WHERE org_id = %s AND email = %s
                     """,
-                    (user_id, email)
+                    (org_id, email)
                 )
                 row = cursor.fetchone()
-                
+
                 if not row:
                     return jsonify({"error": "Email not found"}), 404
-                
-                if row[1]:  # is_verified
+
+                if row[1]:
                     return jsonify({"error": "Email is already verified"}), 400
-                
-                # Generate new code
+
                 verification_code = _generate_verification_code()
                 expires_at = datetime.now() + timedelta(minutes=CODE_EXPIRATION_MINUTES)
-                
+
                 cursor.execute(
                     """
                     UPDATE rca_notification_emails
                     SET verification_code = %s, verification_code_expires_at = %s
-                    WHERE user_id = %s AND email = %s
+                    WHERE org_id = %s AND email = %s
                     """,
-                    (verification_code, expires_at, user_id, email)
+                    (verification_code, expires_at, org_id, email)
                 )
                 conn.commit()
-        
-        # Send verification email
+
         try:
             email_service = get_email_service()
             success = email_service.send_verification_code_email(email, verification_code)
             if not success:
-                logger.warning(f"[RCAEmails] Failed to resend verification email to {email}")
                 return jsonify({"error": "Failed to send verification email"}), 500
         except ValueError as e:
-            logger.error(f"[RCAEmails] Email service not configured: {e}")
+            logger.error(f"{_LOG_PREFIX} Email service not configured: {e}")
             return jsonify({"error": "Email service not configured"}), 500
-        
-        logger.info(f"[RCAEmails] Verification code resent to {email} for user {user_id}")
-        return jsonify({
-            "status": "success",
-            "message": "Verification code resent"
-        })
-    
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error resending code for user {user_id}: {e}")
-        return jsonify({"error": "Failed to resend verification code"}), 500
 
+        logger.info(f"{_LOG_PREFIX} Verification code resent to {email} for org {org_id}")
+        return jsonify({"status": "success", "message": "Verification code resent"})
+
+    except Exception as e:
+        logger.error(f"{_LOG_PREFIX} Error resending code: {e}")
+        return jsonify({"error": "Failed to resend verification code"}), 500
 
 
 @rca_emails_bp.route('/api/rca-emails/<int:email_id>/toggle', methods=['POST'])
@@ -354,72 +290,66 @@ def toggle_rca_email(user_id, email_id: int):
     """Toggle an email address enabled/disabled status."""
     data = request.get_json()
     is_enabled = data.get('is_enabled')
-    
+
     if is_enabled is None:
         return jsonify({"error": "is_enabled field is required"}), 400
-    
+
+    org_id = _get_org_id(user_id)
+    if not org_id:
+        return jsonify({"error": "Could not resolve organization"}), 400
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                
-                # Update enabled status
+
                 cursor.execute(
                     """
-                    UPDATE rca_notification_emails 
+                    UPDATE rca_notification_emails
                     SET is_enabled = %s
-                    WHERE id = %s AND user_id = %s AND is_verified = TRUE
+                    WHERE id = %s AND org_id = %s AND is_verified = TRUE
                     """,
-                    (is_enabled, email_id, user_id)
+                    (is_enabled, email_id, org_id)
                 )
-                rows_updated = cursor.rowcount
-                conn.commit()
-                
-                if rows_updated == 0:
+                if cursor.rowcount == 0:
                     return jsonify({"error": "Email not found or not verified"}), 404
-        
-        logger.info(f"[RCAEmails] Email ID {email_id} toggled to {is_enabled} for user {user_id}")
+                conn.commit()
+
+        logger.info(f"{_LOG_PREFIX} Email ID {email_id} toggled to {is_enabled} for org {org_id}")
         record_audit_event("", user_id, "toggle_notification_email", "rca_email", str(email_id),
                            {"is_enabled": is_enabled}, request)
-        return jsonify({
-            "status": "success",
-            "message": f"Email {'enabled' if is_enabled else 'disabled'} successfully"
-        })
-    
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error toggling email for user {user_id}: {e}")
-        return jsonify({"error": "Failed to toggle email"}), 500
+        return jsonify({"status": "success"})
 
+    except Exception as e:
+        logger.error(f"{_LOG_PREFIX} Error toggling email: {e}")
+        return jsonify({"error": "Failed to toggle email"}), 500
 
 
 @rca_emails_bp.route('/api/rca-emails/<int:email_id>', methods=['DELETE'])
 @require_permission("rca_emails", "write")
 def remove_rca_email(user_id, email_id: int):
-    """Remove an additional email."""
+    """Remove a notification recipient email."""
+    org_id = _get_org_id(user_id)
+    if not org_id:
+        return jsonify({"error": "Could not resolve organization"}), 400
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                
-                # Delete email
-                cursor.execute(
-                    "DELETE FROM rca_notification_emails WHERE id = %s AND user_id = %s",
-                    (email_id, user_id)
-                )
-                rows_deleted = cursor.rowcount
-                conn.commit()
-                
-                if rows_deleted == 0:
-                    return jsonify({"error": "Email not found"}), 404
-        
-        logger.info(f"[RCAEmails] Email ID {email_id} removed for user {user_id}")
-        record_audit_event("", user_id, "remove_notification_email", "rca_email", str(email_id), {}, request)
-        return jsonify({
-            "status": "success",
-            "message": "Email removed successfully"
-        })
-    
-    except Exception as e:
-        logger.error(f"[RCAEmails] Error removing email for user {user_id}: {e}")
-        return jsonify({"error": "Failed to remove email"}), 500
 
+                cursor.execute(
+                    "DELETE FROM rca_notification_emails WHERE id = %s AND org_id = %s",
+                    (email_id, org_id)
+                )
+                if cursor.rowcount == 0:
+                    return jsonify({"error": "Email not found"}), 404
+                conn.commit()
+
+        logger.info(f"{_LOG_PREFIX} Email ID {email_id} removed for org {org_id}")
+        record_audit_event("", user_id, "remove_notification_email", "rca_email", str(email_id), {}, request)
+        return jsonify({"status": "success"})
+
+    except Exception as e:
+        logger.error(f"{_LOG_PREFIX} Error removing email: {e}")
+        return jsonify({"error": "Failed to remove email"}), 500

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -66,7 +66,7 @@ def set_user_preferences(user_id):
         if not enforce_with_reload(user_id, org_id, "notification_settings", "write"):
             return jsonify({"error": "Forbidden - editor or admin role required"}), 403
         store_org_preference(org_id, key, value)
-        logger.info(f"Stored org preference {key} for org {org_id} by user {user_id}")
+        logger.info("Stored org preference %s for org %s by user %s", key, org_id, user_id)
     else:
         store_user_preference(user_id, key, value)
         logger.info(f"Stored preference {key} for user {user_id}")

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -2,16 +2,28 @@
 import logging
 from flask import Blueprint, request, jsonify
 from utils.auth.stateless_auth import (
-    store_user_preference, 
+    store_user_preference,
     get_user_preference,
     get_credentials_from_db,
+    get_org_id_from_request,
+    get_org_id_for_user,
+    store_org_preference,
+    get_org_preference,
     set_rls_context,
 )
 from utils.log_sanitizer import sanitize
 from utils.auth.rbac_decorators import require_permission
+from utils.auth.enforcer import enforce_with_reload
 import json
 
-# Configure logging
+ORG_SCOPED_PREFERENCE_KEYS = frozenset({
+    'rca_email_notifications',
+    'rca_email_start_notifications',
+    'action_email_notifications',
+})
+
+EDITOR_ONLY_PREFERENCE_KEYS = ORG_SCOPED_PREFERENCE_KEYS
+
 logger = logging.getLogger(__name__)
 
 user_preferences_bp = Blueprint('user_preferences', __name__)
@@ -24,8 +36,13 @@ def get_user_preferences(user_id):
     if not key:
         logger.warning(f"Missing preference key for user {user_id}")
         return jsonify({"error": "Missing preference key"}), 400
-    
-    value = get_user_preference(user_id, key)
+
+    if key in ORG_SCOPED_PREFERENCE_KEYS:
+        org_id = get_org_id_from_request() or get_org_id_for_user(user_id)
+        value = get_org_preference(org_id, key) if org_id else None
+    else:
+        value = get_user_preference(user_id, key)
+
     logger.debug(f"Retrieved preference {key} for user {user_id}")
     return jsonify({"value": value})
 
@@ -37,13 +54,23 @@ def set_user_preferences(user_id):
     data = request.get_json()
     key = data.get('key')
     value = data.get('value')
-    
+
     if not key:
         logger.warning(f"Missing preference key for user {user_id}")
         return jsonify({"error": "Missing preference key"}), 400
-    
-    store_user_preference(user_id, key, value)
-    logger.info(f"Stored preference {key} for user {user_id}")
+
+    if key in ORG_SCOPED_PREFERENCE_KEYS:
+        org_id = get_org_id_from_request() or get_org_id_for_user(user_id)
+        if not org_id:
+            return jsonify({"error": "Could not resolve organization"}), 400
+        if not enforce_with_reload(user_id, org_id, "notification_settings", "write"):
+            return jsonify({"error": "Forbidden - editor or admin role required"}), 403
+        store_org_preference(org_id, key, value)
+        logger.info(f"Stored org preference {key} for org {org_id} by user {user_id}")
+    else:
+        store_user_preference(user_id, key, value)
+        logger.info(f"Stored preference {key} for user {user_id}")
+
     return jsonify({"status": "success"})
 
 @user_preferences_bp.route('/api/clear-session', methods=['POST'])
@@ -163,14 +190,29 @@ def set_batch_preferences(user_id):
     """Handle batch storage of user preferences."""
     data = request.get_json()
     preferences = data.get('preferences', {})
-    
+
     if not isinstance(preferences, dict):
         return jsonify({"error": "preferences must be a dictionary"}), 400
-    
+
+    protected_keys = set(preferences.keys()) & EDITOR_ONLY_PREFERENCE_KEYS
+    if protected_keys:
+        org_id = get_org_id_from_request() or get_org_id_for_user(user_id)
+        if not org_id:
+            return jsonify({"error": "Could not resolve organization"}), 400
+        if not enforce_with_reload(user_id, org_id, "notification_settings", "write"):
+            return jsonify({"error": "Forbidden - editor or admin role required for notification settings"}), 403
+
     try:
+        org_id = None
         for key, value in preferences.items():
-            store_user_preference(user_id, key, value)
-        
+            if key in ORG_SCOPED_PREFERENCE_KEYS:
+                if not org_id:
+                    org_id = get_org_id_from_request() or get_org_id_for_user(user_id)
+                if org_id:
+                    store_org_preference(org_id, key, value)
+            else:
+                store_user_preference(user_id, key, value)
+
         logger.info(f"Stored {len(preferences)} preferences for user {user_id}")
         return jsonify({"status": "success", "count": len(preferences)})
     except Exception as e:

--- a/server/routes/user_preferences.py
+++ b/server/routes/user_preferences.py
@@ -66,7 +66,7 @@ def set_user_preferences(user_id):
         if not enforce_with_reload(user_id, org_id, "notification_settings", "write"):
             return jsonify({"error": "Forbidden - editor or admin role required"}), 403
         store_org_preference(org_id, key, value)
-        logger.info("Stored org preference %s for org %s by user %s", key, org_id, user_id)
+        logger.info("Stored org preference %s", key)
     else:
         store_user_preference(user_id, key, value)
         logger.info(f"Stored preference {key} for user {user_id}")

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -54,6 +54,7 @@ _DEFAULT_POLICIES = [
     ("editor", "*", "ssh_keys", "write"),
     ("editor", "*", "vms", "write"),
     ("editor", "*", "rca_emails", "write"),
+    ("editor", "*", "notification_settings", "write"),
     ("editor", "*", "graph", "write"),
     ("editor", "*", "actions", "write"),
 

--- a/server/utils/auth/stateless_auth.py
+++ b/server/utils/auth/stateless_auth.py
@@ -571,9 +571,8 @@ def get_user_email(user_id: str) -> Optional[str]:
     Returns:
         User email address or None if not found
     """
-    import os
     from utils.db.connection_pool import db_pool
-    
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
@@ -587,6 +586,8 @@ def get_user_email(user_id: str) -> Optional[str]:
                     return result[0]
 
                 # Fallback to user_tokens (OAuth providers store email here)
+                # user_tokens is RLS-protected — set context for Celery paths
+                set_rls_context(cursor, conn, user_id, log_prefix="[get_user_email]")
                 cursor.execute(
                     "SELECT email FROM user_tokens WHERE user_id = %s AND email IS NOT NULL LIMIT 1",
                     (user_id,)

--- a/server/utils/auth/stateless_auth.py
+++ b/server/utils/auth/stateless_auth.py
@@ -575,10 +575,18 @@ def get_user_email(user_id: str) -> Optional[str]:
     from utils.db.connection_pool import db_pool
     
     try:
-        # Try to get email from user_tokens table first (faster)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                # No RLS needed — user_tokens not RLS-protected
+                # Check users table first (always has email for credential-based accounts)
+                cursor.execute(
+                    "SELECT email FROM users WHERE id = %s AND email IS NOT NULL LIMIT 1",
+                    (user_id,)
+                )
+                result = cursor.fetchone()
+                if result and result[0]:
+                    return result[0]
+
+                # Fallback to user_tokens (OAuth providers store email here)
                 cursor.execute(
                     "SELECT email FROM user_tokens WHERE user_id = %s AND email IS NOT NULL LIMIT 1",
                     (user_id,)
@@ -586,9 +594,7 @@ def get_user_email(user_id: str) -> Optional[str]:
                 result = cursor.fetchone()
                 if result and result[0]:
                     return result[0]
-        
-        # Auth.js doesn't have a separate API - email should be in database
-        # If not found, return None
+
         logger.warning(f"Could not find email for user {user_id}")
         return None
         

--- a/server/utils/notifications/email_service.py
+++ b/server/utils/notifications/email_service.py
@@ -516,6 +516,102 @@ If you didn't request this, you can safely ignore this email.{self._text_footer(
         
         return self._send_email(to_email, subject, html_body, text_body)
 
+    def send_action_completed_email(
+        self,
+        to_email: str,
+        action_data: Dict[str, Any],
+    ) -> bool:
+        """Send email notification when an Aurora Action completes.
+
+        Args:
+            to_email: Recipient email address
+            action_data: Dictionary containing action details
+                - action_name: Name of the action
+                - run_id: Action run UUID
+                - status: 'success' or 'error'
+                - error: Optional error message
+                - started_at: When the action started
+                - completed_at: When the action finished
+                - session_id: Chat session ID (for link)
+
+        Returns:
+            True if email sent successfully, False otherwise
+        """
+        action_name = action_data.get('action_name', 'Unknown Action')
+        status = action_data.get('status', 'success')
+        error_msg = action_data.get('error')
+        started_at = action_data.get('started_at')
+        completed_at = action_data.get('completed_at')
+        session_id = action_data.get('session_id')
+
+        duration_str = 'Unknown'
+        if isinstance(started_at, datetime) and isinstance(completed_at, datetime):
+            duration = completed_at - started_at
+            minutes = int(duration.total_seconds() / 60)
+            if minutes < 1:
+                duration_str = 'Less than 1 minute'
+            elif minutes == 1:
+                duration_str = '1 minute'
+            else:
+                duration_str = f'{minutes} minutes'
+
+        is_success = status == 'success'
+        status_label = 'Completed Successfully' if is_success else 'Failed'
+        status_color = '#16a34a' if is_success else '#dc2626'
+
+        subject = f"[Aurora] Action {status_label} - {action_name}"
+
+        session_url = f"{self.frontend_url}/actions?session={session_id}" if session_id else self.frontend_url
+        logo_url = self._get_logo_url()
+
+        text_body = f"""ACTION {status_label.upper()}
+
+Action: {action_name}
+Status: {status_label}
+Duration: {duration_str}
+"""
+        if error_msg:
+            text_body += f"Error: {error_msg}\n"
+        text_body += f"\nView details: {session_url}{self._text_footer()}"
+
+        error_section = ""
+        if error_msg:
+            error_section = f"""<div style="background-color: #fef2f2; border-left: 4px solid #dc2626; padding: 16px; margin-bottom: 32px;">
+                                <div style="font-size: 11px; font-weight: 600; color: #991b1b; text-transform: uppercase; letter-spacing: 1.2px; margin-bottom: 8px;">Error</div>
+                                <div style="font-size: 14px; color: #7f1d1d; line-height: 1.5;">{error_msg}</div>
+                            </div>"""
+
+        html_body = f"""{self._email_header_html(logo_url)}
+{self._status_banner_html("Action " + status_label, f"Duration: {duration_str}")}
+
+                    <!-- Content -->
+                    <tr>
+                        <td style="padding: 48px 40px;">
+                            {self._alert_title_card_html("Action", action_name)}
+
+                            <!-- Status -->
+                            <table role="presentation" style="width: 100%; border-collapse: collapse; margin-bottom: 40px;">
+                                <tr>
+                                    <td style="padding: 20px 16px 20px 0; vertical-align: top; width: 50%; border-top: 1px solid #e5e5e5;">
+                                        <div style="font-size: 11px; font-weight: 600; color: #737373; text-transform: uppercase; letter-spacing: 1.2px; margin-bottom: 12px;">Status</div>
+                                        <span style="display: inline-block; background-color: {status_color}; color: #ffffff; padding: 6px 16px; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px;">{status_label}</span>
+                                    </td>
+                                    <td style="padding: 20px 0 20px 16px; vertical-align: top; width: 50%; border-top: 1px solid #e5e5e5;">
+                                        {self._detail_field_html("Duration", duration_str)}
+                                    </td>
+                                </tr>
+                            </table>
+
+                            {error_section}
+
+                            <!-- CTA Button -->
+                            {self._cta_button_html(session_url, "View Action Details")}
+                        </td>
+                    </tr>
+{self._email_footer_html()}"""
+
+        return self._send_email(to_email, subject, html_body, text_body)
+
 
 # Singleton instance
 _email_service = None

--- a/server/utils/notifications/email_service.py
+++ b/server/utils/notifications/email_service.py
@@ -1,5 +1,6 @@
 """Email service for sending RCA investigation notifications via SMTP."""
 
+import html
 import logging
 import os
 import smtplib
@@ -537,9 +538,9 @@ If you didn't request this, you can safely ignore this email.{self._text_footer(
         Returns:
             True if email sent successfully, False otherwise
         """
-        action_name = action_data.get('action_name', 'Unknown Action')
+        action_name = html.escape(action_data.get('action_name', 'Unknown Action'))
         status = action_data.get('status', 'success')
-        error_msg = action_data.get('error')
+        error_msg = html.escape(action_data.get('error')) if action_data.get('error') else None
         started_at = action_data.get('started_at')
         completed_at = action_data.get('completed_at')
         session_id = action_data.get('session_id')
@@ -561,7 +562,7 @@ If you didn't request this, you can safely ignore this email.{self._text_footer(
 
         subject = f"[Aurora] Action {status_label} - {action_name}"
 
-        session_url = f"{self.frontend_url}/actions?session={session_id}" if session_id else self.frontend_url
+        session_url = f"{self.frontend_url}/chat?sessionId={session_id}" if session_id else f"{self.frontend_url}/actions"
         logo_url = self._get_logo_url()
 
         text_body = f"""ACTION {status_label.upper()}

--- a/server/utils/notifications/email_service.py
+++ b/server/utils/notifications/email_service.py
@@ -538,9 +538,11 @@ If you didn't request this, you can safely ignore this email.{self._text_footer(
         Returns:
             True if email sent successfully, False otherwise
         """
-        action_name = html.escape(action_data.get('action_name', 'Unknown Action'))
+        action_name = str(action_data.get('action_name', 'Unknown Action'))
         status = action_data.get('status', 'success')
-        error_msg = html.escape(action_data.get('error')) if action_data.get('error') else None
+        error_msg = str(action_data.get('error')) if action_data.get('error') else None
+        action_name_html = html.escape(action_name)
+        error_msg_html = html.escape(error_msg) if error_msg else None
         started_at = action_data.get('started_at')
         completed_at = action_data.get('completed_at')
         session_id = action_data.get('session_id')
@@ -579,7 +581,7 @@ Duration: {duration_str}
         if error_msg:
             error_section = f"""<div style="background-color: #fef2f2; border-left: 4px solid #dc2626; padding: 16px; margin-bottom: 32px;">
                                 <div style="font-size: 11px; font-weight: 600; color: #991b1b; text-transform: uppercase; letter-spacing: 1.2px; margin-bottom: 8px;">Error</div>
-                                <div style="font-size: 14px; color: #7f1d1d; line-height: 1.5;">{error_msg}</div>
+                                <div style="font-size: 14px; color: #7f1d1d; line-height: 1.5;">{error_msg_html}</div>
                             </div>"""
 
         html_body = f"""{self._email_header_html(logo_url)}
@@ -588,7 +590,7 @@ Duration: {duration_str}
                     <!-- Content -->
                     <tr>
                         <td style="padding: 48px 40px;">
-                            {self._alert_title_card_html("Action", action_name)}
+                            {self._alert_title_card_html("Action", action_name_html)}
 
                             <!-- Status -->
                             <table role="presentation" style="width: 100%; border-collapse: collapse; margin-bottom: 40px;">


### PR DESCRIPTION
## Summary
- Sends email when Aurora Actions complete (success or failure)
- New user preference toggle `action_email_notifications` in Settings > Notifications
- Reuses existing email recipient system (primary email + verified additional recipients)
- Hooks into all action completion paths: success, guardrail block, timeout, and general errors

## Context
DEV-1170 — Users (e.g. Mario) want to know when actions finish without having to watch the UI.

## Test plan
- [ ] Enable `action_email_notifications` toggle in settings
- [ ] Trigger an action manually, verify email arrives on completion
- [ ] Trigger a failing action (e.g. guardrail block), verify error email arrives
- [ ] Verify toggle OFF = no emails sent
- [ ] Verify additional verified email recipients also receive the notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New settings toggle to opt into "Action Complete" email notifications (off by default).
  * Action-completion emails sent to primary and verified additional recipients, include status, duration, session link, and optional error details.

* **Improvements**
  * Email settings UI reorganized into separate notification cards and streamlined save flow.
  * Toast messages and error handling in email add/verify/resend/toggle/remove flows updated.

* **Bug Fixes**
  * Timeouts, guardrail blocks, and failures now trigger action-completion emails with error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->