### PR TITLE
fix(docker): remove .next volume breaking hot reload

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -570,7 +570,6 @@ services:
     volumes:
       - ./client:/app
       - /app/node_modules
-      - /app/.next
     depends_on:
       - aurora-server
 


### PR DESCRIPTION
## Summary
- Removed the anonymous Docker volume for `/app/.next` in the frontend service
- This volume persisted stale compiled output across container restarts, preventing Next.js Turbopack from detecting file changes
- Hot reload now works correctly — file edits reflect immediately in the browser

## Test plan
- [ ] `docker compose up -d frontend` and edit any `.tsx` file
- [ ] Verify changes appear in browser without needing `docker compose restart frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Docker Compose configuration for container volume setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->