### PR TITLE
fix: remove github_apply_fix from LLM tool list (NameError crash)

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1319,7 +1319,6 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         tool_functions.append((get_connected_repos, "get_connected_repos"))
         tool_functions.append((github_rca, "github_rca"))
         tool_functions.append((github_fix, "github_fix"))
-        tool_functions.append((github_apply_fix, "github_apply_fix"))
         logging.info(f"Added GitHub tools for user {user_id}")
 
     if _safe_connected(is_tailscale_connected, "Tailscale"):


### PR DESCRIPTION
## Summary
- Removes `github_apply_fix` from the tool registration list in `cloud_tools.py`
- This function was added in #437 but never imported, causing a `NameError` that crashes **all chat sessions** for users with GitHub connected
- `github_apply_fix` is intentionally not LLM-callable (per existing comment in the file) — it's only invoked from the incidents route on explicit user approval

## Root Cause
PR #437 moved tool registration to be conditional on connector status but accidentally added `github_apply_fix` to the list without importing it.

## Test plan
- [x] Verified on staging: sessions for users with GitHub connected crash with `name 'github_apply_fix' is not defined`
- [ ] After merge: confirm chat sessions work for GitHub-connected users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub integration to require explicit user approval for apply fix operations instead of allowing automatic LLM invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->