### PR TITLE
fix(ci): free disk space in airtight bundle workflow

### DIFF
--- a/.github/workflows/publish-airtight.yml
+++ b/.github/workflows/publish-airtight.yml
@@ -56,6 +56,12 @@ jobs:
         cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          docker system prune -af
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -93,6 +99,7 @@ jobs:
           docker tag aurora_server:latest aurora_chatbot:latest
           docker tag aurora_server:latest aurora_mcp:latest
 
+          docker builder prune -af
           docker buildx build --platform ${{ matrix.platform }} \
             -f client/Dockerfile --target prod \
             -t aurora_frontend:latest --load \


### PR DESCRIPTION
## Summary
- The airtight amd64 build was failing with `no space left on device` when importing the frontend Docker image
- Removes preinstalled SDKs (.NET, Android, GHC, Boost) at the start of the job to reclaim ~10GB
- Prunes the buildx cache between server and frontend builds to free intermediate layers

## Test plan
- I triggered the action for this branch manually and it suceeded instead of previous failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD build pipeline efficiency through improved disk space management during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->