### PR TITLE
feat(client): add FRONTEND_DEV_RUNTIME flag for bun vs node dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@
 # -----------------------------------------------------------------------------
 AURORA_ENV=dev
 
+# Frontend dev server (make dev only; prod-local ignores this)
+# bun  - Bun process + Turbopack (default)
+# node - Node process + Webpack (use if frontend dev OOMs in Docker Desktop)
+FRONTEND_DEV_RUNTIME=bun
+
 # -----------------------------------------------------------------------------
 # Database [REQUIRED]
 # -----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 .PHONY: help dev down logs rebuild-server restart prod prod-build prod-logs prod-down clean nuke build-no-cache dev-fresh prod-clean prod-nuke prod-build-no-cache prod-fresh prod-prebuilt prod-local init prod-local-logs prod-local-down prod-local-clean prod-local-nuke deploy-build deploy package-airtight prod-airtight vm-deploy
 
+# FRONTEND_DEV_RUNTIME=bun|node in .env selects frontend dev compose overrides (see .env.example).
+FRONTEND_DEV_RUNTIME ?= bun
+ifneq (,$(wildcard .env))
+  FRONTEND_DEV_RUNTIME := $(shell grep -E '^FRONTEND_DEV_RUNTIME=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d ' ' | head -1)
+endif
+ifeq ($(FRONTEND_DEV_RUNTIME),)
+  FRONTEND_DEV_RUNTIME := bun
+endif
+COMPOSE_DEV := docker compose -f docker-compose.yaml$(if $(filter node,$(FRONTEND_DEV_RUNTIME)), -f docker-compose.frontend-dev-node.yml,)
+
 help:
 	@echo "Available commands:"
 	@echo "  make dev                - Build and start all containers in detached mode (Docker Compose)"
@@ -65,14 +75,14 @@ dev:
 		echo "Please run 'make init' first to set up your environment."; \
 		exit 1; \
 	fi
-	docker compose up --build -d
+	$(COMPOSE_DEV) up --build -d
 
 dev-build: build
 build:
-	docker compose build
+	$(COMPOSE_DEV) build
 
 down:
-	@docker compose down --remove-orphans 2>/dev/null || true
+	@$(COMPOSE_DEV) down --remove-orphans 2>/dev/null || true
 	@docker compose -f docker-compose.prod-local.yml down --remove-orphans 2>/dev/null || true
 	@docker compose -f docker-compose.airtight.yml down --remove-orphans 2>/dev/null || true
 	@for ep in $$(docker network inspect aurora_default -f '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null); do docker network disconnect -f aurora_default $$ep 2>/dev/null; done; true
@@ -80,29 +90,29 @@ down:
 
 logs:
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
-		docker compose logs --tail 50 -f; \
+		$(COMPOSE_DEV) logs --tail 50 -f; \
 	else \
-		docker compose logs --tail 50 -f $(filter-out $@,$(MAKECMDGOALS)); \
+		$(COMPOSE_DEV) logs --tail 50 -f $(filter-out $@,$(MAKECMDGOALS)); \
 	fi
 
 restart:
-	docker compose down
-	docker compose up -d
+	$(COMPOSE_DEV) down
+	$(COMPOSE_DEV) up -d
 
 # Build without cache
 build-no-cache:
 	@echo "Building all containers without cache..."
-	docker compose build --no-cache
+	$(COMPOSE_DEV) build --no-cache
 
 # Stop containers and remove volumes
 clean:
 	@echo "Stopping containers and removing volumes..."
-	docker compose down -v
+	$(COMPOSE_DEV) down -v
 
 # Full cleanup: containers, volumes, images, and orphans
 nuke:
 	@echo "Performing full cleanup..."
-	docker compose down -v --rmi local --remove-orphans
+	$(COMPOSE_DEV) down -v --rmi local --remove-orphans
 	@echo "Pruning dangling images..."
 	docker image prune -f
 	@echo "Cleanup complete!"
@@ -110,11 +120,11 @@ nuke:
 # Full cleanup + rebuild without cache + start
 dev-fresh:
 	@echo "Performing full fresh rebuild..."
-	docker compose down -v --rmi local --remove-orphans
+	$(COMPOSE_DEV) down -v --rmi local --remove-orphans
 	@echo "Building without cache..."
-	docker compose build --no-cache
+	$(COMPOSE_DEV) build --no-cache
 	@echo "Starting containers..."
-	docker compose up -d
+	$(COMPOSE_DEV) up -d
 	@echo "Fresh rebuild complete!"
 
 # Production commands

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: help dev down logs rebuild-server restart prod prod-build prod-logs prod-down clean nuke build-no-cache dev-fresh prod-clean prod-nuke prod-build-no-cache prod-fresh prod-prebuilt prod-local init prod-local-logs prod-local-down prod-local-clean prod-local-nuke deploy-build deploy package-airtight prod-airtight vm-deploy
+.PHONY: help dev dev-build down logs rebuild-server restart prod prod-build prod-logs prod-down clean nuke build-no-cache dev-fresh prod-clean prod-nuke prod-build-no-cache prod-fresh prod-prebuilt prod-local init prod-local-logs prod-local-down prod-local-clean prod-local-nuke deploy-build deploy package-airtight prod-airtight vm-deploy
 
 # FRONTEND_DEV_RUNTIME=bun|node in .env selects frontend dev compose overrides (see .env.example).
 FRONTEND_DEV_RUNTIME ?= bun
 ifneq (,$(wildcard .env))
-  FRONTEND_DEV_RUNTIME := $(shell grep -E '^FRONTEND_DEV_RUNTIME=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d ' ' | head -1)
+  FRONTEND_DEV_RUNTIME := $(shell grep -E '^FRONTEND_DEV_RUNTIME=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d ' ' | tr -d '\r' | head -1)
 endif
 ifeq ($(FRONTEND_DEV_RUNTIME),)
   FRONTEND_DEV_RUNTIME := bun

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,6 +3,10 @@
 # ============================================
 FROM oven/bun:1.2.22-alpine AS dev
 
+# Node is optional at runtime (FRONTEND_DEV_RUNTIME=node). Installed in the image so
+# devs can switch via .env without rebuilding a separate Dockerfile target.
+RUN apk add --no-cache nodejs npm
+
 WORKDIR /app
 
 # Install dependencies first (will be overridden by volume mount in dev)
@@ -11,14 +15,15 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+COPY scripts/docker-dev-start.sh /docker-dev-start.sh
+RUN chmod +x /docker-entrypoint.sh /docker-dev-start.sh
 
 # Expose port for Next.js
 EXPOSE 3000
 
 # Use the same entrypoint as prod to generate env-config.js at startup
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["bun", "run", "dev"]
+CMD ["/docker-dev-start.sh"]
 
 # ============================================
 # Production Builder Stage

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:bun": "next dev --turbopack",
+    "dev:node": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/client/scripts/docker-dev-start.sh
+++ b/client/scripts/docker-dev-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# FRONTEND_DEV_RUNTIME selects the Next.js dev server process (Docker dev only).
+#   bun  - Bun + Turbopack (default)
+#   node - Node + Webpack (lower memory use in long-running Docker dev)
+runtime="${FRONTEND_DEV_RUNTIME:-bun}"
+
+case "$runtime" in
+  node)
+    exec npm run dev:node
+    ;;
+  bun)
+    exec bun run dev:bun
+    ;;
+  *)
+    echo "FRONTEND_DEV_RUNTIME must be 'bun' or 'node' (got: $runtime)" >&2
+    exit 1
+    ;;
+esac

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -109,9 +109,16 @@ export default auth((req) => {
     backendOrigin ? backendOrigin.replace(/^http/, 'ws') : '',
   ].filter(Boolean).join(' ')
 
+  // Webpack dev HMR (FRONTEND_DEV_RUNTIME=node) needs unsafe-eval; Turbopack/bun does not.
+  const scriptSrc =
+    process.env.NODE_ENV === 'development' &&
+    process.env.FRONTEND_DEV_RUNTIME === 'node'
+      ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+      : "script-src 'self' 'unsafe-inline'"
+
   response.headers.set('Content-Security-Policy', [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
+    scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",

--- a/docker-compose.frontend-dev-node.yml
+++ b/docker-compose.frontend-dev-node.yml
@@ -1,0 +1,8 @@
+# Merged when FRONTEND_DEV_RUNTIME=node (see Makefile COMPOSE_DEV).
+# Anonymous /app/.next volume reduces bind-mount I/O; omit for bun (hot reload).
+services:
+  frontend:
+    volumes:
+      - ./client:/app
+      - /app/node_modules
+      - /app/.next

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -540,6 +540,7 @@ services:
     environment:
       # Next.js development configuration
       NODE_ENV: development
+      FRONTEND_DEV_RUNTIME: ${FRONTEND_DEV_RUNTIME:-bun}
       AURORA_ENV: ${AURORA_ENV}
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"


### PR DESCRIPTION
Add FRONTEND_DEV_RUNTIME=bun|node so Docker dev can switch between the legacy Bun+Turbopack stack and the Node+Webpack path without separate images. Node mode merges docker-compose.frontend-dev-node.yml for the /app/.next anonymous volume and relaxes dev CSP for Webpack HMR.

Default remains bun for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable frontend dev runtime selector (Bun or Node) with matching dev scripts and a container startup script to choose the runtime at boot.
  * Add an alternate compose file for the Node-based frontend dev setup.

* **Chores**
  * Update dev targets and compose usage to respect the runtime selector; improve Dockerfile dev stage and teardown to remove leftover network.
* **Security**
  * Make Content-Security-Policy dynamic to allow dev-only script behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->