### PR TITLE
fix(rca): prevent worker death from marking completed RCAs as failed

### DIFF
--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -1409,11 +1409,26 @@ def create_mcp_langchain_tools(real_mcp_tools: List, tool_capture=None, send_too
                     if isinstance(result, dict) and "content" in result:
                         content_items = result["content"]
                         if content_items and len(content_items) > 0:
-                            first_content = content_items[0]
-                            if isinstance(first_content, dict) and "text" in first_content:
-                                final_result = first_content["text"]
-                            else:
-                                final_result = str(result)
+                            parts = []
+                            for item in content_items:
+                                if isinstance(item, dict):
+                                    if "text" in item:
+                                        parts.append(item["text"])
+                                    elif "resource" in item and isinstance(item["resource"], dict):
+                                        res = item["resource"]
+                                        if "text" in res:
+                                            parts.append(res["text"])
+                                        elif "blob" in res:
+                                            import base64
+                                            try:
+                                                parts.append(base64.b64decode(res["blob"]).decode("utf-8"))
+                                            except Exception:
+                                                parts.append(f"[binary content, {len(res['blob'])} chars base64]")
+                                    else:
+                                        parts.append(str(item))
+                                else:
+                                    parts.append(str(item))
+                            final_result = "\n".join(parts) if parts else str(result)
                         else:
                             final_result = str(result)
                     else:

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -92,24 +92,30 @@ class Workflow:
         self._history_prefix_len: int = 0
 
     async def _wait_for_ongoing_tool_calls(self):
-        """Waits for any tool calls that are currently in progress to complete."""
+        """Waits briefly for any tool calls that are currently in progress to complete.
+        
+        MCP tool calls don't set the 'completed' flag via capture_tool_end,
+        so we use a short timeout and then force-clear remaining entries.
+        """
         tool_capture = getattr(self.agent, 'tool_capture_instance', None)
         if not tool_capture:
             logger.info("No tool capture instance found, cannot wait for tool calls.")
             return
 
-        # Initial check for ongoing calls
         with tool_capture.lock:
-            ongoing_calls = list(tool_capture.current_tool_calls.keys())
+            ongoing_calls = [
+                k for k, v in tool_capture.current_tool_calls.items()
+                if not v.get('completed')
+            ]
 
         if not ongoing_calls:
             logger.info("No ongoing tool calls detected at the start of wait.")
             return
 
         logger.info(f"Waiting for {len(ongoing_calls)} tool call(s) to complete: {ongoing_calls}")
-        
-        POLL_INTERVAL = 0.5  # seconds
-        MAX_WAIT_TIME = 30   # seconds
+
+        POLL_INTERVAL = 0.5
+        MAX_WAIT_TIME = 5
         time_waited = 0
 
         while time_waited < MAX_WAIT_TIME:
@@ -117,14 +123,20 @@ class Workflow:
             time_waited += POLL_INTERVAL
 
             with tool_capture.lock:
-                # Check if the initial ongoing calls are still present
-                still_ongoing = [call_id for call_id in ongoing_calls if call_id in tool_capture.current_tool_calls]
-            
+                still_ongoing = [call_id for call_id in ongoing_calls if call_id in tool_capture.current_tool_calls and not tool_capture.current_tool_calls[call_id].get('completed')]
+
             if not still_ongoing:
                 logger.info(f"All tracked tool calls have completed after {time_waited:.1f}s.")
                 return
-            
+
             logger.debug(f"Still waiting for {len(still_ongoing)} tool call(s): {still_ongoing}")
+
+        with tool_capture.lock:
+            for call_id in ongoing_calls:
+                if call_id in tool_capture.current_tool_calls:
+                    tool_capture.current_tool_calls[call_id]['completed'] = True
+                    tool_capture.current_tool_calls[call_id]['completion_time'] = __import__('datetime').datetime.now()
+        logger.info(f"Timed out after {MAX_WAIT_TIME}s, force-marked {len(ongoing_calls)} tool calls as completed.")
 
     def _create_workflow(self) -> StateGraph:
         """Create and configure the workflow graph.

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -135,7 +135,7 @@ class Workflow:
             for call_id in ongoing_calls:
                 if call_id in tool_capture.current_tool_calls:
                     tool_capture.current_tool_calls[call_id]['completed'] = True
-                    tool_capture.current_tool_calls[call_id]['completion_time'] = __import__('datetime').datetime.now()
+                    tool_capture.current_tool_calls[call_id]['completion_time'] = datetime.now(timezone.utc)
         logger.info(f"Timed out after {MAX_WAIT_TIME}s, force-marked {len(ongoing_calls)} tool calls as completed.")
 
     def _create_workflow(self) -> StateGraph:

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -241,12 +241,11 @@ If the correlated alerts are relevant, clearly indicate their relationship to th
         reasoning_block = ""
         if agent_reasoning and agent_reasoning.strip():
             reasoning_block = (
-                "\nAGENT REASONING (the investigating agent's own thoughts as shown "
-                "in the Thoughts panel — context, not direct evidence):\n"
+                "\nINVESTIGATOR NOTES (context only — do NOT cite as a source, use numeric evidence citations instead):\n"
                 f"{agent_reasoning}\n"
             )
 
-        prompt = f"""You are writing an incident report from alert data, the investigating agent's reasoning, and forensic evidence.
+        prompt = f"""You are writing an incident report from alert data, investigator notes, and forensic evidence.
 
 ALERT INFORMATION:
 - Source: {source_type}
@@ -261,22 +260,26 @@ INVESTIGATION EVIDENCE (cite using [n] markers):
 Write a 2-3 paragraph incident report:
 
 PARAGRAPH 1 — What Happened:
-State what occurred, when, and what was affected, using only facts present in the alert, agent reasoning, or evidence. Report as known facts, not as an investigation log.
+State what occurred, when, and what was affected, using only facts present in the provided sections. Report as known facts, not as an investigation log.
 
 PARAGRAPH 2 — Root Cause:
-- If evidence and agent reasoning together clearly support a specific root cause, state it and cite the supporting evidence.
+- If the numbered evidence clearly supports a specific root cause, state it and cite the supporting evidence with numeric markers like [3], [7].
   Example: "The root cause was a ConfigMap change that increased BATCH_SIZE from 1000 to 10000 [7], causing memory usage to exceed the 128Mi limit [9, 11]."
 - Otherwise the paragraph MUST begin with "Root cause undetermined." and describe what is and isn't known. Do not invent a cause to fill the paragraph.
 
 PARAGRAPH 3 (if significant) — Impact & Timeline:
-Only the scope and timeline actually present in the alert, agent reasoning, or evidence.
+Only the scope and timeline actually present in the alert or evidence.
 
 ANTI-HALLUCINATION RULES (non-negotiable):
-- Use only facts present in the alert, agent reasoning, or cited evidence — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
+- Use only facts present in the provided sections — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
 - Empty or missing output from a generic probe is NOT evidence of a specific failure mode; never promote absence of data into a confident root cause.
-- Never fabricate a [n] citation — every marker MUST reference a real evidence row above.
+- Never fabricate a [n] citation — every marker MUST reference a real numbered evidence row above.
 - Treat purely temporal correlations as correlations, not causations.
-- If the agent reasoning says the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
+- If the investigator notes indicate the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
+
+CITATION RULES (non-negotiable):
+- ONLY cite numbered evidence items using their numeric index: [1], [3, 5], [7].
+- NEVER cite section headers. Do NOT write [Alert], [Agent Reasoning], [Investigator Notes], or any non-numeric citation.
 
 WRITING RULES:
 - Cite specific evidence that supports factual claims; group related citations [3, 5, 7]; cite only key supporting evidence.
@@ -291,7 +294,7 @@ After the report, add a "## Suggested Next Steps" paragraph with 2-4 concrete di
         reasoning_block = ""
         if agent_reasoning and agent_reasoning.strip():
             reasoning_block = (
-                "\nAGENT REASONING (Thoughts-panel content — context, not direct evidence):\n"
+                "\nINVESTIGATOR NOTES (context only — do NOT cite as a source):\n"
                 f"{agent_reasoning}\n"
             )
         prompt = f"""
@@ -310,10 +313,10 @@ INVESTIGATION TRANSCRIPT (chat log):
 Write a concise 2–3 paragraph summary covering what triggered the alert, the severity and observed impact (only if explicitly present), the affected service, and the best-known root cause. If the root cause is not explicit, the Root Cause paragraph MUST begin with "Root cause undetermined." and describe what is and isn't known.
 
 ANTI-HALLUCINATION RULES (non-negotiable):
-- Use only facts present in the alert, agent reasoning, or transcript — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
+- Use only facts present in the provided sections — do not introduce services, hosts, configs, error messages, or metrics that aren't there.
 - Empty or missing output from a generic probe is NOT evidence of a specific failure mode.
 - Treat purely temporal correlations as correlations, not causations.
-- If the agent reasoning says the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
+- If the investigator notes indicate the investigation was inconclusive, the Root Cause paragraph MUST start with "Root cause undetermined."
 
 Tone: neutral, factual, incident-record style. Descriptive, not advisory. Do not address any audience.
 

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -662,22 +662,28 @@ def run_background_chat(
                 logger.error(f"[BackgroundChat] Failed to determine severity: {e}")
             
             # Regenerate incident summary (skip if already enqueued by inner function)
+            should_enqueue = False
             try:
                 with db_pool.get_admin_connection() as conn:
                     with conn.cursor() as cursor:
                         set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:SumCheck]")
                         cursor.execute("SELECT aurora_status FROM incidents WHERE id = %s", (incident_id,))
                         row = cursor.fetchone()
-                        if row and row[0] != 'summarizing':
-                            from chat.background.summarization import generate_incident_summary_from_chat
-                            generate_incident_summary_from_chat.delay(
-                                incident_id=incident_id,
-                                user_id=user_id,
-                                session_id=session_id,
-                            )
-            except Exception as e:
-                logger.error(f"[BackgroundChat] Failed to enqueue post-RCA summarization for incident {incident_id}: {e}")
-                _update_incident_aurora_status(incident_id, "complete", user_id=user_id)
+                        should_enqueue = bool(row and row[0] != 'summarizing')
+            except Exception:
+                logger.warning("[BackgroundChat] Failed to check summarization state for incident %s", incident_id)
+
+            if should_enqueue:
+                try:
+                    from chat.background.summarization import generate_incident_summary_from_chat
+                    generate_incident_summary_from_chat.delay(
+                        incident_id=incident_id,
+                        user_id=user_id,
+                        session_id=session_id,
+                    )
+                except Exception:
+                    logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization for incident %s", incident_id)
+                    _update_incident_aurora_status(incident_id, "complete", user_id=user_id)
             
             # Generate final complete visualization
             try:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -661,14 +661,20 @@ def run_background_chat(
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to determine severity: {e}")
             
-            # Regenerate incident summary now that RCA chat has completed
+            # Regenerate incident summary (skip if already enqueued by inner function)
             try:
-                from chat.background.summarization import generate_incident_summary_from_chat
-                generate_incident_summary_from_chat.delay(
-                    incident_id=incident_id,
-                    user_id=user_id,
-                    session_id=session_id,
-                )
+                with db_pool.get_admin_connection() as conn:
+                    with conn.cursor() as cursor:
+                        set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:SumCheck]")
+                        cursor.execute("SELECT aurora_status FROM incidents WHERE id = %s", (incident_id,))
+                        row = cursor.fetchone()
+                        if row and row[0] != 'summarizing':
+                            from chat.background.summarization import generate_incident_summary_from_chat
+                            generate_incident_summary_from_chat.delay(
+                                incident_id=incident_id,
+                                user_id=user_id,
+                                session_id=session_id,
+                            )
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to enqueue post-RCA summarization for incident {incident_id}: {e}")
                 _update_incident_aurora_status(incident_id, "complete", user_id=user_id)
@@ -1360,7 +1366,7 @@ async def _execute_background_chat(
                     session_id=session_id,
                 )
             except Exception as e:
-                logger.error(f"[BackgroundChat] Failed to enqueue post-RCA summarization: {e}")
+                logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization")
                 _update_incident_aurora_status(incident_id, "complete", user_id=user_id)
 
         # Fallback: rebuild llm_context_history from UI messages if the save was lost.

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -591,10 +591,6 @@ def run_background_chat(
             logger.error(f"[BackgroundChat] Exception in asyncio.run(_execute_background_chat): {e}", exc_info=True)
             raise
         
-        # Mark as successful immediately after asyncio.run returns.
-        # The worker process can be killed during post-processing (event loop
-        # teardown, MCP subprocess cleanup, etc.) so we must set this flag
-        # before any code that might trigger process exit.
         completed_successfully = True
         logger.info(f"[BackgroundChat] Workflow execution completed for session {session_id}")
         
@@ -602,6 +598,7 @@ def run_background_chat(
         _update_session_status(session_id, "completed", user_id=user_id)
         
         # Update incident status to analyzed if incident_id provided
+        # (may already be done inside _execute_background_chat as crash protection)
         if incident_id:
             # Clear the Celery task ID since we're done
             try:
@@ -609,14 +606,24 @@ def run_background_chat(
                     with conn.cursor() as cursor:
                         set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:ClearTaskID]")
                         cursor.execute(
-                            "UPDATE incidents SET rca_celery_task_id = NULL WHERE id = %s",
+                            "UPDATE incidents SET rca_celery_task_id = NULL WHERE id = %s AND rca_celery_task_id IS NOT NULL",
                             (incident_id,)
                         )
                         conn.commit()
             except Exception as e:
                 logger.warning(f"[BackgroundChat] Failed to clear task ID for incident {incident_id}: {e}")
             
-            _update_incident_status_and_aurora(incident_id, "analyzed", "summarizing", user_id=user_id)
+            # Only update if still in 'running' (not already advanced by inner function)
+            try:
+                with db_pool.get_admin_connection() as conn:
+                    with conn.cursor() as cursor:
+                        set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:StatusCheck]")
+                        cursor.execute("SELECT aurora_status FROM incidents WHERE id = %s", (incident_id,))
+                        row = cursor.fetchone()
+                        if row and row[0] == 'running':
+                            _update_incident_status_and_aurora(incident_id, "analyzed", "summarizing", user_id=user_id)
+            except Exception as e:
+                logger.warning(f"[BackgroundChat] Failed to check/update incident status: {e}")
 
             # Post RCA-complete comment to linked JSM incident
             if (trigger_metadata or {}).get("source") == "opsgenie":
@@ -1321,6 +1328,40 @@ async def _execute_background_chat(
                         logger.error(f"[BackgroundChat] ⚠️ WARNING: Incident {incident_id} aurora_status is already 'complete' before we set it! This indicates a race condition.")
         
         logger.info(f"[BackgroundChat] Workflow execution completed - all streams and tool calls finished")
+
+        # Mark session as completed in DB NOW, before asyncio.run() tears down
+        # the event loop (which can kill the process via MCP subprocess cleanup).
+        # The finally block only marks failed WHERE status='in_progress', so this
+        # protects against the worker dying during event loop shutdown.
+        _update_session_status(session_id, "completed", user_id=user_id)
+
+        # Also finalize the incident and enqueue post-RCA tasks here (inside the
+        # async function) because asyncio.run() may never return to the caller.
+        if incident_id:
+            try:
+                with db_pool.get_admin_connection() as conn:
+                    with conn.cursor() as cursor:
+                        set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:Finalize]")
+                        cursor.execute(
+                            "UPDATE incidents SET rca_celery_task_id = NULL WHERE id = %s",
+                            (incident_id,)
+                        )
+                        conn.commit()
+            except Exception as e:
+                logger.warning(f"[BackgroundChat] Failed to clear task ID: {e}")
+
+            _update_incident_status_and_aurora(incident_id, "analyzed", "summarizing", user_id=user_id)
+
+            try:
+                from chat.background.summarization import generate_incident_summary_from_chat
+                generate_incident_summary_from_chat.delay(
+                    incident_id=incident_id,
+                    user_id=user_id,
+                    session_id=session_id,
+                )
+            except Exception as e:
+                logger.error(f"[BackgroundChat] Failed to enqueue post-RCA summarization: {e}")
+                _update_incident_aurora_status(incident_id, "complete", user_id=user_id)
 
         # Fallback: rebuild llm_context_history from UI messages if the save was lost.
         llm_context = _ensure_llm_context_history(session_id, user_id)

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -587,11 +587,15 @@ def run_background_chat(
                 mode=mode,
                 rail_text=rail_text,
             ))
-            pass
         except Exception as e:
             logger.error(f"[BackgroundChat] Exception in asyncio.run(_execute_background_chat): {e}", exc_info=True)
             raise
         
+        # Mark as successful immediately after asyncio.run returns.
+        # The worker process can be killed during post-processing (event loop
+        # teardown, MCP subprocess cleanup, etc.) so we must set this flag
+        # before any code that might trigger process exit.
+        completed_successfully = True
         logger.info(f"[BackgroundChat] Workflow execution completed for session {session_id}")
         
         # Update session status to completed
@@ -714,7 +718,6 @@ def run_background_chat(
             except Exception:
                 logger.debug("[BackgroundChat] Failed to dispatch after_rca actions")
 
-        completed_successfully = True
         logger.info(f"[BackgroundChat] Completed for session {session_id}")
         return result
     

--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -6,7 +6,6 @@ This module provides comprehensive health checks for all Aurora services.
 import logging
 import time
 import os
-import uuid
 import requests
 import socket
 from datetime import datetime, timezone
@@ -14,10 +13,6 @@ from flask import Blueprint, jsonify
 import psycopg2
 import redis
 from celery_config import celery_app
-import websockets
-import asyncio
-import json
-import jwt as pyjwt
 
 
 logger = logging.getLogger(__name__)
@@ -106,11 +101,13 @@ def check_celery_health():
         logger.warning(f"Celery health check failed: {e}")
         return {"status": "unhealthy", "error": "Celery health check failed"}
 
-async def send_chatbot_test_message():
-    """Send a test message to the chatbot and verify the response."""
-    # CHATBOT_INTERNAL_URL is set by the Helm ConfigMap (e.g. http://aurora-chatbot:5007).
-    # It points at the HTTP health port (5007), not the WebSocket port (5006).
-    # Extract only the hostname; the WS port is always 5006.
+def check_chatbot_websocket():
+    """Check chatbot WebSocket service is accepting connections (TCP only).
+
+    Previous implementation sent a real query that triggered an LLM call,
+    blocking a gunicorn thread for 10+ seconds and exhausting the thread pool.
+    Now we just verify the port is open.
+    """
     internal_url = os.getenv('CHATBOT_INTERNAL_URL')
     if internal_url:
         from urllib.parse import urlparse
@@ -120,82 +117,14 @@ async def send_chatbot_test_message():
         host = os.getenv('CHATBOT_HOST', 'chatbot')
     port = 5006
 
-    # Mint a short-lived JWT matching the chatbot's expected format
-    # (see main_chatbot.py:_validate_ws_token). Skipped when INTERNAL_API_SECRET
-    # is unset (dev mode); the chatbot allows unauthenticated connections then.
-    internal_secret = os.getenv('INTERNAL_API_SECRET', '')
-    token_qs = ''
-    if internal_secret:
-        now = int(time.time())
-        token = pyjwt.encode(
-            {
-                "userId": "health-check",
-                "aud": "chatbot-ws",
-                "jti": str(uuid.uuid4()),
-                "iat": now,
-                "exp": now + 60,
-            },
-            internal_secret + "aurora:ws-token-signing",
-            algorithm="HS256",
-        )
-        token_qs = f"?token={token}"
-
-    uri = f"ws://{host}:{port}{token_qs}"
-    safe_uri = f"ws://{host}:{port}"
-
     try:
-        async with websockets.connect(uri, ping_interval=None) as websocket:
-            # Send init message
-            await websocket.send(json.dumps({
-                "type": "init",
-                "user_id": "health-check"
-            }))
-
-            # Send a test query
-            await websocket.send(json.dumps({
-                "query": "Hello",
-                "user_id": "health-check",
-                "session_id": "health_check_session"
-            }))
-
-            # Wait for a response
-            response = await asyncio.wait_for(websocket.recv(), timeout=10.0)
-            logger.info(f"Chatbot health check response: {response}")
-            
-            # Simple check for a valid JSON response
-            try:
-                response_data = json.loads(response)
-                if response_data.get("type") == "status" and response_data.get("data", {}).get("status") == "START":
-                    return {"status": "healthy", "message": "Chatbot connection and initial response successful"}
-                return {
-                    "status": "unhealthy",
-                    "error": (
-                        f"Unexpected chatbot response: type={response_data.get('type')!r} "
-                        f"status={response_data.get('data', {}).get('status')!r}"
-                    ),
-                }
-            except json.JSONDecodeError:
-                return {"status": "unhealthy", "error": "Invalid JSON response from chatbot"}
-
-    except asyncio.TimeoutError:
-        return {"status": "unhealthy", "error": f"Timeout waiting for chatbot response at {safe_uri}"}
-    except websockets.exceptions.ConnectionClosed as e:
-        return {"status": "unhealthy", "error": f"Chatbot connection closed unexpectedly at {safe_uri}"}
-    except Exception as e:
-        logger.warning("Chatbot WS health check failed at %s: %s", safe_uri, e)
-        return {
-            "status": "unhealthy",
-            "error": f"Chatbot health check failed at {safe_uri}. "
-                     f"WebSocket port is hardcoded to 5006 — if your chatbot uses a different port, update health_routes.py."
-        }
-
-def check_chatbot_websocket():
-    """Check chatbot WebSocket service by sending a test message."""
-    try:
-        return asyncio.run(send_chatbot_test_message())
-    except Exception as e:
-        logger.warning(f"Chatbot health check failed: {e}")
-        return {"status": "unhealthy", "error": "Chatbot WebSocket health check failed"}
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(3)
+        sock.connect((host, port))
+        sock.close()
+        return {"status": "healthy", "message": f"Chatbot accepting connections on {host}:{port}"}
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        return {"status": "unhealthy", "error": f"Chatbot not reachable at {host}:{port}: {e}"}
 
 
 @health_bp.route('/', methods=['GET'])

--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -118,12 +118,12 @@ def check_chatbot_websocket():
     port = 5006
 
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(3)
-        sock.connect((host, port))
-        sock.close()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(3)
+            sock.connect((host, port))
         return {"status": "healthy", "message": f"Chatbot accepting connections on {host}:{port}"}
     except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        logger.warning(f"Chatbot health check failed at {host}:{port}: {e}")
         return {"status": "unhealthy", "error": f"Chatbot not reachable at {host}:{port}: {e}"}
 
 


### PR DESCRIPTION
## Summary

- **RCA/prediscovery/action sessions incorrectly marked as "failed"** despite completing successfully. The Celery worker child process exits (exitcode 0) during `asyncio.run()` event loop teardown after `_execute_background_chat` returns. Critical state transitions (`completed_successfully = True`, session status update, incident advancement) were placed 150+ lines after `asyncio.run()` and never reached before process death. This affects all background task types, not only MCP-tool-using sessions — production evidence confirms the same crash on sessions using only `cloud_exec` (no MCP subprocess involved).
- **30-60 seconds of dead wait time** after every RCA that used MCP tools (`mcp_get_commit`, `mcp_get_file_contents`). The `_wait_for_ongoing_tool_calls` function polled for a `completed` flag that MCP tools never set (they only call `send_tool_completion` for WebSocket notifications, not `capture_tool_end`).
- **Health check causing thread starvation** — the `/health` endpoint performed a full LLM WebSocket round-trip, blocking Gunicorn threads and triggering full agent workflows for a fake `health-check` user every ~15 seconds.
- **MCP file contents not reaching the LLM** — `mcp_get_file_contents` response parsing didn't handle `resource`-type content items (only checked for top-level `text` field).
- **LLM citing section headers instead of numeric evidence** — the summarization prompt's "AGENT REASONING" section name was being used as a citation target, silently dropping all real citations.

## Changes

| File | Fix |
|------|-----|
| `server/chat/background/task.py` | (1) Move `completed_successfully = True` to immediately after `asyncio.run()` returns. (2) Add full finalization inside `_execute_background_chat` before teardown: mark session 'completed', clear `rca_celery_task_id`, advance incident to 'summarizing', enqueue post-RCA summarization. (3) Add idempotent guards in outer function: `WHERE rca_celery_task_id IS NOT NULL`, check `aurora_status = 'running'` before advancing. |
| `server/chat/backend/agent/workflow.py` | Reduce `_wait_for_ongoing_tool_calls` timeout from 30s to 5s, force-mark stale MCP tool entries as completed after timeout (MCP tools never call `capture_tool_end`) |
| `server/chat/backend/agent/tools/mcp_tools.py` | Handle `resource.text` and `resource.blob` content types in MCP tool responses (aggregate all content items, not just first) |
| `server/chat/background/summarization.py` | Rename "AGENT REASONING" section to "INVESTIGATOR NOTES" with explicit "do NOT cite" instruction, add CITATION RULES block requiring numeric-only citations |
| `server/routes/health_routes.py` | Replace full chatbot WebSocket LLM call with TCP port check to prevent Gunicorn thread starvation |

## Evidence

From production logs — 3 incidents in 4 days (May 22-23) with the same pattern:
```
19:43:56,740 - Workflow completed normally for session e63252f2
19:43:56,770 - Workflow execution completed - all streams and tool calls finished
19:43:56,792 - Extracted 23 tool calls for visualization
19:43:56,899 - WorkerLostError: exitcode 0 Job: 2623
```

The async function completes, but `asyncio.run()` teardown kills the child process before execution returns to the outer function. With the fix, session status and incident advancement are committed inside the async function before teardown begins.

Note: This is NOT specific to MCP subprocess cleanup. Production crash on May 23 19:43 (session e63252f2) used only `cloud_exec` and `save_discovery_finding` — no MCP tools. The process death is a general `asyncio.run()` teardown issue in billiard (Celery) child processes.

## Test plan

- [ ] Trigger incident → RCA completes → session status is "completed" (not "failed")
- [ ] Check celery logs: no `WorkerLostError` on the RCA task
- [ ] Verify "Timed out after 5s, force-marked N tool calls" appears (instead of 30s dead wait)
- [ ] Health endpoint responds quickly without blocking threads or triggering agent workflows
- [ ] Prediscovery task completes → session marked "completed" (same fix path)
- [ ] Action task completes → session marked "completed", action_run marked "success"
- [ ] Incident summary uses numeric citations only (no [Agent Reasoning] or [Investigator Notes])

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool output handling to aggregate all content items, extract nested text, and gracefully handle binary/encoded blobs.
  * Improved tool execution completion detection with faster polling and reliable timeout handling that finalizes stalled calls.

* **Improvements**
  * More robust background task completion and incident lifecycle handling to reduce false-running states and ensure post-run updates.
  * Simplified chatbot health check to a lightweight TCP probe.
  * Refined incident-summary prompts to better separate investigator notes from evidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->