### PR TITLE
fix(frontend): switch dev runtime from bun to node to prevent OOM kills

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,14 @@
 # ============================================
 # Development Stage
 # ============================================
-FROM oven/bun:1.2.22-alpine AS dev
+FROM node:22-alpine AS dev
 
 WORKDIR /app
+
+# Install bun for package management (uses bun.lock)
+RUN apk add --no-cache bash curl && \
+    curl -fsSL https://bun.sh/install | bash && \
+    ln -s /root/.bun/bin/bun /usr/local/bin/bun
 
 # Install dependencies first (will be overridden by volume mount in dev)
 COPY package.json bun.lock ./
@@ -18,7 +23,7 @@ EXPOSE 3000
 
 # Use the same entrypoint as prod to generate env-config.js at startup
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["bun", "run", "dev"]
+CMD ["node", "node_modules/.bin/next", "dev", "--turbopack"]
 
 # ============================================
 # Production Builder Stage

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -23,6 +23,9 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    turbopackMemoryLimit: 512 * 1024 * 1024,
+  },
   cacheMaxMemorySize: 0,
   poweredByHeader: false,
   webpack: (config, { isServer, dev }) => {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -540,6 +540,7 @@ services:
     environment:
       # Next.js development configuration
       NODE_ENV: development
+      NODE_OPTIONS: "--max-old-space-size=1024"
       AURORA_ENV: ${AURORA_ENV}
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"


### PR DESCRIPTION
## Summary

- Switch frontend dev stage from `oven/bun:alpine` to `node:22-alpine` (bun kept for package management)
- Add `experimental.turbopackMemoryLimit: 512MB` in next.config.ts to cap Turbopack cache
- Add `NODE_OPTIONS: --max-old-space-size=1024` in docker-compose.yaml to hard-limit V8 heap

## Root Cause

The Linux OOM killer was targeting the frontend's `bun` process (confirmed via `dmesg`):

```
Out of memory: Killed process 5252 (bun) total-vm:75025492kB, anon-rss:1617560kB
```

Three factors:
1. **Bun's JSC GC** doesn't collect aggressively under memory pressure — process grew from 550MB to 1.6GB
2. **No Turbopack memory limit** — in-memory module graph grew without bound (315 routes, 47K files)
3. **Docker VM has only 7.7GB** for 18 containers totaling 7.4GB at peak — OOM killer chose bun as largest process

Additionally, bun's `v8.getHeapStatistics()` polyfill reports a fake 296MB `heap_size_limit`, which broke Next.js's built-in memory restart (exit code 77 at 80% of heap limit) — it could never trigger correctly.

## Result

| Metric | Before (bun) | After (node) |
|--------|-------------|--------------|
| Startup memory | 548 MB | 244 MB |
| Peak after compilation | 1.6 GB+ (unbounded) | ~800 MB (capped) |
| V8 heap limit | 296 MB (fake polyfill) | 1024 MB (real) |
| Auto-restart at 80% | Broken | Works correctly |

## Test plan

- [x] `docker compose build frontend` succeeds
- [x] Container starts, Next.js compiles and serves pages
- [x] `turbopackMemoryLimit: 536870912` shown in startup logs
- [x] Memory stays bounded after compiling multiple routes
- [x] Process tree: `node next-dev` (PID 1) → `next-server` (child) — proper fork/restart chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration and runtime environment
  * Adjusted memory management settings for the development environment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->