### PR TITLE
fix(dev): stop frontend OOM by switching dev runtime to Node

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,6 +3,12 @@
 # ============================================
 FROM oven/bun:1.2.22-alpine AS dev
 
+# Install Node.js to run the dev server. Bun's JSC engine has known memory
+# retention under long-running Next.js dev loads (oven-sh/bun#27514, #29302),
+# causing OOM-kills in Docker Desktop. Bun is still used for `install` because
+# the leak only matters for long-lived processes.
+RUN apk add --no-cache nodejs npm
+
 WORKDIR /app
 
 # Install dependencies first (will be overridden by volume mount in dev)
@@ -18,7 +24,7 @@ EXPOSE 3000
 
 # Use the same entrypoint as prod to generate env-config.js at startup
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["bun", "run", "dev"]
+CMD ["npm", "run", "dev"]
 
 # ============================================
 # Production Builder Stage

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -109,9 +109,15 @@ export default auth((req) => {
     backendOrigin ? backendOrigin.replace(/^http/, 'ws') : '',
   ].filter(Boolean).join(' ')
 
+  // Webpack dev HMR (@next/react-refresh-utils) requires 'unsafe-eval'.
+  // Dev only — production CSP stays strict.
+  const scriptSrc = process.env.NODE_ENV === 'development'
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : "script-src 'self' 'unsafe-inline'"
+
   response.headers.set('Content-Security-Policy', [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
+    scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -570,6 +570,7 @@ services:
     volumes:
       - ./client:/app
       - /app/node_modules
+      - /app/.next
     depends_on:
       - aurora-server
 


### PR DESCRIPTION
## Summary

- Dev frontend was OOM-killing under sustained traffic. Root cause is compounded: Bun's JSC heap retention under long-running Next.js dev, Turbopack running alongside a `webpack:` block in `next.config.ts` (Next.js warns about this at boot), and the `.next` bind-mount regression from #442 putting 668 MB of build cache on the slow macOS bind-mount path.
- Switch the dev Dockerfile stage to run under Node (Bun still handles the fast install step). Drop `--turbopack` from the dev script so Webpack honors `next.config.ts` properly and HMR cache invalidation works. Restore the `/app/.next` anonymous volume so the build cache lives on container overlayfs again, off the bind-mount.
- Webpack dev HMR uses `eval()` in react-refresh-utils; gate `'unsafe-eval'` in the CSP behind `NODE_ENV === 'development'` so prod stays strict.
- Prod (`docker-compose.prod-local.yml`, `docker-compose.airtight.yml`, Helm) is untouched. Only the `dev` Dockerfile stage changed; `builder` and `prod` stages still use Bun.

## Test plan

- [ ] `make down && docker compose build frontend && make dev` boots cleanly
- [ ] No "Webpack is configured while Turbopack is not" warning in `docker logs aurora-frontend-1`
- [ ] `docker exec aurora-frontend-1 node --version` reports v20.x
- [ ] Browser hard-refresh on localhost:3000 renders without CSP `unsafe-eval` violations in console
- [ ] HMR works: edit a component, page updates without full reload
- [ ] Under sustained traffic, `docker inspect aurora-frontend-1 --format '{{.State.OOMKilled}}'` stays `false`


## Flags I tested it with.
### Concurrency

GUNICORN_WORKERS=1
GUNICORN_THREADS=4
CELERY_CONCURRENCY=4