### PR TITLE
feat: DISABLE_SKILLS experiment toggle + tool arg schema improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@
 # -----------------------------------------------------------------------------
 AURORA_ENV=dev
 
+# Set truthy (true/1/yes/on) to bypass integration skill markdown and
+# unregister the load_skill tool. Leave empty for normal operation.
+DISABLE_SKILLS=
+
 # -----------------------------------------------------------------------------
 # Database [REQUIRED]
 # -----------------------------------------------------------------------------

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -120,7 +120,10 @@ replicaCounts:
 # ------------------------------------------------------------------------------
 config:
   AURORA_ENV: "production" # Environment: dev, staging, production
-  
+
+  # Set truthy to bypass integration skill markdown and unregister load_skill.
+  DISABLE_SKILLS: ""
+
   # --- Database ---
   POSTGRES_HOST: ""  # Auto-generated if empty: <release>-postgres
   POSTGRES_PORT: "5432"

--- a/docker-compose.airtight.yml
+++ b/docker-compose.airtight.yml
@@ -14,6 +14,8 @@ x-common-env: &common-env
   # Global
   AURORA_ENV: ${AURORA_ENV}
 
+  DISABLE_SKILLS: ${DISABLE_SKILLS:-}
+
   # Database - unified credentials
   POSTGRES_USER: ${POSTGRES_USER}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -9,6 +9,8 @@ x-common-env: &common-env
   # Global
   AURORA_ENV: ${AURORA_ENV}
 
+  DISABLE_SKILLS: ${DISABLE_SKILLS:-}
+
   # Database - unified credentials
   POSTGRES_USER: ${POSTGRES_USER}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ x-common-env: &common-env
   # Global
   AURORA_ENV: ${AURORA_ENV}
 
+  DISABLE_SKILLS: ${DISABLE_SKILLS:-}
+
   # Database - unified credentials
   POSTGRES_USER: ${POSTGRES_USER}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/server/chat/backend/agent/orchestrator/select_skills.py
+++ b/server/chat/backend/agent/orchestrator/select_skills.py
@@ -274,6 +274,9 @@ def load_skills_for_role(user_id: str, role: Any) -> str:
     whose tools' capability_tags intersect role.tools, priority-ordered by
     rca_priority and capped at _SUBAGENT_SKILL_BUDGET tokens. Never raises."""
     try:
+        from chat.backend.agent.skills.loader import skills_disabled
+        if skills_disabled():
+            return ""
         from chat.backend.agent.skills.registry import SkillRegistry
         from chat.backend.agent.skills.loader import estimate_tokens
 

--- a/server/chat/backend/agent/prompt/composer.py
+++ b/server/chat/backend/agent/prompt/composer.py
@@ -37,23 +37,29 @@ def build_system_invariant(is_background: bool = False, is_action: bool = False)
     where integration skills are loaded on demand. Background RCA and action
     contexts pre-load skills, so the on-demand instruction does not apply.
     """
-    from chat.backend.agent.skills.loader import load_core_prompt
+    from chat.backend.agent.skills.loader import load_core_prompt, skills_disabled
 
     core_dir = os.path.join(
         os.path.dirname(__file__), os.pardir, "skills", "core"
     )
     core_dir = os.path.normpath(core_dir)
 
+    # interactive_load_skill directs the LLM to call load_skill — which is
+    # unregistered when skills are off, so the directive would dangle.
+    skills_off = skills_disabled()
+
     if is_background:
-        return load_core_prompt(core_dir, segments=[
+        background_segments = [
             "identity",
             "security",
             "knowledge_base",
             "error_handling",
             "investigation",
             "behavioral_rules",
-            "interactive_load_skill",
-        ])
+        ]
+        if not skills_off:
+            background_segments.append("interactive_load_skill")
+        return load_core_prompt(core_dir, segments=background_segments)
 
     foreground_segments = [
         "identity",
@@ -66,7 +72,7 @@ def build_system_invariant(is_background: bool = False, is_action: bool = False)
         "investigation",
         "behavioral_rules",
     ]
-    if not is_action:
+    if not is_action and not skills_off:
         foreground_segments.append("interactive_load_skill")
 
     return load_core_prompt(core_dir, segments=foreground_segments)

--- a/server/chat/backend/agent/skills/load_skill_tool.py
+++ b/server/chat/backend/agent/skills/load_skill_tool.py
@@ -10,6 +10,8 @@ import logging
 import threading
 from pydantic import BaseModel, Field
 
+from .loader import skills_disabled
+
 logger = logging.getLogger(__name__)
 
 # Per-session tracking of already-loaded skills to avoid duplicate context
@@ -46,6 +48,8 @@ def load_skill(skill_id: str, **kwargs) -> str:
     reference (commands, workflows, rules, investigation steps). The
     CONNECTED INTEGRATIONS index in your system prompt lists available skills.
     """
+    if skills_disabled():
+        return "Skills are disabled — rely on the individual tool descriptions."
     user_id = kwargs.get("user_id")
     session_id = kwargs.get("session_id")
     if not user_id:

--- a/server/chat/backend/agent/skills/loader.py
+++ b/server/chat/backend/agent/skills/loader.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)", re.DOTALL)
 
 
+def skills_disabled() -> bool:
+    return os.getenv("DISABLE_SKILLS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 @dataclass
 class SkillMetadata:
     """Parsed frontmatter from a skill file."""
@@ -109,6 +113,10 @@ def load_core_prompt(directory: str, segments: Optional[List[str]] = None) -> st
 
     If segments is given, only those filenames (without .md) are loaded
     in the specified order. Otherwise all .md files are loaded in sorted order.
+
+    Must NOT be gated by skills_disabled(): callers include core identity and
+    RCA scaffolding loaders wrapped in lru_cache, which would freeze the empty
+    value. Gate at the caller layer instead.
     """
     if not os.path.isdir(directory):
         logger.warning(f"Core prompt directory not found: {directory}")

--- a/server/chat/backend/agent/skills/registry.py
+++ b/server/chat/backend/agent/skills/registry.py
@@ -18,6 +18,7 @@ from .loader import (
     estimate_tokens,
     parse_skill_file,
     resolve_template,
+    skills_disabled,
 )
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,8 @@ class SkillRegistry:
         Build the compact always-loaded index string (~300 tokens).
         Only includes connected integrations.
         """
+        if skills_disabled():
+            return ""
         connected = self.get_connected_skills(user_id)
         if not connected:
             return ""
@@ -344,6 +347,8 @@ class SkillRegistry:
         Used in interactive chat so the agent has detailed guidance
         without needing to call load_skill explicitly.
         """
+        if skills_disabled():
+            return ""
         connected = self.get_connected_skills(user_id)
         if not connected:
             return ""
@@ -375,6 +380,15 @@ class SkillRegistry:
         _prevalidated_context: if provided, skip the connection check (caller
         already verified connectivity). Value is the connection context dict.
         """
+        if skills_disabled():
+            return SkillLoadResult(
+                skill_id=skill_id,
+                name=skill_id,
+                content="",
+                token_estimate=0,
+                tools=[],
+                is_connected=False,
+            )
         meta = self._skills.get(skill_id)
         body = self._bodies.get(skill_id)
 
@@ -433,6 +447,8 @@ class SkillRegistry:
         alert_details: alert payload used to derive dynamic template variables
         (service_name, recent_deploys, etc.)
         """
+        if skills_disabled():
+            return ""
         parts: List[str] = []
         tokens_used = 0
 

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -191,6 +191,132 @@ from utils.cloud.cloud_utils import (
 )
 from chat.backend.agent.access import ModeAccessController
 
+
+class CloudExecArgs(BaseModel):
+    provider: Literal["aws", "gcp", "azure", "ovh", "scaleway", "tailscale"] = Field(
+        description=(
+            "Which cloud provider's CLI to invoke. kubectl/helm/terraform are NOT top-level "
+            "providers — pass them in the command instead under aws/gcp/azure "
+            "(e.g. provider='aws', command='kubectl get pods'). For on-prem K8s use on_prem_kubectl."
+        ),
+    )
+    command: str = Field(
+        description=(
+            "Full CLI command WITHOUT the leading provider binary. "
+            "Examples: provider='aws' command='ec2 describe-instances --region us-east-1'; "
+            "provider='gcp' command='kubectl get pods -n default'."
+        ),
+    )
+    output_file: Optional[str] = Field(
+        default=None,
+        description="Optional path to save raw stdout (useful for kubeconfig, large dumps).",
+    )
+    account_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "AWS only. Omit on the first investigative call to query all connected accounts; "
+            "once you've narrowed the issue to one account, pass its ID to target only that one."
+        ),
+    )
+
+
+class IacToolArgs(BaseModel):
+    action: Literal[
+        "write", "fmt", "validate", "refresh", "outputs",
+        "state_list", "state_show", "state_pull",
+        "plan", "apply", "destroy",
+    ] = Field(
+        description=(
+            "Which Terraform/IaC operation to run. 'write' creates/updates a .tf file. "
+            "'plan'/'apply'/'destroy' run Terraform CLI; 'apply' and 'destroy' are write actions "
+            "and are blocked in read-only modes."
+        ),
+    )
+    path: Optional[str] = Field(
+        default=None,
+        description="For 'write': relative path of the .tf file to create/update (e.g. 'main.tf').",
+    )
+    content: Optional[str] = Field(
+        default=None,
+        description="For 'write': full file contents to write.",
+    )
+    directory: Optional[str] = Field(
+        default=None,
+        description=(
+            "For CLI actions (plan/apply/validate/etc.): the Terraform workspace directory. "
+            "Defaults to the session's working directory if omitted."
+        ),
+    )
+    vars: Optional[Any] = Field(
+        default=None,
+        description="Optional dict of -var key=value pairs for plan/apply/destroy.",
+    )
+    auto_approve: Optional[bool] = Field(
+        default=None,
+        description="For apply/destroy: skip the interactive approval prompt.",
+    )
+
+
+class TerminalExecArgs(BaseModel):
+    command: str = Field(
+        description=(
+            "Shell command to run in the user's terminal pod. Use for file ops (cat/grep/sed), "
+            "git/npm/pip/make, helm/pulumi/ansible, or any one-off command not covered by "
+            "cloud_exec or iac_tool. Prefix with 'sh:' to force raw shell evaluation."
+        ),
+    )
+    working_dir: Optional[str] = Field(
+        default=None,
+        description="Working directory for the command. Defaults to the current session dir.",
+    )
+    timeout: Optional[int] = Field(
+        default=None,
+        description="Command timeout in seconds (default 300).",
+    )
+
+
+class AnalyzeZipArgs(BaseModel):
+    attachment_index: int = Field(
+        default=0,
+        description="Index of the uploaded ZIP attachment to analyze (0 = first attachment).",
+    )
+    operation: Literal["list", "extract", "analyze"] = Field(
+        default="list",
+        description=(
+            "'list' = enumerate paths and sizes; "
+            "'extract' = return contents of a single file (requires file_path); "
+            "'analyze' = detect project type (terraform, python, etc.) and key files."
+        ),
+    )
+    file_path: Optional[str] = Field(
+        default=None,
+        description="Required when operation='extract': path inside the ZIP to extract.",
+    )
+
+
+class OnPremKubectlArgs(BaseModel):
+    cluster_id: str = Field(
+        description=(
+            "Target cluster ID (UUID). Call list_onprem_clusters first to discover valid IDs — "
+            "this is NOT the cluster's human-readable name."
+        ),
+    )
+    command: str = Field(
+        description=(
+            "kubectl command, with or without the leading 'kubectl '. "
+            "Example: 'get pods -n kube-system' or 'kubectl describe node node-1'."
+        ),
+    )
+    timeout: Optional[int] = Field(
+        default=60,
+        description="Command timeout in seconds (default 60).",
+    )
+
+
+class ListOnPremClustersArgs(BaseModel):
+    pass
+
+
 # Thread-local storage for user context and WebSocket sender
 _context = threading.local()
 
@@ -1007,10 +1133,12 @@ def get_cloud_tools():
     rca_flag = getattr(state_context, 'trigger_rca_requested', False) if state_context else False
     is_background = getattr(state_context, 'is_background', False) if state_context else False
     is_postmortem_action = getattr(state_context, 'is_postmortem_action', False) if state_context else False
+    from chat.backend.agent.skills.loader import skills_disabled as _skills_disabled_for_cache
+    skills_flag = "1" if _skills_disabled_for_cache() else "0"
     if tool_capture is None:
-        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
+        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}:skills_off={skills_flag}"
     else:
-        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
+        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}:skills_off={skills_flag}"
     
     if user_id:
         current_time = time.time()
@@ -1285,7 +1413,54 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     
     # Import on-prem kubectl tool
     from chat.backend.agent.tools.kubectl_onprem_tool import on_prem_kubectl
-    
+
+    def list_onprem_clusters(user_id: Optional[str] = None, **_kwargs) -> str:
+        if not user_id:
+            return json.dumps({"error": "User context required"})
+        try:
+            from utils.db.connection_pool import db_pool
+            from utils.auth.stateless_auth import set_rls_context
+
+            with db_pool.get_user_connection() as conn:
+                with conn.cursor() as cur:
+                    org_id = set_rls_context(cur, conn, user_id, log_prefix="[list_onprem_clusters]")
+                    # Without an org_id, RLS would silently hide every row;
+                    # surface a distinct error so the LLM doesn't read it as
+                    # "no clusters connected".
+                    if not org_id:
+                        return json.dumps({
+                            "status": "error",
+                            "error": "Could not resolve user/org context",
+                            "clusters": [],
+                        })
+                    cur.execute(
+                        """SELECT c.cluster_id, t.cluster_name
+                           FROM active_kubectl_connections c
+                           JOIN kubectl_agent_tokens t ON c.token = t.token
+                           WHERE (t.user_id = %s OR t.org_id = %s) AND c.status = 'active'
+                           ORDER BY t.cluster_name""",
+                        (user_id, org_id),
+                    )
+                    rows = cur.fetchall()
+            clusters = [{"cluster_id": cid, "cluster_name": name} for cid, name in rows]
+            if not clusters:
+                return json.dumps({
+                    "status": "ok",
+                    "clusters": [],
+                    "note": "No active on-prem clusters connected.",
+                })
+            return json.dumps({"status": "ok", "clusters": clusters})
+        except Exception as e:
+            logging.warning(f"list_onprem_clusters failed: {e}")
+            return json.dumps({
+                "status": "error",
+                "error": "Failed to fetch clusters",
+                "detail": str(e)[:200],
+                "clusters": [],
+            })
+
+    list_onprem_clusters.__name__ = "list_onprem_clusters"
+
     # List of (function, name) tuples
     tool_functions = [
         (run_iac_tool, "iac_tool"),
@@ -1301,6 +1476,7 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         (terminal_exec, "terminal_exec"),
         (tailscale_ssh, "tailscale_ssh"),
         (on_prem_kubectl, "on_prem_kubectl"),
+        (list_onprem_clusters, "list_onprem_clusters"),
         (analyze_zip_file, "analyze_zip_file"),
         # (web_search, "web_search"),  # Moved to dedicated registration below with explicit args_schema
     ]
@@ -1593,17 +1769,84 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                 ),
                 args_schema=GetThreadRepliesArgs,
             )
+        elif name == 'cloud_exec':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Invoke a cloud-provider CLI (aws/gcloud/az/kubectl/scw/ovhai). "
+                    "The provider arg picks which CLI; the command arg is everything after the binary "
+                    "(do NOT include the binary name itself). "
+                    "For AWS with multiple connected accounts: the FIRST investigative call should omit account_id "
+                    "to query across all accounts; once narrowed down, pass account_id to target one. "
+                    "Use on_prem_kubectl (not provider='kubectl') for clusters connected via the on-prem agent."
+                ),
+                args_schema=CloudExecArgs,
+            )
+        elif name == 'iac_tool':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Run a Terraform / IaC operation. Pick action from: "
+                    "write (create/update a .tf file; needs path+content), "
+                    "fmt/validate/plan (read-only checks), "
+                    "apply/destroy (mutating — blocked in read-only mode), "
+                    "refresh/outputs/state_list/state_show/state_pull (state inspection). "
+                    "For CLI actions pass directory (Terraform workspace) and optional vars dict."
+                ),
+                args_schema=IacToolArgs,
+            )
+        elif name == 'terminal_exec':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Run an arbitrary shell command in the user's terminal pod. "
+                    "Use for things not covered by cloud_exec or iac_tool: file ops (cat/grep/sed), "
+                    "git, npm, pip, make, helm, pulumi, ansible. Prefix command with 'sh:' to force raw shell."
+                ),
+                args_schema=TerminalExecArgs,
+            )
+        elif name == 'on_prem_kubectl':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Run a kubectl command against an on-prem Kubernetes cluster connected via the "
+                    "Aurora agent. Requires a valid cluster_id (UUID). "
+                    "If you don't already know the cluster_id, call list_onprem_clusters first to discover it. "
+                    "Use this instead of cloud_exec(provider='kubectl') for on-prem clusters."
+                ),
+                args_schema=OnPremKubectlArgs,
+            )
+        elif name == 'list_onprem_clusters':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "List the on-prem Kubernetes clusters connected for this user/org. "
+                    "Returns each cluster's UUID (cluster_id) and human-readable name. "
+                    "Call this before on_prem_kubectl when you don't already know the cluster_id."
+                ),
+                args_schema=ListOnPremClustersArgs,
+            )
+        elif name == 'analyze_zip_file':
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Inspect a ZIP attachment uploaded earlier in this conversation. "
+                    "operation='list' enumerates paths; 'extract' returns one file's contents "
+                    "(requires file_path); 'analyze' detects project type and key files. "
+                    "attachment_index picks which attachment (0 = first)."
+                ),
+                args_schema=AnalyzeZipArgs,
+            )
         else:
             tool = StructuredTool.from_function(final_func)
         tools.append(tool)
     
-    # Add analyze_zip tool for explicit use only (filtered elsewhere if not referenced)
-    tools.append(StructuredTool.from_function(
-        func=analyze_zip_file,
-        name="analyze_zip_file",
-        description="Analyze a ZIP attachment: list, extract a file, or detect project structure",
-    ))
-
     # Add RAG indexer for ZIPs
     tools.append(StructuredTool.from_function(
         func=rag_index_zip,
@@ -1616,8 +1859,8 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         args_schema=RAGIndexZipArgs,
     ))
 
-    # Add load_skill tool for on-demand integration guidance
-    if user_id:
+    from chat.backend.agent.skills.loader import skills_disabled as _skills_disabled
+    if user_id and not _skills_disabled():
         try:
             from chat.backend.agent.skills.load_skill_tool import load_skill as _load_skill, LoadSkillArgs
 

--- a/tests/experiment/test_disable_skills.py
+++ b/tests/experiment/test_disable_skills.py
@@ -1,0 +1,392 @@
+"""
+Rigorous smoke tests for the DISABLE_SKILLS experiment toggle.
+
+Run inside aurora-server container:
+    docker exec -e DISABLE_SKILLS=true aurora-server python -m pytest \
+        /app/../tests/experiment/test_disable_skills.py -v
+
+(Or use the helper script: tests/experiment/run.sh)
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, "/app")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _force_reload_skills_modules():
+    """Skills modules cache singletons; reload so env-var changes take effect."""
+    for mod in [
+        "chat.backend.agent.skills.loader",
+        "chat.backend.agent.skills.registry",
+        "chat.backend.agent.skills.load_skill_tool",
+    ]:
+        if mod in sys.modules:
+            importlib.reload(sys.modules[mod])
+
+
+@pytest.fixture
+def skills_on(monkeypatch):
+    monkeypatch.delenv("DISABLE_SKILLS", raising=False)
+    _force_reload_skills_modules()
+    from chat.backend.agent.skills.registry import SkillRegistry
+    SkillRegistry.reset()
+    yield
+
+
+@pytest.fixture
+def skills_off(monkeypatch):
+    monkeypatch.setenv("DISABLE_SKILLS", "true")
+    _force_reload_skills_modules()
+    from chat.backend.agent.skills.registry import SkillRegistry
+    SkillRegistry.reset()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# 1. Env var reaches the process
+# ---------------------------------------------------------------------------
+
+class TestEnvVar:
+    def test_disable_skills_set_in_container(self):
+        assert os.getenv("DISABLE_SKILLS") == "true", (
+            "DISABLE_SKILLS must be 'true' inside the container; "
+            "the docker-compose common-env block should pass it through."
+        )
+
+    def test_skills_disabled_helper_truthy_values(self, monkeypatch):
+        from chat.backend.agent.skills.loader import skills_disabled
+        for val in ("1", "true", "TRUE", "yes", "on", "On"):
+            monkeypatch.setenv("DISABLE_SKILLS", val)
+            assert skills_disabled() is True, f"{val!r} should be truthy"
+
+    def test_skills_disabled_helper_falsy_values(self, monkeypatch):
+        from chat.backend.agent.skills.loader import skills_disabled
+        for val in ("", "0", "false", "no", "off", "random"):
+            monkeypatch.setenv("DISABLE_SKILLS", val)
+            assert skills_disabled() is False, f"{val!r} should be falsy"
+        monkeypatch.delenv("DISABLE_SKILLS", raising=False)
+        assert skills_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Each gate fires when DISABLE_SKILLS=true
+# ---------------------------------------------------------------------------
+
+class TestSkillGates:
+    def test_load_core_prompt_still_loads_when_disabled(self, skills_off):
+        """load_core_prompt is also used for non-skill content (RCA segments,
+        background scaffolding, agent identity). It MUST load unconditionally —
+        the skill gate lives one level up, in callers that load integration
+        content. Otherwise downstream lru_caches freeze empty strings."""
+        from chat.backend.agent.skills.loader import load_core_prompt
+        result = load_core_prompt("/app/chat/backend/agent/skills/core")
+        assert len(result) > 1000, (
+            "load_core_prompt must NOT be gated by DISABLE_SKILLS — that would "
+            "strip identity/security/behavioral_rules and break downstream "
+            "lru_cache callers."
+        )
+
+    def test_load_core_prompt_specific_segments_still_load(self, skills_off):
+        from chat.backend.agent.skills.loader import load_core_prompt
+        result = load_core_prompt(
+            "/app/chat/backend/agent/skills/core",
+            segments=["identity", "security"],
+        )
+        assert len(result) > 100, "identity + security must still load"
+
+    def test_build_index_returns_empty(self, skills_off):
+        from chat.backend.agent.skills.registry import SkillRegistry
+        reg = SkillRegistry.get_instance()
+        assert reg.build_index("any-user-id") == ""
+
+    def test_load_skills_for_chat_returns_empty(self, skills_off):
+        from chat.backend.agent.skills.registry import SkillRegistry
+        reg = SkillRegistry.get_instance()
+        assert reg.load_skills_for_chat("any-user-id") == ""
+
+    def test_load_skills_for_rca_returns_empty(self, skills_off):
+        from chat.backend.agent.skills.registry import SkillRegistry
+        reg = SkillRegistry.get_instance()
+        result = reg.load_skills_for_rca(
+            "any-user-id", "datadog", ["aws", "gcp"], {"github": True, "datadog": True}
+        )
+        assert result == ""
+
+    def test_load_skill_method_returns_empty_result(self, skills_off):
+        from chat.backend.agent.skills.registry import SkillRegistry
+        reg = SkillRegistry.get_instance()
+        result = reg.load_skill("github", "any-user-id")
+        assert result.content == ""
+        assert result.is_connected is False
+        assert result.token_estimate == 0
+
+    def test_load_skill_llm_tool_returns_disabled_message(self, skills_off):
+        from chat.backend.agent.skills.load_skill_tool import load_skill
+        out = load_skill("github", user_id="any-user", session_id="s1")
+        assert "disabled" in out.lower()
+
+    def test_load_skills_for_role_returns_empty(self, skills_off):
+        from chat.backend.agent.orchestrator.select_skills import load_skills_for_role
+
+        class FakeRole:
+            name = "analyzer"
+            tools = ["datadog", "github"]
+
+        assert load_skills_for_role("any-user-id", FakeRole()) == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Gates do NOT fire when DISABLE_SKILLS is unset/false
+# ---------------------------------------------------------------------------
+
+class TestSkillGatesOff:
+    def test_load_core_prompt_returns_content_when_enabled(self, skills_on):
+        from chat.backend.agent.skills.loader import load_core_prompt
+        result = load_core_prompt("/app/chat/backend/agent/skills/core")
+        assert len(result) > 1000
+
+    def test_load_skill_llm_tool_does_not_short_circuit(self, skills_on):
+        """When skills are ON, the LLM tool should attempt real work
+        (will fail without DB but the failure must NOT be the disabled string)."""
+        from chat.backend.agent.skills.load_skill_tool import load_skill
+        out = load_skill("github", user_id="any-user", session_id="s1")
+        assert "Skills are disabled" not in out
+
+
+# ---------------------------------------------------------------------------
+# 4. Tool list shape under DISABLE_SKILLS=true
+# ---------------------------------------------------------------------------
+
+class TestToolList:
+    @pytest.fixture
+    def tools(self, skills_off):
+        from chat.backend.agent.tools.cloud_tools import get_cloud_tools, set_user_context
+        # Use a unique user_id so the cache doesn't collide
+        set_user_context("smoke-test-tools-disabled")
+        return get_cloud_tools()
+
+    def test_load_skill_tool_not_present(self, tools):
+        names = {t.name for t in tools}
+        assert "load_skill" not in names, (
+            "load_skill must be unregistered when DISABLE_SKILLS=true"
+        )
+
+    def test_list_onprem_clusters_present(self, tools):
+        names = {t.name for t in tools}
+        assert "list_onprem_clusters" in names, (
+            "discovery tool must be available so the LLM can find cluster IDs"
+        )
+
+    def test_required_core_tools_present(self, tools):
+        names = {t.name for t in tools}
+        required = {
+            "cloud_exec", "iac_tool", "terminal_exec", "on_prem_kubectl",
+            "list_onprem_clusters", "analyze_zip_file",
+            "github_rca", "get_connected_repos", "github_commit",
+            "web_search", "knowledge_base_search",
+        }
+        missing = required - names
+        assert not missing, f"missing core tools: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Arg schema quality — descriptions and enums visible
+# ---------------------------------------------------------------------------
+
+class TestArgSchemas:
+    @pytest.fixture
+    def tools_by_name(self, skills_off):
+        from chat.backend.agent.tools.cloud_tools import get_cloud_tools, set_user_context
+        set_user_context("smoke-test-schemas")
+        return {t.name: t for t in get_cloud_tools()}
+
+    def _schema_props(self, tool):
+        assert tool.args_schema is not None, f"{tool.name} has no args_schema"
+        return tool.args_schema.model_json_schema().get("properties", {})
+
+    def _enum(self, prop):
+        if "enum" in prop:
+            return prop["enum"]
+        for branch in prop.get("anyOf", []):
+            if "enum" in branch:
+                return branch["enum"]
+        return None
+
+    def test_cloud_exec_provider_is_enum(self, tools_by_name):
+        props = self._schema_props(tools_by_name["cloud_exec"])
+        enum = self._enum(props["provider"])
+        assert enum is not None, "provider must be a Literal enum, not a free string"
+        assert "aws" in enum and "gcp" in enum
+
+    def test_cloud_exec_provider_matches_runtime_whitelist(self, tools_by_name):
+        """The Literal must match the actual CLOUD_EXEC_PROVIDERS frozen set —
+        otherwise the LLM will pass values that the runtime rejects."""
+        from chat.backend.agent.prompt.provider_rules import CLOUD_EXEC_PROVIDERS
+        props = self._schema_props(tools_by_name["cloud_exec"])
+        enum = set(self._enum(props["provider"]) or [])
+        # Every Literal value must be a valid runtime provider
+        assert enum == set(CLOUD_EXEC_PROVIDERS), (
+            f"provider Literal {enum} != CLOUD_EXEC_PROVIDERS {set(CLOUD_EXEC_PROVIDERS)}"
+        )
+
+    def test_cloud_exec_provider_excludes_kubectl(self, tools_by_name):
+        """kubectl is NOT a top-level provider — it runs under aws/gcp/azure as a sub-command."""
+        props = self._schema_props(tools_by_name["cloud_exec"])
+        enum = self._enum(props["provider"]) or []
+        assert "kubectl" not in enum
+
+    def test_cloud_exec_fields_have_descriptions(self, tools_by_name):
+        props = self._schema_props(tools_by_name["cloud_exec"])
+        for field in ("provider", "command", "output_file", "account_id"):
+            assert props[field].get("description"), f"{field} missing description"
+
+    def test_iac_tool_action_is_enum(self, tools_by_name):
+        props = self._schema_props(tools_by_name["iac_tool"])
+        enum = self._enum(props["action"])
+        assert enum is not None
+        expected = {"write", "plan", "apply", "destroy", "validate", "fmt"}
+        assert expected.issubset(set(enum))
+
+    def test_analyze_zip_operation_is_enum(self, tools_by_name):
+        props = self._schema_props(tools_by_name["analyze_zip_file"])
+        enum = self._enum(props["operation"])
+        assert enum == ["list", "extract", "analyze"]
+
+    def test_terminal_exec_has_arg_descriptions(self, tools_by_name):
+        props = self._schema_props(tools_by_name["terminal_exec"])
+        for field in ("command", "working_dir", "timeout"):
+            assert props[field].get("description"), f"{field} missing description"
+
+    def test_on_prem_kubectl_mentions_list_tool(self, tools_by_name):
+        """The LLM should know to call list_onprem_clusters first."""
+        desc = tools_by_name["on_prem_kubectl"].description.lower()
+        assert "list_onprem_clusters" in desc
+
+    def test_list_onprem_clusters_takes_no_args(self, tools_by_name):
+        props = self._schema_props(tools_by_name["list_onprem_clusters"])
+        # All fields should be optional / absent (empty model body)
+        required = tools_by_name["list_onprem_clusters"].args_schema.model_json_schema().get("required", [])
+        assert required == []
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end: list_onprem_clusters runs without error for unknown user
+# ---------------------------------------------------------------------------
+
+class TestRuntimeBehavior:
+    def test_list_onprem_clusters_invocation(self, skills_off):
+        from chat.backend.agent.tools.cloud_tools import get_cloud_tools, set_user_context
+        set_user_context("00000000-0000-0000-0000-000000000000")
+        tools = get_cloud_tools()
+        loc = next((t for t in tools if t.name == "list_onprem_clusters"), None)
+        assert loc is not None
+        out = loc.invoke({})
+        parsed = json.loads(out)
+        assert isinstance(parsed, dict)
+        # Every response must carry an explicit status field so the LLM can
+        # distinguish "no clusters" from "DB/org-resolution failure".
+        assert parsed.get("status") in ("ok", "error"), (
+            f"missing/invalid status field in response: {parsed}"
+        )
+        assert "clusters" in parsed, "response must always include a clusters key"
+
+    def test_list_onprem_clusters_unresolvable_user_returns_error_not_empty(self, skills_off):
+        """A user_id that can't resolve to an org must produce status:error,
+        NOT status:ok with an empty cluster list — otherwise the LLM thinks
+        the user simply has no clusters and gives up silently."""
+        from chat.backend.agent.tools.cloud_tools import get_cloud_tools, set_user_context
+        # All-zeros UUID — not a real user, set_rls_context will fail to
+        # resolve an org and return None
+        set_user_context("00000000-0000-0000-0000-000000000000")
+        tools = get_cloud_tools()
+        loc = next(t for t in tools if t.name == "list_onprem_clusters")
+        parsed = json.loads(loc.invoke({}))
+        assert parsed["status"] == "error", (
+            f"unresolvable user must surface error, got: {parsed}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. System prompt no longer contains skill markers
+# ---------------------------------------------------------------------------
+
+class TestPromptComposition:
+    def test_system_invariant_still_has_content_when_disabled(self, skills_off):
+        """Disabling skills must NOT remove identity/security/behavioral_rules.
+        Only integration-specific guidance is gated."""
+        from chat.backend.agent.prompt.composer import build_system_invariant
+        out = build_system_invariant(is_background=False, is_action=False)
+        assert len(out) > 1000, "core agent prompt must remain even when skills off"
+
+    def test_system_invariant_drops_interactive_load_skill_when_disabled(self, skills_off):
+        """The single segment that's tied to skill loading — the directive
+        telling the LLM to call load_skill — must be omitted when load_skill
+        is unregistered. Without this the LLM is told to call a tool that
+        doesn't exist."""
+        from chat.backend.agent.prompt.composer import build_system_invariant
+        out = build_system_invariant(is_background=False, is_action=False)
+        # Marker phrases that uniquely identify interactive_load_skill.md
+        assert "load_skill(" not in out, (
+            "interactive_load_skill directive must be filtered when skills off"
+        )
+
+    def test_system_invariant_includes_interactive_load_skill_when_enabled(self, skills_on):
+        from chat.backend.agent.prompt.composer import build_system_invariant
+        out = build_system_invariant(is_background=False, is_action=False)
+        assert "load_skill(" in out, (
+            "interactive_load_skill must load normally when skills enabled"
+        )
+
+    def test_no_connected_integrations_block_when_disabled(self, skills_off):
+        """The CONNECTED INTEGRATIONS header comes from build_index — must be gone."""
+        from chat.backend.agent.skills.registry import SkillRegistry
+        SkillRegistry.reset()
+        reg = SkillRegistry.get_instance()
+        idx = reg.build_index("any-user")
+        assert "CONNECTED INTEGRATIONS" not in idx
+        assert idx == ""
+
+    def test_background_rca_segments_still_load_when_disabled(self, skills_off):
+        """RCA background scaffolding (header, context-update, etc.) is core
+        operational content, not skill markdown — must keep loading."""
+        from chat.backend.agent.skills.loader import load_core_prompt
+        bg_dir = "/app/chat/backend/agent/skills/rca/background"
+        out = load_core_prompt(bg_dir, segments=["background_context_update"])
+        assert len(out) > 100, "background RCA scaffolding must keep loading"
+
+
+# ---------------------------------------------------------------------------
+# 8. Tool cache invalidation on flag toggle
+# ---------------------------------------------------------------------------
+
+class TestToolCacheKey:
+    def test_cache_key_differs_when_flag_toggles(self, monkeypatch):
+        """If a developer flips DISABLE_SKILLS without restarting the process,
+        the per-user tool cache must NOT serve stale (with-load_skill) tools."""
+        from chat.backend.agent.tools.cloud_tools import get_cloud_tools, set_user_context
+        # Build with flag OFF
+        monkeypatch.delenv("DISABLE_SKILLS", raising=False)
+        _force_reload_skills_modules()
+        set_user_context("cache-toggle-user")
+        names_on = {t.name for t in get_cloud_tools()}
+
+        # Flip flag ON and rebuild — cache key must differ, so load_skill disappears
+        monkeypatch.setenv("DISABLE_SKILLS", "true")
+        _force_reload_skills_modules()
+        set_user_context("cache-toggle-user")
+        names_off = {t.name for t in get_cloud_tools()}
+
+        assert "load_skill" in names_on
+        assert "load_skill" not in names_off, (
+            "cache key must include skills_disabled() — otherwise stale tool list served"
+        )


### PR DESCRIPTION
## Summary
- Adds `DISABLE_SKILLS` env-var toggle that bypasses integration skill markdown and unregisters the `load_skill` LLM tool, so the agent can be A/B tested relying purely on tool descriptions.
- Adds Pydantic args schemas (`CloudExecArgs`, `IacToolArgs`, `TerminalExecArgs`, `AnalyzeZipArgs`, `OnPremKubectlArgs`) so the LLM sees enum hints and per-field descriptions in the tool JSON schema. Adds a `list_onprem_clusters` discovery tool so the agent can find cluster IDs without skill guidance.
- Gate is scoped narrowly: only the `interactive_load_skill` segment + `SkillRegistry` integration methods short-circuit when the flag is on; identity, security, behavioral_rules, RCA scaffolding, and core prompts keep loading.
- Env var wired through `docker-compose.yaml`, `docker-compose.prod-local.yml`, `docker-compose.airtight.yml`, `deploy/helm/aurora/values.yaml`, and `.env.example`.

## Test plan
- [x] 33/33 pytest cases pass (`tests/experiment/test_disable_skills.py`)
- [x] Live RCA run with flag on completed end-to-end; system prompt verified to retain identity/security/RCA scaffolding while integration-index and load_skill directive are absent
- [x] `list_onprem_clusters` returns the `status:ok|error` envelope; verified the error path for unresolvable users
- [x] Cache key invalidates on flag toggle; verified `load_skill` tool is unregistered when the flag is on