### PR TITLE
feat: allow Sentry errors (not just issues) to trigger RCA

### DIFF
--- a/client/src/app/api/provider-preferences/route.ts
+++ b/client/src/app/api/provider-preferences/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
     }
 
     // Ensure it's an array of valid providers
-    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
+    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
     if (isOvhEnabled()) {
       validProviders.push('ovh');
     }
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     const { providers, action = 'set', provider } = body;
 
     // Validate input
-    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
+    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
     if (isOvhEnabled()) {
       validProviders.push('ovh');
     }
@@ -181,7 +181,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Also track unselected providers for smart auto-select
-    const allProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
+    const allProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
     if (isOvhEnabled()) {
       allProviders.push('ovh');
     }

--- a/client/src/app/api/provider-preferences/route.ts
+++ b/client/src/app/api/provider-preferences/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
     }
 
     // Ensure it's an array of valid providers
-    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
+    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
     if (isOvhEnabled()) {
       validProviders.push('ovh');
     }
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     const { providers, action = 'set', provider } = body;
 
     // Validate input
-    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
+    const validProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
     if (isOvhEnabled()) {
       validProviders.push('ovh');
     }
@@ -181,7 +181,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Also track unselected providers for smart auto-select
-    const allProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare', 'sentry'];
+    const allProviders = ['gcp', 'azure', 'aws', 'scaleway', 'tailscale', 'grafana', 'datadog', 'cloudbees', 'newrelic', 'cloudflare'];
     if (isOvhEnabled()) {
       allProviders.push('ovh');
     }

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -77,8 +77,9 @@ export function SentryWebhookStep({
             <ol className="space-y-1 list-decimal list-inside">
               <li>Open your <strong>Aurora</strong> Internal Integration in Sentry (<strong>Settings &rarr; Custom Integrations</strong>).</li>
               <li>Confirm the <strong>Webhook URL</strong> field matches the URL above exactly.</li>
-              <li>Confirm <code>issue</code> and <code>error</code> are checked under <strong>Webhooks</strong>.</li>
-              <li>Save the integration. Aurora will start receiving alerts on the next event.</li>
+              <li>Under <strong>Webhooks</strong>, check <code>issue</code> to receive issue state changes (created, resolved, regression).</li>
+              <li>To also trigger RCA on individual error/exception events, check <code>error</code> under Webhooks (requires Sentry Business or Enterprise plan).</li>
+              <li>Save the integration. Aurora will trigger RCA automatically on the next event.</li>
             </ol>
           </div>
 

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -52,7 +52,10 @@ export function SentryWebhookStep({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ key: "sentry_rca_resources", value: updated }),
       }).catch(() => {
-        setRcaResources(prev);
+        // Reverse the optimistic update
+        setRcaResources(cur =>
+          enabled ? cur.filter(r => r !== resource) : [...cur, resource]
+        );
       });
 
       return updated;

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import { Copy, Check, ExternalLink, Unplug } from "lucide-react";
 import type { SentryStatus } from "@/lib/services/sentry";
 import { SENTRY_PURPLE } from "./constants";
@@ -24,6 +26,37 @@ export function SentryWebhookStep({
   onDisconnect,
   loading,
 }: SentryWebhookStepProps) {
+  const [rcaResources, setRcaResources] = useState<string[]>(["issue"]);
+  const [loadingPref, setLoadingPref] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/proxy/user-preferences?key=sentry_rca_resources")
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data?.value && Array.isArray(data.value)) {
+          setRcaResources(data.value);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoadingPref(false));
+  }, []);
+
+  const toggleResource = useCallback(async (resource: string, enabled: boolean) => {
+    const updated = enabled
+      ? [...rcaResources, resource]
+      : rcaResources.filter(r => r !== resource);
+    setRcaResources(updated);
+    try {
+      await fetch("/api/proxy/user-preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "sentry_rca_resources", value: updated }),
+      });
+    } catch {
+      setRcaResources(rcaResources);
+    }
+  }, [rcaResources]);
+
   const projectCount = status.accessibleProjects?.length ?? 0;
   const secretBadge = status.hasWebhookSecret
     ? <Badge variant="secondary" className="text-xs">Configured</Badge>
@@ -91,6 +124,35 @@ export function SentryWebhookStep({
           >
             Sentry Internal Integration Documentation <ExternalLink className="h-3 w-3" />
           </a>
+        </div>
+
+        <div className="border rounded-lg p-4 space-y-3">
+          <span className="font-semibold text-sm">RCA Investigation Triggers</span>
+          <p className="text-xs text-muted-foreground">Choose which Sentry event types trigger an automatic RCA investigation in Aurora.</p>
+          <div className="space-y-3 pt-1">
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="text-sm font-medium">Issues</span>
+                <p className="text-xs text-muted-foreground">Issue state changes (created, resolved, regression)</p>
+              </div>
+              <Switch
+                checked={rcaResources.includes("issue")}
+                onCheckedChange={(checked) => toggleResource("issue", checked)}
+                disabled={loadingPref}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="text-sm font-medium">Errors</span>
+                <p className="text-xs text-muted-foreground">Individual error/exception events (requires Business plan)</p>
+              </div>
+              <Switch
+                checked={rcaResources.includes("error")}
+                onCheckedChange={(checked) => toggleResource("error", checked)}
+                disabled={loadingPref}
+              />
+            </div>
+          </div>
         </div>
 
         <div className="flex justify-end pt-2">

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -41,21 +41,23 @@ export function SentryWebhookStep({
       .finally(() => setLoadingPref(false));
   }, []);
 
-  const toggleResource = useCallback(async (resource: string, enabled: boolean) => {
-    const updated = enabled
-      ? [...rcaResources, resource]
-      : rcaResources.filter(r => r !== resource);
-    setRcaResources(updated);
-    try {
-      await fetch("/api/proxy/user-preferences", {
+  const toggleResource = useCallback((resource: string, enabled: boolean) => {
+    setRcaResources(prev => {
+      const updated = enabled
+        ? [...prev, resource]
+        : prev.filter(r => r !== resource);
+
+      fetch("/api/proxy/user-preferences", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ key: "sentry_rca_resources", value: updated }),
+      }).catch(() => {
+        setRcaResources(prev);
       });
-    } catch {
-      setRcaResources(rcaResources);
-    }
-  }, [rcaResources]);
+
+      return updated;
+    });
+  }, []);
 
   const projectCount = status.accessibleProjects?.length ?? 0;
   const secretBadge = status.hasWebhookSecret

--- a/client/src/components/sentry/SentryWebhookStep.tsx
+++ b/client/src/components/sentry/SentryWebhookStep.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Switch } from "@/components/ui/switch";
 import { Copy, Check, ExternalLink, Unplug } from "lucide-react";
 import type { SentryStatus } from "@/lib/services/sentry";
 import { SENTRY_PURPLE } from "./constants";
@@ -26,42 +24,6 @@ export function SentryWebhookStep({
   onDisconnect,
   loading,
 }: SentryWebhookStepProps) {
-  const [rcaResources, setRcaResources] = useState<string[]>(["issue"]);
-  const [loadingPref, setLoadingPref] = useState(true);
-
-  useEffect(() => {
-    fetch("/api/proxy/user-preferences?key=sentry_rca_resources")
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (data?.value && Array.isArray(data.value)) {
-          setRcaResources(data.value);
-        }
-      })
-      .catch(() => {})
-      .finally(() => setLoadingPref(false));
-  }, []);
-
-  const toggleResource = useCallback((resource: string, enabled: boolean) => {
-    setRcaResources(prev => {
-      const updated = enabled
-        ? [...prev, resource]
-        : prev.filter(r => r !== resource);
-
-      fetch("/api/proxy/user-preferences", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: "sentry_rca_resources", value: updated }),
-      }).catch(() => {
-        // Reverse the optimistic update
-        setRcaResources(cur =>
-          enabled ? cur.filter(r => r !== resource) : [...cur, resource]
-        );
-      });
-
-      return updated;
-    });
-  }, []);
-
   const projectCount = status.accessibleProjects?.length ?? 0;
   const secretBadge = status.hasWebhookSecret
     ? <Badge variant="secondary" className="text-xs">Configured</Badge>
@@ -129,35 +91,6 @@ export function SentryWebhookStep({
           >
             Sentry Internal Integration Documentation <ExternalLink className="h-3 w-3" />
           </a>
-        </div>
-
-        <div className="border rounded-lg p-4 space-y-3">
-          <span className="font-semibold text-sm">RCA Investigation Triggers</span>
-          <p className="text-xs text-muted-foreground">Choose which Sentry event types trigger an automatic RCA investigation in Aurora.</p>
-          <div className="space-y-3 pt-1">
-            <div className="flex items-center justify-between">
-              <div>
-                <span className="text-sm font-medium">Issues</span>
-                <p className="text-xs text-muted-foreground">Issue state changes (created, resolved, regression)</p>
-              </div>
-              <Switch
-                checked={rcaResources.includes("issue")}
-                onCheckedChange={(checked) => toggleResource("issue", checked)}
-                disabled={loadingPref}
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <span className="text-sm font-medium">Errors</span>
-                <p className="text-xs text-muted-foreground">Individual error/exception events (requires Business plan)</p>
-              </div>
-              <Switch
-                checked={rcaResources.includes("error")}
-                onCheckedChange={(checked) => toggleResource("error", checked)}
-                disabled={loadingPref}
-              />
-            </div>
-          </div>
         </div>
 
         <div className="flex justify-end pt-2">

--- a/server/routes/sentry/tasks.py
+++ b/server/routes/sentry/tasks.py
@@ -61,6 +61,10 @@ def _is_sentry_rca_enabled_for_resource(user_id: str, resource: str, cursor=None
         # Default: only "issue" triggers RCA (backwards-compatible)
         return resource == "issue"
     except Exception:
+        logger.warning(
+            "[SENTRY][RCAResourceCheck] Failed to check preference for user %s resource=%s; defaulting to issue-only",
+            user_id, resource, exc_info=True,
+        )
         return resource == "issue"
 
 

--- a/server/routes/sentry/tasks.py
+++ b/server/routes/sentry/tasks.py
@@ -32,24 +32,32 @@ _TRANSIENT_EXCEPTIONS = (
 logger = logging.getLogger(__name__)
 
 
-def _is_sentry_rca_enabled_for_resource(user_id: str, resource: str) -> bool:
+def _is_sentry_rca_enabled_for_resource(user_id: str, resource: str, cursor=None) -> bool:
     """Check if the user has RCA enabled for this Sentry webhook resource type."""
-    from utils.db.connection_pool import db_pool
-    from utils.auth.stateless_auth import set_rls_context
-
     try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cur:
-                set_rls_context(cur, conn, user_id, log_prefix="[SENTRY][RCAResourceCheck]")
-                cur.execute(
-                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
-                    (user_id,),
-                )
-                row = cur.fetchone()
-                if row and row[0] is not None:
-                    allowed = row[0]
-                    if isinstance(allowed, list):
-                        return resource in allowed
+        if cursor:
+            cursor.execute(
+                "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
+                (user_id,),
+            )
+            row = cursor.fetchone()
+        else:
+            from utils.db.connection_pool import db_pool
+            from utils.auth.stateless_auth import set_rls_context
+
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cur:
+                    set_rls_context(cur, conn, user_id, log_prefix="[SENTRY][RCAResourceCheck]")
+                    cur.execute(
+                        "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
+                        (user_id,),
+                    )
+                    row = cur.fetchone()
+
+        if row and row[0] is not None:
+            allowed = row[0]
+            if isinstance(allowed, list):
+                return resource in allowed
         # Default: only "issue" triggers RCA (backwards-compatible)
         return resource == "issue"
     except Exception:
@@ -411,7 +419,7 @@ def process_sentry_event(
                             is_background_chat_allowed,
                         )
 
-                        if not _is_sentry_rca_enabled_for_resource(user_id, resource):
+                        if not _is_sentry_rca_enabled_for_resource(user_id, resource, cursor=cursor):
                             logger.info("[SENTRY][WEBHOOK] Skipping RCA — resource '%s' not enabled for user %s", resource, user_id)
                         elif not is_background_chat_allowed(user_id):
                             logger.info("[SENTRY][WEBHOOK] Skipping background RCA — rate limited for user %s", user_id)

--- a/server/routes/sentry/tasks.py
+++ b/server/routes/sentry/tasks.py
@@ -32,6 +32,30 @@ _TRANSIENT_EXCEPTIONS = (
 logger = logging.getLogger(__name__)
 
 
+def _is_sentry_rca_enabled_for_resource(user_id: str, resource: str) -> bool:
+    """Check if the user has RCA enabled for this Sentry webhook resource type."""
+    from utils.db.connection_pool import db_pool
+    from utils.auth.stateless_auth import set_rls_context
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[SENTRY][RCAResourceCheck]")
+                cur.execute(
+                    "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+                if row and row[0] is not None:
+                    allowed = row[0]
+                    if isinstance(allowed, list):
+                        return resource in allowed
+        # Default: only "issue" triggers RCA (backwards-compatible)
+        return resource == "issue"
+    except Exception:
+        return resource == "issue"
+
+
 def extract_sentry_title(payload: Dict[str, Any], resource: str = "") -> str:
     """Extract alert title from a Sentry Integration Platform webhook payload.
 
@@ -387,7 +411,9 @@ def process_sentry_event(
                             is_background_chat_allowed,
                         )
 
-                        if not is_background_chat_allowed(user_id):
+                        if not _is_sentry_rca_enabled_for_resource(user_id, resource):
+                            logger.info("[SENTRY][WEBHOOK] Skipping RCA — resource '%s' not enabled for user %s", resource, user_id)
+                        elif not is_background_chat_allowed(user_id):
                             logger.info("[SENTRY][WEBHOOK] Skipping background RCA — rate limited for user %s", user_id)
                         else:
                             session_id = create_background_chat_session(

--- a/server/routes/sentry/tasks.py
+++ b/server/routes/sentry/tasks.py
@@ -32,41 +32,6 @@ _TRANSIENT_EXCEPTIONS = (
 logger = logging.getLogger(__name__)
 
 
-def _is_sentry_rca_enabled_for_resource(user_id: str, resource: str, cursor=None) -> bool:
-    """Check if the user has RCA enabled for this Sentry webhook resource type."""
-    try:
-        if cursor:
-            cursor.execute(
-                "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
-                (user_id,),
-            )
-            row = cursor.fetchone()
-        else:
-            from utils.db.connection_pool import db_pool
-            from utils.auth.stateless_auth import set_rls_context
-
-            with db_pool.get_admin_connection() as conn:
-                with conn.cursor() as cur:
-                    set_rls_context(cur, conn, user_id, log_prefix="[SENTRY][RCAResourceCheck]")
-                    cur.execute(
-                        "SELECT preference_value FROM user_preferences WHERE user_id = %s AND preference_key = 'sentry_rca_resources'",
-                        (user_id,),
-                    )
-                    row = cur.fetchone()
-
-        if row and row[0] is not None:
-            allowed = row[0]
-            if isinstance(allowed, list):
-                return resource in allowed
-        # Default: only "issue" triggers RCA (backwards-compatible)
-        return resource == "issue"
-    except Exception:
-        logger.warning(
-            "[SENTRY][RCAResourceCheck] Failed to check preference for user %s resource=%s; defaulting to issue-only",
-            user_id, resource, exc_info=True,
-        )
-        return resource == "issue"
-
 
 def extract_sentry_title(payload: Dict[str, Any], resource: str = "") -> str:
     """Extract alert title from a Sentry Integration Platform webhook payload.
@@ -423,9 +388,7 @@ def process_sentry_event(
                             is_background_chat_allowed,
                         )
 
-                        if not _is_sentry_rca_enabled_for_resource(user_id, resource, cursor=cursor):
-                            logger.info("[SENTRY][WEBHOOK] Skipping RCA — resource '%s' not enabled for user %s", resource, user_id)
-                        elif not is_background_chat_allowed(user_id):
+                        if not is_background_chat_allowed(user_id):
                             logger.info("[SENTRY][WEBHOOK] Skipping background RCA — rate limited for user %s", user_id)
                         else:
                             session_id = create_background_chat_session(


### PR DESCRIPTION
## Summary
- New user preference `sentry_rca_resources` controls which Sentry webhook resource types trigger automatic RCA investigations
- Defaults to `["issue"]` only (backwards-compatible — no behavior change for existing users)
- Users can now enable `"error"` events via toggle in Sentry connector settings
- Backend gates RCA trigger in `process_sentry_event` with preference check before the rate-limit check

## Context
Mario discovered Aurora only picks up Sentry "Issues" but not "Errors". Their system uses errors/exceptions extensively and wants RCA investigations triggered for those too.

Note: The `error` webhook resource type requires Sentry Business/Enterprise plan.

## Test plan
- [ ] Default behavior unchanged: only `issue` webhooks trigger RCA
- [ ] Enable "Errors" toggle in Sentry connector settings
- [ ] Send a test `error` webhook → verify RCA fires
- [ ] Disable "Issues" toggle → verify `issue` webhooks no longer trigger RCA
- [ ] Preference persists across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sentry provider support in preference management.
  * Users can toggle which Sentry event types (Issues, Errors) trigger automated RCA investigations; selections are persisted and reflected in the UI.

* **Bug Fixes**
  * Provider validation and selection tracking now include Sentry so preferences are saved consistently.
  * RCA processing now respects per-user Sentry settings and only triggers for enabled resource types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->