### PR TITLE
feat: add CloudWatch alarm webhook connector

### DIFF
--- a/client/src/app/aws/onboarding/page.tsx
+++ b/client/src/app/aws/onboarding/page.tsx
@@ -32,6 +32,8 @@ import {
 import ConnectorAuthGuard from "@/components/connectors/ConnectorAuthGuard";
 import { copyToClipboard } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
+import { Switch } from '@/components/ui/switch';
+import { useQuery, queryClient, jsonFetcher, fetchR } from '@/lib/query';
 
 interface OnboardingData {
   workspaceId: string;
@@ -113,6 +115,157 @@ function RoleTypeToggle({ value, onChange }: { value: 'ReadOnly' | 'Admin'; onCh
       <span className={`text-xs transition-colors duration-200 ${value === 'Admin' ? 'text-amber-400/70' : 'text-white/30'}`}>
         {value === 'Admin' ? 'Full access' : 'Observation only'}
       </span>
+    </div>
+  );
+}
+
+function CloudWatchAlertToggle() {
+  const { toast } = useToast();
+  const [toggling, setToggling] = React.useState(false);
+  const [copySuccess, setCopySuccess] = React.useState(false);
+
+  const { data: statusData, isLoading: loading } = useQuery<{ connected: boolean }>(
+    '/api/proxy/aws/cloudwatch/status',
+    jsonFetcher,
+    {
+      staleTime: 10_000,
+      revalidateOnFocus: true,
+      revalidateOnEvents: ['cloudwatchStateChanged'],
+    },
+  );
+
+  const enabled = statusData?.connected ?? false;
+
+  const { data: webhookData, isLoading: webhookLoading } = useQuery<{ webhookUrl?: string }>(
+    enabled ? '/api/proxy/aws/cloudwatch/webhook-url' : null,
+    jsonFetcher,
+    {
+      staleTime: 60_000,
+      revalidateOnEvents: ['cloudwatchStateChanged'],
+    },
+  );
+
+  const webhookUrl = webhookData?.webhookUrl ?? null;
+
+  const handleToggle = async (checked: boolean) => {
+    setToggling(true);
+    try {
+      if (checked) {
+        const res = await fetchR('/api/proxy/aws/cloudwatch/connect', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to connect');
+      } else {
+        const res = await fetchR('/api/proxy/aws/cloudwatch/disconnect', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to disconnect');
+      }
+      queryClient.invalidate('/api/proxy/aws/cloudwatch/status', jsonFetcher);
+      globalThis.dispatchEvent(new Event('cloudwatchStateChanged'));
+    } catch {
+      toast({ title: 'Failed to update CloudWatch settings.', variant: 'destructive' });
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleCopy = () => {
+    if (!webhookUrl) return;
+    copyToClipboard(webhookUrl);
+    setCopySuccess(true);
+    setTimeout(() => setCopySuccess(false), 2000);
+  };
+
+  return (
+    <div className="space-y-3 bg-white/5 border border-white/10 rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-white/70">CloudWatch Alerts</p>
+          <p className="text-xs text-white/40 mt-0.5">Receive CloudWatch alarm notifications via SNS webhook</p>
+        </div>
+        {loading ? (
+          <Loader2 className="w-4 h-4 animate-spin text-white/30" />
+        ) : (
+          <Switch
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            disabled={toggling}
+            className="data-[state=checked]:bg-emerald-500"
+          />
+        )}
+      </div>
+
+      {enabled && (
+        <div className="space-y-2 pt-2 border-t border-white/10">
+          {webhookUrl ? (
+            <>
+              <p className="text-xs text-white/50">SNS subscription endpoint</p>
+              <div className="flex gap-2 items-center">
+                <code className="flex-1 bg-black/40 border border-white/10 rounded px-3 py-2 text-xs text-white/70 font-mono truncate">
+                  {webhookUrl}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopy}
+                  className="border-white/10 hover:bg-white/5 text-white/70 h-8 w-8 shrink-0"
+                >
+                  {copySuccess ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+                </Button>
+              </div>
+              <p className="text-xs text-white/30">
+                Create an SNS HTTPS subscription pointing at this URL, then attach that topic to your CloudWatch alarms.
+              </p>
+              {/* Step-by-step setup guide */}
+              <div className="bg-black/20 border border-white/5 rounded-lg p-3 mt-2 space-y-2">
+                <p className="text-xs font-medium text-white/60">
+                  How to connect CloudWatch alarms via SNS
+                </p>
+                <ol className="space-y-2 text-xs text-white/50 list-decimal list-inside">
+                  <li>
+                    In the <strong className="text-white/70">AWS Console</strong>, go to{" "}
+                    <strong className="text-white/70">Amazon SNS → Topics</strong> and
+                    create a new <strong className="text-white/70">Standard</strong> topic
+                    (e.g. <code className="bg-black/50 px-1 rounded">aurora-cloudwatch-alerts</code>).
+                  </li>
+                  <li>
+                    Open the topic and click{" "}
+                    <strong className="text-white/70">Create subscription</strong>. Set
+                    Protocol to <strong className="text-white/70">HTTPS</strong> and paste
+                    the URL above as the Endpoint. Aurora will automatically confirm the
+                    subscription.
+                  </li>
+                  <li>
+                    Go to{" "}
+                    <strong className="text-white/70">CloudWatch → Alarms</strong>, edit
+                    each alarm you want to monitor. Under{" "}
+                    <strong className="text-white/70">Notification</strong>, add an action
+                    to send to the SNS topic you created — do this for{" "}
+                    <em>In alarm</em>, <em>OK</em>, and{" "}
+                    <em>Insufficient data</em> states.
+                  </li>
+                  <li>
+                    Save the alarm. When it next transitions to{" "}
+                    <strong className="text-white/70">ALARM</strong> state, Aurora will
+                    receive the alert and start an RCA investigation automatically.
+                  </li>
+                </ol>
+                <p className="text-[10px] text-white/30 pt-1">
+                  Aurora automatically confirms the SNS subscription when AWS first sends
+                  the <code className="bg-black/30 px-0.5 rounded">SubscriptionConfirmation</code>{" "}
+                  request — no manual action needed.
+                </p>
+              </div>
+            </>
+          ) : (
+            <button
+              onClick={() => queryClient.invalidate('/api/proxy/aws/cloudwatch/webhook-url', jsonFetcher)}
+              disabled={webhookLoading}
+              className="flex items-center gap-1.5 text-xs text-white/50 hover:text-white disabled:opacity-50"
+            >
+              {webhookLoading && <Loader2 className="w-3 h-3 animate-spin" />}
+              {webhookLoading ? 'Loading…' : 'Show webhook URL'}
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -321,7 +474,7 @@ export default function AWSOnboardingPage() {
       await fetchOnboardingData();
       setIsConfigured(true);
       localStorage.setItem("aurora_graph_discovery_trigger", "1");
-      window.dispatchEvent(new CustomEvent('providerStateChanged'));
+      globalThis.dispatchEvent(new CustomEvent('providerStateChanged'));
 
     } catch (err) {
       console.error("Failed to set role:", err);
@@ -351,7 +504,7 @@ export default function AWSOnboardingPage() {
       localStorage.removeItem('isAWSFetched');
       // Notify other components to refresh (chat bar, connectors page, etc.)
       if (typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('providerStateChanged'));
+        globalThis.dispatchEvent(new CustomEvent('providerStateChanged'));
       }
       // Refresh onboarding data
       await fetchOnboardingData();
@@ -478,7 +631,7 @@ export default function AWSOnboardingPage() {
       localStorage.setItem('cloudProvider', 'aws');
       await fetchConnectedAccounts();
       await fetchInactiveAccounts();
-      window.dispatchEvent(new CustomEvent('providerStateChanged'));
+      globalThis.dispatchEvent(new CustomEvent('providerStateChanged'));
     } catch (err) {
       console.error('Reconnect error:', err);
       setError('Failed to reconnect. Check your network connection and try again.');
@@ -552,7 +705,7 @@ export default function AWSOnboardingPage() {
         setIsConfigured(true);
         localStorage.setItem('isAWSConnected', 'true');
         localStorage.setItem('cloudProvider', 'aws');
-        window.dispatchEvent(new CustomEvent('providerStateChanged'));
+        globalThis.dispatchEvent(new CustomEvent('providerStateChanged'));
       }
     } catch (err) {
       console.error('Bulk register error:', err);
@@ -1197,6 +1350,9 @@ make dev`}</pre>
                   )}
                 </div>
               )}
+
+              {/* CloudWatch Alerts */}
+              <CloudWatchAlertToggle />
 
               <Button onClick={handleComplete} className="w-full bg-white text-black hover:bg-white/90 h-11">
                 Back to Connectors

--- a/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
+++ b/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { CorrelatedAlert, incidentsService } from '@/lib/services/incidents';
+import { CorrelatedAlert, incidentsService, getSourceIconSrc, getSourceIconBgColor } from '@/lib/services/incidents';
 import { ChevronDown, Link2, Clock, Server, Zap, Target, Type } from 'lucide-react';
 import Image from 'next/image';
 
@@ -82,12 +82,12 @@ function CorrelatedAlertCard({ alert, isNew }: { alert: CorrelatedAlert; isNew: 
         {/* Source icon */}
         {alert.sourceType !== 'chat' && (
           <div className="flex-shrink-0 mt-0.5">
-            <Image 
-              src={`/${alert.sourceType}.svg`}
+            <Image
+              src={getSourceIconSrc(alert.sourceType)!}
               alt={alert.sourceType}
               width={18}
               height={18}
-              className={`object-contain opacity-70${alert.sourceType === 'bigpanda' ? ' bg-white rounded-sm p-0.5' : ''}`}
+              className={`${getSourceIconBgColor(alert.sourceType)} opacity-70`}
             />
           </div>
         )}

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Incident, AuroraStatus, Citation, incidentsService } from '@/lib/services/incidents';
+import { Incident, AuroraStatus, Citation, Suggestion, incidentsService, getSourceIconSrc, getSourceIconBgColor } from '@/lib/services/incidents';
 import { Badge } from '@/components/ui/badge';
 import {
   ExternalLink,
@@ -33,7 +33,6 @@ import IncidentFeedback from './IncidentFeedback';
 import CorrelatedAlertsSection from './CorrelatedAlertsSection';
 import RecentAlertsSection from './RecentAlertsSection';
 import PostmortemPanel from './PostmortemPanel';
-import { Suggestion } from '@/lib/services/incidents';
 import InfrastructureVisualization from '@/components/incidents/InfrastructureVisualization';
 import ExecutionWaterfall from './ExecutionWaterfall';
 import { ReactFlowProvider } from '@xyflow/react';
@@ -121,7 +120,8 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
   const { user } = useUser();
   const canWrite = checkCanWrite(user?.role);
   const showSeverity = (alert.severity && (alert.severity as string) !== 'unknown') || incident.status === 'analyzed';
-  const sourceIconSrc = alert.source === 'chat' ? null : `/${alert.source}.svg`;
+  const sourceIconSrc = getSourceIconSrc(alert.source);
+  const sourceIconBgColor = getSourceIconBgColor(alert.source);
 
   const [justResolved, setJustResolved] = useState(false);
 
@@ -392,7 +392,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
                   alt={alert.source}
                   width={20}
                   height={20}
-                  className={`object-contain${alert.source === 'bigpanda' ? ' bg-white rounded-sm p-0.5' : ''}`}
+                  className={sourceIconBgColor}
                 />
               )}
               {isSafeUrl(alert.sourceUrl) ? (

--- a/client/src/app/incidents/components/RecentAlertsSection.tsx
+++ b/client/src/app/incidents/components/RecentAlertsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { RecentIncident, incidentsService, AuroraStatus } from '@/lib/services/incidents';
+import { RecentIncident, incidentsService, AuroraStatus, getSourceIconSrc, getSourceIconBgColor } from '@/lib/services/incidents';
 import { ChevronDown, Clock, Server, ArrowRight, Loader2, Check, X } from 'lucide-react';
 import Image from 'next/image';
 
@@ -29,11 +29,11 @@ function RecentAlertCard({
         {incident.sourceType !== 'chat' && (
           <div className="flex-shrink-0 mt-0.5 opacity-50">
             <Image 
-              src={`/${incident.sourceType}.svg`}
+              src={getSourceIconSrc(incident.sourceType)!}
               alt={incident.sourceType}
               width={16}
               height={16}
-              className={`object-contain${incident.sourceType === 'bigpanda' ? ' bg-white rounded-sm p-0.5' : ''}`}
+              className={getSourceIconBgColor(incident.sourceType)}
             />
           </div>
         )}

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -22,12 +22,13 @@ import { useToast } from '@/hooks/use-toast';
 
 const ALERT_CATEGORIES = new Set(['Monitoring', 'Incident Management']);
 
-const ALERT_PROVIDERS = new Set(
-  connectorRegistry
+const ALERT_PROVIDERS = new Set([
+  ...connectorRegistry
     .getAll()
     .filter(c => c.category && ALERT_CATEGORIES.has(c.category))
     .map(c => c.id),
-);
+  'aws',
+]);
 
 interface IncidentsResponse { incidents: any[] }
 

--- a/client/src/components/connectors/ConnectorRegistry.ts
+++ b/client/src/components/connectors/ConnectorRegistry.ts
@@ -138,6 +138,17 @@ class ConnectorRegistry {
       });
 
     this.register({
+      id: "cloudwatch",
+      name: "CloudWatch",
+      description: "Receive Amazon CloudWatch alarm notifications via SNS webhooks. Alarm state changes automatically create incidents and trigger root cause analysis.",
+      iconPath: "/aws.ico",
+      iconBgColor: "bg-white dark:bg-white",
+      category: "Monitoring",
+      path: "/aws/onboarding",
+      storageKey: "isCloudWatchConnected",
+    });
+
+    this.register({
       id: "pagerduty",
       name: "PagerDuty",
       description: "Connect PagerDuty to receive incident alerts and manage on-call schedules. Integrate with your PagerDuty account for real-time incident management.",

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -8,7 +8,20 @@ import { apiGet, apiPost, apiRequest, type ApiError } from '@/lib/services/api-c
 // streaming thoughts, and copy-pasteable post-mortems
 // ============================================================================
 
-export type AlertSource = 'netdata' | 'datadog' | 'grafana' | 'prometheus' | 'pagerduty' | 'splunk' | 'dynatrace' | 'coroot' | 'bigpanda' | 'chat';
+export type AlertSource = 'netdata' | 'datadog' | 'grafana' | 'prometheus' | 'pagerduty' | 'splunk' | 'dynatrace' | 'coroot' | 'bigpanda' | 'cloudwatch' | 'chat';
+
+export function getSourceIconSrc(source: string): string | null {
+  if (source === 'chat') return null;
+  if (source === 'cloudwatch') return '/aws.ico';
+  return `/${source}.svg`;
+}
+
+const _WHITE_BG_ICONS = new Set(['bigpanda', 'cloudwatch']);
+
+export function getSourceIconBgColor(source: string): string {
+  return `object-contain${_WHITE_BG_ICONS.has(source) ? ' bg-white rounded-sm p-0.5' : ''}`;
+}
+
 export type IncidentStatus = 'investigating' | 'analyzed' | 'merged' | 'resolved';
 export type AuroraStatus = 'running' | 'summarizing' | 'complete' | 'error';
 export type SuggestionRisk = 'safe' | 'low' | 'medium' | 'high';

--- a/server/celery_config.py
+++ b/server/celery_config.py
@@ -94,6 +94,7 @@ celery_app.conf.update(
         'routes.knowledge_base.tasks',
         'services.discovery.tasks',
         'utils.aws.credential_refresh',
+        'routes.aws.cloudwatch_tasks',
         'tasks.github_webhook_tasks',
         'routes.github.github_repo_metadata',
         'services.actions.scheduler',

--- a/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
@@ -51,8 +51,8 @@ The agent must never write or modify CloudWatch alarms during RCA.
 
 ## Alarm State Mapping
 
-| CloudWatch State | Aurora Severity |
+| CloudWatch State | Aurora Behavior |
 |---|---|
-| ALARM | high (critical if "critical" in alarm name) |
-| INSUFFICIENT_DATA | medium |
-| OK | low (resolution) |
+| ALARM | Creates incident — severity **high** (or **critical** if "critical" in alarm name) |
+| INSUFFICIENT_DATA | Creates incident — severity **medium** |
+| OK | Resolves matching open incident (no new incident created) |

--- a/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: cloudwatch
+id: cloudwatch
+description: "Amazon CloudWatch alarm integration — receives alarm state-change notifications via SNS webhooks and creates incidents automatically"
+category: observability
+connection_check:
+  method: provider_in_preference
+  provider_key: cloudwatch
+tools: []
+index: "CloudWatch — observation-only alarm ingestion via SNS webhook, no CLI tools"
+rca_priority: 30
+allowed-tools: ""
+metadata:
+  author: aurora
+  version: "1.0"
+---
+
+# CloudWatch Integration
+
+## Overview
+
+Amazon CloudWatch alarm integration. Aurora receives alarm state-change notifications from CloudWatch via AWS SNS webhooks and creates incidents automatically.
+
+## Instructions
+
+### IMPORTANT — NO CLI SUPPORT
+
+- Do NOT use `cloud_exec('cloudwatch', ...)` — there is no CloudWatch CLI connector.
+- You CAN use `cloud_exec('aws', ...)` to query CloudWatch metrics and logs via the AWS CLI.
+
+### WHAT YOU CAN DO
+
+- **Investigate infrastructure**: If an alarm references a specific AWS resource (EC2, RDS, Lambda, EKS),
+  use the AWS cloud provider tool (`cloud_exec` with 'aws') to investigate.
+
+### CRITICAL RULES
+
+- NEVER call cloud_exec with provider='cloudwatch' — it will fail.
+- Use the alert context already available in the conversation.
+- For deeper investigation, use the AWS provider tools for the affected resource.
+
+## RCA Investigation Workflow (read-only)
+
+During RCA the agent may:
+- Query CloudWatch alarms history for the affected account/region
+- Cross-reference with EC2, RDS, Lambda, EKS metrics for the affected resource
+- Look up related incidents with the same alarm_name
+- Check AWS CloudWatch Logs for errors near the alarm fire time
+
+The agent must never write or modify CloudWatch alarms during RCA.
+
+## Alarm State Mapping
+
+| CloudWatch State | Aurora Severity |
+|---|---|
+| ALARM | high (critical if "critical" in alarm name) |
+| INSUFFICIENT_DATA | medium |
+| OK | low (resolution) |

--- a/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/cloudwatch/SKILL.md
@@ -54,5 +54,5 @@ The agent must never write or modify CloudWatch alarms during RCA.
 | CloudWatch State | Aurora Behavior |
 |---|---|
 | ALARM | Creates incident — severity **high** (or **critical** if "critical" in alarm name) |
-| INSUFFICIENT_DATA | Creates incident — severity **medium** |
+| INSUFFICIENT_DATA | No incident created (state recorded only) |
 | OK | Resolves matching open incident (no new incident created) |

--- a/server/chat/background/rca_prompt_builder.py
+++ b/server/chat/background/rca_prompt_builder.py
@@ -587,6 +587,56 @@ def build_rca_prompt(
     return "\n".join(prompt_parts), build_alert_rail_text(alert_details)
 
 
+def _format_cloudwatch_dimensions(dimensions: list) -> str:
+    """Format CloudWatch trigger dimensions into a comma-separated string."""
+    parts = []
+    for d in dimensions:
+        if not isinstance(d, dict):
+            continue
+        name = d.get('name') or d.get('Name')
+        value = d.get('value') or d.get('Value')
+        if name and value:
+            parts.append(f"{name}={value}")
+    return ", ".join(parts)
+
+
+def _build_cloudwatch_message(namespace: str, metric_name: str, reason: str, dim_str: str) -> str:
+    """Compose the CloudWatch alert message from metric info and reason."""
+    message = reason
+    if namespace and metric_name:
+        message = f"Metric: {namespace}/{metric_name}. {reason}"
+    if dim_str:
+        message += f" Dimensions: {dim_str}."
+    return message.strip()
+
+
+def build_cloudwatch_rca_prompt(
+    payload: Dict[str, Any],
+    providers: Optional[List[str]] = None,
+    user_id: Optional[str] = None,
+) -> tuple[str, str]:
+    """Build RCA prompt from a CloudWatch alarm payload."""
+    alarm_name = payload.get("AlarmName") or "Unknown Alarm"
+    state_value = payload.get("NewStateValue") or payload.get("state_value") or "ALARM"
+    reason = payload.get("NewStateReason") or payload.get("reason") or ""
+
+    trigger = payload.get("Trigger") or {}
+    namespace = trigger.get("Namespace") or ""
+    metric_name = trigger.get("MetricName") or ""
+    dim_str = _format_cloudwatch_dimensions(trigger.get("Dimensions") or [])
+    message = _build_cloudwatch_message(namespace, metric_name, reason, dim_str)
+
+    alert_details = {
+        "title": alarm_name,
+        "status": state_value,
+        "message": message,
+        "namespace": namespace,
+        "metric_name": metric_name,
+    }
+
+    return build_rca_prompt("cloudwatch", alert_details, providers, user_id)
+
+
 def build_grafana_rca_prompt(
     payload: Dict[str, Any],
     providers: Optional[List[str]] = None,

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -220,6 +220,7 @@ _OPEN_PREFIXES = (
     "/aws/setup-role",
     "/aws/setup-script-ps1",
     "/aws/setup-role-ps1",
+    "/aws/cloudwatch/webhook/",
 )
 
 @app.before_request

--- a/server/routes/aws/__init__.py
+++ b/server/routes/aws/__init__.py
@@ -3,7 +3,10 @@ from flask import Blueprint
 bp = Blueprint('aws', __name__)
 
 from . import aws_routes, auth, onboarding
+from .cloudwatch_routes import cloudwatch_bp
+from . import cloudwatch_tasks  # noqa: F401 — registers Celery task
 
 bp.register_blueprint(aws_routes.aws_bp)
 bp.register_blueprint(auth.auth_bp)
 bp.register_blueprint(onboarding.onboarding_bp)
+bp.register_blueprint(cloudwatch_bp)

--- a/server/routes/aws/cloudwatch_routes.py
+++ b/server/routes/aws/cloudwatch_routes.py
@@ -286,6 +286,14 @@ def _validate_topic_arn(user_id: str, sns_message: dict) -> bool:
     approved = _get_approved_topic_arn(user_id)
     if approved is None:
         _store_approved_topic(user_id, topic_arn)
+        # Re-read to guard against a concurrent write binding a different topic.
+        stored = _get_approved_topic_arn(user_id)
+        if stored and stored != topic_arn:
+            logger.warning(
+                "[CLOUDWATCH] TopicArn race for user %s: rejected unauthorized topic",
+                sanitize(user_id),
+            )
+            return False
         return True
 
     if topic_arn != approved:
@@ -449,6 +457,15 @@ def get_webhook_url(user_id):
     })
 
 
+def _parse_notification_payload(sns_message: dict) -> dict:
+    """Extract the alarm payload from an SNS notification envelope."""
+    raw_message = sns_message.get("Message") or ""
+    try:
+        return json.loads(raw_message) if raw_message else sns_message
+    except Exception:
+        return sns_message
+
+
 @cloudwatch_bp.route("/aws/cloudwatch/webhook/<user_id>", methods=["POST"])
 def cloudwatch_alarm_webhook(user_id: str):
     """Receive SNS alarm notifications from CloudWatch for a specific user.
@@ -495,11 +512,7 @@ def cloudwatch_alarm_webhook(user_id: str):
         )
         return jsonify({"received": True})
 
-    raw_message = sns_message.get("Message") or ""
-    try:
-        payload = json.loads(raw_message) if raw_message else sns_message
-    except Exception:
-        payload = sns_message
+    payload = _parse_notification_payload(sns_message)
 
     skip_rca, should_skip, is_error = _ensure_cloudwatch_connection(user_id)
     if should_skip:

--- a/server/routes/aws/cloudwatch_routes.py
+++ b/server/routes/aws/cloudwatch_routes.py
@@ -40,12 +40,8 @@ _SNS_TYPE_HEADER = "x-amz-sns-message-type"
 _SNS_SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation"
 _SNS_NOTIFICATION = "Notification"
 
-# AWS SNS SubscribeURL pattern — prevents SSRF by ensuring we only fetch
+# AWS SNS hostname pattern — prevents SSRF by ensuring we only communicate with
 # legitimate Amazon-owned endpoints (includes China regions).
-_SNS_URL_PATTERN = re.compile(
-    r"^https://sns\.[a-z0-9-]+\.amazonaws\.com(\.cn)?[/?]"
-)
-
 _SNS_HOSTNAME_PATTERN = re.compile(
     r"^sns\.[a-z0-9-]+\.amazonaws\.com(\.cn)?$"
 )
@@ -58,11 +54,9 @@ _SNS_HOSTNAME_PATTERN = re.compile(
 def _is_valid_sns_url(url: str) -> bool:
     """Verify a SubscribeURL is a legitimate AWS SNS endpoint (SSRF prevention).
 
-    Defense-in-depth: regex check + parsed URL structural validation to ensure
-    only HTTPS requests to genuine SNS hostnames are issued.
+    Defense-in-depth: parsed URL structural validation ensures only HTTPS
+    requests to genuine SNS hostnames are issued.
     """
-    if not _SNS_URL_PATTERN.match(url):
-        return False
     parsed = urlparse(url)
     if parsed.scheme != "https":
         return False

--- a/server/routes/aws/cloudwatch_routes.py
+++ b/server/routes/aws/cloudwatch_routes.py
@@ -1,0 +1,472 @@
+"""
+CloudWatch Alarm Routes — receives SNS alarm notifications and manages
+the CloudWatch connection record for each Aurora user.
+
+AWS SNS delivers CloudWatch alarm state changes as HTTP POSTs containing
+either a subscription-confirmation message or an alarm-state-change notification
+wrapped in an SNS envelope. This route handles both cases.
+
+Webhook URL format: /aws/cloudwatch/webhook/<user_id>
+"""
+
+import base64
+import json
+import logging
+import os
+import re
+import string
+from typing import Tuple
+from urllib.parse import urlparse, urlunparse
+
+from flask import Blueprint, jsonify, request
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+from routes.aws.cloudwatch_tasks import process_cloudwatch_alarm
+from utils.auth.rbac_decorators import require_permission
+from utils.auth.stateless_auth import validate_user_exists, set_rls_context
+from utils.auth.token_management import store_tokens_in_db
+from utils.db.connection_pool import db_pool
+from utils.log_sanitizer import sanitize
+
+logger = logging.getLogger(__name__)
+
+cloudwatch_bp = Blueprint("cloudwatch", __name__)
+
+# SNS message types
+_SNS_TYPE_HEADER = "x-amz-sns-message-type"
+_SNS_SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation"
+_SNS_NOTIFICATION = "Notification"
+
+# AWS SNS SubscribeURL pattern — prevents SSRF by ensuring we only fetch
+# legitimate Amazon-owned endpoints (includes China regions).
+_SNS_URL_PATTERN = re.compile(
+    r"^https://sns\.[a-z0-9-]+\.amazonaws\.com(\.cn)?[/?]"
+)
+
+_SNS_HOSTNAME_PATTERN = re.compile(
+    r"^sns\.[a-z0-9-]+\.amazonaws\.com(\.cn)?$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+def _is_valid_sns_url(url: str) -> bool:
+    """Verify a SubscribeURL is a legitimate AWS SNS endpoint (SSRF prevention).
+
+    Defense-in-depth: regex check + parsed URL structural validation to ensure
+    only HTTPS requests to genuine SNS hostnames are issued.
+    """
+    if not _SNS_URL_PATTERN.match(url):
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    if parsed.username or parsed.password:
+        return False
+    hostname = parsed.hostname or ""
+    if not _SNS_HOSTNAME_PATTERN.match(hostname):
+        return False
+    if parsed.fragment:
+        return False
+    return True
+
+
+# Cache fetched/parsed certificates with TTL to avoid re-downloading per message
+# while ensuring rotated certs are eventually refreshed.
+_CERT_CACHE_TTL = 3600  # 1 hour
+_CERT_CACHE_MAX_SIZE = 32
+_cert_cache: dict = {}  # url -> (cert, timestamp)
+
+
+def _sanitize_signing_cert_url(url: str) -> tuple[str, str] | None:
+    """Validate SigningCertURL and extract (hostname, path) for safe reconstruction.
+
+    Returns validated (hostname, path) tuple on success, or None if validation fails.
+    Prevents SSRF by only extracting parts that pass the allowlist — the caller
+    reconstructs the URL from a hardcoded template.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return None
+    hostname = parsed.hostname or ""
+    if not _SNS_HOSTNAME_PATTERN.match(hostname):
+        return None
+    path = parsed.path or ""
+    if not path.endswith(".pem"):
+        return None
+    if len(path) > 256:
+        return None
+    allowed = set(string.ascii_letters + string.digits + "._/-")
+    if not path.startswith("/") or not all(c in allowed for c in path):
+        return None
+    return (hostname, path)
+
+
+def _get_sns_certificate(hostname: str, path: str):
+    """Fetch and parse the X.509 certificate from a validated SNS endpoint."""
+    import time as _time
+
+    safe_url = f"https://{hostname}{path}"
+    cached = _cert_cache.get(safe_url)
+    if cached:
+        cert, ts = cached
+        if _time.monotonic() - ts < _CERT_CACHE_TTL:
+            return cert
+
+    import urllib.request
+    with urllib.request.urlopen(safe_url, timeout=10) as resp:  # noqa: S310
+        pem_data = resp.read()
+
+    cert = x509.load_pem_x509_certificate(pem_data)
+
+    if len(_cert_cache) >= _CERT_CACHE_MAX_SIZE:
+        _cert_cache.clear()
+    _cert_cache[safe_url] = (cert, _time.monotonic())
+    return cert
+
+
+def _build_sns_string_to_sign(message: dict) -> str:
+    """Build the canonical string-to-sign for SNS message verification.
+
+    AWS SNS signing uses a specific set of fields in alphabetical order,
+    depending on the message type.
+    """
+    msg_type = message.get("Type", "")
+
+    if msg_type == "Notification":
+        fields = ["Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"]
+    else:
+        fields = ["Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type"]
+
+    pairs = []
+    for field in fields:
+        value = message.get(field)
+        if value is not None:
+            pairs.append(f"{field}\n{value}\n")
+
+    return "".join(pairs)
+
+
+def _verify_sns_signature(message: dict) -> bool:
+    """Verify the cryptographic signature of an SNS message.
+
+    Returns True if the signature is valid, False otherwise.
+    """
+    cert_url = message.get("SigningCertURL") or message.get("SigningCertUrl") or ""
+    signature_b64 = message.get("Signature") or ""
+    signature_version = message.get("SignatureVersion", "1")
+
+    if not cert_url or not signature_b64:
+        return False
+
+    safe_cert_url = _sanitize_signing_cert_url(cert_url)
+    if not safe_cert_url:
+        logger.warning("[CLOUDWATCH] Invalid SigningCertURL: rejected")
+        return False
+
+    try:
+        cert = _get_sns_certificate(*safe_cert_url)
+        signature = base64.b64decode(signature_b64)
+        string_to_sign = _build_sns_string_to_sign(message)
+
+        public_key = cert.public_key()
+
+        if signature_version == "2":
+            public_key.verify(
+                signature,
+                string_to_sign.encode("utf-8"),
+                padding.PKCS1v15(),
+                hashes.SHA256(),
+            )
+        else:
+            # AWS SNS SignatureVersion 1 mandates SHA1 for verification — not a design choice.
+            public_key.verify(  # nosec B303
+                signature,
+                string_to_sign.encode("utf-8"),
+                padding.PKCS1v15(),
+                hashes.SHA1(),  # NOSONAR — AWS protocol-mandated, signature verification only
+            )
+
+        return True
+    except Exception as exc:
+        logger.warning("[CLOUDWATCH] SNS signature verification failed: %s", type(exc).__name__)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _has_cloudwatch_row(user_id: str) -> Tuple[bool, bool]:
+    """Return (row_exists, is_active) for the user's CloudWatch token row."""
+    try:
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix="[CLOUDWATCH:has_row]")
+                cursor.execute(
+                    f"SELECT is_active FROM user_tokens "
+                    f"WHERE {predicate} AND provider = 'cloudwatch' "
+                    f"ORDER BY is_active DESC LIMIT 1",
+                    (*pred_params,),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    return False, False
+                return True, bool(row[0])
+    except Exception:
+        logger.exception("[CLOUDWATCH] Failed to check user_tokens row")
+        return False, False
+
+
+def _set_cloudwatch_active(user_id: str, active: bool) -> bool:
+    """Flip is_active on the existing CloudWatch user_tokens row."""
+    try:
+        from utils.db.org_scope import resolve_org, org_read_predicate
+        org_id = resolve_org(user_id)
+        predicate, pred_params = org_read_predicate(user_id, org_id)
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix="[CLOUDWATCH:set_active]")
+                cursor.execute(
+                    f"UPDATE user_tokens SET is_active = %s, timestamp = CURRENT_TIMESTAMP "
+                    f"WHERE {predicate} AND provider = 'cloudwatch'",
+                    (active, *pred_params),
+                )
+                updated = cursor.rowcount > 0
+            conn.commit()
+            return updated
+    except Exception:
+        logger.exception("[CLOUDWATCH] Failed to set is_active=%s", active)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Webhook helpers
+# ---------------------------------------------------------------------------
+
+def _handle_subscription_confirmation(sns_message: dict, user_id: str):
+    """Process SNS SubscriptionConfirmation by visiting the SubscribeURL.
+
+    SSRF mitigation: _is_valid_sns_url() enforces that the URL is an HTTPS
+    endpoint on sns.<region>.amazonaws.com(.cn) with no embedded credentials,
+    fragments, or suspicious path components. We additionally reconstruct the
+    URL from its parsed components to neutralize any encoding tricks.
+    """
+    subscribe_url = sns_message.get("SubscribeURL") or ""
+    if subscribe_url and _is_valid_sns_url(subscribe_url):
+        import urllib.request
+        parsed = urlparse(subscribe_url)
+        safe_url = urlunparse((parsed.scheme, parsed.hostname, parsed.path, "", parsed.query, ""))
+        try:
+            with urllib.request.urlopen(safe_url, timeout=10) as resp:  # noqa: S310
+                status_code = int(resp.status)
+                logger.info(
+                    "[CLOUDWATCH] Auto-confirmed SNS subscription for user %s (status=%d)",
+                    sanitize(user_id), status_code,
+                )
+        except Exception as exc:
+            logger.warning(
+                "[CLOUDWATCH] Failed to confirm SNS subscription for user %s: %s",
+                sanitize(user_id), type(exc).__name__,
+            )
+    elif subscribe_url:
+        logger.warning(
+            "[CLOUDWATCH] Rejected non-SNS SubscribeURL for user %s",
+            sanitize(user_id),
+        )
+
+
+def _ensure_cloudwatch_connection(user_id: str) -> Tuple[bool, bool, bool]:
+    """Ensure a CloudWatch connection exists. Returns (skip_rca, should_skip, is_error).
+
+    Design: On first-ever webhook for a user, we auto-create the connection record
+    so users don't need to manually toggle "connect" before configuring SNS. The
+    webhook is protected by SNS signature verification + validate_user_exists, so
+    this cannot be triggered by arbitrary external requests. RCA is skipped for the
+    auto-connect event to avoid investigating stale/test alarms during initial setup.
+
+    Unlike Grafana, we intentionally do NOT re-activate a disabled connection on
+    webhook receipt — if a user explicitly disconnected, we respect that choice.
+
+    - If the row doesn't exist, auto-creates it and returns (True, False, False).
+    - If the row exists but is inactive, returns (False, True, False).
+    - If the row exists and is active, returns (False, False, False).
+    - On creation failure, returns (False, True, True) — caller should return 500.
+    """
+    row_exists, is_active = _has_cloudwatch_row(user_id)
+
+    if not row_exists:
+        logger.info("[CLOUDWATCH] Auto-connecting user %s via webhook", sanitize(user_id))
+        try:
+            store_tokens_in_db(user_id, {}, "cloudwatch")
+        except Exception:
+            logger.exception("[CLOUDWATCH] Failed to auto-connect user %s", sanitize(user_id))
+            return False, True, True
+        return True, False, False
+
+    if not is_active:
+        logger.info(
+            "[CLOUDWATCH] Webhook received for user %s but connection is disabled, skipping",
+            sanitize(user_id),
+        )
+        return False, True, False
+
+    return False, False, False
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@cloudwatch_bp.route("/aws/cloudwatch/status", methods=["GET"])
+@require_permission("connectors", "read")
+def status(user_id):
+    """Return whether the CloudWatch integration is active for this user."""
+    row_exists, is_active = _has_cloudwatch_row(user_id)
+    if not row_exists or not is_active:
+        return jsonify({"connected": False})
+    return jsonify({"connected": True})
+
+
+@cloudwatch_bp.route("/aws/cloudwatch/connect", methods=["POST"])
+@require_permission("connectors", "write")
+def connect(user_id):
+    """Activate (or create) the CloudWatch connection record."""
+    try:
+        row_exists, is_active = _has_cloudwatch_row(user_id)
+        if row_exists and is_active:
+            return jsonify({"success": True, "message": "Already connected"}), 200
+        if row_exists:
+            if _set_cloudwatch_active(user_id, True):
+                logger.info("[CLOUDWATCH] Re-activated for user %s", sanitize(user_id))
+                return jsonify({"success": True, "message": "CloudWatch re-activated"}), 200
+            return jsonify({"error": "Failed to activate CloudWatch"}), 500
+        store_tokens_in_db(user_id, {}, "cloudwatch")
+        logger.info("[CLOUDWATCH] Connected for user %s", sanitize(user_id))
+        return jsonify({"success": True, "message": "CloudWatch connected"}), 200
+    except Exception:
+        logger.exception("[CLOUDWATCH] Failed to connect")
+        return jsonify({"error": "Failed to connect CloudWatch"}), 500
+
+
+@cloudwatch_bp.route("/aws/cloudwatch/disconnect", methods=["POST", "DELETE"])
+@require_permission("connectors", "write")
+def disconnect(user_id):
+    """Deactivate (but retain) the CloudWatch connection record."""
+    try:
+        row_exists, is_active = _has_cloudwatch_row(user_id)
+        if not row_exists:
+            return jsonify({"success": True, "message": "No connection to disconnect"}), 200
+        if not is_active:
+            return jsonify({"success": True, "message": "Already disconnected"}), 200
+        if _set_cloudwatch_active(user_id, False):
+            logger.info("[CLOUDWATCH] Disconnected for user %s", sanitize(user_id))
+            return jsonify({"success": True, "message": "CloudWatch disconnected successfully"}), 200
+        return jsonify({"error": "Failed to disconnect CloudWatch"}), 500
+    except Exception:
+        logger.exception("[CLOUDWATCH] Failed to disconnect")
+        return jsonify({"error": "Failed to disconnect CloudWatch"}), 500
+
+
+@cloudwatch_bp.route("/aws/cloudwatch/webhook-url", methods=["GET"])
+@require_permission("connectors", "read")
+def get_webhook_url(user_id):
+    """Return the SNS subscription URL the user should configure in AWS."""
+    from utils.secrets.secret_ref_utils import get_token_owner_id
+    webhook_owner_id = get_token_owner_id(user_id, "cloudwatch")
+
+    ngrok_url = os.getenv("NGROK_URL", "").rstrip("/")
+    backend_url = os.getenv("NEXT_PUBLIC_BACKEND_URL", "").rstrip("/")
+
+    if ngrok_url and backend_url.startswith("http://localhost"):
+        base_url = ngrok_url
+    else:
+        base_url = backend_url
+
+    webhook_url = f"{base_url}/aws/cloudwatch/webhook/{webhook_owner_id}"
+
+    return jsonify({
+        "webhookUrl": webhook_url,
+    })
+
+
+@cloudwatch_bp.route("/aws/cloudwatch/webhook/<user_id>", methods=["POST"])
+def cloudwatch_alarm_webhook(user_id: str):
+    """Receive SNS alarm notifications from CloudWatch for a specific user.
+
+    Handles two SNS message types:
+    - SubscriptionConfirmation: visit the SubscribeURL to confirm the subscription.
+    - Notification: parse the CloudWatch alarm payload and process it.
+
+    Auto-creates the connection record on first-ever notification. If the user
+    has explicitly disabled the connection, webhooks are acknowledged but skipped.
+    """
+    if not validate_user_exists(user_id):
+        return jsonify({"error": "Unknown user"}), 404
+
+    body = request.get_data(as_text=True)
+    try:
+        sns_message = json.loads(body)
+    except Exception:
+        logger.warning("[CLOUDWATCH] Could not parse webhook body for user %s", sanitize(user_id))
+        return jsonify({"error": "Invalid JSON body"}), 400
+
+    if not _verify_sns_signature(sns_message):
+        logger.warning(
+            "[CLOUDWATCH] SNS signature verification failed for user %s", sanitize(user_id)
+        )
+        return jsonify({"error": "Invalid SNS signature"}), 403
+
+    sns_type = (
+        request.headers.get(_SNS_TYPE_HEADER)
+        or sns_message.get("Type")
+        or ""
+    )
+
+    if sns_type == _SNS_SUBSCRIPTION_CONFIRMATION:
+        _handle_subscription_confirmation(sns_message, user_id)
+        return jsonify({"received": True, "type": "subscription_confirmed"})
+
+    if sns_type not in (_SNS_NOTIFICATION, ""):
+        logger.info(
+            "[CLOUDWATCH] Unknown SNS type=%s for user %s, ignoring", sns_type, sanitize(user_id)
+        )
+        return jsonify({"received": True})
+
+    raw_message = sns_message.get("Message") or ""
+    try:
+        payload = json.loads(raw_message) if raw_message else sns_message
+    except Exception:
+        payload = sns_message
+
+    skip_rca, should_skip, is_error = _ensure_cloudwatch_connection(user_id)
+    if should_skip:
+        if is_error:
+            return jsonify({"error": "Failed to create CloudWatch connection"}), 500
+        return jsonify({"received": True, "skipped": True, "reason": "connection_disabled"})
+
+    alarm_name = payload.get("AlarmName") or "unknown"
+    state_value = payload.get("NewStateValue") or payload.get("state_value") or "unknown"
+    logger.info(
+        "[CLOUDWATCH] Received alarm webhook for user %s: %s (state=%s)",
+        sanitize(user_id), sanitize(alarm_name), sanitize(state_value),
+    )
+
+    sns_message_id = sns_message.get("MessageId") or ""
+    metadata = {
+        "headers": dict(request.headers),
+        "remote_addr": request.remote_addr,
+        "sns_message_id": sns_message_id,
+    }
+
+    process_cloudwatch_alarm.delay(payload, metadata, user_id, skip_rca=skip_rca)
+
+    return jsonify({"received": True})

--- a/server/routes/aws/cloudwatch_routes.py
+++ b/server/routes/aws/cloudwatch_routes.py
@@ -27,7 +27,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from routes.aws.cloudwatch_tasks import process_cloudwatch_alarm
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import validate_user_exists, set_rls_context
-from utils.auth.token_management import store_tokens_in_db
+from utils.auth.token_management import store_tokens_in_db, get_token_data
 from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 
@@ -243,6 +243,62 @@ def _set_cloudwatch_active(user_id: str, active: bool) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# TopicArn binding helpers
+# ---------------------------------------------------------------------------
+
+def _get_approved_topic_arn(user_id: str) -> str | None:
+    """Retrieve the approved TopicArn stored for this user's CloudWatch connection."""
+    try:
+        data = get_token_data(user_id, "cloudwatch")
+        if data:
+            return data.get("approved_topic_arn")
+    except Exception:
+        logger.debug("[CLOUDWATCH] Could not retrieve token data for topic check")
+    return None
+
+
+def _store_approved_topic(user_id: str, topic_arn: str) -> None:
+    """Persist the TopicArn as the approved source for this user's CloudWatch webhook."""
+    try:
+        existing = get_token_data(user_id, "cloudwatch") or {}
+        existing["approved_topic_arn"] = topic_arn
+        store_tokens_in_db(user_id, existing, "cloudwatch")
+        logger.info(
+            "[CLOUDWATCH] Bound TopicArn for user %s: %s",
+            sanitize(user_id), sanitize(topic_arn),
+        )
+    except Exception:
+        logger.exception("[CLOUDWATCH] Failed to persist TopicArn binding for user %s", sanitize(user_id))
+
+
+def _validate_topic_arn(user_id: str, sns_message: dict) -> bool:
+    """Validate the TopicArn in an SNS message against the stored binding.
+
+    On first interaction (no binding stored yet), the topic is trusted and persisted.
+    On subsequent interactions, the topic must match.
+    Returns True if the message should be processed, False to reject.
+    """
+    topic_arn = sns_message.get("TopicArn") or ""
+    if not topic_arn:
+        logger.warning("[CLOUDWATCH] SNS message missing TopicArn for user %s", sanitize(user_id))
+        return False
+
+    approved = _get_approved_topic_arn(user_id)
+    if approved is None:
+        _store_approved_topic(user_id, topic_arn)
+        return True
+
+    if topic_arn != approved:
+        logger.warning(
+            "[CLOUDWATCH] TopicArn mismatch for user %s: got %s, expected %s",
+            sanitize(user_id), sanitize(topic_arn), sanitize(approved),
+        )
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Webhook helpers
 # ---------------------------------------------------------------------------
 
@@ -300,7 +356,8 @@ def _ensure_cloudwatch_connection(user_id: str) -> Tuple[bool, bool, bool]:
     if not row_exists:
         logger.info("[CLOUDWATCH] Auto-connecting user %s via webhook", sanitize(user_id))
         try:
-            store_tokens_in_db(user_id, {}, "cloudwatch")
+            existing = get_token_data(user_id, "cloudwatch") or {}
+            store_tokens_in_db(user_id, existing, "cloudwatch")
         except Exception:
             logger.exception("[CLOUDWATCH] Failed to auto-connect user %s", sanitize(user_id))
             return False, True, True
@@ -418,6 +475,9 @@ def cloudwatch_alarm_webhook(user_id: str):
             "[CLOUDWATCH] SNS signature verification failed for user %s", sanitize(user_id)
         )
         return jsonify({"error": "Invalid SNS signature"}), 403
+
+    if not _validate_topic_arn(user_id, sns_message):
+        return jsonify({"error": "TopicArn not authorized"}), 403
 
     sns_type = (
         request.headers.get(_SNS_TYPE_HEADER)

--- a/server/routes/aws/cloudwatch_routes.py
+++ b/server/routes/aws/cloudwatch_routes.py
@@ -264,8 +264,8 @@ def _store_approved_topic(user_id: str, topic_arn: str) -> None:
         existing["approved_topic_arn"] = topic_arn
         store_tokens_in_db(user_id, existing, "cloudwatch")
         logger.info(
-            "[CLOUDWATCH] Bound TopicArn for user %s: %s",
-            sanitize(user_id), sanitize(topic_arn),
+            "[CLOUDWATCH] Bound TopicArn for user %s",
+            sanitize(user_id),
         )
     except Exception:
         logger.exception("[CLOUDWATCH] Failed to persist TopicArn binding for user %s", sanitize(user_id))
@@ -290,8 +290,8 @@ def _validate_topic_arn(user_id: str, sns_message: dict) -> bool:
 
     if topic_arn != approved:
         logger.warning(
-            "[CLOUDWATCH] TopicArn mismatch for user %s: got %s, expected %s",
-            sanitize(user_id), sanitize(topic_arn), sanitize(approved),
+            "[CLOUDWATCH] TopicArn mismatch for user %s: rejected unauthorized topic",
+            sanitize(user_id),
         )
         return False
 

--- a/server/routes/aws/cloudwatch_tasks.py
+++ b/server/routes/aws/cloudwatch_tasks.py
@@ -44,8 +44,6 @@ def _extract_severity(state_value: str, payload: Dict[str, Any]) -> str:
         if "critical" in alarm_name:
             return "critical"
         return "high"
-    elif state == _INSUFFICIENT_DATA_STATE:
-        return "medium"
     return "unknown"
 
 
@@ -150,15 +148,19 @@ def _handle_resolved_alarm(
     alarm_db_id, state_value: str, payload: Dict[str, Any],
 ) -> None:
     """Correlate a resolved alarm back to its original incident and mark it resolved."""
+    account_id = payload.get("AWSAccountId") or payload.get("account_id") or ""
+    region = payload.get("Region") or payload.get("region") or ""
     cursor.execute(
         """
         SELECT id FROM incidents
         WHERE user_id = %s AND source_type = 'cloudwatch'
           AND alert_metadata::jsonb ->> 'alarm_name' = %s
+          AND (%s = '' OR alert_metadata::jsonb ->> 'account_id' = %s)
+          AND (%s = '' OR alert_metadata::jsonb ->> 'region' = %s)
           AND status NOT IN ('resolved', 'closed')
         ORDER BY started_at DESC LIMIT 1
         """,
-        (user_id, alarm_name),
+        (user_id, alarm_name, account_id, account_id, region, region),
     )
     row = cursor.fetchone()
     if row:

--- a/server/routes/aws/cloudwatch_tasks.py
+++ b/server/routes/aws/cloudwatch_tasks.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 # CloudWatch alarm states
 _ALARM_STATE = "ALARM"
 _OK_STATE = "OK"
-_INSUFFICIENT_DATA_STATE = "INSUFFICIENT_DATA"
 
 
 def _is_alarm_firing(state_value: str) -> bool:

--- a/server/routes/aws/cloudwatch_tasks.py
+++ b/server/routes/aws/cloudwatch_tasks.py
@@ -1,0 +1,565 @@
+"""Celery tasks for CloudWatch alarm webhook processing.
+
+AWS SNS delivers CloudWatch alarm state-change notifications as HTTP POST requests.
+Each notification contains a single alarm state transition. We process each notification
+to:
+- Persist the raw alarm to cloudwatch_alarms for audit / MCP queries.
+- Create an incident when the alarm enters ALARM state.
+- Correlate ALARM->OK transitions back to the original incident (auto-resolve).
+- Trigger a background RCA chat for ALARM-state notifications.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from celery_config import celery_app
+from services.correlation.alert_correlator import AlertCorrelator
+from services.correlation import handle_correlated_alert
+
+logger = logging.getLogger(__name__)
+
+# CloudWatch alarm states
+_ALARM_STATE = "ALARM"
+_OK_STATE = "OK"
+_INSUFFICIENT_DATA_STATE = "INSUFFICIENT_DATA"
+
+
+def _is_alarm_firing(state_value: str) -> bool:
+    return (state_value or "").upper() == _ALARM_STATE
+
+
+def _is_alarm_resolved(state_value: str) -> bool:
+    return (state_value or "").upper() == _OK_STATE
+
+
+def _extract_severity(state_value: str, payload: Dict[str, Any]) -> str:
+    """Map CloudWatch alarm state to Aurora severity."""
+    state = (state_value or "").upper()
+    if state == _ALARM_STATE:
+        alarm_name = (payload.get("AlarmName") or "").lower()
+        if "critical" in alarm_name:
+            return "critical"
+        return "high"
+    elif state == _INSUFFICIENT_DATA_STATE:
+        return "medium"
+    return "unknown"
+
+
+def _extract_service(payload: Dict[str, Any]) -> str:
+    """Best-effort service extraction from a CloudWatch alarm payload."""
+    # Dimensions carry service/resource context (e.g. {"InstanceId": "i-123"})
+    trigger = payload.get("Trigger") or {}
+    dimensions = trigger.get("Dimensions") or []
+    if dimensions and isinstance(dimensions, list):
+        dim = dimensions[0]
+        val = dim.get("value") or dim.get("Value")
+        name = dim.get("name") or dim.get("Name")
+        if val:
+            return str(val)[:255]
+        if name:
+            return str(name)[:255]
+    namespace = trigger.get("Namespace") or payload.get("Namespace") or ""
+    return str(namespace)[:255] or "aws"
+
+
+def _safe_json(data: Any) -> str:
+    try:
+        return json.dumps(data, ensure_ascii=False)
+    except Exception:
+        return str(data)
+
+
+class AlarmFields:
+    """Bundle of fields extracted from a CloudWatch alarm payload."""
+    __slots__ = (
+        'alarm_name', 'alarm_arn', 'state_value', 'previous_state',
+        'reason', 'account_id', 'region',
+    )
+
+    def __init__(
+        self, alarm_name: str, alarm_arn: str, state_value: str,
+        previous_state: str, reason: str, account_id: str, region: str,
+    ):
+        self.alarm_name = alarm_name
+        self.alarm_arn = alarm_arn
+        self.state_value = state_value
+        self.previous_state = previous_state
+        self.reason = reason
+        self.account_id = account_id
+        self.region = region
+
+
+def _persist_alarm(
+    cursor, conn, user_id: str, org_id: str, fields: AlarmFields,
+    payload: Dict[str, Any], received_at, sns_message_id: str = "",
+):
+    """Insert raw alarm into cloudwatch_alarms. Returns (alarm_db_id, was_inserted) or (None, False).
+
+    Uses sns_message_id for deduplication — if the same SNS message is delivered
+    more than once (retry), we return the existing row instead of creating a duplicate.
+    """
+    if sns_message_id:
+        cursor.execute(
+            "SELECT id FROM cloudwatch_alarms WHERE sns_message_id = %s AND user_id = %s",
+            (sns_message_id, user_id),
+        )
+        existing = cursor.fetchone()
+        if existing:
+            logger.info(
+                "[CLOUDWATCH][ALARM] Dedup: sns_message_id=%s already stored (db_id=%s)",
+                sns_message_id, existing[0],
+            )
+            return existing[0], False
+
+    cursor.execute(
+        """
+        INSERT INTO cloudwatch_alarms
+          (user_id, org_id, alarm_name, alarm_arn, state_value,
+           previous_state_value, reason, account_id, region, payload, received_at,
+           sns_message_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING id
+        """,
+        (
+            user_id, org_id, fields.alarm_name, fields.alarm_arn, fields.state_value,
+            fields.previous_state, fields.reason, fields.account_id, fields.region,
+            json.dumps(payload), received_at, sns_message_id or None,
+        ),
+    )
+    row = cursor.fetchone()
+    alarm_db_id = row[0] if row else None
+    conn.commit()
+
+    if not alarm_db_id:
+        logger.error("[CLOUDWATCH][ALARM] Failed to persist alarm for user %s", user_id)
+        return None, False
+
+    logger.info(
+        "[CLOUDWATCH][ALARM] Stored alarm (db_id=%s) for user %s",
+        alarm_db_id, user_id,
+    )
+    return alarm_db_id, True
+
+
+def _handle_resolved_alarm(
+    cursor, conn, user_id: str, org_id: str, alarm_name: str,
+    alarm_db_id, state_value: str, payload: Dict[str, Any],
+) -> None:
+    """Correlate a resolved alarm back to its original incident and mark it resolved."""
+    cursor.execute(
+        """
+        SELECT id FROM incidents
+        WHERE user_id = %s AND source_type = 'cloudwatch'
+          AND alert_metadata::jsonb ->> 'alarm_name' = %s
+          AND status NOT IN ('resolved', 'closed')
+        ORDER BY started_at DESC LIMIT 1
+        """,
+        (user_id, alarm_name),
+    )
+    row = cursor.fetchone()
+    if row:
+        original_incident_id = row[0]
+        cursor.execute(
+            """
+            INSERT INTO incident_alerts
+              (user_id, org_id, incident_id, source_type, source_alert_id,
+               alert_title, alert_service, alert_severity, correlation_strategy,
+               correlation_score, alert_metadata)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                user_id, org_id, original_incident_id, "cloudwatch",
+                alarm_db_id, alarm_name,
+                _extract_service(payload),
+                _extract_severity(state_value, payload),
+                "resolved_webhook", 1.0,
+                json.dumps({"resolved_webhook": True, "alarm_name": alarm_name}),
+            ),
+        )
+        cursor.execute(
+            """
+            UPDATE incidents SET status = 'resolved', resolved_at = CURRENT_TIMESTAMP
+            WHERE id = %s
+            """,
+            (original_incident_id,),
+        )
+        cursor.execute(
+            """
+            INSERT INTO incident_lifecycle_events
+              (incident_id, user_id, org_id, event_type, new_value)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (original_incident_id, user_id, org_id, "status_change", "resolved"),
+        )
+        conn.commit()
+        logger.info(
+            "[CLOUDWATCH][ALARM] Resolved alarm (%s) — incident %s marked resolved",
+            alarm_name, original_incident_id,
+        )
+    else:
+        logger.info(
+            "[CLOUDWATCH][ALARM] Resolved alarm for user %s, no matching incident. Skipping.",
+            user_id,
+        )
+
+
+def _build_alert_metadata(
+    alarm_name: str, alarm_arn: str, account_id: str,
+    region: str, reason: str, previous_state: str, payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Construct the alert_metadata dict for a CloudWatch alarm."""
+    alert_metadata: Dict[str, Any] = {
+        "alarm_name": alarm_name,
+        "alarm_arn": alarm_arn,
+        "account_id": account_id,
+        "region": region,
+        "reason": reason,
+        "previous_state": previous_state,
+    }
+    trigger = payload.get("Trigger") or {}
+    if trigger.get("Namespace"):
+        alert_metadata["namespace"] = trigger["Namespace"]
+    if trigger.get("MetricName"):
+        alert_metadata["metric_name"] = trigger["MetricName"]
+    if trigger.get("Dimensions"):
+        alert_metadata["dimensions"] = trigger["Dimensions"]
+    return alert_metadata
+
+
+def _try_correlate_alarm(
+    cursor, conn, user_id: str, org_id: str, alarm_db_id,
+    alarm_name: str, service: str, severity: str,
+    alert_metadata: Dict[str, Any], payload: Dict[str, Any],
+) -> bool:
+    """Attempt to correlate the alarm with an existing incident. Returns True if correlated."""
+    correlation_result = None
+    try:
+        cursor.execute("SAVEPOINT sp_correlation")
+        correlator = AlertCorrelator()
+        correlation_result = correlator.correlate(
+            cursor=cursor, user_id=user_id, source_type="cloudwatch",
+            source_alert_id=alarm_db_id, alert_title=alarm_name,
+            alert_service=service, alert_severity=severity,
+            alert_metadata=alert_metadata, org_id=org_id,
+        )
+        cursor.execute("RELEASE SAVEPOINT sp_correlation")
+    except Exception as exc:
+        cursor.execute("ROLLBACK TO SAVEPOINT sp_correlation")
+        logger.warning("[CLOUDWATCH][ALARM] Correlation check failed: %s", exc)
+
+    if not (correlation_result and correlation_result.is_correlated):
+        return False
+
+    try:
+        cursor.execute("SAVEPOINT sp_handle_correlated")
+        handle_correlated_alert(
+            cursor=cursor, user_id=user_id,
+            incident_id=correlation_result.incident_id,
+            source_type="cloudwatch", source_alert_id=alarm_db_id,
+            alert_title=alarm_name, alert_service=service,
+            alert_severity=severity,
+            correlation_result=correlation_result,
+            alert_metadata=alert_metadata, raw_payload=payload,
+            org_id=org_id,
+        )
+        cursor.execute("RELEASE SAVEPOINT sp_handle_correlated")
+        conn.commit()
+        logger.info(
+            "[CLOUDWATCH][ALARM] Correlated alarm '%s' to incident %s",
+            alarm_name, correlation_result.incident_id,
+        )
+    except Exception as exc:
+        cursor.execute("ROLLBACK TO SAVEPOINT sp_handle_correlated")
+        logger.warning("[CLOUDWATCH][ALARM] handle_correlated_alert failed: %s", exc)
+        return False
+    return True
+
+
+def _create_incident_record(
+    cursor, conn, user_id: str, org_id: str, alarm_db_id,
+    alarm_name: str, service: str, severity: str,
+    alert_metadata: Dict[str, Any], received_at,
+):
+    """Insert the incident + lifecycle event + alert link. Returns incident_id or None."""
+    cursor.execute(
+        """
+        INSERT INTO incidents
+          (user_id, org_id, source_type, source_alert_id, alert_title, alert_service,
+           severity, status, started_at, alert_metadata, alert_fired_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (org_id, source_type, source_alert_id, user_id) DO UPDATE
+          SET updated_at = CURRENT_TIMESTAMP,
+              started_at = CASE WHEN incidents.status != 'analyzed'
+                           THEN EXCLUDED.started_at ELSE incidents.started_at END,
+              alert_metadata = EXCLUDED.alert_metadata
+        RETURNING id, (xmax = 0) AS inserted
+        """,
+        (
+            user_id, org_id, "cloudwatch", alarm_db_id, alarm_name,
+            service, severity, "investigating", received_at,
+            json.dumps(alert_metadata), received_at,
+        ),
+    )
+    incident_row = cursor.fetchone()
+    incident_id = incident_row[0] if incident_row else None
+    incident_was_inserted = bool(incident_row[1]) if incident_row else False
+    conn.commit()
+
+    if not incident_id:
+        logger.error("[CLOUDWATCH][ALARM] Failed to create incident for alarm %s", alarm_name)
+        return None
+
+    if incident_was_inserted:
+        try:
+            cursor.execute("SAVEPOINT sp_lifecycle")
+            cursor.execute(
+                """
+                INSERT INTO incident_lifecycle_events
+                  (incident_id, user_id, org_id, event_type, new_value)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (incident_id, user_id, org_id, "created", "investigating"),
+            )
+            cursor.execute("RELEASE SAVEPOINT sp_lifecycle")
+            conn.commit()
+        except Exception as exc:
+            cursor.execute("ROLLBACK TO SAVEPOINT sp_lifecycle")
+            logger.warning("[CLOUDWATCH][ALARM] Failed to record lifecycle event: %s", exc)
+
+    try:
+        cursor.execute("SAVEPOINT sp_incident_alerts")
+        cursor.execute(
+            """
+            INSERT INTO incident_alerts
+              (user_id, org_id, incident_id, source_type, source_alert_id, alert_title,
+               alert_service, alert_severity, correlation_strategy, correlation_score,
+               alert_metadata)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                user_id, org_id, incident_id, "cloudwatch", alarm_db_id, alarm_name,
+                service, severity, "primary", 1.0, json.dumps(alert_metadata),
+            ),
+        )
+        cursor.execute(
+            "UPDATE incidents SET affected_services = ARRAY[%s] WHERE id = %s",
+            (service, incident_id),
+        )
+        cursor.execute("RELEASE SAVEPOINT sp_incident_alerts")
+        conn.commit()
+    except Exception as exc:
+        cursor.execute("ROLLBACK TO SAVEPOINT sp_incident_alerts")
+        logger.warning("[CLOUDWATCH][ALARM] Failed to record primary alert: %s", exc)
+
+    return incident_id
+
+
+def _post_incident_actions(
+    user_id: str, org_id: str, incident_id, alarm_name: str,
+    service: str, severity: str, state_value: str,
+    alert_metadata: Dict[str, Any], payload: Dict[str, Any],
+    skip_rca: bool, cursor, conn,
+) -> None:
+    """SSE broadcast, summary generation, and RCA trigger."""
+    try:
+        from routes.incidents_sse import broadcast_incident_update_to_user_connections
+        broadcast_incident_update_to_user_connections(
+            user_id,
+            {"type": "incident_update", "incident_id": str(incident_id), "source": "cloudwatch"},
+            org_id=org_id,
+        )
+    except Exception as exc:
+        logger.warning("[CLOUDWATCH][ALARM] Failed to notify SSE: %s", exc)
+
+    try:
+        from chat.background.summarization import generate_incident_summary
+        generate_incident_summary.delay(
+            incident_id=str(incident_id), user_id=user_id, source_type="cloudwatch",
+            alert_title=alarm_name, severity=severity,
+            service=service, raw_payload=payload, alert_metadata=alert_metadata,
+        )
+    except Exception as exc:
+        logger.warning(
+            "[CLOUDWATCH][ALARM] Failed to enqueue summary for incident %s: %s",
+            incident_id, exc,
+        )
+
+    if skip_rca:
+        return
+
+    try:
+        from chat.background.task import (
+            run_background_chat,
+            create_background_chat_session,
+            is_background_chat_allowed,
+        )
+        if not is_background_chat_allowed(user_id):
+            logger.info("[CLOUDWATCH][ALARM] Skipping RCA — rate limited for user %s", user_id)
+            return
+
+        from chat.background.rca_prompt_builder import build_cloudwatch_rca_prompt
+        rca_prompt, rail_text = build_cloudwatch_rca_prompt(payload, user_id=user_id)
+        chat_title = f"RCA: {alarm_name}"
+        session_id = create_background_chat_session(
+            user_id=user_id,
+            title=chat_title,
+            trigger_metadata={
+                "source": "cloudwatch",
+                "alarm_name": alarm_name,
+                "state": state_value,
+            },
+            incident_id=str(incident_id),
+        )
+        task = run_background_chat.delay(
+            user_id=user_id,
+            session_id=session_id,
+            initial_message=rca_prompt,
+            trigger_metadata={
+                "source": "cloudwatch",
+                "alarm_name": alarm_name,
+                "state": state_value,
+            },
+            incident_id=str(incident_id),
+            rail_text=rail_text,
+        )
+        cursor.execute(
+            "UPDATE incidents SET rca_celery_task_id = %s WHERE id = %s",
+            (task.id, str(incident_id)),
+        )
+        conn.commit()
+        logger.info(
+            "[CLOUDWATCH][ALARM] Triggered RCA for session %s (task=%s)",
+            session_id, task.id,
+        )
+    except Exception as exc:
+        logger.exception("[CLOUDWATCH][ALARM] Failed to trigger RCA: %s", exc)
+
+
+def _extract_alarm_fields(payload: Dict[str, Any]) -> AlarmFields:
+    """Parse alarm field values from the CloudWatch/SNS payload."""
+    return AlarmFields(
+        alarm_name=payload.get("AlarmName") or "Unknown Alarm",
+        alarm_arn=payload.get("AlarmArn") or payload.get("alarm_arn") or "",
+        state_value=payload.get("NewStateValue") or payload.get("state_value") or "",
+        previous_state=payload.get("OldStateValue") or "",
+        reason=payload.get("NewStateReason") or payload.get("reason") or "",
+        account_id=payload.get("AWSAccountId") or payload.get("account_id") or "",
+        region=payload.get("Region") or payload.get("region") or "",
+    )
+
+
+def _process_alarm_in_db(
+    user_id: str, payload: Dict[str, Any],
+    metadata: Optional[Dict[str, Any]], skip_rca: bool,
+) -> None:
+    """Core DB logic for processing a CloudWatch alarm (called from Celery task)."""
+    from utils.db.connection_pool import db_pool
+    from utils.auth.stateless_auth import set_rls_context
+
+    fields = _extract_alarm_fields(payload)
+
+    with db_pool.get_admin_connection() as conn:
+        with conn.cursor() as cursor:
+            received_at = datetime.now(timezone.utc)
+            org_id = set_rls_context(cursor, conn, user_id, log_prefix="[CLOUDWATCH][ALARM]")
+            if not org_id:
+                return
+
+            alarm_db_id, was_inserted = _persist_alarm(
+                cursor, conn, user_id, org_id, fields,
+                payload, received_at,
+                sns_message_id=(metadata or {}).get("sns_message_id", ""),
+            )
+            if not alarm_db_id:
+                return
+
+            if not was_inserted:
+                logger.info("[CLOUDWATCH][ALARM] Duplicate SNS delivery, skipping processing")
+                return
+
+            if _is_alarm_resolved(fields.state_value):
+                _handle_resolved_alarm(
+                    cursor, conn, user_id, org_id, fields.alarm_name,
+                    alarm_db_id, fields.state_value, payload,
+                )
+                return
+
+            if not _is_alarm_firing(fields.state_value):
+                logger.info(
+                    "[CLOUDWATCH][ALARM] State=%s for user %s — not firing, skipping incident.",
+                    fields.state_value, user_id,
+                )
+                return
+
+            severity = _extract_severity(fields.state_value, payload)
+            service = _extract_service(payload)
+            alert_metadata = _build_alert_metadata(
+                fields.alarm_name, fields.alarm_arn, fields.account_id,
+                fields.region, fields.reason, fields.previous_state, payload,
+            )
+
+            if _try_correlate_alarm(
+                cursor, conn, user_id, org_id, alarm_db_id,
+                fields.alarm_name, service, severity, alert_metadata, payload,
+            ):
+                return
+
+            incident_id = _create_incident_record(
+                cursor, conn, user_id, org_id, alarm_db_id,
+                fields.alarm_name, service, severity, alert_metadata, received_at,
+            )
+            if not incident_id:
+                return
+
+            logger.info(
+                "[CLOUDWATCH][ALARM] Created incident %s for alarm '%s'",
+                incident_id, fields.alarm_name,
+            )
+
+            _post_incident_actions(
+                user_id, org_id, incident_id, fields.alarm_name,
+                service, severity, fields.state_value, alert_metadata,
+                payload, skip_rca, cursor, conn,
+            )
+
+
+@celery_app.task(
+    bind=True, max_retries=3, default_retry_delay=30, name="cloudwatch.process_alarm"
+)
+def process_cloudwatch_alarm(
+    self,
+    payload: Dict[str, Any],
+    metadata: Optional[Dict[str, Any]] = None,
+    user_id: Optional[str] = None,
+    skip_rca: bool = False,
+) -> None:
+    """Background processor for CloudWatch alarm notifications.
+
+    Args:
+        payload: Parsed SNS/CloudWatch JSON payload.
+        metadata: Auxiliary HTTP context captured at the route layer.
+        user_id: Aurora user ID this alarm belongs to.
+        skip_rca: If True, store but do not trigger RCA.
+    """
+    try:
+        fields = _extract_alarm_fields(payload)
+        logger.info(
+            "[CLOUDWATCH][ALARM][USER:%s] %s  state=%s -> %s",
+            user_id or "unknown", fields.alarm_name, fields.previous_state, fields.state_value,
+        )
+        logger.debug("[CLOUDWATCH][ALARM] full payload=%s", _safe_json(payload))
+
+        if not user_id:
+            logger.warning("[CLOUDWATCH][ALARM] No user_id provided, alarm not stored")
+            return
+
+        _process_alarm_in_db(user_id, payload, metadata, skip_rca)
+
+    except Exception as exc:
+        logger.exception("[CLOUDWATCH][ALARM] Failed to process alarm payload")
+        if user_id:
+            raise self.retry(exc=exc) from exc

--- a/server/tests/architectural/test_connector_rbac.py
+++ b/server/tests/architectural/test_connector_rbac.py
@@ -62,6 +62,7 @@ EXEMPT_FUNCTIONS: Set[str] = {
     "webhook",
     "github_webhook",
     "alert_webhook",
+    "cloudwatch_alarm_webhook",
     "deployment_webhook",
     # Setup scripts (static content, no user data)
     "home",

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -549,6 +549,31 @@ def initialize_tables():
                     
                     CREATE INDEX IF NOT EXISTS idx_ingestion_in_progress ON cloud_ingestion_state(user_id, provider) WHERE in_progress = TRUE;
                 """,
+                "cloudwatch_alarms": """
+                    CREATE TABLE IF NOT EXISTS cloudwatch_alarms (
+                        id SERIAL PRIMARY KEY,
+                        user_id VARCHAR(255) NOT NULL,
+                        org_id VARCHAR(255),
+                        alarm_name TEXT,
+                        alarm_arn TEXT,
+                        state_value VARCHAR(50),
+                        previous_state_value VARCHAR(50),
+                        reason TEXT,
+                        account_id VARCHAR(50),
+                        region VARCHAR(100),
+                        payload JSONB NOT NULL,
+                        received_at TIMESTAMP NOT NULL,
+                        sns_message_id VARCHAR(255),
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
+                    ALTER TABLE cloudwatch_alarms ADD COLUMN IF NOT EXISTS sns_message_id VARCHAR(255);
+
+                    CREATE INDEX IF NOT EXISTS idx_cloudwatch_alarms_user_id ON cloudwatch_alarms(user_id, received_at DESC);
+                    CREATE INDEX IF NOT EXISTS idx_cloudwatch_alarms_state ON cloudwatch_alarms(state_value);
+                    CREATE INDEX IF NOT EXISTS idx_cloudwatch_alarms_received_at ON cloudwatch_alarms(received_at DESC);
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_cloudwatch_alarms_sns_dedup ON cloudwatch_alarms(sns_message_id, user_id) WHERE sns_message_id IS NOT NULL;
+                """,
                 "grafana_alerts": """
                     CREATE TABLE IF NOT EXISTS grafana_alerts (
                         id SERIAL PRIMARY KEY,
@@ -1359,6 +1384,7 @@ def initialize_tables():
             rls_tables.append("pagerduty_events")
 
             # Add monitoring tables
+            rls_tables.append("cloudwatch_alarms")
             rls_tables.append("grafana_alerts")
             rls_tables.append("datadog_events")
             rls_tables.append("netdata_alerts")
@@ -2609,6 +2635,7 @@ def initialize_tables():
                 "rca_notification_emails", "splunk_alerts",
                 "jenkins_deployment_events", "dynatrace_problems",
                 "bigpanda_events", "kubectl_agent_tokens",
+                "cloudwatch_alarms",
                 "mcp_tokens",
                 "k8s_pods", "k8s_nodes", "k8s_node_conditions",
                 "k8s_services", "k8s_deployments", "k8s_ingresses",


### PR DESCRIPTION
Add CloudWatch SNS webhook endpoint that receives alarm state-change notifications and auto-confirms subscriptions
Implement Celery task to process alarms into Aurora incidents with severity mapping and deduplication
Add connect/disconnect/status routes with RBAC and agent SKILL.md for RCA integration
Extend AWS onboarding page with CloudWatch setup wizard and webhook URL display
Surface CloudWatch alerts in the incidents UI (IncidentCard, correlated & recent alerts sections)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS CloudWatch onboarding: connect/disconnect toggle, copyable webhook URL, embedded SNS setup guide; CloudWatch added to connectors list.

* **New Functionality**
  * Automated CloudWatch alarm ingestion: creates, correlates, or resolves incidents and enqueues background RCA generation.

* **UI / Visual**
  * Unified alert source icons and consistent styling across providers, including CloudWatch.

* **Documentation**
  * Added CloudWatch integration skill/spec and RCA guidance.

* **Security**
  * Strengthened webhook validation and SNS request authenticity checks.

* **Tests**
  * RBAC test updated to exempt CloudWatch webhook handler.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->