### PR TITLE
Add PodDisruptionBudgets for frontend and MCP deployments

### DIFF
--- a/deploy/helm/aurora/templates/pdb.yaml
+++ b/deploy/helm/aurora/templates/pdb.yaml
@@ -1,5 +1,5 @@
-# PodDisruptionBudgets — prevent Autopilot from evicting all replicas
-# simultaneously, which drops active WebSocket sessions and API requests.
+# PodDisruptionBudgets — prevent the cluster autoscaler from evicting all
+# replicas simultaneously during node scale-down.
 {{- if ge (int .Values.replicaCounts.server) 2 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -12,6 +12,21 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "aurora.name" . }}-server
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+---
+{{- if ge (int .Values.replicaCounts.frontend) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aurora.fullname" . }}-frontend
+  labels:
+    {{- include "aurora.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aurora.name" . }}-frontend
       app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 ---
@@ -42,5 +57,20 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "aurora.name" . }}-celery-worker
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+---
+{{- if ge (int .Values.replicaCounts.mcp) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aurora.fullname" . }}-mcp
+  labels:
+    {{- include "aurora.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aurora.name" . }}-mcp
       app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
## Summary

The `aurora-oss-frontend` and `aurora-oss-mcp` deployments had no PodDisruptionBudget, unlike server, chatbot, and celery-worker which all had one. This allowed the GKE cluster autoscaler to evict all pods of these services simultaneously during node scale-down, causing **36+ hours of recurring 502/504 errors** on the `/chatbotws` and `/mcp` endpoints (May 25-27).

## Root Cause

The autoscaler entered a tight oscillation loop: scale-up nodes (due to 2-replica pod scheduling), then scale-down (due to low utilization at 3-10% CPU). Without a PDB on frontend/MCP, both pods could be evicted at the same second, leaving the ingress controller with zero live upstreams.

Verified via GCP Cloud Logging:
- Frontend pods were killed and rescheduled **6+ times per hour** for 36 hours
- Both frontend replicas were evicted simultaneously at 00:29:52 UTC May 26
- Ingress logged continuous `no live upstreams` errors every ~35 seconds during disruption windows

## Changes

- Added PDB for `frontend` (gated on `replicaCounts.frontend >= 2`)
- Added PDB for `mcp` (gated on `replicaCounts.mcp >= 2`)
- Both use `minAvailable: 1` consistent with existing PDBs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service resilience by improving availability protection for frontend and mcp components, ensuring at least one pod remains available during cluster operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->