### PR TITLE
GCP connector: multi-SA support + project-aware RCA + hide OAuth UI

### DIFF
--- a/client/src/app/api/proxy/gcp/service-accounts/[[...path]]/route.ts
+++ b/client/src/app/api/proxy/gcp/service-accounts/[[...path]]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+async function handler(
+  request: NextRequest,
+  { params }: { params: Promise<{ path?: string[] }> },
+) {
+  const { path } = await params;
+  const suffix = path && path.length > 0 ? '/' + path.join('/') : '';
+  const backendPath = '/api/gcp/service-accounts' + suffix;
+  return forwardRequest(request, request.method, backendPath, 'gcp');
+}
+
+export { handler as GET, handler as POST, handler as DELETE };

--- a/client/src/app/gcp/auth/page.tsx
+++ b/client/src/app/gcp/auth/page.tsx
@@ -1,114 +1,314 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertCircle,
+  Loader2,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 import { ProjectCache } from "@/components/cloud-provider/projects/projectUtils";
 import { fetchConnectedAccounts } from "@/lib/connected-accounts-cache";
 import { GcpServiceAccountForm } from "@/components/connectors/GcpServiceAccountForm";
 
-export default function GcpAuthPage() {
-  const router = useRouter();
-  const { toast } = useToast();
-  const [oauthLoading, setOauthLoading] = useState(false);
+interface ServiceAccount {
+  account_id: string;
+  account_alias: string | null;
+  project_id: string | null;
+  accessible_project_ids: string[];
+  visibility: "private" | "org" | string;
+  status: "active" | "inactive" | string;
+  last_verified_at: string | null;
+}
 
-  const handleOAuthConnect = async () => {
-    setOauthLoading(true);
+interface ListResponse {
+  service_accounts: ServiceAccount[];
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function dispatchProviderChanged() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("providerStateChanged"));
+  void fetchConnectedAccounts(true).catch(() => {});
+  ProjectCache.invalidate("gcp");
+}
+
+export default function GcpAuthPage() {
+  const { toast } = useToast();
+
+  const [serviceAccounts, setServiceAccounts] = useState<ServiceAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const loadServiceAccounts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
     try {
-      const response = await fetch("/api/gcp/oauth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const res = await fetch("/api/proxy/gcp/service-accounts", {
+        credentials: "include",
       });
-      if (!response.ok) {
-        throw new Error(`Login request failed with status: ${response.status}`);
+      if (!res.ok) {
+        throw new Error(`Request failed (${res.status})`);
       }
-      const data = await response.json();
-      if (!data.login_url) {
-        throw new Error("No OAuth URL received");
+      const data = (await res.json()) as ListResponse;
+      setServiceAccounts(Array.isArray(data.service_accounts) ? data.service_accounts : []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load service accounts";
+      setError(message);
+      setServiceAccounts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadServiceAccounts();
+  }, [loadServiceAccounts]);
+
+  // Disconnect deletes the Vault secret, so inactive rows cannot be
+  // reconnected without re-uploading the SA key. The backend already filters
+  // them out of the list response; this is just a defensive guard.
+  const active = useMemo(
+    () => serviceAccounts.filter((sa) => sa.status === "active"),
+    [serviceAccounts],
+  );
+
+  const toggleProjects = (accountId: string) => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(accountId)) next.delete(accountId);
+      else next.add(accountId);
+      return next;
+    });
+  };
+
+  const handleDelete = async (sa: ServiceAccount) => {
+    setPendingAction(`delete:${sa.account_id}`);
+    try {
+      const res = await fetch(
+        `/api/proxy/gcp/service-accounts/${encodeURIComponent(sa.account_id)}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error || `Failed (${res.status})`);
       }
-      ProjectCache.invalidate("gcp");
-      localStorage.setItem("aurora_graph_discovery_trigger", "1");
-      window.location.href = data.login_url;
-    } catch (error: unknown) {
-      console.error("GCP OAuth connect failed", error);
+      toast({ title: "Disconnected", description: sa.account_id });
+      dispatchProviderChanged();
+      await loadServiceAccounts();
+    } catch (err) {
       toast({
-        title: "Failed to connect to Google Cloud",
-        description: error instanceof Error ? error.message : "Unknown error",
+        title: "Failed to disconnect",
+        description: err instanceof Error ? err.message : "Unknown error",
         variant: "destructive",
       });
-      setOauthLoading(false);
+    } finally {
+      setPendingAction(null);
     }
   };
 
-  const handleServiceAccountSuccess = () => {
-    void fetchConnectedAccounts(true).catch(() => {});
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("providerStateChanged"));
+  const handleDisconnectAll = async () => {
+    if (active.length === 0) return;
+    const confirmed = typeof window === "undefined"
+      ? true
+      : window.confirm(`Disconnect all ${active.length} GCP service account(s)?`);
+    if (!confirmed) return;
+
+    setPendingAction("disconnect-all");
+    try {
+      const res = await fetch("/api/proxy/gcp/service-accounts/disconnect-all", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error || `Failed (${res.status})`);
+      }
+      toast({ title: "Disconnected all GCP service accounts" });
+      dispatchProviderChanged();
+      await loadServiceAccounts();
+    } catch (err) {
+      toast({
+        title: "Failed to disconnect all",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingAction(null);
     }
-    router.push("/connectors");
+  };
+
+  const handleFormSuccess = async () => {
+    dispatchProviderChanged();
+    await loadServiceAccounts();
   };
 
   return (
-    <div className="container mx-auto py-8 px-4 max-w-3xl">
+    <div className="container mx-auto py-8 px-4 max-w-4xl">
       <div className="flex items-center gap-4 mb-8">
         <div className="p-2 rounded-xl shadow-sm border overflow-hidden">
-          <img src="/google-cloud-svgrepo-com.svg" alt="Google Cloud" className="h-9 w-9 object-contain rounded-md" />
+          <img
+            src="/google-cloud-svgrepo-com.svg"
+            alt="Google Cloud"
+            className="h-9 w-9 object-contain rounded-md"
+          />
         </div>
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Google Cloud</h1>
           <p className="text-muted-foreground text-sm">
-            Connect to Google Cloud Platform to manage cloud resources, monitor services, and deploy applications across your GCP infrastructure.
+            Manage the service accounts Aurora uses to access your Google Cloud
+            projects.
           </p>
         </div>
       </div>
 
-      <Card>
+      <Card className="mb-6">
+        <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+          <div>
+            <CardTitle className="text-lg">Connected Service Accounts</CardTitle>
+            <CardDescription>
+              {active.length} active
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => loadServiceAccounts()}
+              disabled={loading}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDisconnectAll}
+              disabled={active.length === 0 || pendingAction === "disconnect-all"}
+            >
+              {pendingAction === "disconnect-all" ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4 mr-2" />
+              )}
+              Disconnect All
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-destructive mb-4">
+              <AlertCircle className="h-4 w-4" />
+              {error}
+            </div>
+          )}
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            </div>
+          ) : active.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4">
+              No active service accounts yet. Add one below.
+            </p>
+          ) : (
+            <div className="divide-y rounded-md border">
+              {active.map((sa) => {
+                const isExpanded = expandedProjects.has(sa.account_id);
+                const accessibleCount = sa.accessible_project_ids?.length ?? 0;
+                return (
+                  <div key={sa.account_id} className="p-4 space-y-2">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="font-medium text-sm truncate">
+                          {sa.account_alias || sa.account_id}
+                        </div>
+                        {sa.account_alias && (
+                          <div className="text-xs text-muted-foreground truncate">
+                            {sa.account_id}
+                          </div>
+                        )}
+                        <div className="flex flex-wrap items-center gap-2 mt-1.5">
+                          {sa.project_id && (
+                            <Badge variant="secondary" className="text-xs font-mono">
+                              {sa.project_id}
+                            </Badge>
+                          )}
+                          <Badge
+                            variant={sa.visibility === "org" ? "default" : "outline"}
+                            className="text-xs"
+                          >
+                            {sa.visibility === "org" ? "Org" : "Private"}
+                          </Badge>
+                          <button
+                            type="button"
+                            onClick={() => toggleProjects(sa.account_id)}
+                            className="text-xs underline text-muted-foreground hover:text-foreground"
+                          >
+                            {accessibleCount} project{accessibleCount === 1 ? "" : "s"}
+                          </button>
+                          <span className="text-xs text-muted-foreground">
+                            Verified {formatTimestamp(sa.last_verified_at)}
+                          </span>
+                        </div>
+                        {isExpanded && accessibleCount > 0 && (
+                          <ul className="mt-2 text-xs text-muted-foreground font-mono space-y-0.5 max-h-40 overflow-auto">
+                            {sa.accessible_project_ids.map((pid) => (
+                              <li key={pid}>{pid}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleDelete(sa)}
+                        disabled={pendingAction === `delete:${sa.account_id}`}
+                      >
+                        {pendingAction === `delete:${sa.account_id}` ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
         <CardHeader>
-          <CardTitle className="text-lg">Connect Your Google Cloud Account</CardTitle>
+          <CardTitle className="text-lg">Add a Service Account</CardTitle>
           <CardDescription>
-            Choose how Aurora should authenticate with your Google Cloud projects. You can always switch later by disconnecting and reconnecting.
+            Upload or paste a Google Cloud service account JSON key. Aurora will
+            verify it has access to the project before storing it.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Tabs defaultValue="oauth" className="w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="oauth">OAuth</TabsTrigger>
-              <TabsTrigger value="service-account">Service Account</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="oauth" className="mt-6 space-y-4">
-              <div className="space-y-2 text-sm text-muted-foreground">
-                <p>
-                  Sign in with your Google account. Aurora will use your OAuth
-                  consent to access the projects you select. Best for individual
-                  users and quick setup.
-                </p>
-                <p>You&apos;ll be redirected to Google to grant consent.</p>
-              </div>
-              <Button
-                className="w-full"
-                onClick={handleOAuthConnect}
-                disabled={oauthLoading}
-              >
-                {oauthLoading ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Redirecting to Google...
-                  </>
-                ) : (
-                  "Connect with Google"
-                )}
-              </Button>
-            </TabsContent>
-
-            <TabsContent value="service-account" className="mt-6">
-              <GcpServiceAccountForm onSuccess={handleServiceAccountSuccess} />
-            </TabsContent>
-          </Tabs>
+          <GcpServiceAccountForm onSuccess={handleFormSuccess} />
         </CardContent>
       </Card>
     </div>

--- a/client/src/app/gcp/auth/page.tsx
+++ b/client/src/app/gcp/auth/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -26,8 +27,9 @@ interface ServiceAccount {
   account_alias: string | null;
   project_id: string | null;
   accessible_project_ids: string[];
-  visibility: "private" | "org" | string;
-  status: "active" | "inactive" | string;
+  // Free-form so the backend can introduce new values without breaking the UI.
+  visibility: string;
+  status: string;
   last_verified_at: string | null;
 }
 
@@ -45,9 +47,9 @@ function formatTimestamp(value: string | null): string {
 }
 
 function dispatchProviderChanged() {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent("providerStateChanged"));
-  void fetchConnectedAccounts(true).catch(() => {});
+  if (typeof globalThis.window === "undefined") return;
+  globalThis.window.dispatchEvent(new CustomEvent("providerStateChanged"));
+  fetchConnectedAccounts(true).catch(() => {});
   ProjectCache.invalidate("gcp");
 }
 
@@ -82,7 +84,7 @@ export default function GcpAuthPage() {
   }, []);
 
   useEffect(() => {
-    void loadServiceAccounts();
+    loadServiceAccounts().catch(() => {});
   }, [loadServiceAccounts]);
 
   // Disconnect deletes the Vault secret, so inactive rows cannot be
@@ -129,9 +131,9 @@ export default function GcpAuthPage() {
 
   const handleDisconnectAll = async () => {
     if (active.length === 0) return;
-    const confirmed = typeof window === "undefined"
+    const confirmed = typeof globalThis.window === "undefined"
       ? true
-      : window.confirm(`Disconnect all ${active.length} GCP service account(s)?`);
+      : globalThis.confirm(`Disconnect all ${active.length} GCP service account(s)?`);
     if (!confirmed) return;
 
     setPendingAction("disconnect-all");
@@ -162,6 +164,88 @@ export default function GcpAuthPage() {
     dispatchProviderChanged();
     await loadServiceAccounts();
   };
+
+  let saListContent: ReactNode;
+  if (loading) {
+    saListContent = (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  } else if (active.length === 0) {
+    saListContent = (
+      <p className="text-sm text-muted-foreground py-4">
+        No active service accounts yet. Add one below.
+      </p>
+    );
+  } else {
+    saListContent = (
+      <div className="divide-y rounded-md border">
+        {active.map((sa) => {
+          const isExpanded = expandedProjects.has(sa.account_id);
+          const accessibleCount = sa.accessible_project_ids?.length ?? 0;
+          return (
+            <div key={sa.account_id} className="p-4 space-y-2">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-medium text-sm truncate">
+                    {sa.account_alias || sa.account_id}
+                  </div>
+                  {sa.account_alias && (
+                    <div className="text-xs text-muted-foreground truncate">
+                      {sa.account_id}
+                    </div>
+                  )}
+                  <div className="flex flex-wrap items-center gap-2 mt-1.5">
+                    {sa.project_id && (
+                      <Badge variant="secondary" className="text-xs font-mono">
+                        {sa.project_id}
+                      </Badge>
+                    )}
+                    <Badge
+                      variant={sa.visibility === "org" ? "default" : "outline"}
+                      className="text-xs"
+                    >
+                      {sa.visibility === "org" ? "Org" : "Private"}
+                    </Badge>
+                    <button
+                      type="button"
+                      onClick={() => toggleProjects(sa.account_id)}
+                      className="text-xs underline text-muted-foreground hover:text-foreground"
+                    >
+                      {accessibleCount} project{accessibleCount === 1 ? "" : "s"}
+                    </button>
+                    <span className="text-xs text-muted-foreground">
+                      Verified {formatTimestamp(sa.last_verified_at)}
+                    </span>
+                  </div>
+                  {isExpanded && accessibleCount > 0 && (
+                    <ul className="mt-2 text-xs text-muted-foreground font-mono space-y-0.5 max-h-40 overflow-auto">
+                      {sa.accessible_project_ids.map((pid) => (
+                        <li key={pid}>{pid}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleDelete(sa)}
+                  disabled={pendingAction === `delete:${sa.account_id}`}
+                >
+                  {pendingAction === `delete:${sa.account_id}` ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">
@@ -222,80 +306,7 @@ export default function GcpAuthPage() {
               {error}
             </div>
           )}
-          {loading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin text-primary" />
-            </div>
-          ) : active.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4">
-              No active service accounts yet. Add one below.
-            </p>
-          ) : (
-            <div className="divide-y rounded-md border">
-              {active.map((sa) => {
-                const isExpanded = expandedProjects.has(sa.account_id);
-                const accessibleCount = sa.accessible_project_ids?.length ?? 0;
-                return (
-                  <div key={sa.account_id} className="p-4 space-y-2">
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="font-medium text-sm truncate">
-                          {sa.account_alias || sa.account_id}
-                        </div>
-                        {sa.account_alias && (
-                          <div className="text-xs text-muted-foreground truncate">
-                            {sa.account_id}
-                          </div>
-                        )}
-                        <div className="flex flex-wrap items-center gap-2 mt-1.5">
-                          {sa.project_id && (
-                            <Badge variant="secondary" className="text-xs font-mono">
-                              {sa.project_id}
-                            </Badge>
-                          )}
-                          <Badge
-                            variant={sa.visibility === "org" ? "default" : "outline"}
-                            className="text-xs"
-                          >
-                            {sa.visibility === "org" ? "Org" : "Private"}
-                          </Badge>
-                          <button
-                            type="button"
-                            onClick={() => toggleProjects(sa.account_id)}
-                            className="text-xs underline text-muted-foreground hover:text-foreground"
-                          >
-                            {accessibleCount} project{accessibleCount === 1 ? "" : "s"}
-                          </button>
-                          <span className="text-xs text-muted-foreground">
-                            Verified {formatTimestamp(sa.last_verified_at)}
-                          </span>
-                        </div>
-                        {isExpanded && accessibleCount > 0 && (
-                          <ul className="mt-2 text-xs text-muted-foreground font-mono space-y-0.5 max-h-40 overflow-auto">
-                            {sa.accessible_project_ids.map((pid) => (
-                              <li key={pid}>{pid}</li>
-                            ))}
-                          </ul>
-                        )}
-                      </div>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleDelete(sa)}
-                        disabled={pendingAction === `delete:${sa.account_id}`}
-                      >
-                        {pendingAction === `delete:${sa.account_id}` ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
+          {saListContent}
         </CardContent>
       </Card>
 

--- a/client/src/app/gcp/auth/page.tsx
+++ b/client/src/app/gcp/auth/page.tsx
@@ -47,7 +47,7 @@ function formatTimestamp(value: string | null): string {
 }
 
 function dispatchProviderChanged() {
-  if (typeof globalThis.window === "undefined") return;
+  if (globalThis.window === undefined) return;
   globalThis.window.dispatchEvent(new CustomEvent("providerStateChanged"));
   fetchConnectedAccounts(true).catch(() => {});
   ProjectCache.invalidate("gcp");
@@ -131,7 +131,7 @@ export default function GcpAuthPage() {
 
   const handleDisconnectAll = async () => {
     if (active.length === 0) return;
-    const confirmed = typeof globalThis.window === "undefined"
+    const confirmed = globalThis.window === undefined
       ? true
       : globalThis.confirm(`Disconnect all ${active.length} GCP service account(s)?`);
     if (!confirmed) return;

--- a/client/src/components/connectors/GcpServiceAccountForm.tsx
+++ b/client/src/components/connectors/GcpServiceAccountForm.tsx
@@ -188,12 +188,12 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
       const accessibleCount = accessibleList ? accessibleList.length : null;
       const connectedAs = successPayload.account_id || successPayload.email;
       let description: string;
-      if (!connectedAs) {
-        description = "Service account connected successfully.";
-      } else if (accessibleCount !== null) {
+      if (connectedAs && accessibleCount !== null) {
         description = `Connected as ${connectedAs} — ${accessibleCount} project${accessibleCount === 1 ? "" : "s"} accessible.`;
-      } else {
+      } else if (connectedAs) {
         description = `Connected as ${connectedAs}.`;
+      } else {
+        description = "Service account connected successfully.";
       }
 
       toast({

--- a/client/src/components/connectors/GcpServiceAccountForm.tsx
+++ b/client/src/components/connectors/GcpServiceAccountForm.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -76,6 +77,7 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
   const { toast } = useToast();
   const [saJsonText, setSaJsonText] = useState("");
   const [fileName, setFileName] = useState<string>("");
+  const [alias, setAlias] = useState("");
   const [loading, setLoading] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -129,11 +131,15 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
     setSubmitError(null);
 
     try {
-      const response = await fetch("/api/gcp/service-account/connect", {
+      const trimmedAlias = alias.trim();
+      const response = await fetch("/api/proxy/gcp/service-accounts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ service_account_json: saJsonText }),
+        body: JSON.stringify({
+          service_account_json: saJsonText,
+          alias: trimmedAlias ? trimmedAlias : undefined,
+        }),
       });
 
       const text = await response.text();
@@ -166,18 +172,24 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
       const successPayload =
         payload && typeof payload === "object"
           ? (payload as {
+              account_id?: string;
               email?: string;
-              default_project_id?: string;
+              project_id?: string;
+              accessible_project_ids?: unknown;
               accessible_projects?: unknown;
             })
           : {};
-      const accessibleCount = Array.isArray(successPayload.accessible_projects)
-        ? successPayload.accessible_projects.length
-        : null;
-      const description = successPayload.email
+      const accessibleList = Array.isArray(successPayload.accessible_project_ids)
+        ? successPayload.accessible_project_ids
+        : Array.isArray(successPayload.accessible_projects)
+          ? successPayload.accessible_projects
+          : null;
+      const accessibleCount = accessibleList ? accessibleList.length : null;
+      const connectedAs = successPayload.account_id || successPayload.email;
+      const description = connectedAs
         ? accessibleCount !== null
-          ? `Connected as ${successPayload.email} — ${accessibleCount} project${accessibleCount === 1 ? "" : "s"} accessible.`
-          : `Connected as ${successPayload.email}.`
+          ? `Connected as ${connectedAs} — ${accessibleCount} project${accessibleCount === 1 ? "" : "s"} accessible.`
+          : `Connected as ${connectedAs}.`
         : "Service account connected successfully.";
 
       toast({
@@ -187,6 +199,7 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
 
       setSaJsonText("");
       setFileName("");
+      setAlias("");
 
       ProjectCache.invalidate("gcp");
       // Fire-and-forget: don't block dialog close on a potentially slow
@@ -272,6 +285,24 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
             {validation.error}
           </p>
         )}
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label htmlFor="sa-alias" className="text-sm font-medium">
+          Alias (optional)
+        </Label>
+        <Input
+          id="sa-alias"
+          value={alias}
+          onChange={(event) => setAlias(event.target.value)}
+          placeholder="e.g. prod-readonly"
+          maxLength={120}
+          disabled={loading}
+          autoComplete="off"
+        />
+        <p className="text-xs text-muted-foreground">
+          A short, friendly label so you can recognize this account later.
+        </p>
       </div>
 
       <Alert>

--- a/client/src/components/connectors/GcpServiceAccountForm.tsx
+++ b/client/src/components/connectors/GcpServiceAccountForm.tsx
@@ -138,7 +138,7 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
         credentials: "include",
         body: JSON.stringify({
           service_account_json: saJsonText,
-          alias: trimmedAlias ? trimmedAlias : undefined,
+          alias: trimmedAlias || undefined,
         }),
       });
 
@@ -179,18 +179,22 @@ export function GcpServiceAccountForm({ onSuccess }: GcpServiceAccountFormProps)
               accessible_projects?: unknown;
             })
           : {};
-      const accessibleList = Array.isArray(successPayload.accessible_project_ids)
-        ? successPayload.accessible_project_ids
-        : Array.isArray(successPayload.accessible_projects)
-          ? successPayload.accessible_projects
-          : null;
+      let accessibleList: unknown[] | null = null;
+      if (Array.isArray(successPayload.accessible_project_ids)) {
+        accessibleList = successPayload.accessible_project_ids;
+      } else if (Array.isArray(successPayload.accessible_projects)) {
+        accessibleList = successPayload.accessible_projects;
+      }
       const accessibleCount = accessibleList ? accessibleList.length : null;
       const connectedAs = successPayload.account_id || successPayload.email;
-      const description = connectedAs
-        ? accessibleCount !== null
-          ? `Connected as ${connectedAs} — ${accessibleCount} project${accessibleCount === 1 ? "" : "s"} accessible.`
-          : `Connected as ${connectedAs}.`
-        : "Service account connected successfully.";
+      let description: string;
+      if (!connectedAs) {
+        description = "Service account connected successfully.";
+      } else if (accessibleCount !== null) {
+        description = `Connected as ${connectedAs} — ${accessibleCount} project${accessibleCount === 1 ? "" : "s"} accessible.`;
+      } else {
+        description = `Connected as ${connectedAs}.`;
+      }
 
       toast({
         title: "GCP connected",

--- a/client/src/components/gcp-provider-integration.tsx
+++ b/client/src/components/gcp-provider-integration.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
 import { Button } from "@/components/ui/button";
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, RefreshCw, LogOut } from 'lucide-react';
+import { Loader2, RefreshCw, Settings } from 'lucide-react';
 import { ProjectListItem } from '@/components/cloud-provider/ui/ProjectListItem';
-import { fetchProjects, saveProjects, ProjectCache } from '@/components/cloud-provider/projects/projectUtils';
+import { fetchProjects, saveProjects } from '@/components/cloud-provider/projects/projectUtils';
 import { Project } from '@/components/cloud-provider/types';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
@@ -15,19 +16,38 @@ interface GcpProviderIntegrationProps {
   onDisconnect?: () => void;
 }
 
-export default function GcpProviderIntegration({ onDisconnect }: GcpProviderIntegrationProps) {
+interface GcpAccountSummary {
+  email?: string;
+  project_id?: string;
+  alias?: string;
+  authType?: string;
+  accessibleProjectIds?: string[];
+}
+
+interface GcpProviderEntry {
+  count?: number;
+  accounts?: GcpAccountSummary[];
+  authType?: string;
+}
+
+export default function GcpProviderIntegration({ onDisconnect: _onDisconnect }: GcpProviderIntegrationProps) {
   const [userId, setUserId] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
-  const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [togglingProjectId, setTogglingProjectId] = useState<string | null>(null);
   const { toast } = useToast();
 
   const { accounts } = useConnectedAccounts();
-  const rawAuthType = (accounts.gcp as { authType?: string } | undefined)?.authType;
+  const gcpEntry = accounts.gcp as GcpProviderEntry | undefined;
+  const gcpAccounts: GcpAccountSummary[] = useMemo(
+    () => (Array.isArray(gcpEntry?.accounts) ? gcpEntry!.accounts : []),
+    [gcpEntry],
+  );
   const authType: 'oauth' | 'service_account' | null =
-    rawAuthType === 'service_account' || rawAuthType === 'oauth' ? rawAuthType : null;
+    gcpEntry?.authType === 'service_account' || gcpEntry?.authType === 'oauth'
+      ? gcpEntry.authType
+      : null;
 
   // Fetch user ID on mount
   useEffect(() => {
@@ -50,6 +70,7 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
     if (userId) {
       loadProjects(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId]);
 
   const loadProjects = async (forceRefresh = false) => {
@@ -72,22 +93,19 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
   const handleToggle = async (projectId: string) => {
     setTogglingProjectId(projectId);
     try {
-      // Update local state immediately for better UX
       const updatedProjects = projects.map(p =>
         p.projectId === projectId ? { ...p, enabled: !p.enabled } : p
       );
       setProjects(updatedProjects);
 
-      // Save to backend
       await saveProjects('gcp', updatedProjects);
-      
+
       toast({
         title: "Success",
         description: `Project ${updatedProjects.find(p => p.projectId === projectId)?.enabled ? 'enabled' : 'disabled'}`,
       });
     } catch (error: any) {
       console.error('Error toggling project:', error);
-      // Revert on error
       loadProjects();
       toast({
         title: "Error",
@@ -99,9 +117,9 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
     }
   };
 
-  const handleSetAsRoot = async (providerId: string, projectId: string) => {
+  const handleSetAsRoot = async (_providerId: string, projectId: string) => {
     if (!userId) return;
-    
+
     setIsSaving(true);
     try {
       const response = await fetch('/api/root-project', {
@@ -117,9 +135,8 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
         throw new Error(error.error || 'Failed to set root project');
       }
 
-      // Refresh projects to get updated root project status
       await loadProjects();
-      
+
       toast({
         title: "Success",
         description: "Root project updated successfully",
@@ -136,51 +153,39 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
     }
   };
 
-  const handleDisconnect = async () => {
-    if (!userId) return;
-    
-    setIsDisconnecting(true);
-    try {
-      const response = await fetch('/api/connected-accounts/gcp', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to disconnect GCP');
-      }
-
-      // Clear local state
-      setProjects([]);
-      ProjectCache.invalidate('gcp');
-      // Notify other components to refresh their status
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('providerStateChanged'));
-      }
-      
-      toast({
-        title: "Disconnected",
-        description: "GCP account disconnected successfully",
-      });
-
-      // Close dialog if callback provided
-      if (onDisconnect) {
-        onDisconnect();
-      }
-    } catch (error: any) {
-      console.error('Error disconnecting GCP:', error);
-      toast({
-        title: "Error",
-        description: error.message || "Failed to disconnect GCP",
-        variant: "destructive",
-      });
-    } finally {
-      setIsDisconnecting(false);
+  // Group projects by service account using accessibleProjectIds
+  const grouped = useMemo(() => {
+    if (gcpAccounts.length === 0) {
+      return [{ key: '__all__', sa: null as GcpAccountSummary | null, projects }];
     }
-  };
+    const projectIdToAccount: Record<string, GcpAccountSummary> = {};
+    for (const sa of gcpAccounts) {
+      for (const pid of sa.accessibleProjectIds ?? []) {
+        if (!projectIdToAccount[pid]) projectIdToAccount[pid] = sa;
+      }
+    }
+    const groups: Array<{ key: string; sa: GcpAccountSummary | null; projects: Project[] }> = gcpAccounts.map((sa, idx) => ({
+      // Stable key: prefer email, then project_id, then a deterministic index
+      // fallback. Math.random() here would change on every useMemo recompute
+      // and force React to unmount/remount the whole account block.
+      key: sa.email ?? sa.project_id ?? `gcp-account-${idx}`,
+      sa,
+      projects: [],
+    }));
+    const ungrouped: Project[] = [];
+    for (const project of projects) {
+      const owner = projectIdToAccount[project.projectId];
+      const group = owner
+        ? groups.find(g => g.sa?.email === owner.email)
+        : undefined;
+      if (group) group.projects.push(project);
+      else ungrouped.push(project);
+    }
+    if (ungrouped.length > 0) {
+      groups.push({ key: '__other__', sa: null, projects: ungrouped });
+    }
+    return groups.filter(g => g.projects.length > 0);
+  }, [projects, gcpAccounts]);
 
   if (isLoading) {
     return (
@@ -202,9 +207,14 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
                 {authType === 'service_account' ? 'Service Account' : 'OAuth'}
               </Badge>
             )}
+            {typeof gcpEntry?.count === 'number' && gcpEntry.count > 0 && (
+              <Badge variant="outline" className="text-xs">
+                {gcpEntry.count} account{gcpEntry.count === 1 ? '' : 's'}
+              </Badge>
+            )}
           </div>
           <p className="text-sm text-muted-foreground">
-            Manage which projects your service account can access
+            Manage which projects each service account can access
           </p>
         </div>
         <div className="flex items-center gap-2 flex-wrap justify-end">
@@ -217,23 +227,11 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
             <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={handleDisconnect}
-            disabled={isDisconnecting}
-          >
-            {isDisconnecting ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Disconnecting...
-              </>
-            ) : (
-              <>
-                <LogOut className="h-4 w-4 mr-2" />
-                Disconnect
-              </>
-            )}
+          <Button asChild variant="outline" size="sm">
+            <Link href="/gcp/auth">
+              <Settings className="h-4 w-4 mr-2" />
+              Manage Service Accounts
+            </Link>
           </Button>
         </div>
       </div>
@@ -244,17 +242,40 @@ export default function GcpProviderIntegration({ onDisconnect }: GcpProviderInte
         </div>
       ) : (
         <ScrollArea className="h-[400px] pr-4">
-          <div className="space-y-2">
-            {projects.map((project) => (
-              <ProjectListItem
-                key={project.projectId}
-                project={project}
-                providerId="gcp"
-                isLoading={togglingProjectId === project.projectId}
-                onToggle={handleToggle}
-                onSetAsRoot={handleSetAsRoot}
-                showToggle={true}
-              />
+          <div className="space-y-6">
+            {grouped.map(group => (
+              <div key={group.key} className="space-y-2">
+                {group.sa && (
+                  <div className="flex flex-col gap-0.5 px-1">
+                    <div className="text-sm font-medium">
+                      {group.sa.alias || group.sa.email || 'Service Account'}
+                    </div>
+                    {group.sa.alias && group.sa.email && (
+                      <div className="text-xs text-muted-foreground truncate">
+                        {group.sa.email}
+                      </div>
+                    )}
+                  </div>
+                )}
+                {group.key === '__other__' && (
+                  <div className="text-xs text-muted-foreground px-1">
+                    Other projects
+                  </div>
+                )}
+                <div className="space-y-2">
+                  {group.projects.map(project => (
+                    <ProjectListItem
+                      key={project.projectId}
+                      project={project}
+                      providerId="gcp"
+                      isLoading={togglingProjectId === project.projectId || isSaving}
+                      onToggle={handleToggle}
+                      onSetAsRoot={handleSetAsRoot}
+                      showToggle={true}
+                    />
+                  ))}
+                </div>
+              </div>
             ))}
           </div>
         </ScrollArea>

--- a/client/src/components/gcp-provider-integration.tsx
+++ b/client/src/components/gcp-provider-integration.tsx
@@ -30,7 +30,7 @@ interface GcpProviderEntry {
   authType?: string;
 }
 
-export default function GcpProviderIntegration({ onDisconnect: _onDisconnect }: GcpProviderIntegrationProps) {
+export default function GcpProviderIntegration({ onDisconnect: _onDisconnect }: Readonly<GcpProviderIntegrationProps>) {
   const [userId, setUserId] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -41,7 +41,7 @@ export default function GcpProviderIntegration({ onDisconnect: _onDisconnect }: 
   const { accounts } = useConnectedAccounts();
   const gcpEntry = accounts.gcp as GcpProviderEntry | undefined;
   const gcpAccounts: GcpAccountSummary[] = useMemo(
-    () => (Array.isArray(gcpEntry?.accounts) ? gcpEntry!.accounts : []),
+    () => (Array.isArray(gcpEntry?.accounts) ? gcpEntry.accounts : []),
     [gcpEntry],
   );
   const authType: 'oauth' | 'service_account' | null =

--- a/server/chat/backend/agent/skills/rca/provider_gcp.md
+++ b/server/chat/backend/agent/skills/rca/provider_gcp.md
@@ -26,3 +26,7 @@ metadata:
 - Check services: `cloud_exec('gcp', 'kubectl get svc -n NAMESPACE')`
 - Check HPA: `cloud_exec('gcp', 'kubectl get hpa -n NAMESPACE')`
 - Check PVC status: `cloud_exec('gcp', 'kubectl get pvc -n NAMESPACE')`
+
+## Multi-service-account guidance
+
+When an alert tag includes a project ID (`project_id:foo` in tags, `gcp_project` in labels, or `projects/foo/...` in resource names), pass `project_id='foo'` to `cloud_exec('gcp', ...)`. To enumerate across all connected projects, omit `project_id` — Aurora will fan out across every active service account.

--- a/server/chat/backend/agent/tools/auth/gcp_cached_auth.py
+++ b/server/chat/backend/agent/tools/auth/gcp_cached_auth.py
@@ -130,17 +130,21 @@ def clear_gcp_cache_for_user(user_id: str) -> None:
     ]:
         os.environ.pop(var, None)
     
-    # Also drop any cached SA ADC file for this user from cloud_exec_tool's
-    # in-memory cache so the next tool call rewrites it from the fresh Vault
-    # payload.
+    # Also drop any cached SA ADC files for this user from cloud_exec_tool's
+    # in-memory cache so the next tool call rewrites them from the fresh Vault
+    # payload. The cache is keyed (user_id, project_id) tuples, so a single
+    # pop(user_id) silently never matches — we have to scan and evict every
+    # tuple whose first element is this user_id.
     try:
         from chat.backend.agent.tools.cloud_exec_tool import _sa_adc_file_cache
-        stale_path = _sa_adc_file_cache.pop(user_id, None)
-        if stale_path and os.path.exists(stale_path):
-            try:
-                os.remove(stale_path)
-            except Exception as e:
-                logger.debug(f"Could not remove cached SA ADC file {stale_path}: {e}")
+        stale_keys = [k for k in _sa_adc_file_cache if isinstance(k, tuple) and k and k[0] == user_id]
+        for key in stale_keys:
+            stale_path = _sa_adc_file_cache.pop(key, None)
+            if stale_path and os.path.exists(stale_path):
+                try:
+                    os.remove(stale_path)
+                except Exception as e:
+                    logger.debug(f"Could not remove cached SA ADC file {stale_path}: {e}")
     except Exception as e:
         logger.debug(f"Could not clear SA ADC file cache for user {user_id}: {e}")
 

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1303,6 +1303,7 @@ def _run_gcp_sa_command(
             f"<error>Connection record is missing project_id; reconnect this service account.</error>"
         )
 
+    isolated_env: Optional[dict] = None
     try:
         ok, resolved_project_id, _auth_method, isolated_env = (
             setup_gcp_environment_isolated(
@@ -1341,6 +1342,21 @@ def _run_gcp_sa_command(
             f"[project: {project_id} / sa: {alias_or_email}]\n"
             f"<error>{str(e)[:300]}</error>"
         )
+    finally:
+        # Eagerly remove the per-call CLOUDSDK_CONFIG tempdir. setup_gcp_environment_isolated
+        # registers an atexit cleanup as a safety-net, but in long-running workers a multi-SA
+        # fan-out across N accounts would otherwise leak N ".gcloud-*" dirs until process exit.
+        if isolated_env:
+            tmpdir = isolated_env.get("_gcloud_tmpdir") or isolated_env.get("CLOUDSDK_CONFIG")
+            if tmpdir and os.path.basename(tmpdir).startswith(".gcloud-"):
+                try:
+                    import shutil
+                    shutil.rmtree(tmpdir, ignore_errors=True)
+                except Exception as cleanup_err:
+                    logger.debug(
+                        "Multi-SA tempdir cleanup failed for %s: %s",
+                        tmpdir, cleanup_err,
+                    )
 
 
 def _cloud_exec_gcp_multi_sa(
@@ -1416,6 +1432,9 @@ def _cloud_exec_gcp_multi_sa(
     })
 
 
+_INLINE_PROJECT_FLAG = re.compile(r"(?:^|\s)--project(?:=|\s+)(\S+)")
+
+
 def _maybe_fan_out_gcp_multi_sa(
     *,
     user_id: Optional[str],
@@ -1430,10 +1449,15 @@ def _maybe_fan_out_gcp_multi_sa(
     """Return a fan-out response JSON when multi-SA dispatch applies, else None.
 
     Fans out only when no account_id / project_id / context project is set AND
-    more than one active GCP SA is connected. Single-SA users fall through to
-    the legacy path.
+    no ``--project`` flag is embedded in the command AND more than one active
+    GCP SA is connected. Single-SA users fall through to the legacy path.
     """
     if account_id or project_id or not user_id:
+        return None
+    # If the caller put --project=foo (or --project foo) directly in the command,
+    # treat that as an explicit target — don't fan out and run the same command
+    # against every other SA where it would simply fail.
+    if _INLINE_PROJECT_FLAG.search(original_command or ""):
         return None
     from utils.cloud.cloud_utils import get_selected_project_id
     try:

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -56,6 +56,8 @@ def count_tokens(text: str, model: str = "gpt-4o") -> int:
 
 logger = logging.getLogger(__name__)
 
+_READ_ONLY_BLOCKED_LOG = "Cloud command blocked in read-only/Ask mode (cmd_hash=%s)"
+
 
 def _extract_serial_port_pagination_hint(stderr_text: str) -> Optional[str]:
     """
@@ -1198,7 +1200,7 @@ def _cloud_exec_aws_multi_account(
         command,
     )
     if not allowed:
-        logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
+        logger.warning(_READ_ONLY_BLOCKED_LOG, hash_for_log(command))
         return json.dumps({
             "success": False,
             "error": read_only_message,
@@ -1363,7 +1365,7 @@ def _cloud_exec_gcp_multi_sa(
         command,
     )
     if not allowed:
-        logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
+        logger.warning(_READ_ONLY_BLOCKED_LOG, hash_for_log(command))
         return json.dumps({
             "success": False,
             "error": read_only_message,
@@ -1823,7 +1825,7 @@ Security & Compliance
                     command,
                 )
                 if not allowed:
-                    logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
+                    logger.warning(_READ_ONLY_BLOCKED_LOG, hash_for_log(command))
                     return json.dumps({
                         "success": False,
                         "error": read_only_message,
@@ -2009,7 +2011,7 @@ Security & Compliance
             command,
         )
         if not allowed:
-            logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
+            logger.warning(_READ_ONLY_BLOCKED_LOG, hash_for_log(command))
             return json.dumps({
                 "success": False,
                 "error": read_only_message,

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1198,7 +1198,7 @@ def _cloud_exec_aws_multi_account(
         command,
     )
     if not allowed:
-        logger.warning(read_only_message)
+        logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
         return json.dumps({
             "success": False,
             "error": read_only_message,
@@ -1363,7 +1363,7 @@ def _cloud_exec_gcp_multi_sa(
         command,
     )
     if not allowed:
-        logger.warning(read_only_message)
+        logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
         return json.dumps({
             "success": False,
             "error": read_only_message,
@@ -1823,7 +1823,7 @@ Security & Compliance
                     command,
                 )
                 if not allowed:
-                    logger.warning(read_only_message)
+                    logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
                     return json.dumps({
                         "success": False,
                         "error": read_only_message,
@@ -2009,7 +2009,7 @@ Security & Compliance
             command,
         )
         if not allowed:
-            logger.warning(read_only_message)
+            logger.warning("Cloud command blocked in read-only/Ask mode (cmd_hash=%s)", hash_for_log(command))
             return json.dumps({
                 "success": False,
                 "error": read_only_message,

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1270,6 +1270,77 @@ def _cloud_exec_aws_multi_account(
     })
 
 
+_GCP_CLI_PREFIXES = ("gcloud", "kubectl", "gsutil", "bq", "terraform", "helm")
+
+
+def _run_gcp_sa_command(
+    user_id: str,
+    conn: dict,
+    command: str,
+    provider_preference: Optional[str],
+    timeout: Optional[int],
+) -> Tuple[bool, str]:
+    """Execute ``command`` against the SA in ``conn``. Returns ``(ok, block_text)``.
+
+    The returned block is already wrapped with a per-SA header for inclusion in
+    the multi-SA fan-out output.
+    """
+    project_id = conn.get("project_id")
+    sa_email = conn.get("account_id") or "unknown"
+    alias_or_email = conn.get("account_alias") or sa_email
+
+    if not project_id:
+        # Without a distinct project_id, two SAs would collide on the
+        # ADC-file cache key and silently reuse the first SA's tempfile.
+        logger.warning(
+            "Multi-SA fan-out skipping sa=%s with no project_id",
+            hash_for_log(sa_email),
+        )
+        return False, (
+            f"[sa: {alias_or_email}]\n"
+            f"<error>Connection record is missing project_id; reconnect this service account.</error>"
+        )
+
+    try:
+        ok, resolved_project_id, _auth_method, isolated_env = (
+            setup_gcp_environment_isolated(
+                user_id,
+                selected_project_id=project_id,
+                provider_preference=provider_preference,
+            )
+        )
+        if not ok or not isolated_env:
+            return False, (
+                f"[project: {project_id} / sa: {alias_or_email}]\n"
+                f"<error>Failed to set up GCP environment for project {project_id}</error>"
+            )
+
+        effective_project = resolved_project_id or project_id
+        cmd = command.strip()
+        if not any(cmd.startswith(p) for p in _GCP_CLI_PREFIXES):
+            cmd = f"gcloud {cmd}"
+        if cmd.startswith("gcloud") and effective_project and "--project" not in cmd \
+                and "gcloud config" not in cmd:
+            cmd += f" --project={effective_project}"
+
+        result = terminal_run(
+            shlex.split(cmd), capture_output=True, text=True,
+            timeout=get_command_timeout(cmd, timeout), env=isolated_env,
+        )
+        ok_run = result.returncode == 0
+        output = (result.stdout if ok_run else (result.stderr or result.stdout)).strip()
+        return ok_run, f"[project: {effective_project} / sa: {alias_or_email}]\n{output}"
+    except Exception as e:
+        logger.exception(
+            "Multi-SA exec failed for project=%s sa=%s",
+            project_id, hash_for_log(sa_email),
+        )
+        return False, (
+            f"[project: {project_id} / sa: {alias_or_email}]\n"
+            f"<error>{str(e)[:300]}</error>"
+        )
+
+
 def _cloud_exec_gcp_multi_sa(
     user_id: str,
     connections: list,
@@ -1302,10 +1373,9 @@ def _cloud_exec_gcp_multi_sa(
             "provider": "gcp",
         })
 
-    # output_file is intentionally not supported in fan-out mode: there is no
-    # single canonical output to persist when N SAs run the command. Force the
-    # caller (LLM) to pick a project so the single-SA path writes the file.
     if output_file:
+        # No single canonical output exists when N SAs run the command — force
+        # the caller (LLM) to pick a project so the single-SA path writes it.
         return json.dumps({
             "success": False,
             "error": (
@@ -1320,79 +1390,13 @@ def _cloud_exec_gcp_multi_sa(
 
     blocks: list[str] = []
     overall_success = True
-
     for conn in connections:
-        project_id = conn.get("project_id")
-        sa_email = conn.get("account_id") or "unknown"
-        alias_or_email = conn.get("account_alias") or sa_email
-
-        # Without a distinct project_id, two SAs would collide on the
-        # ADC-file cache key (user_id, project_id or "") and silently reuse
-        # the first SA's tempfile. Skip the row — it indicates a malformed
-        # connection record anyway.
-        if not project_id:
-            logger.warning(
-                "Multi-SA fan-out skipping sa=%s with no project_id",
-                hash_for_log(sa_email),
-            )
-            blocks.append(
-                f"[sa: {alias_or_email}]\n"
-                f"<error>Connection record is missing project_id; reconnect this service account.</error>"
-            )
+        ok, block = _run_gcp_sa_command(
+            user_id, conn, command, provider_preference, timeout,
+        )
+        if not ok:
             overall_success = False
-            continue
-
-        try:
-            ok, resolved_project_id, _auth_method, isolated_env = (
-                setup_gcp_environment_isolated(
-                    user_id,
-                    selected_project_id=project_id,
-                    provider_preference=provider_preference,
-                )
-            )
-            if not ok or not isolated_env:
-                blocks.append(
-                    f"[project: {project_id} / sa: {alias_or_email}]\n"
-                    f"<error>Failed to set up GCP environment for project {project_id}</error>"
-                )
-                overall_success = False
-                continue
-
-            effective_project = resolved_project_id or project_id
-            cmd = command.strip()
-            if not cmd.startswith("gcloud") and not cmd.startswith("kubectl") \
-                    and not cmd.startswith("gsutil") and not cmd.startswith("bq") \
-                    and not cmd.startswith("terraform") and not cmd.startswith("helm"):
-                cmd = f"gcloud {cmd}"
-            if cmd.startswith("gcloud") and effective_project and "--project" not in cmd \
-                    and "gcloud config" not in cmd:
-                cmd += f" --project={effective_project}"
-
-            effective_timeout = get_command_timeout(cmd, timeout)
-            cmd_args = shlex.split(cmd)
-            result = terminal_run(
-                cmd_args, capture_output=True, text=True,
-                timeout=effective_timeout, env=isolated_env,
-            )
-            if result.returncode == 0:
-                output = result.stdout.strip()
-            else:
-                output = (result.stderr or result.stdout).strip()
-                overall_success = False
-
-            blocks.append(
-                f"[project: {effective_project} / sa: {alias_or_email}]\n{output}"
-            )
-        except Exception as e:
-            logger.exception(
-                "Multi-SA exec failed for project=%s sa=%s",
-                project_id, hash_for_log(sa_email),
-            )
-            overall_success = False
-            blocks.append(
-                f"[project: {project_id} / sa: {alias_or_email}]\n"
-                f"<error>{str(e)[:300]}</error>"
-            )
+        blocks.append(block)
 
     elapsed = time.perf_counter() - fn_start if fn_start else 0
     logger.info(
@@ -1408,6 +1412,66 @@ def _cloud_exec_gcp_multi_sa(
         "provider": "gcp",
         "output": "\n\n".join(blocks),
     })
+
+
+def _maybe_fan_out_gcp_multi_sa(
+    *,
+    user_id: Optional[str],
+    account_id: Optional[str],
+    project_id: Optional[str],
+    original_command: str,
+    provider_preference: Optional[str],
+    timeout: Optional[int],
+    output_file: Optional[str],
+    fn_start: float,
+) -> Optional[str]:
+    """Return a fan-out response JSON when multi-SA dispatch applies, else None.
+
+    Fans out only when no account_id / project_id / context project is set AND
+    more than one active GCP SA is connected. Single-SA users fall through to
+    the legacy path.
+    """
+    if account_id or project_id or not user_id:
+        return None
+    from utils.cloud.cloud_utils import get_selected_project_id
+    try:
+        if get_selected_project_id():
+            return None
+    except Exception:
+        pass
+    from utils.db.connection_utils import get_all_user_connections
+    all_gcp_conns = get_all_user_connections(user_id, "gcp")
+    if len(all_gcp_conns) <= 1:
+        return None
+    return _cloud_exec_gcp_multi_sa(
+        user_id=user_id,
+        connections=all_gcp_conns,
+        command=original_command,
+        provider_preference=provider_preference,
+        timeout=timeout,
+        output_file=output_file,
+        fn_start=fn_start,
+    )
+
+
+def _resolve_gcp_target_project(
+    *,
+    user_id: Optional[str],
+    account_id: Optional[str],
+    project_id: Optional[str],
+) -> Optional[str]:
+    """Pick the project ID to bind a single-SA GCP exec to (or None for default)."""
+    if account_id and user_id:
+        from utils.db.connection_utils import get_user_connection
+        conn_row = get_user_connection(user_id, "gcp", account_id)
+        return conn_row.get("project_id") if conn_row else None
+    if project_id:
+        return project_id
+    from utils.cloud.cloud_utils import get_selected_project_id
+    try:
+        return get_selected_project_id()
+    except Exception:
+        return None
 
 
 def cloud_exec(provider: str, command: str, user_id: Optional[str] = None, session_id: Optional[str] = None, provider_preference: Optional[str] = None, timeout: Optional[int] = None, output_file: Optional[str] = None, account_id: Optional[str] = None, project_id: Optional[str] = None) -> str:
@@ -1589,51 +1653,23 @@ Security & Compliance
                 "provider": normalized_provider,
             })
         else:
-            # GCP multi-SA dispatch:
-            #   1. account_id (SA email) explicit → single-SA path for that SA
-            #   2. project_id explicit → single-SA path resolved via that project
-            #   3. selected_project_id in context (Track C) → single-SA path
-            #   4. multiple active SAs → fan out via _cloud_exec_gcp_multi_sa
-            #   5. else (0 or 1 SA) → legacy single-SA path
-            from utils.db.connection_utils import (
-                get_all_user_connections,
-                get_user_connection,
-                find_connection_for_project,
+            fanout_response = _maybe_fan_out_gcp_multi_sa(
+                user_id=user_id,
+                account_id=account_id,
+                project_id=project_id,
+                original_command=original_command,
+                provider_preference=provider_preference,
+                timeout=timeout,
+                output_file=output_file,
+                fn_start=fn_start,
             )
-            from utils.cloud.cloud_utils import get_selected_project_id
-
-            gcp_target_project = None
-            if account_id:
-                conn_row = get_user_connection(user_id, "gcp", account_id) if user_id else None
-                if conn_row:
-                    gcp_target_project = conn_row.get("project_id")
-            elif project_id:
-                conn_row = find_connection_for_project(user_id, "gcp", project_id) if user_id else None
-                if conn_row:
-                    gcp_target_project = project_id
-                else:
-                    gcp_target_project = project_id  # let setup attempt anyway
-            else:
-                ctx_project = None
-                try:
-                    ctx_project = get_selected_project_id()
-                except Exception:
-                    ctx_project = None
-                if ctx_project:
-                    gcp_target_project = ctx_project
-                else:
-                    # No specific project — fan out if multiple SAs are connected
-                    all_gcp_conns = get_all_user_connections(user_id, "gcp") if user_id else []
-                    if len(all_gcp_conns) > 1:
-                        return _cloud_exec_gcp_multi_sa(
-                            user_id=user_id,
-                            connections=all_gcp_conns,
-                            command=original_command,
-                            provider_preference=provider_preference,
-                            timeout=timeout,
-                            output_file=output_file,
-                            fn_start=fn_start,
-                        )
+            if fanout_response is not None:
+                return fanout_response
+            gcp_target_project = _resolve_gcp_target_project(
+                user_id=user_id,
+                account_id=account_id,
+                project_id=project_id,
+            )
 
             effective_selected_project = gcp_target_project or selected_project_id
             success, project_id, auth_method, isolated_env = setup_gcp_environment_isolated(

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -461,29 +461,45 @@ def setup_aws_environments_all_accounts(user_id: str):
 # GCE metadata server and can inflate a ~1s 403 into a 60s timeout. Writing
 # the SA JSON once per user and pointing GOOGLE_APPLICATION_CREDENTIALS at it
 # gives gcloud a concrete, refreshable credential source.
-_sa_adc_file_cache: dict[str, str] = {}
+_sa_adc_file_cache: dict[tuple, str] = {}
 
 
-def _get_sa_adc_file(user_id: str) -> Optional[str]:
-    """Return a tempfile path containing the user's SA JSON (cached per user)."""
-    cached = _sa_adc_file_cache.get(user_id)
+def _get_sa_adc_file(user_id: str, selected_project_id: Optional[str] = None) -> Optional[str]:
+    """Return a tempfile path containing the right SA's JSON for this project.
+
+    Cached per (user_id, selected_project_id) so multi-SA users get a distinct
+    ADC file per project — different SAs must never share a tempfile.
+    """
+    cache_key = (user_id, selected_project_id or "")
+    cached = _sa_adc_file_cache.get(cache_key)
     if cached and os.path.exists(cached):
         return cached
     try:
-        from utils.auth.token_management import get_token_data
-        from connectors.gcp_connector.auth import GCP_AUTH_TYPE_SA, get_gcp_auth_type
-        token_data = get_token_data(user_id, "gcp")
-        if not token_data or get_gcp_auth_type(token_data) != GCP_AUTH_TYPE_SA:
-            return None
-        sa_json = token_data.get("service_account_json")
-        if not sa_json:
-            return None
-        # Sanity-check that the stored JSON parses before writing it.
-        json.loads(sa_json)
+        # Multi-SA first: pick the SA that owns/has-access to the project, or
+        # the first connected SA when no project is specified.
+        from connectors.gcp_connector.auth.multi_sa import load_sa_json_for_project
+        sa_info = load_sa_json_for_project(user_id, selected_project_id)
+
+        sa_json_text: Optional[str] = None
+        if sa_info:
+            sa_json_text = json.dumps(sa_info)
+        else:
+            # Legacy single-SA fallback (user_tokens).
+            from utils.auth.token_management import get_token_data
+            from connectors.gcp_connector.auth import GCP_AUTH_TYPE_SA, get_gcp_auth_type
+            token_data = get_token_data(user_id, "gcp")
+            if not token_data or get_gcp_auth_type(token_data) != GCP_AUTH_TYPE_SA:
+                return None
+            sa_json_text = token_data.get("service_account_json")
+            if not sa_json_text:
+                return None
+            # Sanity-check that the stored JSON parses before writing it.
+            json.loads(sa_json_text)
+
         fd, path = tempfile.mkstemp(suffix=".json", prefix="gcp_sa_adc_")
         with os.fdopen(fd, "w") as f:
-            f.write(sa_json)
-        _sa_adc_file_cache[user_id] = path
+            f.write(sa_json_text)
+        _sa_adc_file_cache[cache_key] = path
         logger.info("Wrote SA ADC file for local GCP tooling")
         return path
     except Exception as e:
@@ -555,7 +571,7 @@ def setup_gcp_environment_isolated(user_id: str, selected_project_id: str | None
             # to GCE metadata-server probing when the access token hits a 403
             # (that probe hangs in non-GCE environments and turns fast API
             # errors into 60s timeouts).
-            adc_file = _get_sa_adc_file(user_id)
+            adc_file = _get_sa_adc_file(user_id, selected_project_id=selected_project_id)
             if adc_file:
                 isolated_env["GOOGLE_APPLICATION_CREDENTIALS"] = adc_file
         else:
@@ -1254,7 +1270,147 @@ def _cloud_exec_aws_multi_account(
     })
 
 
-def cloud_exec(provider: str, command: str, user_id: Optional[str] = None, session_id: Optional[str] = None, provider_preference: Optional[str] = None, timeout: Optional[int] = None, output_file: Optional[str] = None, account_id: Optional[str] = None) -> str:
+def _cloud_exec_gcp_multi_sa(
+    user_id: str,
+    connections: list,
+    command: str,
+    provider_preference: Optional[str] = None,
+    timeout: Optional[int] = None,
+    output_file: Optional[str] = None,
+    fn_start: float = 0,
+) -> str:
+    """Run a gcloud/kubectl command across every connected GCP SA, sequentially.
+
+    Mirrors the AWS multi-account fan-out but with per-SA env isolation and
+    sequential execution (v1). Each SA's output is wrapped with a header so
+    the agent can attribute results to the right project.
+    """
+    current_mode = get_mode_from_context()
+    allowed, read_only_message = ModeAccessController.ensure_cloud_command_allowed(
+        current_mode,
+        is_read_only_command(command),
+        command,
+    )
+    if not allowed:
+        logger.warning(read_only_message)
+        return json.dumps({
+            "success": False,
+            "error": read_only_message,
+            "code": "READ_ONLY_MODE",
+            "multi_sa": True,
+            "command": command,
+            "provider": "gcp",
+        })
+
+    # output_file is intentionally not supported in fan-out mode: there is no
+    # single canonical output to persist when N SAs run the command. Force the
+    # caller (LLM) to pick a project so the single-SA path writes the file.
+    if output_file:
+        return json.dumps({
+            "success": False,
+            "error": (
+                "output_file is not supported with multi-SA fan-out — "
+                "pass project_id='<your-gcp-project>' to target one SA."
+            ),
+            "code": "MULTI_SA_OUTPUT_FILE_UNSUPPORTED",
+            "multi_sa": True,
+            "command": command,
+            "provider": "gcp",
+        })
+
+    blocks: list[str] = []
+    overall_success = True
+
+    for conn in connections:
+        project_id = conn.get("project_id")
+        sa_email = conn.get("account_id") or "unknown"
+        alias_or_email = conn.get("account_alias") or sa_email
+
+        # Without a distinct project_id, two SAs would collide on the
+        # ADC-file cache key (user_id, project_id or "") and silently reuse
+        # the first SA's tempfile. Skip the row — it indicates a malformed
+        # connection record anyway.
+        if not project_id:
+            logger.warning(
+                "Multi-SA fan-out skipping sa=%s with no project_id",
+                hash_for_log(sa_email),
+            )
+            blocks.append(
+                f"[sa: {alias_or_email}]\n"
+                f"<error>Connection record is missing project_id; reconnect this service account.</error>"
+            )
+            overall_success = False
+            continue
+
+        try:
+            ok, resolved_project_id, _auth_method, isolated_env = (
+                setup_gcp_environment_isolated(
+                    user_id,
+                    selected_project_id=project_id,
+                    provider_preference=provider_preference,
+                )
+            )
+            if not ok or not isolated_env:
+                blocks.append(
+                    f"[project: {project_id} / sa: {alias_or_email}]\n"
+                    f"<error>Failed to set up GCP environment for project {project_id}</error>"
+                )
+                overall_success = False
+                continue
+
+            effective_project = resolved_project_id or project_id
+            cmd = command.strip()
+            if not cmd.startswith("gcloud") and not cmd.startswith("kubectl") \
+                    and not cmd.startswith("gsutil") and not cmd.startswith("bq") \
+                    and not cmd.startswith("terraform") and not cmd.startswith("helm"):
+                cmd = f"gcloud {cmd}"
+            if cmd.startswith("gcloud") and effective_project and "--project" not in cmd \
+                    and "gcloud config" not in cmd:
+                cmd += f" --project={effective_project}"
+
+            effective_timeout = get_command_timeout(cmd, timeout)
+            cmd_args = shlex.split(cmd)
+            result = terminal_run(
+                cmd_args, capture_output=True, text=True,
+                timeout=effective_timeout, env=isolated_env,
+            )
+            if result.returncode == 0:
+                output = result.stdout.strip()
+            else:
+                output = (result.stderr or result.stdout).strip()
+                overall_success = False
+
+            blocks.append(
+                f"[project: {effective_project} / sa: {alias_or_email}]\n{output}"
+            )
+        except Exception as e:
+            logger.exception(
+                "Multi-SA exec failed for project=%s sa=%s",
+                project_id, hash_for_log(sa_email),
+            )
+            overall_success = False
+            blocks.append(
+                f"[project: {project_id} / sa: {alias_or_email}]\n"
+                f"<error>{str(e)[:300]}</error>"
+            )
+
+    elapsed = time.perf_counter() - fn_start if fn_start else 0
+    logger.info(
+        "TIME: cloud_exec GCP multi-SA (%d SAs) completed in %.2fs",
+        len(connections), elapsed,
+    )
+
+    return json.dumps({
+        "success": overall_success,
+        "multi_sa": True,
+        "sas_queried": len(connections),
+        "command": command,
+        "provider": "gcp",
+        "output": "\n\n".join(blocks),
+    })
+
+
+def cloud_exec(provider: str, command: str, user_id: Optional[str] = None, session_id: Optional[str] = None, provider_preference: Optional[str] = None, timeout: Optional[int] = None, output_file: Optional[str] = None, account_id: Optional[str] = None, project_id: Optional[str] = None) -> str:
     """Run arbitrary command against *provider* (gcloud/kubectl/gsutil for GCP, aws/kubectl for AWS).
 
 CLI is very versatile and can be used to do the following things. It should be priority over IaC tools unless it can't be done or better done with IaC.
@@ -1433,8 +1589,56 @@ Security & Compliance
                 "provider": normalized_provider,
             })
         else:
-            # GCP isolated setup (default)
-            success, project_id, auth_method, isolated_env = setup_gcp_environment_isolated(user_id, selected_project_id, provider_preference)
+            # GCP multi-SA dispatch:
+            #   1. account_id (SA email) explicit → single-SA path for that SA
+            #   2. project_id explicit → single-SA path resolved via that project
+            #   3. selected_project_id in context (Track C) → single-SA path
+            #   4. multiple active SAs → fan out via _cloud_exec_gcp_multi_sa
+            #   5. else (0 or 1 SA) → legacy single-SA path
+            from utils.db.connection_utils import (
+                get_all_user_connections,
+                get_user_connection,
+                find_connection_for_project,
+            )
+            from utils.cloud.cloud_utils import get_selected_project_id
+
+            gcp_target_project = None
+            if account_id:
+                conn_row = get_user_connection(user_id, "gcp", account_id) if user_id else None
+                if conn_row:
+                    gcp_target_project = conn_row.get("project_id")
+            elif project_id:
+                conn_row = find_connection_for_project(user_id, "gcp", project_id) if user_id else None
+                if conn_row:
+                    gcp_target_project = project_id
+                else:
+                    gcp_target_project = project_id  # let setup attempt anyway
+            else:
+                ctx_project = None
+                try:
+                    ctx_project = get_selected_project_id()
+                except Exception:
+                    ctx_project = None
+                if ctx_project:
+                    gcp_target_project = ctx_project
+                else:
+                    # No specific project — fan out if multiple SAs are connected
+                    all_gcp_conns = get_all_user_connections(user_id, "gcp") if user_id else []
+                    if len(all_gcp_conns) > 1:
+                        return _cloud_exec_gcp_multi_sa(
+                            user_id=user_id,
+                            connections=all_gcp_conns,
+                            command=original_command,
+                            provider_preference=provider_preference,
+                            timeout=timeout,
+                            output_file=output_file,
+                            fn_start=fn_start,
+                        )
+
+            effective_selected_project = gcp_target_project or selected_project_id
+            success, project_id, auth_method, isolated_env = setup_gcp_environment_isolated(
+                user_id, effective_selected_project, provider_preference,
+            )
             if not success:
                 return json.dumps({"error": f"Failed to setup GCP environment with {provider_preference} authentication", "final_command": command})
             resource_id = project_id

--- a/server/chat/backend/agent/tools/cloud_exec_tool.py
+++ b/server/chat/backend/agent/tools/cloud_exec_tool.py
@@ -1437,8 +1437,12 @@ def _maybe_fan_out_gcp_multi_sa(
     try:
         if get_selected_project_id():
             return None
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(
+            "Failed to resolve selected GCP project in _maybe_fan_out_gcp_multi_sa; "
+            "continuing with fallback fan-out decision. Error: %s",
+            e,
+        )
     from utils.db.connection_utils import get_all_user_connections
     all_gcp_conns = get_all_user_connections(user_id, "gcp")
     if len(all_gcp_conns) <= 1:

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1261,19 +1261,22 @@ def get_cloud_tools():
     tools = []
     
     # Create wrapper for cloud_exec to hide internal parameters from AI
-    def cloud_exec_wrapper(provider: str, command: str, output_file: Optional[str] = None, account_id: Optional[str] = None, **kwargs) -> str:
+    def cloud_exec_wrapper(provider: str, command: str, output_file: Optional[str] = None, account_id: Optional[str] = None, project_id: Optional[str] = None, **kwargs) -> str:
         """Execute cloud CLI commands. Provider and command are required. Use output_file to save raw output to a file (useful for kubeconfig).
-        
+
 For AWS with multiple connected accounts: the FIRST investigative call omit account_id to query all accounts.
-Once you identify which account has the issue, pass account_id (e.g. 'account') to target that specific account."""
+Once you identify which account has the issue, pass account_id (e.g. 'account') to target that specific account.
+
+project_id (optional, GCP only): Set this when the alert mentions a specific GCP project (look for `project_id:foo` in tags, `gcp_project` in labels, or `projects/foo/...` in resource names). Aurora will authenticate as the service account that owns or has access to that project. Omit to fan out across all connected GCP projects."""
         user_id = kwargs.get('user_id')
         session_id = kwargs.get('session_id')
         provider_preference = kwargs.get('provider_preference')
         timeout = kwargs.get('timeout')
-        
-        return cloud_exec(provider, command, user_id=user_id, session_id=session_id, 
+
+        return cloud_exec(provider, command, user_id=user_id, session_id=session_id,
                          provider_preference=provider_preference, timeout=timeout,
-                         output_file=output_file, account_id=account_id)
+                         output_file=output_file, account_id=account_id,
+                         project_id=project_id)
     
     # Set the name to match what the system prompt expects
     cloud_exec_wrapper.__name__ = "cloud_exec"

--- a/server/chat/background/rca_prompt_builder.py
+++ b/server/chat/background/rca_prompt_builder.py
@@ -561,6 +561,39 @@ def build_rca_prompt(
         f"You have access to: {', '.join(providers) if providers else 'No cloud/monitoring providers connected'}",
     ])
 
+    # Enumerate connected GCP service accounts (multi-SA) so the agent knows
+    # which projects are reachable and can pick the right project_id.
+    if user_id and 'gcp' in providers_lower:
+        try:
+            from utils.db.connection_utils import get_all_user_connections
+            gcp_conns = get_all_user_connections(user_id, 'gcp') or []
+            if gcp_conns:
+                lines = ["- GCP service accounts:"]
+                for conn in gcp_conns:
+                    alias = (
+                        conn.get('account_alias')
+                        or conn.get('account_id')
+                        or 'unknown'
+                    )
+                    if isinstance(alias, str) and len(alias) > 80:
+                        alias = alias[:77] + '...'
+                    home = conn.get('project_id') or 'unknown'
+                    accessible = conn.get('accessible_project_ids') or []
+                    # Drop the home project from the accessible list to avoid noise.
+                    extra = [p for p in accessible if p and p != home]
+                    if extra:
+                        extra_str = ", ".join(extra[:10])
+                        if len(extra) > 10:
+                            extra_str += f", +{len(extra) - 10} more"
+                        lines.append(
+                            f"    - {alias} (home project: {home}; accessible: {extra_str})"
+                        )
+                    else:
+                        lines.append(f"    - {alias} (home project: {home})")
+                prompt_parts.append("\n".join(lines))
+        except Exception as _e:
+            logger.debug("Skipping GCP SA enumeration in RCA prompt: %s", type(_e).__name__)
+
     # Aurora Learn: Inject context from similar past incidents
     if user_id:
         similar_context = _get_similar_good_rcas_context(

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1151,6 +1151,22 @@ def _action_is_generate_postmortem(action_id: Optional[str]) -> bool:
         return False
 
 
+def _latest_gcp_project_for_incident(cursor, incident_id) -> Optional[str]:
+    """Fetch the most recent gcp_project_id seen on an alert for this incident.
+
+    Caller must have RLS context set on the cursor (this runs in Celery, no
+    Flask request context). incident_alerts is RLS-protected.
+    """
+    cursor.execute(
+        "SELECT alert_metadata->>'gcp_project_id' FROM incident_alerts "
+        "WHERE incident_id = %s AND alert_metadata ? 'gcp_project_id' "
+        "ORDER BY created_at DESC LIMIT 1",
+        (incident_id,),
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
 async def _execute_background_chat(
     user_id: str,
     session_id: str,
@@ -1273,6 +1289,27 @@ async def _execute_background_chat(
             and _action_is_generate_postmortem((trigger_metadata or {}).get("action_id"))
         )
 
+        # Look up the most recent GCP project tied to this incident's alerts so
+        # downstream cloud tools can default to the right project without the
+        # agent having to guess. Falls back to None on any failure.
+        selected_gcp_project_id: Optional[str] = None
+        if context_incident_id:
+            try:
+                with db_pool.get_admin_connection() as _gcp_conn:
+                    with _gcp_conn.cursor() as _gcp_cur:
+                        set_rls_context(
+                            _gcp_cur, _gcp_conn, user_id,
+                            log_prefix="[BackgroundChat:GcpProject]",
+                        )
+                        selected_gcp_project_id = _latest_gcp_project_for_incident(
+                            _gcp_cur, context_incident_id
+                        )
+            except Exception as _e:
+                logger.warning(
+                    "[BackgroundChat] Could not fetch gcp_project_id for incident: %s", _e
+                )
+                selected_gcp_project_id = None
+
         # Create state with is_background=True and rca_context for system prompt
         # Use centralized model configuration for RCA with provider mode awareness
         state = State(
@@ -1281,7 +1318,7 @@ async def _execute_background_chat(
             incident_id=context_incident_id,
             incident_start_time=incident_start_time,
             provider_preference=provider_preference,
-            selected_project_id=None,
+            selected_project_id=selected_gcp_project_id,
             messages=[human_message],
             question=rail_question,
             model=ModelConfig.RCA_MODEL,
@@ -1301,7 +1338,7 @@ async def _execute_background_chat(
             user_id=user_id,
             session_id=session_id,
             provider_preference=provider_preference,
-            selected_project_id=None,
+            selected_project_id=selected_gcp_project_id,
             mode=mode,
             state=state,  # Pass state so incident_id is available in context
             workflow=wf,  # Pass workflow so RCA context updates can be injected

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1160,7 +1160,7 @@ def _latest_gcp_project_for_incident(cursor, incident_id) -> Optional[str]:
     cursor.execute(
         "SELECT alert_metadata->>'gcp_project_id' FROM incident_alerts "
         "WHERE incident_id = %s AND alert_metadata ? 'gcp_project_id' "
-        "ORDER BY created_at DESC LIMIT 1",
+        "ORDER BY received_at DESC LIMIT 1",
         (incident_id,),
     )
     row = cursor.fetchone()

--- a/server/connectors/gcp_connector/auth/multi_sa.py
+++ b/server/connectors/gcp_connector/auth/multi_sa.py
@@ -1,0 +1,143 @@
+"""Multi-SA credential loading helpers.
+
+Bridges the new ``user_connections`` storage (one row per uploaded SA key) with
+the legacy code paths that still expect a single ``token_data`` dict from
+``user_tokens``. Read-only — never writes.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional, Tuple
+
+from google.oauth2 import service_account as google_sa
+
+from utils.db.connection_utils import get_all_user_connections, find_connection_for_project
+from utils.secrets.secret_ref_utils import get_connection_secret
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+def _unwrap_sa_info(sa_info: dict) -> dict:
+    """Normalize stored SA blobs to the raw SA dict shape google-auth expects.
+
+    Aurora has historically stored SA credentials in two shapes inside the
+    Vault/Secrets-Manager blob:
+
+    1. The raw GCP key JSON (``{type, project_id, client_email, private_key,
+       ...}``) — what google-auth wants directly.
+    2. A wrapper from the legacy connect route: ``{service_account_json: "<raw
+       JSON string>", client_email, project_id}``.
+
+    This helper accepts either shape and returns the raw dict.
+    """
+    if not isinstance(sa_info, dict):
+        return sa_info
+    raw = sa_info.get("service_account_json")
+    if raw and isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError as exc:
+            # Returning the wrapper dict will fail downstream in google-auth
+            # with a confusing "missing 'type'" error; log so the real cause
+            # is recoverable from logs.
+            logger.warning(
+                "[GCP-MultiSA] Stored service_account_json is not valid JSON: %s",
+                exc,
+            )
+    elif isinstance(raw, dict):
+        return raw
+    return sa_info
+
+
+def _build_sa_credentials(sa_info: dict, scopes: Optional[List[str]] = None):
+    """Build a google-auth Credentials object from an SA JSON dict."""
+    return google_sa.Credentials.from_service_account_info(
+        _unwrap_sa_info(sa_info), scopes=scopes or _DEFAULT_SCOPES
+    )
+
+
+def load_gcp_connections_with_creds(
+    user_id: str, scopes: Optional[List[str]] = None
+) -> List[Tuple[dict, object]]:
+    """Return ``[(connection_row, Credentials), ...]`` for every active SA.
+
+    Empty list when the user has no ``user_connections`` rows for GCP, even if a
+    legacy ``user_tokens`` row exists — callers handle the fallback themselves
+    so they can keep their existing single-cred logic.
+    """
+    rows = get_all_user_connections(user_id, "gcp") or []
+    out: List[Tuple[dict, object]] = []
+    for row in rows:
+        ref = row.get("secret_ref")
+        if not ref:
+            continue
+        sa_info = get_connection_secret(ref)
+        if not sa_info:
+            logger.warning(
+                "[GCP-MultiSA] Could not load secret for account=%s — skipping",
+                (row.get("account_id") or "")[:12] + "...",
+            )
+            continue
+        try:
+            creds = _build_sa_credentials(sa_info, scopes)
+        except Exception as e:
+            logger.warning(
+                "[GCP-MultiSA] Failed to build credentials for account=%s: %s",
+                (row.get("account_id") or "")[:12] + "...",
+                type(e).__name__,
+            )
+            continue
+        out.append((row, creds))
+    return out
+
+
+def load_sa_json_for_project(user_id: str, project_id: Optional[str]) -> Optional[dict]:
+    """Return the raw SA JSON dict that should be used for ``project_id``.
+
+    Falls back to the first active SA when ``project_id`` is None or no SA
+    matches. Returns None when the user has no multi-SA connections at all.
+    """
+    if project_id:
+        row = find_connection_for_project(user_id, "gcp", project_id)
+        if row and row.get("secret_ref"):
+            sa_info = get_connection_secret(row["secret_ref"])
+            if sa_info:
+                return _unwrap_sa_info(sa_info)
+    rows = get_all_user_connections(user_id, "gcp") or []
+    for row in rows:
+        ref = row.get("secret_ref")
+        if not ref:
+            continue
+        sa_info = get_connection_secret(ref)
+        if sa_info:
+            return _unwrap_sa_info(sa_info)
+    return None
+
+
+def load_gcp_credentials_for_project(
+    user_id: str, project_id: str, scopes: Optional[List[str]] = None
+) -> Optional[Tuple[dict, object]]:
+    """Resolve a single ``(connection_row, Credentials)`` for ``project_id``.
+
+    Returns None when no SA owns or has access to the project.
+    """
+    row = find_connection_for_project(user_id, "gcp", project_id)
+    if not row or not row.get("secret_ref"):
+        return None
+    sa_info = get_connection_secret(row["secret_ref"])
+    if not sa_info:
+        return None
+    try:
+        return row, _build_sa_credentials(sa_info, scopes)
+    except Exception as e:
+        logger.warning(
+            "[GCP-MultiSA] Failed to build credentials for project=%s: %s",
+            project_id,
+            type(e).__name__,
+        )
+        return None

--- a/server/connectors/gcp_connector/auth/service_accounts.py
+++ b/server/connectors/gcp_connector/auth/service_accounts.py
@@ -16,6 +16,7 @@ from connectors.gcp_connector.gcp.project_selection import (
     ProjectSelectionStrategy,
     DefaultProjectSelectionStrategy,
 )
+from utils.log_sanitizer import hash_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -446,11 +447,12 @@ def generate_sa_access_token(user_id: str, scopes: List[str] = None,
         if selected_project_id:
             row = find_connection_for_project(user_id, "gcp", selected_project_id)
             if row:
-                alias = row.get("account_alias") or (row.get("account_id") or "")[:32]
+                # Hash both identifiers — SA aliases and project IDs are
+                # user-controlled and CodeQL treats them as sensitive.
                 logger.info(
                     "[GCP-SA-Auth] Using SA %s for project %s",
-                    alias,
-                    selected_project_id,
+                    hash_for_log(row.get("account_alias") or row.get("account_id") or ""),
+                    hash_for_log(selected_project_id),
                 )
             else:
                 # Project was explicitly requested but no SA owns/has-access:
@@ -460,7 +462,7 @@ def generate_sa_access_token(user_id: str, scopes: List[str] = None,
                 # the first connected SA.
                 logger.warning(
                     "[GCP-SA-Auth] No SA matches project=%s; will fall through to legacy token store",
-                    selected_project_id,
+                    hash_for_log(selected_project_id),
                 )
         else:
             rows = get_all_user_connections(user_id, "gcp")

--- a/server/connectors/gcp_connector/auth/service_accounts.py
+++ b/server/connectors/gcp_connector/auth/service_accounts.py
@@ -416,14 +416,88 @@ def generate_sa_access_token(user_id: str, scopes: List[str] = None,
         scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
     normalized_mode = (mode or '').strip().lower()
-    
+
     from utils.auth.token_management import get_token_data
     from connectors.gcp_connector.auth.oauth import get_credentials
     from connectors.gcp_connector.gcp.projects import get_project_list, select_best_project
     from google.oauth2 import service_account as google_service_account
     from google.auth.transport.requests import Request as GoogleAuthRequest
 
-    token_data = get_token_data(user_id, "gcp")
+    # ------------------------------------------------------------------
+    # Multi-SA credential lookup (three-tier priority).
+    #
+    # 1. selected_project_id → find_connection_for_project()
+    # 2. else → first active row from get_all_user_connections()
+    # 3. else (pre-migration) → fall back to legacy get_token_data()
+    #
+    # When a user_connections row is found, we synthesise a token_data dict
+    # that matches the shape returned by get_token_data() for the SA branch
+    # below, so the rest of the function is unchanged.
+    # ------------------------------------------------------------------
+    token_data = None
+    try:
+        from utils.db.connection_utils import (
+            get_all_user_connections,
+            find_connection_for_project,
+        )
+        from utils.secrets.secret_ref_utils import get_connection_secret
+
+        row = None
+        if selected_project_id:
+            row = find_connection_for_project(user_id, "gcp", selected_project_id)
+            if row:
+                alias = row.get("account_alias") or (row.get("account_id") or "")[:32]
+                logger.info(
+                    "[GCP-SA-Auth] Using SA %s for project %s",
+                    alias,
+                    selected_project_id,
+                )
+            else:
+                # Project was explicitly requested but no SA owns/has-access:
+                # do NOT silently fall back to an arbitrary SA — that would
+                # mint a token against the wrong project's default. Only the
+                # legacy single-SA path (selected_project_id=None) may pick
+                # the first connected SA.
+                logger.warning(
+                    "[GCP-SA-Auth] No SA matches project=%s; will fall through to legacy token store",
+                    selected_project_id,
+                )
+        else:
+            rows = get_all_user_connections(user_id, "gcp")
+            if rows:
+                row = rows[0]
+
+        if row is not None and row.get("secret_ref"):
+            sa_payload = get_connection_secret(row["secret_ref"])
+            if sa_payload:
+                # Normalise to the token_data shape consumed by the SA branch.
+                sa_json_str = (
+                    sa_payload.get("service_account_json")
+                    if isinstance(sa_payload, dict) and "service_account_json" in sa_payload
+                    else json.dumps(sa_payload)
+                )
+                token_data = {
+                    "auth_type": GCP_AUTH_TYPE_SA,
+                    "service_account_json": sa_json_str,
+                    "client_email": row.get("account_id"),
+                    "default_project_id": row.get("project_id"),
+                    "accessible_projects": [
+                        {"project_id": pid}
+                        for pid in (row.get("accessible_project_ids") or [])
+                    ],
+                }
+    except Exception as e:
+        # Never let the new lookup break legacy auth — fall through to
+        # get_token_data() below.
+        logger.warning(
+            "[GCP-SA-Auth] user_connections lookup failed (error_type=%s); "
+            "falling back to legacy token store",
+            type(e).__name__,
+        )
+        token_data = None
+
+    if token_data is None:
+        token_data = get_token_data(user_id, "gcp")
     if not token_data:
         raise ValueError("No GCP token data for user")
 

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -566,11 +566,13 @@ from routes.gcp import bp as gcp_auth_bp
 from routes.gcp.projects import gcp_projects_bp
 from routes.gcp.billing import gcp_billing_bp
 from routes.gcp.root_project import root_project_bp
+from routes.gcp.service_accounts import gcp_service_accounts_bp
 
 app.register_blueprint(gcp_auth_bp)
 app.register_blueprint(gcp_projects_bp)
 app.register_blueprint(gcp_billing_bp)
 app.register_blueprint(root_project_bp)
+app.register_blueprint(gcp_service_accounts_bp)
 
 # --- AWS Routes ---
 # AWS blueprint already registered above with url_prefix="/aws_api"

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -138,7 +138,7 @@ def get_connected_accounts(user_id, target_user_id):
             provider,
             account_id,
             role_arn,
-            last_verified,
+            _last_verified,
             account_alias,
             project_id,
             accessible_project_ids,

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -1,4 +1,5 @@
 """Account management routes for connected accounts."""
+import json
 import logging
 from flask import Blueprint, request, jsonify
 from utils.auth.rbac_decorators import require_auth_only
@@ -119,11 +120,12 @@ def get_connected_accounts(user_id, target_user_id):
             executor.shutdown(wait=False, cancel_futures=True)
         
         # ------------------------------
-        # 2) Role-based connections (user_connections – AWS today)
+        # 2) Role-based / multi-account connections (user_connections)
         # ------------------------------
         cursor.execute(
             """
-            SELECT provider, account_id, role_arn, last_verified_at
+            SELECT provider, account_id, role_arn, last_verified_at,
+                   account_alias, project_id, accessible_project_ids
             FROM user_connections
             WHERE (user_id = %s OR org_id = %s) AND status = 'active'
             ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END
@@ -131,7 +133,34 @@ def get_connected_accounts(user_id, target_user_id):
             (user_id, org_id, user_id),
         )
 
-        for provider, account_id, role_arn, last_verified in cursor.fetchall():
+        gcp_accounts_list: list = []
+        for (
+            provider,
+            account_id,
+            role_arn,
+            last_verified,
+            account_alias,
+            project_id,
+            accessible_project_ids,
+        ) in cursor.fetchall():
+            if provider == "gcp":
+                # Collect every GCP SA — frontend uses the list, not the
+                # single-account shape.
+                accessible_list = accessible_project_ids
+                if isinstance(accessible_list, str):
+                    try:
+                        accessible_list = json.loads(accessible_list)
+                    except Exception:
+                        accessible_list = []
+                gcp_accounts_list.append({
+                    "email": account_id,
+                    "project_id": project_id,
+                    "alias": account_alias,
+                    "authType": "service_account",
+                    "accessibleProjectIds": accessible_list or [],
+                })
+                continue
+
             if provider in accounts:
                 continue
 
@@ -145,16 +174,34 @@ def get_connected_accounts(user_id, target_user_id):
                 account_info["accountId"] = account_id
                 account_info["roleArn"] = role_arn
                 account_info["name"] = "AWS Account"
-            elif provider == "gcp":
-                account_info["projectId"] = account_id
-                account_info["name"] = "Google Cloud"
-                account_info["displayText"] = account_id or "Google Cloud"
             elif provider == "azure":
                 account_info["subscriptionId"] = account_id
                 account_info["name"] = "Azure"
                 account_info["displayText"] = account_id or "Azure Subscription"
 
             accounts[provider] = account_info
+
+        # Rebuild the GCP entry from the per-account rows + the legacy entry
+        # (which may have been set above from a user_tokens row).
+        if gcp_accounts_list or "gcp" in accounts:
+            legacy = accounts.get("gcp") or {}
+            primary = gcp_accounts_list[0] if gcp_accounts_list else None
+            accounts["gcp"] = {
+                "isConnected": True,
+                "name": "Google Cloud",
+                "displayText": (
+                    (primary["alias"] or primary["email"] or legacy.get("displayText") or "Google Cloud")
+                    if primary
+                    else (legacy.get("displayText") or "Google Cloud")
+                ),
+                "count": len(gcp_accounts_list),
+                "accounts": gcp_accounts_list,
+                "authType": (
+                    "service_account" if gcp_accounts_list
+                    else legacy.get("authType")
+                ),
+                "email": primary["email"] if primary else legacy.get("email"),
+            }
 
         # ------------------------------
         # 3) Webhook-based connectors (Grafana — no secret_ref)

--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -13,7 +13,7 @@ import base64
 import logging
 import time as _time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 from flask import Blueprint, jsonify
@@ -645,6 +645,30 @@ def _check_credentials_only(creds: Dict[str, Any]) -> Dict[str, Any]:
     return {"connected": True}
 
 
+def _gcp_multi_sa_status(user_id: str) -> Optional[Dict[str, Any]]:
+    """Return multi-SA status payload or ``None`` when no rows / lookup failed."""
+    try:
+        from utils.db.connection_utils import get_all_user_connections
+
+        connections = get_all_user_connections(user_id, "gcp")
+    except Exception as exc:
+        logger.debug("[STATUS] gcp user_connections lookup failed: %s", exc)
+        return None
+    if not connections:
+        return None
+    primary = connections[0]
+    response: Dict[str, Any] = {
+        "connected": True,
+        "authType": "service_account",
+        "count": len(connections),
+    }
+    if primary.get("account_id"):
+        response["clientEmail"] = primary["account_id"]
+    if primary.get("project_id"):
+        response["defaultProjectId"] = primary["project_id"]
+    return response
+
+
 def _check_gcp_credentials(creds: Dict[str, Any]) -> Dict[str, Any]:
     """GCP credential-existence check.
 
@@ -655,24 +679,9 @@ def _check_gcp_credentials(creds: Dict[str, Any]) -> Dict[str, Any]:
     """
     user_id = creds.get("_user_id")
     if user_id:
-        try:
-            from utils.db.connection_utils import get_all_user_connections
-
-            connections = get_all_user_connections(user_id, "gcp")
-            if connections:
-                primary = connections[0]
-                response: Dict[str, Any] = {
-                    "connected": True,
-                    "authType": "service_account",
-                    "count": len(connections),
-                }
-                if primary.get("account_id"):
-                    response["clientEmail"] = primary["account_id"]
-                if primary.get("project_id"):
-                    response["defaultProjectId"] = primary["project_id"]
-                return response
-        except Exception as exc:
-            logger.debug("[STATUS] gcp user_connections lookup failed: %s", exc)
+        multi_sa = _gcp_multi_sa_status(user_id)
+        if multi_sa:
+            return multi_sa
 
     # ── Legacy fallback: OAuth/single-SA stored in user_tokens ──────
     from connectors.gcp_connector.auth import GCP_AUTH_TYPE_SA, get_gcp_auth_type

--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -646,13 +646,39 @@ def _check_credentials_only(creds: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _check_gcp_credentials(creds: Dict[str, Any]) -> Dict[str, Any]:
-    """GCP credential-existence check that also surfaces the auth mode
-    (OAuth vs service-account) so the frontend can label the connection.
+    """GCP credential-existence check.
+
+    Prefers the multi-SA ``user_connections`` rows (one per service account).
+    Falls back to the legacy OAuth/single-SA ``user_tokens`` blob when no
+    user_connections rows exist (transition period until the migration is
+    complete).
     """
+    user_id = creds.get("_user_id")
+    if user_id:
+        try:
+            from utils.db.connection_utils import get_all_user_connections
+
+            connections = get_all_user_connections(user_id, "gcp")
+            if connections:
+                primary = connections[0]
+                response: Dict[str, Any] = {
+                    "connected": True,
+                    "authType": "service_account",
+                    "count": len(connections),
+                }
+                if primary.get("account_id"):
+                    response["clientEmail"] = primary["account_id"]
+                if primary.get("project_id"):
+                    response["defaultProjectId"] = primary["project_id"]
+                return response
+        except Exception as exc:
+            logger.debug("[STATUS] gcp user_connections lookup failed: %s", exc)
+
+    # ── Legacy fallback: OAuth/single-SA stored in user_tokens ──────
     from connectors.gcp_connector.auth import GCP_AUTH_TYPE_SA, get_gcp_auth_type
 
     auth_type = get_gcp_auth_type(creds)
-    response: Dict[str, Any] = {"connected": True, "authType": auth_type}
+    response = {"connected": True, "authType": auth_type}
     if auth_type == GCP_AUTH_TYPE_SA:
         if creds.get("client_email"):
             response["clientEmail"] = creds["client_email"]
@@ -860,6 +886,16 @@ def _check_all_connectors(
                         (user_id, org_id, provider),
                     )
                     if cur.fetchone():
+                        # Provider-specific checker may enrich the connected
+                        # response (e.g. GCP multi-SA returns count/authType
+                        # from user_connections). Pass a sentinel creds dict
+                        # so the checker can opt in via creds.get("_user_id").
+                        checker = PROVIDER_CHECKERS.get(provider)
+                        if checker:
+                            try:
+                                return provider, checker({"_user_id": token_owner_id})
+                            except Exception as exc:
+                                logger.warning("[STATUS] %s enrich check raised: %s", provider, exc)
                         return provider, {"connected": True}
             return provider, {"connected": False}
         creds["_user_id"] = token_owner_id

--- a/server/routes/datadog/tasks.py
+++ b/server/routes/datadog/tasks.py
@@ -11,6 +11,7 @@ from celery_config import celery_app
 from chat.background.rca_prompt_builder import build_datadog_rca_prompt
 from services.correlation.alert_correlator import AlertCorrelator
 from services.correlation import handle_correlated_alert
+from utils.cloud.gcp_project_extraction import extract_gcp_project_from_alert
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +214,10 @@ def process_datadog_event(
                     alert_metadata["priority"] = payload.get("priority")
                 if payload.get("snapshot"):
                     alert_metadata["snapshotUrl"] = payload.get("snapshot")
+
+                pid = extract_gcp_project_from_alert(payload, "datadog")
+                if pid:
+                    alert_metadata["gcp_project_id"] = pid
 
                 try:
                     correlator = AlertCorrelator()

--- a/server/routes/gcp/__init__.py
+++ b/server/routes/gcp/__init__.py
@@ -4,5 +4,6 @@ from .auth import gcp_auth_bp as bp  # Main auth blueprint for backward compatib
 # Additional GCP blueprints can be imported directly
 from .projects import gcp_projects_bp
 from .billing import gcp_billing_bp
+from .service_accounts import gcp_service_accounts_bp
 
-__all__ = ['bp', 'gcp_projects_bp', 'gcp_billing_bp']
+__all__ = ['bp', 'gcp_projects_bp', 'gcp_billing_bp', 'gcp_service_accounts_bp']

--- a/server/routes/gcp/auth.py
+++ b/server/routes/gcp/auth.py
@@ -9,7 +9,9 @@ from connectors.gcp_connector.gcp_post_auth_tasks import gcp_post_auth_setup_tas
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.db.db_utils import connect_to_db_as_admin
+from utils.db.connection_utils import deactivate_all_connections
 from utils.secrets.secret_cache import clear_secret_cache
+from utils.secrets.secret_ref_utils import delete_connection_secret
 from time import time
 import os
 
@@ -152,6 +154,32 @@ def get_gcp_setup_status(user_id, task_id):
         return jsonify({"error": "Failed to fetch task status"}), 500
 
 
+def _cleanup_multi_sa_connections(user_id: str) -> None:
+    """Deactivate every user_connections GCP row and delete each Vault secret.
+
+    Best-effort: failures are logged but never raised, since this runs alongside
+    the legacy user_tokens cleanup and must not regress the existing contract.
+    """
+    try:
+        ok, secret_refs = deactivate_all_connections(user_id, "gcp")
+    except Exception as e:
+        logging.error("force-disconnect: failed to deactivate user_connections: %s", e)
+        return
+
+    for ref in secret_refs:
+        try:
+            delete_connection_secret(ref)
+        except Exception as e:
+            logging.warning("force-disconnect: failed to delete connection secret: %s", e)
+
+    if ok:
+        logging.info(
+            "force-disconnect: deactivated %d GCP user_connections rows for user %s",
+            len(secret_refs),
+            user_id,
+        )
+
+
 @gcp_auth_bp.route("/api/gcp/force-disconnect", methods=["POST"])
 @require_permission("connectors", "write")
 def force_disconnect_gcp(user_id):
@@ -221,6 +249,8 @@ def force_disconnect_gcp(user_id):
             logging.info(f"Cleared secret cache for user {user_id}")
         except Exception as e:
             logging.warning(f"Failed to clear secret cache: {e}")
+
+    _cleanup_multi_sa_connections(user_id)
 
     # Delete discovered infrastructure nodes from Memgraph
     try:

--- a/server/routes/gcp/auth.py
+++ b/server/routes/gcp/auth.py
@@ -162,8 +162,8 @@ def _cleanup_multi_sa_connections(user_id: str) -> None:
     """
     try:
         ok, secret_refs = deactivate_all_connections(user_id, "gcp")
-    except Exception as e:
-        logging.error("force-disconnect: failed to deactivate user_connections: %s", e)
+    except Exception:
+        logging.exception("force-disconnect: failed to deactivate user_connections")
         return
 
     for ref in secret_refs:

--- a/server/routes/gcp/billing.py
+++ b/server/routes/gcp/billing.py
@@ -38,7 +38,7 @@ def billing(user_id):
                 return jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401
             creds_list = [("legacy", get_credentials(token_data))]
 
-        processed_projects = []
+        processed_projects: set[str] = set()
         for sa_label, credentials in creds_list:
             try:
                 projects = get_project_list(credentials) or []
@@ -53,14 +53,14 @@ def billing(user_id):
                     if is_bigquery_enabled(project_id, credentials):
                         logging.info(f"Storing billing data for project: {project_id}")
                         store_bigquery_data(credentials, project_id, user_id)
-                        processed_projects.append(project_id)
+                        processed_projects.add(project_id)
                     else:
                         logging.info(f"BigQuery not enabled for project: {project_id}, skipping")
                 except ValueError as e:
                     if "Permission Denied" in str(e):
                         logging.warning(f"Permission denied for project {project_id}, skipping.")
                         continue
-                    raise e
+                    raise
                 except Exception as e:
                     logging.warning(f"Error checking project {project_id}: {e}. Skipping.")
                     continue

--- a/server/routes/gcp/billing.py
+++ b/server/routes/gcp/billing.py
@@ -7,6 +7,7 @@ from connectors.gcp_connector.auth.oauth import get_credentials
 from utils.auth.token_management import get_token_data
 from connectors.gcp_connector.gcp.projects import get_project_list
 from connectors.gcp_connector.billing import store_bigquery_data, is_bigquery_enabled
+from connectors.gcp_connector.auth.multi_sa import load_gcp_connections_with_creds
 
 gcp_billing_bp = Blueprint("gcp_billing", __name__)
 
@@ -18,49 +19,51 @@ def billing(user_id):
         data = request.get_json()
         provider = data.get("X-Provider", "gcp") if data else "gcp"
 
-        # Refresh token if needed before proceeding
-        try:
-            refresh_token_if_needed(user_id, provider)
-        except Exception as e:
-            logging.error(f"Token refresh failed: {e}", exc_info=True)
-            return jsonify({"error": "Token refresh failed"}), 401
+        # Multi-SA path: build a list of (label, credentials) to iterate.
+        # Falls back to the legacy single-token path when no user_connections
+        # rows exist (OAuth users, pre-migration).
+        sa_pairs = load_gcp_connections_with_creds(user_id)
+        creds_list = [(conn.get("account_id", "sa"), creds) for conn, creds in sa_pairs]
 
-        logging.info(f"Received user id:'{user_id}' successfully.")
-        token_data = get_token_data(user_id, provider)
-        if not token_data:
-            logging.warning(f"No token data found for user_id: {user_id}, provider: {provider}")
-            return jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401
-        credentials = get_credentials(token_data)
-        logging.info(f"Credentials successfully retrieved for user_id:'{user_id}'")
+        if not creds_list:
+            try:
+                refresh_token_if_needed(user_id, provider)
+            except Exception as e:
+                logging.error(f"Token refresh failed: {e}", exc_info=True)
+                return jsonify({"error": "Token refresh failed"}), 401
 
-        # Rest of the existing function code...
-        projects = get_project_list(credentials)
-        if not projects:
-            return jsonify({"message": "No projects found for the authenticated user."}), 404
+            token_data = get_token_data(user_id, provider)
+            if not token_data:
+                logging.warning(f"No token data found for user_id: {user_id}, provider: {provider}")
+                return jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401
+            creds_list = [("legacy", get_credentials(token_data))]
 
         processed_projects = []
-        for project in projects:
-            project_id = project.get('projectId')
-            if not project_id:
-                continue
-
+        for sa_label, credentials in creds_list:
             try:
-                if is_bigquery_enabled(project_id, credentials):
-                    logging.info(f"Storing billing data for project: {project_id}")
-                    store_bigquery_data(credentials, project_id, user_id)
-                    processed_projects.append(project_id)
-                else:
-                    logging.info(f"BigQuery not enabled for project: {project_id}, skipping")
-            except ValueError as e:
-                if "Permission Denied" in str(e):
-                    logging.warning(f"Permission denied for project {project_id}, likely deleted or inaccessible. Skipping.")
-                    continue
-                else:
-                    # Re-raise other ValueError exceptions
-                    raise e
+                projects = get_project_list(credentials) or []
             except Exception as e:
-                logging.warning(f"Error checking project {project_id}: {e}. Skipping.")
+                logging.warning("Failed to list projects for sa=%s: %s", sa_label[:12], type(e).__name__)
                 continue
+            for project in projects:
+                project_id = project.get('projectId')
+                if not project_id or project_id in processed_projects:
+                    continue
+                try:
+                    if is_bigquery_enabled(project_id, credentials):
+                        logging.info(f"Storing billing data for project: {project_id}")
+                        store_bigquery_data(credentials, project_id, user_id)
+                        processed_projects.append(project_id)
+                    else:
+                        logging.info(f"BigQuery not enabled for project: {project_id}, skipping")
+                except ValueError as e:
+                    if "Permission Denied" in str(e):
+                        logging.warning(f"Permission denied for project {project_id}, skipping.")
+                        continue
+                    raise e
+                except Exception as e:
+                    logging.warning(f"Error checking project {project_id}: {e}. Skipping.")
+                    continue
 
         if processed_projects:
             return jsonify({"message": "Billing successful"}), 200

--- a/server/routes/gcp/projects.py
+++ b/server/routes/gcp/projects.py
@@ -1,5 +1,6 @@
 """GCP project management routes."""
 import logging
+from typing import Optional
 from flask import Blueprint, request, jsonify
 from utils.auth.stateless_auth import get_user_preference
 from utils.auth.rbac_decorators import require_permission
@@ -15,10 +16,53 @@ from connectors.gcp_connector.auth.service_accounts import (
     GCP_AUTH_TYPE_SA,
 )
 from connectors.gcp_connector.billing import has_active_billing
+from connectors.gcp_connector.auth.multi_sa import load_gcp_connections_with_creds
 from googleapiclient.discovery import build
 from utils.secrets.secret_ref_utils import get_token_owner_id
 
 gcp_projects_bp = Blueprint("gcp_projects", __name__)
+
+def _multi_sa_project_list(user_id: str) -> Optional[list]:
+    """Aggregate projects across every active GCP SA connection.
+
+    Returns ``None`` when no multi-SA connections exist (caller should fall back
+    to the legacy single-token path). Returns ``[]`` when SAs exist but none
+    expose any accessible projects.
+    """
+    sa_creds_pairs = load_gcp_connections_with_creds(user_id)
+    if not sa_creds_pairs:
+        return None
+
+    # Deduplicate by projectId; first SA to see a project wins.
+    seen: dict = {}
+    for conn, creds in sa_creds_pairs:
+        try:
+            projects = get_project_list(creds) or []
+        except Exception as e:
+            logging.warning(
+                "[GCP] get_project_list failed for sa=%s: %s",
+                (conn.get("account_id") or "")[:12] + "...",
+                type(e).__name__,
+            )
+            continue
+        for project in projects:
+            pid = project.get("projectId")
+            if not pid or pid in seen:
+                continue
+            try:
+                billing_active = has_active_billing(pid, creds)
+            except Exception:
+                billing_active = False
+            seen[pid] = {
+                "projectId": pid,
+                "name": project.get("name", pid),
+                "projectNumber": project.get("projectNumber"),
+                "lifecycleState": project.get("lifecycleState", "UNKNOWN"),
+                "billingEnabled": billing_active,
+                "available": billing_active,
+            }
+    return list(seen.values())
+
 
 @gcp_projects_bp.route("/api/gcp/projects", methods=["POST"])
 @require_permission("connectors", "read")
@@ -28,53 +72,42 @@ def get_projects(user_id):
         logging.info("Fetching GCP projects with billing status")
         provider = "gcp"
 
-        # Refresh token if needed before proceeding
-        try:
-            refresh_token_if_needed(user_id, provider)
-        except Exception as e:
-            logging.error(f"Token refresh failed: {e}", exc_info=True)
-            return jsonify({"error": "Token refresh failed"}), 401
+        # Multi-SA path: aggregate projects across every connected SA. Falls
+        # through to the legacy single-token path when no user_connections rows
+        # exist (OAuth users, pre-migration).
+        project_list = _multi_sa_project_list(user_id)
 
-        logging.info(f"Received user id:'{user_id}' successfully.")
-        token_data = get_token_data(user_id, provider)
-        if not token_data:
-            logging.warning(f"No token data found for user_id: {user_id}, provider: {provider}")
-            return jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401
-        credentials = get_credentials(token_data)
-        logging.info(f"Credentials successfully retrieved for user_id:'{user_id}'")
+        if project_list is None:
+            # Legacy fallback — single token in user_tokens.
+            try:
+                refresh_token_if_needed(user_id, provider)
+            except Exception as e:
+                logging.error(f"Token refresh failed: {e}", exc_info=True)
+                return jsonify({"error": "Token refresh failed"}), 401
 
-        projects = get_project_list(credentials)
-        logging.info(f"Returning {len(projects)} accessible projects")
-        if not projects:
+            token_data = get_token_data(user_id, provider)
+            if not token_data:
+                logging.warning(f"No token data found for user_id: {user_id}, provider: {provider}")
+                return jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401
+            credentials = get_credentials(token_data)
+            projects = get_project_list(credentials)
+            project_list = []
+            for project in projects:
+                pid = project.get("projectId")
+                if not pid:
+                    continue
+                billing_active = has_active_billing(pid, credentials)
+                project_list.append({
+                    "projectId": pid,
+                    "name": project.get("name", pid),
+                    "projectNumber": project.get("projectNumber"),
+                    "lifecycleState": project.get("lifecycleState", "UNKNOWN"),
+                    "billingEnabled": billing_active,
+                    "available": billing_active,
+                })
+
+        if not project_list:
             return jsonify({"message": "No projects found for the authenticated user.", "projects": []}), 200
-
-        logging.info(f"Found {len(projects)} GCP projects. Checking billing status...")
-
-        # Process each project to include billing status
-        project_list = []
-        for project in projects:
-            project_id = project.get('projectId')
-            project_name = project.get('name', project_id)
-            project_number = project.get('projectNumber')
-            lifecycle_state = project.get('lifecycleState', 'UNKNOWN')
-            
-            if not project_id:
-                continue
-
-            # Check billing status for this project
-            billing_active = has_active_billing(project_id, credentials)
-            
-            project_info = {
-                "projectId": project_id,
-                "name": project_name,
-                "projectNumber": project_number,
-                "lifecycleState": lifecycle_state,
-                "billingEnabled": billing_active,
-                "available": billing_active  # Projects are only available if billing is enabled
-            }
-            
-            project_list.append(project_info)
-            logging.info(f"Project {project_id}: billing_enabled={billing_active}")
 
         # Sort projects: billing-enabled projects first, then by name
         project_list.sort(key=lambda x: (not x["billingEnabled"], x["name"]))
@@ -98,10 +131,42 @@ def get_projects(user_id):
         return jsonify({"error": "Failed to fetch GCP projects"}), 500
 
 
+def _synthesize_multi_sa_token(user_id):
+    """Build a SA-mode token_data dict from user_connections rows.
+
+    Mirrors the legacy single-SA shape so downstream code (_sa_mode_project_list,
+    get_gcp_auth_type) works unchanged. Returns None when the user has no
+    active multi-SA connections.
+
+    Uses get_all_user_connections (metadata only) rather than
+    load_gcp_connections_with_creds — we only need the project list, not the
+    parsed google-auth Credentials objects (which require an SA key parse per
+    row).
+    """
+    from utils.db.connection_utils import get_all_user_connections
+    rows = get_all_user_connections(user_id, "gcp")
+    if not rows:
+        return None
+    accessible = []
+    seen = set()
+    for conn in rows:
+        for pid in (conn.get("accessible_project_ids") or []):
+            if pid and pid not in seen:
+                seen.add(pid)
+                accessible.append({"project_id": pid, "name": pid})
+    return {"auth_type": "service_account", "accessible_projects": accessible}
+
+
 def _load_gcp_token(user_id):
-    """Fetch GCP token data; return (token_data, None) or (None, error_response)."""
+    """Fetch GCP token data; return (token_data, None) or (None, error_response).
+
+    Prefers multi-SA when present, falls back to the legacy single-token path.
+    """
     token_data = get_token_data(user_id, "gcp")
     if not token_data:
+        synth = _synthesize_multi_sa_token(user_id)
+        if synth is not None:
+            return synth, None
         logging.warning("No token data found for user_id: %s, provider: gcp", sanitize(user_id))
         return None, (jsonify({"error": "No GCP credentials found. Please authenticate with GCP."}), 401)
     return token_data, None

--- a/server/routes/gcp/root_project.py
+++ b/server/routes/gcp/root_project.py
@@ -11,6 +11,10 @@ from utils.auth.stateless_auth import (
 )
 from utils.auth.rbac_decorators import require_permission
 from connectors.gcp_connector.auth.oauth import get_credentials
+from connectors.gcp_connector.auth.multi_sa import (
+    load_gcp_credentials_for_project,
+    load_gcp_connections_with_creds,
+)
 from connectors.gcp_connector.gcp.projects import check_billing_enabled
 from routes.gcp.root_project_tasks import setup_root_project_async
 from googleapiclient.discovery import build
@@ -49,12 +53,22 @@ def set_root_project(user_id):
         if not project_id:
             return jsonify({"error": "Missing project_id"}), 400
 
-        # Get user credentials
-        token_data = get_credentials_from_db(user_id, 'gcp')
-        if not token_data:
-            return jsonify({"error": "No GCP credentials found"}), 401
-
-        credentials = get_credentials(token_data)
+        # Prefer the SA that owns/has-access to the requested project; fall
+        # back to any active multi-SA connection; finally fall back to legacy
+        # OAuth/single-SA credentials in user_tokens.
+        credentials = None
+        pair = load_gcp_credentials_for_project(user_id, project_id)
+        if pair:
+            credentials = pair[1]
+        else:
+            multi = load_gcp_connections_with_creds(user_id)
+            if multi:
+                credentials = multi[0][1]
+            else:
+                token_data = get_credentials_from_db(user_id, 'gcp')
+                if not token_data:
+                    return jsonify({"error": "No GCP credentials found"}), 401
+                credentials = get_credentials(token_data)
 
         # Validate the project
         validation_result = validate_root_project(credentials, project_id)

--- a/server/routes/gcp/root_project_tasks.py
+++ b/server/routes/gcp/root_project_tasks.py
@@ -20,9 +20,30 @@ def setup_root_project_async(self, user_id: str, project_id: str) -> dict:
 
     token_data = get_credentials_from_db(user_id, "gcp")
     if not token_data:
-        error_message = f"No GCP credentials found for user {user_id}"
-        logger.error(error_message)
-        raise ValueError(error_message)
+        # Multi-SA users have no user_tokens row. Synthesize an SA-mode
+        # token_data from the user_connections row that owns project_id.
+        from connectors.gcp_connector.auth.multi_sa import (
+            load_gcp_credentials_for_project,
+            load_gcp_connections_with_creds,
+        )
+        pair = load_gcp_credentials_for_project(user_id, project_id) or (
+            (load_gcp_connections_with_creds(user_id) or [(None, None)])[0]
+        )
+        if not pair or not pair[0]:
+            error_message = f"No GCP credentials found for user {user_id}"
+            logger.error(error_message)
+            raise ValueError(error_message)
+        conn = pair[0]
+        accessible = [
+            {"project_id": pid, "name": pid}
+            for pid in (conn.get("accessible_project_ids") or [])
+            if pid
+        ]
+        token_data = {
+            "auth_type": GCP_AUTH_TYPE_SA,
+            "client_email": conn.get("account_id"),
+            "accessible_projects": accessible,
+        }
 
     # Service-account mode: Aurora never created a per-user SA to provision
     # against the root project. The uploaded SA is already the working

--- a/server/routes/gcp/service_accounts.py
+++ b/server/routes/gcp/service_accounts.py
@@ -1,0 +1,296 @@
+"""GCP service-account management routes (multi-SA per user).
+
+Each row in ``user_connections`` for provider='gcp' represents one connected
+service account, keyed on the SA's client_email. Visibility (private | org)
+controls whether org-mates can use the same credential.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import unquote
+
+from flask import Blueprint, jsonify, request
+from google.oauth2 import service_account as google_sa
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from utils.auth.rbac_decorators import require_permission
+from utils.db.connection_utils import (
+    deactivate_all_connections,
+    deactivate_connection,
+    get_all_user_connections,
+    save_connection_metadata,
+)
+from utils.log_sanitizer import hash_for_log
+from utils.secrets.secret_ref_utils import (
+    delete_connection_secret,
+    store_connection_secret,
+)
+
+logger = logging.getLogger(__name__)
+
+gcp_service_accounts_bp = Blueprint("gcp_service_accounts", __name__)
+
+PROVIDER = "gcp"
+READ_ONLY_SCOPE = "https://www.googleapis.com/auth/cloud-platform.read-only"
+_LOG_PREFIX = "[GCP-SA]"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _strip_secret_ref(conn_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of the connection dict without ``secret_ref``."""
+    out = dict(conn_dict)
+    out.pop("secret_ref", None)
+    return out
+
+
+def _build_credentials(sa_info: Dict[str, Any]):
+    """Build read-only SA credentials. Caller handles exceptions.
+
+    Routes through the same unwrap helper as the runtime credential loader so
+    legacy wrapper-shape blobs (``{service_account_json, client_email, project_id}``)
+    also work — necessary for reconnect to succeed on rows written by an
+    earlier iteration of this route.
+    """
+    from connectors.gcp_connector.auth.multi_sa import _unwrap_sa_info
+    return google_sa.Credentials.from_service_account_info(
+        _unwrap_sa_info(sa_info), scopes=[READ_ONLY_SCOPE]
+    )
+
+
+def _verify_and_enumerate(
+    sa_info: Dict[str, Any], project_id: str
+) -> Tuple[bool, List[str], Optional[str]]:
+    """Verify SA against ``project_id`` and enumerate accessible projects.
+
+    Returns ``(ok, accessible_project_ids, error_message)``. Enumeration falls
+    back to ``[project_id]`` if the broader list call fails (common when the SA
+    only has project-level perms).
+    """
+    try:
+        creds = _build_credentials(sa_info)
+    except Exception as exc:
+        return False, [], f"Invalid service account JSON: {type(exc).__name__}"
+
+    try:
+        crm = build(
+            "cloudresourcemanager",
+            "v1",
+            credentials=creds,
+            cache_discovery=False,
+        )
+    except Exception as exc:
+        return False, [], f"Failed to build GCP client: {type(exc).__name__}"
+
+    # 1. Verify against the home project (cheap, definitive)
+    try:
+        crm.projects().get(projectId=project_id).execute()
+    except HttpError as exc:
+        status = getattr(exc, "status_code", None) or getattr(getattr(exc, "resp", None), "status", None)
+        return False, [], f"Service account cannot access project (HTTP {status})"
+    except Exception as exc:
+        return False, [], f"Verification failed: {type(exc).__name__}"
+
+    # 2. Best-effort enumeration of all accessible projects
+    accessible: List[str] = []
+    try:
+        resp = crm.projects().list().execute()
+        for proj in resp.get("projects") or []:
+            pid = proj.get("projectId")
+            if not pid:
+                continue
+            if (proj.get("lifecycleState") or "ACTIVE") != "ACTIVE":
+                continue
+            accessible.append(pid)
+    except Exception as exc:
+        logger.info(
+            "%s projects.list failed for project=%s (%s) — falling back to home project",
+            _LOG_PREFIX,
+            hash_for_log(project_id),
+            type(exc).__name__,
+        )
+
+    if project_id not in accessible:
+        accessible.append(project_id)
+
+    return True, accessible, None
+
+
+# ── Routes ─────────────────────────────────────────────────────────────
+
+
+@gcp_service_accounts_bp.route("/api/gcp/service-accounts", methods=["GET"])
+@require_permission("connectors", "read")
+def list_service_accounts(user_id):
+    """Return active GCP service-account connections for the user.
+
+    Inactive rows are intentionally excluded: the disconnect flow deletes the
+    Vault secret, so an inactive row cannot be re-activated without re-uploading
+    the SA key — surfacing it as "reconnectable" would mislead the user.
+    """
+    rows = get_all_user_connections(user_id, PROVIDER)
+    return jsonify({"service_accounts": [_strip_secret_ref(r) for r in rows]}), 200
+
+
+@gcp_service_accounts_bp.route("/api/gcp/service-accounts", methods=["POST"])
+@require_permission("connectors", "write")
+def add_service_account(user_id):
+    """Verify and store a new GCP service-account credential."""
+    body = request.get_json(silent=True) or {}
+    sa_raw = body.get("service_account_json")
+    alias = body.get("alias")
+    visibility = body.get("visibility") or "private"
+
+    if visibility not in ("private", "org"):
+        return jsonify({"error": "visibility must be 'private' or 'org'"}), 400
+
+    if not sa_raw:
+        return jsonify({"error": "service_account_json is required"}), 400
+
+    # Accept either a dict or a JSON string
+    if isinstance(sa_raw, str):
+        try:
+            sa_info = json.loads(sa_raw)
+        except json.JSONDecodeError:
+            return jsonify({"error": "service_account_json is not valid JSON"}), 400
+    elif isinstance(sa_raw, dict):
+        sa_info = sa_raw
+    else:
+        return jsonify({"error": "service_account_json must be JSON object or string"}), 400
+
+    client_email = sa_info.get("client_email")
+    project_id = sa_info.get("project_id")
+    if not client_email or not project_id:
+        return jsonify(
+            {"error": "service_account_json must contain client_email and project_id"}
+        ), 400
+
+    if alias is not None and not isinstance(alias, str):
+        return jsonify({"error": "alias must be a string"}), 400
+    if alias:
+        alias = alias.strip()[:120] or None
+
+    ok, accessible, err = _verify_and_enumerate(sa_info, project_id)
+    if not ok:
+        logger.warning(
+            "%s SA verification failed user=%s project=%s: %s",
+            _LOG_PREFIX,
+            hash_for_log(user_id),
+            hash_for_log(project_id),
+            err,
+        )
+        return jsonify({"error": err or "Service account verification failed"}), 400
+
+    secret_ref = store_connection_secret(user_id, PROVIDER, client_email, sa_info)
+    if not secret_ref:
+        return jsonify({"error": "Failed to store credentials"}), 500
+
+    saved = save_connection_metadata(
+        user_id,
+        PROVIDER,
+        client_email,
+        account_alias=alias,
+        project_id=project_id,
+        accessible_project_ids=accessible,
+        visibility=visibility,
+        secret_ref=secret_ref,
+        connection_method="service_account",
+        status="active",
+    )
+    if not saved:
+        # Best-effort cleanup of the orphaned secret
+        delete_connection_secret(secret_ref)
+        return jsonify({"error": "Failed to save connection metadata"}), 500
+
+    logger.info(
+        "%s SA connected user=%s account=%s project=%s accessible=%d visibility=%s",
+        _LOG_PREFIX,
+        hash_for_log(user_id),
+        hash_for_log(client_email),
+        hash_for_log(project_id),
+        len(accessible),
+        visibility,
+    )
+
+    return jsonify(
+        _strip_secret_ref(
+            {
+                "account_id": client_email,
+                "account_alias": alias,
+                "project_id": project_id,
+                "accessible_project_ids": accessible,
+                "visibility": visibility,
+                "status": "active",
+            }
+        )
+    ), 201
+
+
+@gcp_service_accounts_bp.route(
+    "/api/gcp/service-accounts/<path:sa_email>", methods=["DELETE"]
+)
+@require_permission("connectors", "write")
+def delete_service_account(user_id, sa_email):
+    """Deactivate a single SA connection and delete its Vault secret."""
+    sa_email = unquote(sa_email or "").strip()
+    if not sa_email:
+        return jsonify({"error": "service account email required"}), 400
+
+    ok, secret_ref = deactivate_connection(user_id, PROVIDER, sa_email)
+    if not ok:
+        return jsonify({"error": "Service account not found or already inactive"}), 404
+
+    if secret_ref:
+        try:
+            delete_connection_secret(secret_ref)
+        except Exception as exc:
+            logger.warning(
+                "%s Secret cleanup failed user=%s account=%s: %s",
+                _LOG_PREFIX,
+                hash_for_log(user_id),
+                hash_for_log(sa_email),
+                type(exc).__name__,
+            )
+
+    logger.info(
+        "%s SA disconnected user=%s account=%s",
+        _LOG_PREFIX,
+        hash_for_log(user_id),
+        hash_for_log(sa_email),
+    )
+    return jsonify({"success": True}), 200
+
+
+@gcp_service_accounts_bp.route(
+    "/api/gcp/service-accounts/disconnect-all", methods=["POST"]
+)
+@require_permission("connectors", "write")
+def disconnect_all_service_accounts(user_id):
+    """Deactivate every GCP SA for this user and delete each Vault secret."""
+    ok, refs = deactivate_all_connections(user_id, PROVIDER)
+    if not ok:
+        return jsonify({"error": "Failed to disconnect service accounts"}), 500
+
+    for ref in refs:
+        if not ref:
+            continue
+        try:
+            delete_connection_secret(ref)
+        except Exception as exc:
+            logger.warning(
+                "%s Bulk secret cleanup failed user=%s: %s",
+                _LOG_PREFIX,
+                hash_for_log(user_id),
+                type(exc).__name__,
+            )
+
+    logger.info(
+        "%s All SAs disconnected user=%s count=%d",
+        _LOG_PREFIX,
+        hash_for_log(user_id),
+        len(refs),
+    )
+    return jsonify({"success": True, "disconnected": len(refs)}), 200

--- a/server/routes/gcp/service_accounts.py
+++ b/server/routes/gcp/service_accounts.py
@@ -110,17 +110,24 @@ def _verify_and_enumerate(
     except Exception as exc:
         return False, [], f"Verification failed: {type(exc).__name__}"
 
-    # 2. Best-effort enumeration of all accessible projects
+    # 2. Best-effort enumeration of all accessible projects (paginated — orgs
+    # with browser/viewer at folder level routinely return >hundreds of pages)
     accessible: List[str] = []
     try:
-        resp = crm.projects().list().execute()
-        for proj in resp.get("projects") or []:
-            pid = proj.get("projectId")
-            if not pid:
-                continue
-            if (proj.get("lifecycleState") or "ACTIVE") != "ACTIVE":
-                continue
-            accessible.append(pid)
+        page_token: Optional[str] = None
+        while True:
+            req_kwargs = {"pageToken": page_token} if page_token else {}
+            resp = crm.projects().list(**req_kwargs).execute()
+            for proj in resp.get("projects") or []:
+                pid = proj.get("projectId")
+                if not pid:
+                    continue
+                if (proj.get("lifecycleState") or "ACTIVE") != "ACTIVE":
+                    continue
+                accessible.append(pid)
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
     except Exception as exc:
         logger.info(
             "%s projects.list failed for project=%s (%s) — falling back to home project",
@@ -278,7 +285,13 @@ def delete_service_account(user_id, sa_email):
 
     if secret_ref:
         try:
-            delete_connection_secret(secret_ref)
+            if not delete_connection_secret(secret_ref):
+                logger.warning(
+                    "%s Secret cleanup failed (delete returned False) user=%s account=%s",
+                    _LOG_PREFIX,
+                    hash_for_log(user_id),
+                    hash_for_log(sa_email),
+                )
         except Exception as exc:
             logger.warning(
                 "%s Secret cleanup failed user=%s account=%s: %s",
@@ -311,7 +324,12 @@ def disconnect_all_service_accounts(user_id):
         if not ref:
             continue
         try:
-            delete_connection_secret(ref)
+            if not delete_connection_secret(ref):
+                logger.warning(
+                    "%s Bulk secret cleanup failed (delete returned False) user=%s",
+                    _LOG_PREFIX,
+                    hash_for_log(user_id),
+                )
         except Exception as exc:
             logger.warning(
                 "%s Bulk secret cleanup failed user=%s: %s",

--- a/server/routes/gcp/service_accounts.py
+++ b/server/routes/gcp/service_accounts.py
@@ -206,13 +206,12 @@ def add_service_account(user_id):
         return jsonify({"error": "Failed to save connection metadata"}), 500
 
     logger.info(
-        "%s SA connected user=%s account=%s project=%s accessible=%d visibility=%s",
+        "%s SA connected user=%s account=%s project=%s accessible=%d",
         _LOG_PREFIX,
         hash_for_log(user_id),
         hash_for_log(client_email),
         hash_for_log(project_id),
         len(accessible),
-        visibility,
     )
 
     return jsonify(

--- a/server/routes/gcp/service_accounts.py
+++ b/server/routes/gcp/service_accounts.py
@@ -37,6 +37,21 @@ PROVIDER = "gcp"
 READ_ONLY_SCOPE = "https://www.googleapis.com/auth/cloud-platform.read-only"
 _LOG_PREFIX = "[GCP-SA]"
 
+# Validation error codes for _parse_add_sa_request. The dict maps code -> (message, http_status).
+# Returning a code (instead of a message dict) keeps the user-input taint out of the response body
+# so static analysis (CodeQL py/reflected-xss) cannot trace request data to jsonify().
+_VALIDATION_ERRORS: Dict[str, Tuple[str, int]] = {
+    "BAD_VISIBILITY": ("visibility must be 'private' or 'org'", 400),
+    "MISSING_SA_JSON": ("service_account_json is required", 400),
+    "INVALID_SA_JSON": ("service_account_json is not valid JSON", 400),
+    "BAD_SA_TYPE": ("service_account_json must be JSON object or string", 400),
+    "MISSING_SA_FIELDS": (
+        "service_account_json must contain client_email and project_id",
+        400,
+    ),
+    "BAD_ALIAS_TYPE": ("alias must be a string", 400),
+}
+
 
 # ── Helpers ────────────────────────────────────────────────────────────
 
@@ -137,41 +152,39 @@ def list_service_accounts(user_id):
 
 
 def _parse_add_sa_request(body: Dict[str, Any]) -> Tuple[
-    Optional[Dict[str, Any]], Optional[str], Optional[str], Optional[Tuple[Dict[str, str], int]]
+    Optional[Dict[str, Any]], Optional[str], Optional[str], Optional[str]
 ]:
-    """Validate the POST body and return ``(sa_info, alias, visibility, error_response)``.
+    """Validate the POST body and return ``(sa_info, alias, visibility, error_code)``.
 
-    On any validation failure returns ``(None, None, None, (json_body, http_status))``
-    so the caller can ``return jsonify(*error_response)`` directly.
+    On any validation failure returns ``(None, None, None, "<CODE>")`` where
+    ``<CODE>`` is a key in ``_VALIDATION_ERRORS``. The caller maps the code to
+    a constant message — this prevents user input from flowing back into the
+    response body (CodeQL py/reflected-xss).
     """
     sa_raw = body.get("service_account_json")
     alias = body.get("alias")
     visibility = body.get("visibility") or "private"
 
     if visibility not in ("private", "org"):
-        return None, None, None, ({"error": "visibility must be 'private' or 'org'"}, 400)
+        return None, None, None, "BAD_VISIBILITY"
     if not sa_raw:
-        return None, None, None, ({"error": "service_account_json is required"}, 400)
+        return None, None, None, "MISSING_SA_JSON"
 
     if isinstance(sa_raw, str):
         try:
             sa_info = json.loads(sa_raw)
         except json.JSONDecodeError:
-            return None, None, None, ({"error": "service_account_json is not valid JSON"}, 400)
+            return None, None, None, "INVALID_SA_JSON"
     elif isinstance(sa_raw, dict):
         sa_info = sa_raw
     else:
-        return None, None, None, (
-            {"error": "service_account_json must be JSON object or string"}, 400,
-        )
+        return None, None, None, "BAD_SA_TYPE"
 
     if not sa_info.get("client_email") or not sa_info.get("project_id"):
-        return None, None, None, (
-            {"error": "service_account_json must contain client_email and project_id"}, 400,
-        )
+        return None, None, None, "MISSING_SA_FIELDS"
 
     if alias is not None and not isinstance(alias, str):
-        return None, None, None, ({"error": "alias must be a string"}, 400)
+        return None, None, None, "BAD_ALIAS_TYPE"
     if alias:
         alias = alias.strip()[:120] or None
 
@@ -182,11 +195,12 @@ def _parse_add_sa_request(body: Dict[str, Any]) -> Tuple[
 @require_permission("connectors", "write")
 def add_service_account(user_id):
     """Verify and store a new GCP service-account credential."""
-    sa_info, alias, visibility, err_resp = _parse_add_sa_request(
+    sa_info, alias, visibility, err_code = _parse_add_sa_request(
         request.get_json(silent=True) or {}
     )
-    if err_resp:
-        return jsonify(err_resp[0]), err_resp[1]
+    if err_code:
+        msg, status = _VALIDATION_ERRORS[err_code]
+        return jsonify({"error": msg}), status
 
     client_email = sa_info["client_email"]
     project_id = sa_info["project_id"]

--- a/server/routes/gcp/service_accounts.py
+++ b/server/routes/gcp/service_accounts.py
@@ -17,6 +17,7 @@ from googleapiclient.errors import HttpError
 
 from utils.auth.rbac_decorators import require_permission
 from utils.db.connection_utils import (
+    GcpConnectionExtras,
     deactivate_all_connections,
     deactivate_connection,
     get_all_user_connections,
@@ -135,43 +136,60 @@ def list_service_accounts(user_id):
     return jsonify({"service_accounts": [_strip_secret_ref(r) for r in rows]}), 200
 
 
-@gcp_service_accounts_bp.route("/api/gcp/service-accounts", methods=["POST"])
-@require_permission("connectors", "write")
-def add_service_account(user_id):
-    """Verify and store a new GCP service-account credential."""
-    body = request.get_json(silent=True) or {}
+def _parse_add_sa_request(body: Dict[str, Any]) -> Tuple[
+    Optional[Dict[str, Any]], Optional[str], Optional[str], Optional[Tuple[Dict[str, str], int]]
+]:
+    """Validate the POST body and return ``(sa_info, alias, visibility, error_response)``.
+
+    On any validation failure returns ``(None, None, None, (json_body, http_status))``
+    so the caller can ``return jsonify(*error_response)`` directly.
+    """
     sa_raw = body.get("service_account_json")
     alias = body.get("alias")
     visibility = body.get("visibility") or "private"
 
     if visibility not in ("private", "org"):
-        return jsonify({"error": "visibility must be 'private' or 'org'"}), 400
-
+        return None, None, None, ({"error": "visibility must be 'private' or 'org'"}, 400)
     if not sa_raw:
-        return jsonify({"error": "service_account_json is required"}), 400
+        return None, None, None, ({"error": "service_account_json is required"}, 400)
 
-    # Accept either a dict or a JSON string
     if isinstance(sa_raw, str):
         try:
             sa_info = json.loads(sa_raw)
         except json.JSONDecodeError:
-            return jsonify({"error": "service_account_json is not valid JSON"}), 400
+            return None, None, None, ({"error": "service_account_json is not valid JSON"}, 400)
     elif isinstance(sa_raw, dict):
         sa_info = sa_raw
     else:
-        return jsonify({"error": "service_account_json must be JSON object or string"}), 400
+        return None, None, None, (
+            {"error": "service_account_json must be JSON object or string"}, 400,
+        )
 
-    client_email = sa_info.get("client_email")
-    project_id = sa_info.get("project_id")
-    if not client_email or not project_id:
-        return jsonify(
-            {"error": "service_account_json must contain client_email and project_id"}
-        ), 400
+    if not sa_info.get("client_email") or not sa_info.get("project_id"):
+        return None, None, None, (
+            {"error": "service_account_json must contain client_email and project_id"}, 400,
+        )
 
     if alias is not None and not isinstance(alias, str):
-        return jsonify({"error": "alias must be a string"}), 400
+        return None, None, None, ({"error": "alias must be a string"}, 400)
     if alias:
         alias = alias.strip()[:120] or None
+
+    return sa_info, alias, visibility, None
+
+
+@gcp_service_accounts_bp.route("/api/gcp/service-accounts", methods=["POST"])
+@require_permission("connectors", "write")
+def add_service_account(user_id):
+    """Verify and store a new GCP service-account credential."""
+    sa_info, alias, visibility, err_resp = _parse_add_sa_request(
+        request.get_json(silent=True) or {}
+    )
+    if err_resp:
+        return jsonify(err_resp[0]), err_resp[1]
+
+    client_email = sa_info["client_email"]
+    project_id = sa_info["project_id"]
 
     ok, accessible, err = _verify_and_enumerate(sa_info, project_id)
     if not ok:
@@ -192,13 +210,15 @@ def add_service_account(user_id):
         user_id,
         PROVIDER,
         client_email,
-        account_alias=alias,
-        project_id=project_id,
-        accessible_project_ids=accessible,
-        visibility=visibility,
-        secret_ref=secret_ref,
         connection_method="service_account",
         status="active",
+        gcp_extras=GcpConnectionExtras(
+            account_alias=alias,
+            project_id=project_id,
+            accessible_project_ids=accessible,
+            visibility=visibility,
+            secret_ref=secret_ref,
+        ),
     )
     if not saved:
         # Best-effort cleanup of the orphaned secret

--- a/server/routes/grafana/tasks.py
+++ b/server/routes/grafana/tasks.py
@@ -21,6 +21,7 @@ from celery_config import celery_app
 from chat.background.rca_prompt_builder import build_grafana_rca_prompt
 from services.correlation.alert_correlator import AlertCorrelator
 from services.correlation import handle_correlated_alert
+from utils.cloud.gcp_project_extraction import extract_gcp_project_from_alert
 
 logger = logging.getLogger(__name__)
 
@@ -367,6 +368,10 @@ def process_grafana_alert(
                             per_alert_rule_uid = single_alert.get("ruleUID") or single_alert.get("ruleUid")
                             if per_alert_rule_uid:
                                 alert_metadata["ruleUID"] = per_alert_rule_uid
+
+                            pid = extract_gcp_project_from_alert(alert_payload, "grafana")
+                            if pid:
+                                alert_metadata["gcp_project_id"] = pid
 
                             # Try to correlate with an existing open incident (time/similarity/topology based)
                             correlation_result = None

--- a/server/routes/pagerduty/tasks.py
+++ b/server/routes/pagerduty/tasks.py
@@ -12,6 +12,7 @@ from chat.background.rca_prompt_builder import build_pagerduty_rca_prompt
 from services.correlation.alert_correlator import AlertCorrelator
 from services.correlation import handle_correlated_alert
 from utils.auth.stateless_auth import set_rls_context
+from utils.cloud.gcp_project_extraction import extract_gcp_project_from_alert
 
 logger = logging.getLogger(__name__)
 
@@ -589,6 +590,10 @@ def process_pagerduty_event(
                 # Preserve existing custom fields (e.g., runbook_link from custom field updates)
                 if "customFields" in existing_metadata:
                     alert_metadata["customFields"] = existing_metadata["customFields"]
+
+                pid = extract_gcp_project_from_alert(raw_payload, "pagerduty")
+                if pid:
+                    alert_metadata["gcp_project_id"] = pid
 
                 if event_type == "incident.triggered":
                     try:

--- a/server/routes/sentry/tasks.py
+++ b/server/routes/sentry/tasks.py
@@ -14,6 +14,7 @@ from celery_config import celery_app
 from chat.background.rca_prompt_builder import build_sentry_rca_prompt
 from services.correlation.alert_correlator import AlertCorrelator
 from services.correlation import handle_correlated_alert
+from utils.cloud.gcp_project_extraction import extract_gcp_project_from_alert
 from utils.payload_timestamp import extract_alert_fired_at
 
 # Exceptions that warrant retrying the task — DB connectivity hiccups,
@@ -155,6 +156,10 @@ def _build_alert_metadata(payload: Dict[str, Any], resource: str) -> Dict[str, A
     triggered_rule = data.get("triggered_rule")
     if triggered_rule:
         meta["triggeredRule"] = triggered_rule
+
+    pid = extract_gcp_project_from_alert(payload, "sentry")
+    if pid:
+        meta["gcp_project_id"] = pid
 
     return {k: v for k, v in meta.items() if v is not None}
 

--- a/server/routes/setup_terraform_environment.py
+++ b/server/routes/setup_terraform_environment.py
@@ -218,6 +218,17 @@ def setup_gcp_terraform_environment_isolated(user_id: str):
                 GCP_AUTH_TYPE_SA,
             )
             token_data = get_token_data(user_id, "gcp")
+            if not token_data:
+                # Multi-SA users have no user_tokens row — synthesize an
+                # SA-mode payload from user_connections for the target project.
+                from connectors.gcp_connector.auth.multi_sa import load_sa_json_for_project
+                sa_info = load_sa_json_for_project(user_id, project_id)
+                if sa_info:
+                    import json as _json
+                    token_data = {
+                        "auth_type": GCP_AUTH_TYPE_SA,
+                        "service_account_json": _json.dumps(sa_info),
+                    }
             # SA mode uses service_account_json; OAuth mode uses refresh_token.
             # create_local_credentials_file handles both.
             has_creds = token_data and (

--- a/server/scripts/migrate_gcp_tokens_to_connections.py
+++ b/server/scripts/migrate_gcp_tokens_to_connections.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Migrate legacy GCP credentials from ``user_tokens`` to ``user_connections``.
+
+Idempotent: re-running on already-migrated rows is a no-op (the upsert just
+refreshes ``last_verified_at`` + ``accessible_project_ids``). Legacy rows are
+left intact so the system stays bilingual during the transition.
+
+# TODO(2026-Q3): remove user_tokens.gcp legacy storage after one release.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# Make ``server/`` importable when run via `python server/scripts/...`
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SERVER = os.path.dirname(_HERE)
+if _SERVER not in sys.path:
+    sys.path.insert(0, _SERVER)
+
+from google.oauth2 import service_account as google_sa  # noqa: E402
+from googleapiclient.discovery import build  # noqa: E402
+
+from utils.db.connection_utils import save_connection_metadata  # noqa: E402
+from utils.db.db_utils import connect_to_db_as_admin  # noqa: E402
+from utils.log_sanitizer import hash_for_log  # noqa: E402
+from utils.secrets.secret_ref_utils import (  # noqa: E402
+    secret_manager,
+    store_connection_secret,
+)
+
+logger = logging.getLogger("migrate_gcp_tokens")
+
+READ_ONLY_SCOPE = "https://www.googleapis.com/auth/cloud-platform.read-only"
+
+
+def _iter_gcp_token_rows() -> List[Tuple[str, str]]:
+    """Return ``(user_id, secret_ref)`` for every active GCP user_tokens row."""
+    sql = (
+        "SELECT user_id, secret_ref FROM user_tokens "
+        "WHERE provider = 'gcp' AND secret_ref IS NOT NULL AND is_active = TRUE"
+    )
+    rows: List[Tuple[str, str]] = []
+    conn = None
+    try:
+        conn = connect_to_db_as_admin()
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            for user_id, secret_ref in cur.fetchall():
+                if user_id and secret_ref:
+                    rows.append((user_id, secret_ref))
+    finally:
+        if conn:
+            conn.close()
+    return rows
+
+
+def _decode_secret(secret_ref: str) -> Optional[Dict[str, Any]]:
+    try:
+        raw = secret_manager.get_secret(secret_ref)
+    except Exception as exc:
+        logger.warning("Failed to read secret %s: %s", secret_ref, type(exc).__name__)
+        return None
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _extract_sa_info(token_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Pull out the SA JSON blob from the legacy token payload.
+
+    Aurora has stored SA creds in several shapes over time — at the top level,
+    nested under ``service_account``, or nested under ``sa_info``. Try each.
+    """
+    if not isinstance(token_data, dict):
+        return None
+
+    candidates = (
+        token_data,
+        token_data.get("service_account"),
+        token_data.get("sa_info"),
+        token_data.get("credentials"),
+    )
+    for cand in candidates:
+        if isinstance(cand, dict) and cand.get("client_email") and cand.get("project_id"):
+            return cand
+    return None
+
+
+def _enumerate_projects(sa_info: Dict[str, Any], project_id: str) -> List[str]:
+    try:
+        creds = google_sa.Credentials.from_service_account_info(
+            sa_info, scopes=[READ_ONLY_SCOPE]
+        )
+        crm = build("cloudresourcemanager", "v1", credentials=creds, cache_discovery=False)
+        resp = crm.projects().list().execute()
+    except Exception as exc:
+        logger.info(
+            "projects.list failed for project=%s (%s) — using home project only",
+            hash_for_log(project_id),
+            type(exc).__name__,
+        )
+        return [project_id]
+
+    accessible: List[str] = []
+    for proj in resp.get("projects") or []:
+        pid = proj.get("projectId")
+        if not pid:
+            continue
+        if (proj.get("lifecycleState") or "ACTIVE") != "ACTIVE":
+            continue
+        accessible.append(pid)
+    if project_id not in accessible:
+        accessible.append(project_id)
+    return accessible
+
+
+def migrate(dry_run: bool) -> Tuple[int, int, int]:
+    """Returns ``(processed, migrated, skipped)``."""
+    rows = _iter_gcp_token_rows()
+    logger.info("Found %d GCP user_tokens rows", len(rows))
+
+    processed = migrated = skipped = 0
+    for user_id, secret_ref in rows:
+        processed += 1
+        token_data = _decode_secret(secret_ref)
+        if token_data is None:
+            logger.info(
+                "Skipping user=%s — secret unavailable",
+                hash_for_log(user_id),
+            )
+            skipped += 1
+            continue
+
+        sa_info = _extract_sa_info(token_data)
+        if not sa_info:
+            logger.info(
+                "Skipping user=%s — no SA JSON in payload (likely OAuth row)",
+                hash_for_log(user_id),
+            )
+            skipped += 1
+            continue
+
+        client_email = sa_info["client_email"]
+        project_id = sa_info["project_id"]
+
+        if dry_run:
+            logger.info(
+                "[DRY-RUN] Would migrate user=%s account=%s project=%s",
+                hash_for_log(user_id),
+                hash_for_log(client_email),
+                hash_for_log(project_id),
+            )
+            migrated += 1
+            continue
+
+        accessible = _enumerate_projects(sa_info, project_id)
+        new_ref = store_connection_secret(user_id, "gcp", client_email, sa_info)
+        if not new_ref:
+            logger.warning(
+                "Failed to store secret for user=%s account=%s",
+                hash_for_log(user_id),
+                hash_for_log(client_email),
+            )
+            skipped += 1
+            continue
+
+        ok = save_connection_metadata(
+            user_id,
+            "gcp",
+            client_email,
+            project_id=project_id,
+            accessible_project_ids=accessible,
+            visibility="private",
+            secret_ref=new_ref,
+            connection_method="service_account",
+            status="active",
+        )
+        if not ok:
+            logger.warning(
+                "Failed to save metadata for user=%s account=%s",
+                hash_for_log(user_id),
+                hash_for_log(client_email),
+            )
+            skipped += 1
+            continue
+
+        logger.info(
+            "Migrated user=%s account=%s project=%s accessible=%d",
+            hash_for_log(user_id),
+            hash_for_log(client_email),
+            hash_for_log(project_id),
+            len(accessible),
+        )
+        migrated += 1
+
+    return processed, migrated, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be migrated without writing to Vault or the DB.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable DEBUG logging."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    processed, migrated, skipped = migrate(args.dry_run)
+    logger.info(
+        "Done — processed=%d migrated=%d skipped=%d dry_run=%s",
+        processed,
+        migrated,
+        skipped,
+        args.dry_run,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/migrate_gcp_tokens_to_connections.py
+++ b/server/scripts/migrate_gcp_tokens_to_connections.py
@@ -63,7 +63,7 @@ def _decode_secret(secret_ref: str) -> Optional[Dict[str, Any]]:
     try:
         raw = secret_manager.get_secret(secret_ref)
     except Exception as exc:
-        logger.warning("Failed to read secret %s: %s", secret_ref, type(exc).__name__)
+        logger.warning("Failed to read secret %s: %s", hash_for_log(secret_ref), type(exc).__name__)
         return None
     if not raw:
         return None

--- a/server/scripts/migrate_gcp_tokens_to_connections.py
+++ b/server/scripts/migrate_gcp_tokens_to_connections.py
@@ -25,7 +25,10 @@ if _SERVER not in sys.path:
 from google.oauth2 import service_account as google_sa  # noqa: E402
 from googleapiclient.discovery import build  # noqa: E402
 
-from utils.db.connection_utils import save_connection_metadata  # noqa: E402
+from utils.db.connection_utils import (  # noqa: E402
+    GcpConnectionExtras,
+    save_connection_metadata,
+)
 from utils.db.db_utils import connect_to_db_as_admin  # noqa: E402
 from utils.log_sanitizer import hash_for_log  # noqa: E402
 from utils.secrets.secret_ref_utils import (  # noqa: E402
@@ -176,12 +179,14 @@ def migrate(dry_run: bool) -> Tuple[int, int, int]:
             user_id,
             "gcp",
             client_email,
-            project_id=project_id,
-            accessible_project_ids=accessible,
-            visibility="private",
-            secret_ref=new_ref,
             connection_method="service_account",
             status="active",
+            gcp_extras=GcpConnectionExtras(
+                project_id=project_id,
+                accessible_project_ids=accessible,
+                visibility="private",
+                secret_ref=new_ref,
+            ),
         )
         if not ok:
             logger.warning(

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -3,6 +3,7 @@ Celery tasks for scheduled infrastructure discovery.
 """
 
 import logging
+from typing import List, Optional, Tuple
 
 from celery_config import celery_app
 from utils.auth.stateless_auth import set_rls_context, get_org_id_for_user
@@ -405,7 +406,7 @@ def _oauth_full_enumeration(refreshed) -> list:
     return project_ids
 
 
-def _get_oauth_project_ids(user_id):
+def _get_oauth_project_ids(user_id) -> Tuple[List[str], Optional[str]]:
     """Return project IDs via the Cloud Resource Manager API (OAuth path).
 
     Resolution order:

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -356,76 +356,36 @@ def _get_sa_project_ids(token_data, user_id):
     return project_ids, None
 
 
-def _get_oauth_project_ids(user_id):
-    """Return project IDs via the Cloud Resource Manager API (OAuth path).
-
-    Proactively refreshes the access token before use so a near-expired token
-    doesn't cause the enumeration call to fail.
-
-    Only returns projects that were explicitly set up during GCP post-auth
-    (stored as the ``gcp_connected_projects`` user preference).  This prevents
-    stale or unintended projects from being scanned when the OAuth account has
-    access to more projects than the user connected in Aurora.  Falls back to
-    the full billing-filtered enumeration when the preference has not been set
-    yet (e.g. accounts connected before this preference was introduced).
-
-    Returns:
-        Tuple of (project_ids: list[str], credential_error: str | None).
-    """
-    from utils.auth.token_refresh import refresh_token_if_needed as _refresh_gcp
-    from utils.auth.stateless_auth import get_user_preference
-
-    # Multi-SA: prefer the union of accessible_project_ids across all rows in
-    # user_connections BEFORE attempting OAuth refresh — pure multi-SA users
-    # have no user_tokens row to refresh, so the refresh would short-circuit
-    # the multi-SA path with a misleading "reauthenticate" error.
+def _multi_sa_project_ids(user_id) -> list:
+    """Return the union of accessible project IDs across all GCP user_connections rows."""
     try:
         from utils.db.connection_utils import get_all_user_connections
         gcp_conns = get_all_user_connections(user_id, "gcp") or []
     except Exception as _e:
         logger.warning("[Discovery] get_all_user_connections(gcp) failed: %s", _e)
-        gcp_conns = []
+        return []
+    if not gcp_conns:
+        return []
 
-    if gcp_conns:
-        seen = set()
-        union: list = []
-        for row in gcp_conns:
-            for pid in (row.get("accessible_project_ids") or []):
-                if isinstance(pid, str) and pid and pid not in seen:
-                    seen.add(pid)
-                    union.append(pid)
-        if not union:
-            for row in gcp_conns:
-                pid = row.get("project_id")
-                if isinstance(pid, str) and pid and pid not in seen:
-                    seen.add(pid)
-                    union.append(pid)
-        if union:
-            logger.info(
-                "[Discovery] Using %d GCP project(s) from user_connections for user %s",
-                len(union), user_id,
-            )
-            return union, None
+    seen: set = set()
+    union: list = []
+    for row in gcp_conns:
+        for pid in (row.get("accessible_project_ids") or []):
+            if isinstance(pid, str) and pid and pid not in seen:
+                seen.add(pid)
+                union.append(pid)
+    if union:
+        return union
+    for row in gcp_conns:
+        pid = row.get("project_id")
+        if isinstance(pid, str) and pid and pid not in seen:
+            seen.add(pid)
+            union.append(pid)
+    return union
 
-    refreshed = _refresh_gcp(user_id, "gcp")
-    if refreshed is None:
-        err = "GCP token refresh failed: Reauthentication is needed. Please reconnect your GCP account."
-        logger.warning("[Discovery] %s (user=%s)", err, user_id)
-        return [], err
 
-    # If the user has a stored allowlist of connected projects, use it directly
-    # instead of enumerating every project the OAuth token can see.
-    connected_projects = get_user_preference(user_id, "gcp_connected_projects")
-    if connected_projects and isinstance(connected_projects, list):
-        project_ids = [p for p in connected_projects if isinstance(p, str) and p]
-        logger.info(
-            "[Discovery] Using stored gcp_connected_projects (%d) for user %s",
-            len(project_ids), user_id,
-        )
-        return project_ids, None
-
-    # Fallback: enumerate all projects the OAuth token can see (legacy path for
-    # accounts that predate the gcp_connected_projects preference).
+def _oauth_full_enumeration(refreshed) -> list:
+    """Full OAuth enumeration with billing filter — legacy path."""
     from connectors.gcp_connector.auth_compatibility import get_credentials, get_project_list
     from connectors.gcp_connector.billing import has_active_billing
 
@@ -442,8 +402,53 @@ def _get_oauth_project_ids(user_id):
                 project_ids.append(pid)
         except Exception:
             project_ids.append(pid)
+    return project_ids
 
-    logger.info("[Discovery] Found %d GCP projects (OAuth, full enumeration) for user %s", len(project_ids), user_id)
+
+def _get_oauth_project_ids(user_id):
+    """Return project IDs via the Cloud Resource Manager API (OAuth path).
+
+    Resolution order:
+      1. Multi-SA union from ``user_connections`` (pure-SA users have no
+         user_tokens row to refresh; trying that first would surface a
+         misleading "reauthenticate" error).
+      2. Stored ``gcp_connected_projects`` user preference (allowlist set
+         during post-auth).
+      3. Full billing-filtered OAuth enumeration (legacy accounts).
+
+    Returns ``(project_ids: list[str], credential_error: str | None)``.
+    """
+    from utils.auth.token_refresh import refresh_token_if_needed as _refresh_gcp
+    from utils.auth.stateless_auth import get_user_preference
+
+    union = _multi_sa_project_ids(user_id)
+    if union:
+        logger.info(
+            "[Discovery] Using %d GCP project(s) from user_connections for user %s",
+            len(union), user_id,
+        )
+        return union, None
+
+    refreshed = _refresh_gcp(user_id, "gcp")
+    if refreshed is None:
+        err = "GCP token refresh failed: Reauthentication is needed. Please reconnect your GCP account."
+        logger.warning("[Discovery] %s (user=%s)", err, user_id)
+        return [], err
+
+    connected_projects = get_user_preference(user_id, "gcp_connected_projects")
+    if connected_projects and isinstance(connected_projects, list):
+        project_ids = [p for p in connected_projects if isinstance(p, str) and p]
+        logger.info(
+            "[Discovery] Using stored gcp_connected_projects (%d) for user %s",
+            len(project_ids), user_id,
+        )
+        return project_ids, None
+
+    project_ids = _oauth_full_enumeration(refreshed)
+    logger.info(
+        "[Discovery] Found %d GCP projects (OAuth, full enumeration) for user %s",
+        len(project_ids), user_id,
+    )
     return project_ids, None
 
 

--- a/server/services/discovery/tasks.py
+++ b/server/services/discovery/tasks.py
@@ -375,6 +375,38 @@ def _get_oauth_project_ids(user_id):
     from utils.auth.token_refresh import refresh_token_if_needed as _refresh_gcp
     from utils.auth.stateless_auth import get_user_preference
 
+    # Multi-SA: prefer the union of accessible_project_ids across all rows in
+    # user_connections BEFORE attempting OAuth refresh — pure multi-SA users
+    # have no user_tokens row to refresh, so the refresh would short-circuit
+    # the multi-SA path with a misleading "reauthenticate" error.
+    try:
+        from utils.db.connection_utils import get_all_user_connections
+        gcp_conns = get_all_user_connections(user_id, "gcp") or []
+    except Exception as _e:
+        logger.warning("[Discovery] get_all_user_connections(gcp) failed: %s", _e)
+        gcp_conns = []
+
+    if gcp_conns:
+        seen = set()
+        union: list = []
+        for row in gcp_conns:
+            for pid in (row.get("accessible_project_ids") or []):
+                if isinstance(pid, str) and pid and pid not in seen:
+                    seen.add(pid)
+                    union.append(pid)
+        if not union:
+            for row in gcp_conns:
+                pid = row.get("project_id")
+                if isinstance(pid, str) and pid and pid not in seen:
+                    seen.add(pid)
+                    union.append(pid)
+        if union:
+            logger.info(
+                "[Discovery] Using %d GCP project(s) from user_connections for user %s",
+                len(union), user_id,
+            )
+            return union, None
+
     refreshed = _refresh_gcp(user_id, "gcp")
     if refreshed is None:
         err = "GCP token refresh failed: Reauthentication is needed. Please reconnect your GCP account."
@@ -436,6 +468,12 @@ def _get_all_gcp_project_ids(user_id):
 
         token_data = get_token_data(user_id, "gcp")
         if not token_data:
+            # Multi-SA users have no user_tokens row — _get_oauth_project_ids
+            # reads user_connections directly (Track C §10) and returns the
+            # union of accessible_project_ids.
+            from utils.db.connection_utils import get_all_user_connections
+            if get_all_user_connections(user_id, "gcp"):
+                return _get_oauth_project_ids(user_id)
             logger.warning("[Discovery] No GCP credentials found for user %s", user_id)
             return [], None
 

--- a/server/utils/cloud/gcp_project_extraction.py
+++ b/server/utils/cloud/gcp_project_extraction.py
@@ -78,109 +78,105 @@ def _from_sentry_tag_pairs(pairs: Any) -> Optional[str]:
     return None
 
 
+def _scan_string_node(node: str) -> Optional[str]:
+    m = _PROJECTS_PATH_RE.search(node)
+    return _valid(m.group(1)) if m else None
+
+
 def _scan_strings(node: Any, depth: int = 0) -> Optional[str]:
     """Walk arbitrary structure looking for ``projects/<id>/`` strings."""
     if depth > 6:
         return None
     try:
         if isinstance(node, str):
-            m = _PROJECTS_PATH_RE.search(node)
-            if m:
-                pid = _valid(m.group(1))
-                if pid:
-                    return pid
-            return None
+            return _scan_string_node(node)
         if isinstance(node, dict):
-            for v in node.values():
-                found = _scan_strings(v, depth + 1)
-                if found:
-                    return found
+            children: Iterable = node.values()
+        elif isinstance(node, (list, tuple)):
+            children = node
+        else:
             return None
-        if isinstance(node, (list, tuple)):
-            for v in node:
-                found = _scan_strings(v, depth + 1)
-                if found:
-                    return found
-            return None
+        for child in children:
+            found = _scan_strings(child, depth + 1)
+            if found:
+                return found
     except Exception:
         return None
     return None
 
 
+def _from_datadog(payload: dict) -> Optional[str]:
+    return _from_tag_list(payload.get("tags") or [])
+
+
+def _from_grafana(payload: dict) -> Optional[str]:
+    for key in ("commonLabels", "labels", "groupLabels"):
+        pid = _from_mapping(payload.get(key))
+        if pid:
+            return pid
+    alerts = payload.get("alerts")
+    if isinstance(alerts, list):
+        for alert in alerts:
+            if isinstance(alert, dict):
+                pid = _from_mapping(alert.get("labels"))
+                if pid:
+                    return pid
+    return None
+
+
+def _from_sentry(payload: dict) -> Optional[str]:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    issue = data.get("issue") if isinstance(data.get("issue"), dict) else {}
+    event = data.get("event") if isinstance(data.get("event"), dict) else {}
+    for tag_holder in (issue, event, payload):
+        if not isinstance(tag_holder, dict):
+            continue
+        pid = _from_sentry_tag_pairs(tag_holder.get("tags"))
+        if pid:
+            return pid
+        contexts = tag_holder.get("contexts")
+        if isinstance(contexts, dict):
+            pid = _from_mapping(contexts.get("gcp"))
+            if pid:
+                return pid
+    return None
+
+
+def _from_pagerduty(payload: dict) -> Optional[str]:
+    for key in ("custom_details", "details", "payload"):
+        pid = _from_mapping(payload.get(key))
+        if pid:
+            return pid
+    return None
+
+
+_SOURCE_EXTRACTORS = {
+    "datadog": _from_datadog,
+    "grafana": _from_grafana,
+    "sentry": _from_sentry,
+    "pagerduty": _from_pagerduty,
+}
+
+
 def extract_gcp_project_from_alert(payload: dict, source: str) -> Optional[str]:
     """Pull a GCP project ID out of an alert payload.
 
-    Handles:
-      - Datadog:   payload['tags'] = ["project_id:foo", "gcp_project:foo", ...]
-      - Grafana:   payload['commonLabels']/['labels'] = {"gcp_project": ...} or
-                   {"project_id": ...}
-      - Sentry:    payload['data']['issue']['tags'] (list of [k,v]) /
-                   contexts.gcp.project_id
-      - PagerDuty: payload['custom_details'] dict + generic scan
-      - Generic fallback: scan all string values for ``projects/<id>/`` patterns.
-
-    Returns None when no valid project ID can be extracted.
+    Handles Datadog tags, Grafana labels, Sentry contexts/tags, PagerDuty
+    custom_details, and a generic ``projects/<id>/`` scan fallback. Returns
+    None when no valid project ID can be extracted.
     """
     if not isinstance(payload, dict):
         return None
-
     try:
-        src = (source or "").lower()
-
-        # --- Datadog ----------------------------------------------------------
-        if src == "datadog":
-            pid = _from_tag_list(payload.get("tags") or [])
+        extractor = _SOURCE_EXTRACTORS.get((source or "").lower())
+        if extractor:
+            pid = extractor(payload)
             if pid:
                 return pid
-
-        # --- Grafana ----------------------------------------------------------
-        if src == "grafana":
-            for key in ("commonLabels", "labels", "groupLabels"):
-                pid = _from_mapping(payload.get(key))
-                if pid:
-                    return pid
-            # alerts: [{ labels: {...} }, ...]
-            alerts = payload.get("alerts")
-            if isinstance(alerts, list):
-                for alert in alerts:
-                    if isinstance(alert, dict):
-                        pid = _from_mapping(alert.get("labels"))
-                        if pid:
-                            return pid
-
-        # --- Sentry -----------------------------------------------------------
-        if src == "sentry":
-            data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
-            issue = data.get("issue") if isinstance(data.get("issue"), dict) else {}
-            event = data.get("event") if isinstance(data.get("event"), dict) else {}
-            for tag_holder in (issue, event, payload):
-                if not isinstance(tag_holder, dict):
-                    continue
-                pid = _from_sentry_tag_pairs(tag_holder.get("tags"))
-                if pid:
-                    return pid
-                contexts = tag_holder.get("contexts")
-                if isinstance(contexts, dict):
-                    gcp_ctx = contexts.get("gcp")
-                    pid = _from_mapping(gcp_ctx)
-                    if pid:
-                        return pid
-
-        # --- PagerDuty --------------------------------------------------------
-        if src == "pagerduty":
-            for key in ("custom_details", "details", "payload"):
-                pid = _from_mapping(payload.get(key))
-                if pid:
-                    return pid
-
-        # --- Generic top-level mapping check ---------------------------------
         pid = _from_mapping(payload)
         if pid:
             return pid
-
-        # --- Generic fallback: scan for ``projects/<id>/`` patterns ----------
         return _scan_strings(payload)
-
     except Exception as e:
         logger.debug(
             "extract_gcp_project_from_alert failed for source=%s: %s",

--- a/server/utils/cloud/gcp_project_extraction.py
+++ b/server/utils/cloud/gcp_project_extraction.py
@@ -1,0 +1,190 @@
+"""Pure helper to extract a GCP project ID from heterogeneous alert payloads.
+
+No DB or network access. Safe to call from any context. Returns ``None`` when
+no valid project ID can be extracted.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# GCP project IDs: 6-30 chars, start with lowercase letter, lowercase letters /
+# digits / hyphens only.
+_PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9\-]{5,29}$")
+_PROJECTS_PATH_RE = re.compile(r"projects/([a-z][a-z0-9\-]{5,29})(?:/|$)")
+
+# Keys we consider authoritative when they appear in a key/value mapping.
+_PROJECT_KEYS = ("project_id", "gcp_project", "gcp_project_id", "projectId", "project")
+
+
+def _valid(pid: Any) -> Optional[str]:
+    if not isinstance(pid, str):
+        return None
+    pid = pid.strip()
+    if _PROJECT_ID_RE.match(pid):
+        return pid
+    return None
+
+
+def _from_tag_list(tags: Iterable[Any]) -> Optional[str]:
+    """Datadog-style: ['key:value', 'project_id:foo']."""
+    try:
+        for tag in tags:
+            if not isinstance(tag, str) or ":" not in tag:
+                continue
+            key, _, value = tag.partition(":")
+            if key.strip() in _PROJECT_KEYS:
+                pid = _valid(value)
+                if pid:
+                    return pid
+    except Exception:
+        return None
+    return None
+
+
+def _from_mapping(mapping: Any) -> Optional[str]:
+    try:
+        if not isinstance(mapping, dict):
+            return None
+        for key in _PROJECT_KEYS:
+            if key in mapping:
+                pid = _valid(mapping[key])
+                if pid:
+                    return pid
+    except Exception:
+        return None
+    return None
+
+
+def _from_sentry_tag_pairs(pairs: Any) -> Optional[str]:
+    """Sentry-style: [['key', 'value'], ['project_id', 'foo']]."""
+    try:
+        if not isinstance(pairs, list):
+            return None
+        for pair in pairs:
+            if not isinstance(pair, (list, tuple)) or len(pair) < 2:
+                continue
+            key, value = pair[0], pair[1]
+            if isinstance(key, str) and key in _PROJECT_KEYS:
+                pid = _valid(value)
+                if pid:
+                    return pid
+    except Exception:
+        return None
+    return None
+
+
+def _scan_strings(node: Any, depth: int = 0) -> Optional[str]:
+    """Walk arbitrary structure looking for ``projects/<id>/`` strings."""
+    if depth > 6:
+        return None
+    try:
+        if isinstance(node, str):
+            m = _PROJECTS_PATH_RE.search(node)
+            if m:
+                pid = _valid(m.group(1))
+                if pid:
+                    return pid
+            return None
+        if isinstance(node, dict):
+            for v in node.values():
+                found = _scan_strings(v, depth + 1)
+                if found:
+                    return found
+            return None
+        if isinstance(node, (list, tuple)):
+            for v in node:
+                found = _scan_strings(v, depth + 1)
+                if found:
+                    return found
+            return None
+    except Exception:
+        return None
+    return None
+
+
+def extract_gcp_project_from_alert(payload: dict, source: str) -> Optional[str]:
+    """Pull a GCP project ID out of an alert payload.
+
+    Handles:
+      - Datadog:   payload['tags'] = ["project_id:foo", "gcp_project:foo", ...]
+      - Grafana:   payload['commonLabels']/['labels'] = {"gcp_project": ...} or
+                   {"project_id": ...}
+      - Sentry:    payload['data']['issue']['tags'] (list of [k,v]) /
+                   contexts.gcp.project_id
+      - PagerDuty: payload['custom_details'] dict + generic scan
+      - Generic fallback: scan all string values for ``projects/<id>/`` patterns.
+
+    Returns None when no valid project ID can be extracted.
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    try:
+        src = (source or "").lower()
+
+        # --- Datadog ----------------------------------------------------------
+        if src == "datadog":
+            pid = _from_tag_list(payload.get("tags") or [])
+            if pid:
+                return pid
+
+        # --- Grafana ----------------------------------------------------------
+        if src == "grafana":
+            for key in ("commonLabels", "labels", "groupLabels"):
+                pid = _from_mapping(payload.get(key))
+                if pid:
+                    return pid
+            # alerts: [{ labels: {...} }, ...]
+            alerts = payload.get("alerts")
+            if isinstance(alerts, list):
+                for alert in alerts:
+                    if isinstance(alert, dict):
+                        pid = _from_mapping(alert.get("labels"))
+                        if pid:
+                            return pid
+
+        # --- Sentry -----------------------------------------------------------
+        if src == "sentry":
+            data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+            issue = data.get("issue") if isinstance(data.get("issue"), dict) else {}
+            event = data.get("event") if isinstance(data.get("event"), dict) else {}
+            for tag_holder in (issue, event, payload):
+                if not isinstance(tag_holder, dict):
+                    continue
+                pid = _from_sentry_tag_pairs(tag_holder.get("tags"))
+                if pid:
+                    return pid
+                contexts = tag_holder.get("contexts")
+                if isinstance(contexts, dict):
+                    gcp_ctx = contexts.get("gcp")
+                    pid = _from_mapping(gcp_ctx)
+                    if pid:
+                        return pid
+
+        # --- PagerDuty --------------------------------------------------------
+        if src == "pagerduty":
+            for key in ("custom_details", "details", "payload"):
+                pid = _from_mapping(payload.get(key))
+                if pid:
+                    return pid
+
+        # --- Generic top-level mapping check ---------------------------------
+        pid = _from_mapping(payload)
+        if pid:
+            return pid
+
+        # --- Generic fallback: scan for ``projects/<id>/`` patterns ----------
+        return _scan_strings(payload)
+
+    except Exception as e:
+        logger.debug(
+            "extract_gcp_project_from_alert failed for source=%s: %s",
+            source,
+            type(e).__name__,
+        )
+        return None

--- a/server/utils/db/connection_utils.py
+++ b/server/utils/db/connection_utils.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional, List, Dict, Tuple
 
@@ -11,6 +12,24 @@ from utils.auth.stateless_auth import set_rls_context
 from utils.log_sanitizer import sanitize, safe_provider, hash_for_log
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GcpConnectionExtras:
+    """Per-SA fields used only by GCP multi-SA rows.
+
+    Bundled so ``save_connection_metadata`` stays under the 13-parameter cap —
+    AWS callers omit the argument entirely.
+    """
+    account_alias: Optional[str] = None
+    project_id: Optional[str] = None
+    accessible_project_ids: Optional[List[str]] = None
+    visibility: Optional[str] = None
+    secret_ref: Optional[str] = None
+
+# Shared SQL fragments used by multiple GCP-helper queries.
+_WHERE_USER_ONLY = "user_id = %s"
+_WHERE_USER_OR_ORG_SHARED = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
 
 
 def _resolve_org_id(user_id: str) -> Optional[str]:
@@ -37,25 +56,21 @@ def save_connection_metadata(
     region: Optional[str] = None,
     workspace_id: Optional[str] = None,
     status: str = "active",
-    account_alias: Optional[str] = None,
-    project_id: Optional[str] = None,
-    accessible_project_ids: Optional[List[str]] = None,
-    visibility: Optional[str] = None,
-    secret_ref: Optional[str] = None,
+    gcp_extras: Optional[GcpConnectionExtras] = None,
 ) -> bool:
     """Insert or update a row in user_connections.
 
-    Uses an UPSERT so callers can invoke freely. New GCP-multi-SA columns
-    (account_alias, project_id, accessible_project_ids, visibility, secret_ref)
-    are optional; COALESCE preserves existing values when callers (e.g. AWS)
-    don't pass them.
+    Uses an UPSERT so callers can invoke freely. ``gcp_extras`` carries the
+    multi-SA-only fields (alias / project / accessible_projects / visibility /
+    secret_ref); COALESCE preserves existing values when omitted (e.g. AWS).
 
     Returns True on success, False otherwise.
     """
     org_id = _resolve_org_id(user_id)
+    extras = gcp_extras or GcpConnectionExtras()
     accessible_json = (
-        json.dumps(accessible_project_ids)
-        if accessible_project_ids is not None
+        json.dumps(extras.accessible_project_ids)
+        if extras.accessible_project_ids is not None
         else None
     )
     sql = """
@@ -103,18 +118,18 @@ def save_connection_metadata(
                     workspace_id,
                     status,
                     datetime.now(timezone.utc),
-                    account_alias,
-                    project_id,
+                    extras.account_alias,
+                    extras.project_id,
                     accessible_json,
-                    visibility,
-                    secret_ref,
+                    extras.visibility,
+                    extras.secret_ref,
                 ),
             )
         conn.commit()
         logger.info("[CONN-META] Upsert successful user=%s provider=%s account=%s", hash_for_log(user_id), safe_provider(provider), hash_for_log(account_id))
         return True
-    except Exception as e:
-        logger.error("Failed to save connection metadata: %s", e)
+    except Exception:
+        logger.exception("Failed to save connection metadata")
         if conn:
             conn.rollback()
         return False
@@ -401,44 +416,56 @@ def delete_connection_secret(
 # ---------------------------------------------------------------------------
 
 
-def _row_to_connection_dict(row) -> Dict:
-    """Decode a SELECT row from the standard GCP-helper column list.
+def _gcp_visibility_clause(user_id: str) -> Tuple[str, Tuple]:
+    """Build the SQL WHERE clause + params for GCP visibility scoping.
 
-    Normalizes ``accessible_project_ids`` to ``List[str]``. The column may have
-    been written as either ``["foo", "bar"]`` (new shape) or as the legacy
-    dict shape ``[{"project_id": "foo", "name": "Foo"}]`` from older code.
+    Returns ``(where_fragment, params_tuple)`` — own private rows always
+    visible, plus org-shared rows in the same org when ``org_id`` resolves.
     """
-    accessible = row[3]
-    if isinstance(accessible, str):
+    org_id = _resolve_org_id(user_id)
+    if org_id is None:
+        return _WHERE_USER_ONLY, (user_id,)
+    return _WHERE_USER_OR_ORG_SHARED, (user_id, org_id)
+
+
+def _normalize_accessible_projects(raw, account_id_for_log: str) -> List[str]:
+    """Coerce ``accessible_project_ids`` (str|list[str|dict]|other) to ``List[str]``.
+
+    Tolerates the legacy ``[{"project_id": "foo"}]`` shape and JSON-encoded
+    strings. Silently dropping malformed values would surface to the LLM as
+    "this SA has zero accessible projects" — a confusing symptom of a data
+    issue, so we log a warning.
+    """
+    if isinstance(raw, str):
         try:
-            accessible = json.loads(accessible)
+            raw = json.loads(raw)
         except Exception as _exc:
-            # Silently dropping malformed JSON would surface to the LLM as
-            # "this SA has zero accessible projects" — a confusing symptom
-            # for what is really a data-integrity problem.
             logger.warning(
                 "[CONN-META] Failed to decode accessible_project_ids JSON for account=%s: %s",
-                hash_for_log(row[0] or ""),
+                hash_for_log(account_id_for_log),
                 _exc,
             )
-            accessible = []
-    if isinstance(accessible, list):
-        normalized = []
-        for item in accessible:
-            if isinstance(item, str) and item:
-                normalized.append(item)
-            elif isinstance(item, dict):
-                pid = item.get("project_id") or item.get("projectId")
-                if pid:
-                    normalized.append(pid)
-        accessible = normalized
-    else:
-        accessible = []
+            return []
+    if not isinstance(raw, list):
+        return []
+    out: List[str] = []
+    for item in raw:
+        if isinstance(item, str) and item:
+            out.append(item)
+        elif isinstance(item, dict):
+            pid = item.get("project_id") or item.get("projectId")
+            if pid:
+                out.append(pid)
+    return out
+
+
+def _row_to_connection_dict(row) -> Dict:
+    """Decode a SELECT row from the standard GCP-helper column list."""
     return {
         "account_id": row[0],
         "account_alias": row[1],
         "project_id": row[2],
-        "accessible_project_ids": accessible,
+        "accessible_project_ids": _normalize_accessible_projects(row[3], row[0] or ""),
         "visibility": row[4],
         "secret_ref": row[5],
         "status": row[6],
@@ -458,14 +485,7 @@ def get_all_user_connections(user_id: str, provider: str) -> List[Dict]:
     Includes org-shared rows when ``visibility = 'org'``; private rows from
     other users in the same org are excluded.
     """
-    org_id = _resolve_org_id(user_id)
-    if org_id is None:
-        where = "user_id = %s"
-        params = (user_id,)
-    else:
-        # Own private rows + any org-shared rows in the same org.
-        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
-        params = (user_id, org_id)
+    where, params = _gcp_visibility_clause(user_id)
 
     sql = f"""
         SELECT {_GCP_SELECT_COLUMNS}
@@ -481,12 +501,11 @@ def get_all_user_connections(user_id: str, provider: str) -> List[Dict]:
             cur.execute(sql, (*params, provider, user_id))
             rows = cur.fetchall()
         return [_row_to_connection_dict(r) for r in rows]
-    except Exception as e:
-        logger.error(
-            "Error listing connections for user=%s provider=%s: %s",
+    except Exception:
+        logger.exception(
+            "Error listing connections for user=%s provider=%s",
             hash_for_log(user_id),
             safe_provider(provider),
-            e,
         )
         return []
     finally:
@@ -501,13 +520,7 @@ def get_user_connection(
 
     Honors org sharing: org-shared rows in the same org are visible.
     """
-    org_id = _resolve_org_id(user_id)
-    if org_id is None:
-        where = "user_id = %s"
-        params = (user_id,)
-    else:
-        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
-        params = (user_id, org_id)
+    where, params = _gcp_visibility_clause(user_id)
 
     sql = f"""
         SELECT {_GCP_SELECT_COLUMNS}
@@ -523,12 +536,11 @@ def get_user_connection(
             cur.execute(sql, (*params, provider, account_id))
             row = cur.fetchone()
         return _row_to_connection_dict(row) if row else None
-    except Exception as e:
-        logger.error(
-            "Error fetching connection user=%s provider=%s: %s",
+    except Exception:
+        logger.exception(
+            "Error fetching connection user=%s provider=%s",
             hash_for_log(user_id),
             safe_provider(provider),
-            e,
         )
         return None
     finally:
@@ -549,13 +561,7 @@ def find_connection_for_project(
     if not project_id:
         return None
 
-    org_id = _resolve_org_id(user_id)
-    if org_id is None:
-        where = "user_id = %s"
-        params = (user_id,)
-    else:
-        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
-        params = (user_id, org_id)
+    where, params = _gcp_visibility_clause(user_id)
 
     # accessible_project_ids may be stored in either shape:
     #   ["foo", "bar"]                              ← canonical (new code)
@@ -598,13 +604,12 @@ def find_connection_for_project(
             )
             row = cur.fetchone()
         return _row_to_connection_dict(row) if row else None
-    except Exception as e:
-        logger.error(
-            "Error finding connection for project=%s user=%s provider=%s: %s",
+    except Exception:
+        logger.exception(
+            "Error finding connection for project=%s user=%s provider=%s",
             hash_for_log(project_id),
             hash_for_log(user_id),
             safe_provider(provider),
-            e,
         )
         return None
     finally:
@@ -656,8 +661,8 @@ def deactivate_connection(
             hash_for_log(account_id),
         )
         return True, secret_ref
-    except Exception as e:
-        logger.error("[CONN-META] Failed to deactivate connection: %s", e)
+    except Exception:
+        logger.exception("[CONN-META] Failed to deactivate connection")
         if conn:
             conn.rollback()
         return False, None
@@ -704,8 +709,8 @@ def deactivate_all_connections(
             safe_provider(provider),
         )
         return True, refs
-    except Exception as e:
-        logger.error("[CONN-META] Failed to deactivate all connections: %s", e)
+    except Exception:
+        logger.exception("[CONN-META] Failed to deactivate all connections")
         if conn:
             conn.rollback()
         return False, []

--- a/server/utils/db/connection_utils.py
+++ b/server/utils/db/connection_utils.py
@@ -73,6 +73,11 @@ def save_connection_metadata(
         if extras.accessible_project_ids is not None
         else None
     )
+    # Visibility is bound twice: the VALUES position uses COALESCE-with-default
+    # so a brand-new INSERT satisfies the column's NOT NULL DEFAULT 'private',
+    # while DO UPDATE uses the raw param so a NULL passed by the caller actually
+    # preserves the existing row's visibility (e.g. an org-flipped SA isn't
+    # silently reset to 'private' by a metadata refresh).
     sql = """
         INSERT INTO user_connections (
             user_id, org_id, provider, account_id, role_arn, read_only_role_arn,
@@ -96,7 +101,7 @@ def save_connection_metadata(
             account_alias = COALESCE(EXCLUDED.account_alias, user_connections.account_alias),
             project_id = COALESCE(EXCLUDED.project_id, user_connections.project_id),
             accessible_project_ids = COALESCE(EXCLUDED.accessible_project_ids, user_connections.accessible_project_ids),
-            visibility = COALESCE(EXCLUDED.visibility, user_connections.visibility),
+            visibility = COALESCE(%s, user_connections.visibility),
             secret_ref = COALESCE(EXCLUDED.secret_ref, user_connections.secret_ref);
     """
     conn = None
@@ -123,6 +128,7 @@ def save_connection_metadata(
                     accessible_json,
                     extras.visibility,
                     extras.secret_ref,
+                    extras.visibility,  # 2nd binding for DO UPDATE's COALESCE
                 ),
             )
         conn.commit()
@@ -526,6 +532,7 @@ def get_user_connection(
         SELECT {_GCP_SELECT_COLUMNS}
         FROM user_connections
         WHERE {where} AND provider = %s AND account_id = %s AND status = 'active'
+        ORDER BY (user_id = %s) DESC, id DESC
         LIMIT 1;
     """
     conn = None
@@ -533,7 +540,7 @@ def get_user_connection(
         conn = connect_to_db_as_user()
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:getOne]")
-            cur.execute(sql, (*params, provider, account_id))
+            cur.execute(sql, (*params, provider, account_id, user_id))
             row = cur.fetchone()
         return _row_to_connection_dict(row) if row else None
     except Exception:

--- a/server/utils/db/connection_utils.py
+++ b/server/utils/db/connection_utils.py
@@ -1,9 +1,10 @@
 # utils/connection_utils.py
 """Utility helpers for working with the user_connections table."""
 
+import json
 import logging
 from datetime import datetime, timezone
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 
 from utils.db.db_utils import connect_to_db_as_user, connect_to_db_as_admin
 from utils.auth.stateless_auth import set_rls_context
@@ -36,18 +37,37 @@ def save_connection_metadata(
     region: Optional[str] = None,
     workspace_id: Optional[str] = None,
     status: str = "active",
+    account_alias: Optional[str] = None,
+    project_id: Optional[str] = None,
+    accessible_project_ids: Optional[List[str]] = None,
+    visibility: Optional[str] = None,
+    secret_ref: Optional[str] = None,
 ) -> bool:
     """Insert or update a row in user_connections.
 
-    Uses an UPSERT so callers can invoke freely.
+    Uses an UPSERT so callers can invoke freely. New GCP-multi-SA columns
+    (account_alias, project_id, accessible_project_ids, visibility, secret_ref)
+    are optional; COALESCE preserves existing values when callers (e.g. AWS)
+    don't pass them.
+
     Returns True on success, False otherwise.
     """
     org_id = _resolve_org_id(user_id)
+    accessible_json = (
+        json.dumps(accessible_project_ids)
+        if accessible_project_ids is not None
+        else None
+    )
     sql = """
         INSERT INTO user_connections (
             user_id, org_id, provider, account_id, role_arn, read_only_role_arn,
-            connection_method, region, workspace_id, status, last_verified_at
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            connection_method, region, workspace_id, status, last_verified_at,
+            account_alias, project_id, accessible_project_ids, visibility, secret_ref
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s,
+            %s, %s, %s::jsonb, COALESCE(%s, 'private'), %s
+        )
         ON CONFLICT (user_id, provider, account_id)
         DO UPDATE SET
             org_id = COALESCE(EXCLUDED.org_id, user_connections.org_id),
@@ -57,7 +77,12 @@ def save_connection_metadata(
             region = COALESCE(EXCLUDED.region, user_connections.region),
             workspace_id = COALESCE(EXCLUDED.workspace_id, user_connections.workspace_id),
             status = EXCLUDED.status,
-            last_verified_at = EXCLUDED.last_verified_at;
+            last_verified_at = EXCLUDED.last_verified_at,
+            account_alias = COALESCE(EXCLUDED.account_alias, user_connections.account_alias),
+            project_id = COALESCE(EXCLUDED.project_id, user_connections.project_id),
+            accessible_project_ids = COALESCE(EXCLUDED.accessible_project_ids, user_connections.accessible_project_ids),
+            visibility = COALESCE(EXCLUDED.visibility, user_connections.visibility),
+            secret_ref = COALESCE(EXCLUDED.secret_ref, user_connections.secret_ref);
     """
     conn = None
     try:
@@ -78,6 +103,11 @@ def save_connection_metadata(
                     workspace_id,
                     status,
                     datetime.now(timezone.utc),
+                    account_alias,
+                    project_id,
+                    accessible_json,
+                    visibility,
+                    secret_ref,
                 ),
             )
         conn.commit()
@@ -357,6 +387,328 @@ def delete_connection_secret(
         if conn:
             conn.rollback()
         return False
+    finally:
+        if conn:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# GCP multi-service-account helpers
+#
+# These intentionally live alongside the AWS helpers above (which they do not
+# modify). GCP rows are one-per-(user_id, provider='gcp', account_id=sa_email),
+# with project_id / accessible_project_ids / visibility / secret_ref columns.
+# ---------------------------------------------------------------------------
+
+
+def _row_to_connection_dict(row) -> Dict:
+    """Decode a SELECT row from the standard GCP-helper column list.
+
+    Normalizes ``accessible_project_ids`` to ``List[str]``. The column may have
+    been written as either ``["foo", "bar"]`` (new shape) or as the legacy
+    dict shape ``[{"project_id": "foo", "name": "Foo"}]`` from older code.
+    """
+    accessible = row[3]
+    if isinstance(accessible, str):
+        try:
+            accessible = json.loads(accessible)
+        except Exception as _exc:
+            # Silently dropping malformed JSON would surface to the LLM as
+            # "this SA has zero accessible projects" — a confusing symptom
+            # for what is really a data-integrity problem.
+            logger.warning(
+                "[CONN-META] Failed to decode accessible_project_ids JSON for account=%s: %s",
+                hash_for_log(row[0] or ""),
+                _exc,
+            )
+            accessible = []
+    if isinstance(accessible, list):
+        normalized = []
+        for item in accessible:
+            if isinstance(item, str) and item:
+                normalized.append(item)
+            elif isinstance(item, dict):
+                pid = item.get("project_id") or item.get("projectId")
+                if pid:
+                    normalized.append(pid)
+        accessible = normalized
+    else:
+        accessible = []
+    return {
+        "account_id": row[0],
+        "account_alias": row[1],
+        "project_id": row[2],
+        "accessible_project_ids": accessible,
+        "visibility": row[4],
+        "secret_ref": row[5],
+        "status": row[6],
+        "last_verified_at": row[7].isoformat() if row[7] else None,
+    }
+
+
+_GCP_SELECT_COLUMNS = (
+    "account_id, account_alias, project_id, accessible_project_ids, "
+    "visibility, secret_ref, status, last_verified_at"
+)
+
+
+def get_all_user_connections(user_id: str, provider: str) -> List[Dict]:
+    """Return all active connections for (user_id, provider).
+
+    Includes org-shared rows when ``visibility = 'org'``; private rows from
+    other users in the same org are excluded.
+    """
+    org_id = _resolve_org_id(user_id)
+    if org_id is None:
+        where = "user_id = %s"
+        params = (user_id,)
+    else:
+        # Own private rows + any org-shared rows in the same org.
+        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
+        params = (user_id, org_id)
+
+    sql = f"""
+        SELECT {_GCP_SELECT_COLUMNS}
+        FROM user_connections
+        WHERE {where} AND provider = %s AND status = 'active'
+        ORDER BY CASE WHEN user_id = %s THEN 0 ELSE 1 END, account_id;
+    """
+    conn = None
+    try:
+        conn = connect_to_db_as_user()
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:listAll]")
+            cur.execute(sql, (*params, provider, user_id))
+            rows = cur.fetchall()
+        return [_row_to_connection_dict(r) for r in rows]
+    except Exception as e:
+        logger.error(
+            "Error listing connections for user=%s provider=%s: %s",
+            hash_for_log(user_id),
+            safe_provider(provider),
+            e,
+        )
+        return []
+    finally:
+        if conn:
+            conn.close()
+
+
+def get_user_connection(
+    user_id: str, provider: str, account_id: str
+) -> Optional[Dict]:
+    """Fetch a single active connection by (user_id, provider, account_id).
+
+    Honors org sharing: org-shared rows in the same org are visible.
+    """
+    org_id = _resolve_org_id(user_id)
+    if org_id is None:
+        where = "user_id = %s"
+        params = (user_id,)
+    else:
+        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
+        params = (user_id, org_id)
+
+    sql = f"""
+        SELECT {_GCP_SELECT_COLUMNS}
+        FROM user_connections
+        WHERE {where} AND provider = %s AND account_id = %s AND status = 'active'
+        LIMIT 1;
+    """
+    conn = None
+    try:
+        conn = connect_to_db_as_user()
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:getOne]")
+            cur.execute(sql, (*params, provider, account_id))
+            row = cur.fetchone()
+        return _row_to_connection_dict(row) if row else None
+    except Exception as e:
+        logger.error(
+            "Error fetching connection user=%s provider=%s: %s",
+            hash_for_log(user_id),
+            safe_provider(provider),
+            e,
+        )
+        return None
+    finally:
+        if conn:
+            conn.close()
+
+
+def find_connection_for_project(
+    user_id: str, provider: str, project_id: str
+) -> Optional[Dict]:
+    """Resolve a connection row that owns or has access to ``project_id``.
+
+    Prefers a row whose ``project_id`` (the SA's home project) matches exactly.
+    Falls back to any row whose ``accessible_project_ids`` JSONB array contains
+    ``project_id``. Used by the GCP auth layer to pick the right SA for a
+    project referenced in an alert payload.
+    """
+    if not project_id:
+        return None
+
+    org_id = _resolve_org_id(user_id)
+    if org_id is None:
+        where = "user_id = %s"
+        params = (user_id,)
+    else:
+        where = "(user_id = %s OR (org_id = %s AND visibility = 'org'))"
+        params = (user_id, org_id)
+
+    # accessible_project_ids may be stored in either shape:
+    #   ["foo", "bar"]                              ← canonical (new code)
+    #   [{"project_id": "foo", "name": "Foo"}, …]  ← legacy connect-route shape
+    # Match both via two @> probes joined by OR.
+    sql = f"""
+        SELECT {_GCP_SELECT_COLUMNS}
+        FROM user_connections
+        WHERE {where}
+          AND provider = %s
+          AND status = 'active'
+          AND (
+                project_id = %s
+                OR accessible_project_ids @> %s::jsonb
+                OR accessible_project_ids @> %s::jsonb
+              )
+        ORDER BY
+            CASE WHEN project_id = %s THEN 0 ELSE 1 END,
+            CASE WHEN user_id = %s THEN 0 ELSE 1 END
+        LIMIT 1;
+    """
+    project_jsonb_str = json.dumps([project_id])
+    project_jsonb_obj = json.dumps([{"project_id": project_id}])
+    conn = None
+    try:
+        conn = connect_to_db_as_user()
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:findProj]")
+            cur.execute(
+                sql,
+                (
+                    *params,
+                    provider,
+                    project_id,
+                    project_jsonb_str,
+                    project_jsonb_obj,
+                    project_id,
+                    user_id,
+                ),
+            )
+            row = cur.fetchone()
+        return _row_to_connection_dict(row) if row else None
+    except Exception as e:
+        logger.error(
+            "Error finding connection for project=%s user=%s provider=%s: %s",
+            hash_for_log(project_id),
+            hash_for_log(user_id),
+            safe_provider(provider),
+            e,
+        )
+        return None
+    finally:
+        if conn:
+            conn.close()
+
+
+def deactivate_connection(
+    user_id: str, provider: str, account_id: str
+) -> Tuple[bool, Optional[str]]:
+    """Atomically flip a single connection to ``status='inactive'``.
+
+    Guarded on ``status='active'`` so concurrent deactivates don't race. Returns
+    ``(True, secret_ref)`` on success so the caller can delete the Vault secret;
+    ``(False, None)`` if nothing was updated.
+    """
+    sql_select = (
+        "SELECT secret_ref FROM user_connections "
+        "WHERE user_id = %s AND provider = %s AND account_id = %s "
+        "  AND status = 'active' "
+        "FOR UPDATE;"
+    )
+    sql_update = (
+        "UPDATE user_connections "
+        "SET status = 'inactive', last_verified_at = %s "
+        "WHERE user_id = %s AND provider = %s AND account_id = %s "
+        "  AND status = 'active';"
+    )
+    conn = None
+    try:
+        conn = connect_to_db_as_admin()
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:deactivate]")
+            cur.execute(sql_select, (user_id, provider, account_id))
+            row = cur.fetchone()
+            if not row:
+                conn.commit()
+                return False, None
+            secret_ref = row[0]
+            cur.execute(
+                sql_update,
+                (datetime.now(timezone.utc), user_id, provider, account_id),
+            )
+        conn.commit()
+        logger.info(
+            "[CONN-META] Deactivated user=%s provider=%s account=%s",
+            hash_for_log(user_id),
+            safe_provider(provider),
+            hash_for_log(account_id),
+        )
+        return True, secret_ref
+    except Exception as e:
+        logger.error("[CONN-META] Failed to deactivate connection: %s", e)
+        if conn:
+            conn.rollback()
+        return False, None
+    finally:
+        if conn:
+            conn.close()
+
+
+def deactivate_all_connections(
+    user_id: str, provider: str
+) -> Tuple[bool, List[str]]:
+    """Flip every active row for (user_id, provider) to inactive.
+
+    Returns ``(True, [secret_refs])`` so the caller can delete each Vault
+    secret. The deactivation is scoped strictly to ``user_id`` (not org) so
+    one user disconnecting doesn't wipe an org-mate's credentials.
+    """
+    sql_select = (
+        "SELECT secret_ref FROM user_connections "
+        "WHERE user_id = %s AND provider = %s AND status = 'active' "
+        "FOR UPDATE;"
+    )
+    sql_update = (
+        "UPDATE user_connections "
+        "SET status = 'inactive', last_verified_at = %s "
+        "WHERE user_id = %s AND provider = %s AND status = 'active';"
+    )
+    conn = None
+    try:
+        conn = connect_to_db_as_admin()
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[CONN-META:deactivateAll]")
+            cur.execute(sql_select, (user_id, provider))
+            refs = [r[0] for r in cur.fetchall() if r[0]]
+            cur.execute(
+                sql_update,
+                (datetime.now(timezone.utc), user_id, provider),
+            )
+        conn.commit()
+        logger.info(
+            "[CONN-META] Deactivated %d connections user=%s provider=%s",
+            len(refs),
+            hash_for_log(user_id),
+            safe_provider(provider),
+        )
+        return True, refs
+    except Exception as e:
+        logger.error("[CONN-META] Failed to deactivate all connections: %s", e)
+        if conn:
+            conn.rollback()
+        return False, []
     finally:
         if conn:
             conn.close()

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1630,6 +1630,32 @@ def initialize_tables():
                 conn.rollback()
                 raise
 
+            # Multi-SA GCP columns: one row per (user, provider='gcp', client_email).
+            # All nullable / defaulted so existing AWS rows are unaffected.
+            try:
+                cursor.execute(
+                    """
+                    ALTER TABLE user_connections
+                        ADD COLUMN IF NOT EXISTS account_alias VARCHAR(120),
+                        ADD COLUMN IF NOT EXISTS project_id VARCHAR(255),
+                        ADD COLUMN IF NOT EXISTS accessible_project_ids JSONB,
+                        ADD COLUMN IF NOT EXISTS visibility VARCHAR(20) NOT NULL DEFAULT 'private',
+                        ADD COLUMN IF NOT EXISTS secret_ref TEXT;
+                    """
+                )
+                conn.commit()
+                logging.info(
+                    "Ensured multi-SA GCP columns (account_alias, project_id, "
+                    "accessible_project_ids, visibility, secret_ref) on user_connections."
+                )
+            except Exception as e:
+                logging.error(
+                    "FATAL: Failed to ensure multi-SA GCP columns on user_connections: %s",
+                    e,
+                )
+                conn.rollback()
+                raise
+
             # Add stateless migration columns to user_tokens if they don't exist
             try:
                 cursor.execute("""

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1648,10 +1648,9 @@ def initialize_tables():
                     "Ensured multi-SA GCP columns (account_alias, project_id, "
                     "accessible_project_ids, visibility, secret_ref) on user_connections."
                 )
-            except Exception as e:
-                logging.error(
-                    "FATAL: Failed to ensure multi-SA GCP columns on user_connections: %s",
-                    e,
+            except Exception:
+                logging.exception(
+                    "FATAL: Failed to ensure multi-SA GCP columns on user_connections"
                 )
                 conn.rollback()
                 raise

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -496,7 +496,7 @@ def _connection_secret_name(user_id: str, provider: str, account_id: str) -> str
     which AWS Secrets Manager (and some Vault paths) reject. user_id is sanitized
     inline rather than hashed so operators can still recognize ownership.
     """
-    env = os.environ.get("AURORA_ENV") or os.environ.get("APP_ENV") or "dev"
+    env = os.environ.get("AURORA_ENV") or "dev"
     safe_env = ''.join(c for c in env.lower() if c.isalnum() or c == '-') or "dev"
     safe_user_id = ''.join(c for c in user_id if c.isalnum() or c in '-_')
     safe_provider = ''.join(c for c in provider.lower() if c.isalnum() or c == '-')

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -5,8 +5,10 @@ This module provides functions to store and retrieve secrets using HashiCorp
 Vault instead of storing actual token data in the database.
 """
 
+import hashlib
 import logging
 import json
+import os
 from typing import TYPE_CHECKING, Optional, Dict, Any, Set, Tuple
 
 from utils.db.db_utils import connect_to_db_as_admin
@@ -476,3 +478,89 @@ def migrate_user_token_to_secret_ref(user_id: str, provider: str) -> bool:
 def delete_user_secret(user_id: str, provider: str) -> Tuple[bool, int]:
     """Delete a user's secret from Vault and clear its reference from the database."""
     return secret_manager.delete_user_secret(user_id, provider)
+
+
+# ------------------------------------------------------------------
+# Per-connection secret helpers (multi-account, e.g. multi-SA GCP)
+#
+# Distinct from user_tokens-based helpers above: these store one blob per
+# (user_id, provider, account_id) and return the secret_ref for the caller
+# to persist on its own row (e.g. user_connections.secret_ref).
+# ------------------------------------------------------------------
+
+
+def _connection_secret_name(user_id: str, provider: str, account_id: str) -> str:
+    """Build the backend-safe secret name for a per-connection blob.
+
+    Hashes account_id because GCP service-account emails contain ``@`` and ``.``
+    which AWS Secrets Manager (and some Vault paths) reject. user_id is sanitized
+    inline rather than hashed so operators can still recognize ownership.
+    """
+    env = os.environ.get("AURORA_ENV") or os.environ.get("APP_ENV") or "dev"
+    safe_env = ''.join(c for c in env.lower() if c.isalnum() or c == '-') or "dev"
+    safe_user_id = ''.join(c for c in user_id if c.isalnum() or c in '-_')
+    safe_provider = ''.join(c for c in provider.lower() if c.isalnum() or c == '-')
+    account_hash = hashlib.sha256(account_id.encode("utf-8")).hexdigest()[:16]
+    return f"aurora-{safe_env}-{safe_user_id}-{safe_provider}-{account_hash}-conn"
+
+
+def store_connection_secret(
+    user_id: str,
+    provider: str,
+    account_id: str,
+    payload: Dict[str, Any],
+) -> Optional[str]:
+    """Store a per-connection secret blob and return its secret_ref.
+
+    Caller is responsible for persisting the returned ``secret_ref`` on the
+    relevant row (e.g. ``user_connections.secret_ref``).
+    Returns None on failure.
+    """
+    try:
+        secret_name = _connection_secret_name(user_id, provider, account_id)
+        payload_json = json.dumps(payload)
+        secret_ref = secret_manager.store_secret(secret_name, payload_json)
+        logger.info(
+            "Stored connection secret for provider %s account=%s",
+            safe_provider(provider),
+            account_id[:8] + "..." if len(account_id) > 8 else account_id,
+        )
+        return secret_ref
+    except Exception as e:
+        logger.error(
+            "Failed to store connection secret for provider %s: %s",
+            safe_provider(provider),
+            e,
+        )
+        return None
+
+
+def get_connection_secret(secret_ref: str) -> Optional[Dict[str, Any]]:
+    """Retrieve a per-connection secret blob by its ``secret_ref``.
+
+    Returns the decoded dict, or None if the secret cannot be retrieved or
+    decoded. Never raises — callers treat None as "credentials unavailable".
+    """
+    if not secret_ref:
+        return None
+    try:
+        raw = secret_manager.get_secret(secret_ref)
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {"token": raw}
+    except Exception as e:
+        logger.error("Failed to retrieve connection secret: %s", e)
+        return None
+
+
+def delete_connection_secret(secret_ref: str) -> bool:
+    """Delete a per-connection secret by its ``secret_ref``.
+
+    Returns True on success or when ``secret_ref`` is empty (nothing to delete).
+    """
+    if not secret_ref:
+        return True
+    return secret_manager.delete_secret(secret_ref)

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional, Dict, Any, Set, Tuple
 
 from utils.db.db_utils import connect_to_db_as_admin
 from utils.auth.stateless_auth import set_rls_context
-from utils.log_sanitizer import safe_provider
+from utils.log_sanitizer import safe_provider, hash_for_log
 from utils.db.org_scope import resolve_org, org_read_predicate
 from utils.secrets.secret_cache import (
     get_cached_secret,
@@ -523,7 +523,7 @@ def store_connection_secret(
         logger.info(
             "Stored connection secret for provider %s account=%s",
             safe_provider(provider),
-            account_id[:8] + "..." if len(account_id) > 8 else account_id,
+            hash_for_log(account_id),
         )
         return secret_ref
     except Exception as e:

--- a/server/utils/secrets/secret_ref_utils.py
+++ b/server/utils/secrets/secret_ref_utils.py
@@ -526,11 +526,10 @@ def store_connection_secret(
             hash_for_log(account_id),
         )
         return secret_ref
-    except Exception as e:
-        logger.error(
-            "Failed to store connection secret for provider %s: %s",
+    except Exception:
+        logger.exception(
+            "Failed to store connection secret for provider %s",
             safe_provider(provider),
-            e,
         )
         return None
 
@@ -551,8 +550,8 @@ def get_connection_secret(secret_ref: str) -> Optional[Dict[str, Any]]:
             return json.loads(raw)
         except json.JSONDecodeError:
             return {"token": raw}
-    except Exception as e:
-        logger.error("Failed to retrieve connection secret: %s", e)
+    except Exception:
+        logger.exception("Failed to retrieve connection secret")
         return None
 
 


### PR DESCRIPTION
## Summary
- One GCP service account per org → many per user. Each upload is its own row in `user_connections` with a per-(user, sa_email) Vault/SM secret.
- RCA picks the right SA per alert: extracts `gcp_project_id` from Datadog/Grafana/PagerDuty/Sentry payloads, propagates into `State.selected_project_id`, and the auth layer resolves SA via project → first-active → legacy fallback.
- OAuth hidden in the UI but the backend stays fully reachable.

## Implementation
- **Foundation:** schema columns on `user_connections` (`account_alias`, `project_id`, `accessible_project_ids` JSONB, `visibility`, `secret_ref`), new connection helpers, per-connection secret helpers.
- **CRUD + UI:** `/api/gcp/service-accounts` blueprint, multi-SA management page at `/gcp/auth`, connected-accounts API returns `{count, accounts:[...]}`.
- **Project-aware exec:** `cloud_exec_wrapper` exposes `project_id` to the LLM; new `_cloud_exec_gcp_multi_sa` fan-out across all SAs; per-(user, project) ADC tempfile cache.
- **Bridge:** legacy routes (`projects`, `billing`, `root_project`, `root_project_tasks`, terraform setup) fall back to multi-SA before erroring, so multi-SA-only users see real data instead of 401s.
- **Migration:** one-shot `server/scripts/migrate_gcp_tokens_to_connections.py --dry-run` to move existing single-SA users into `user_connections`.

## Test plan
- [ ] `make dev`, connect one SA via `/gcp/auth`; confirm it appears in the Manage dialog with its projects
- [ ] Add a second SA for a different project; both visible; delete one and the Vault secret is gone
- [ ] Submit a Datadog alert payload with `tags: ["project_id:foo"]`; confirm `incident_alerts.alert_metadata->>'gcp_project_id' = 'foo'` and the RCA cloud_exec authenticates as the right SA
- [ ] Alert with no project hint → fan-out: `cloud_exec('gcp', 'gcloud projects list')` returns annotated blocks for both SAs
- [ ] OAuth tab no longer in UI; `curl -X POST .../api/gcp/oauth/login` still returns 200
- [ ] Bad SA JSON → 400, no row written, no secret leaked
- [ ] `pytest server/tests/architectural/test_connector_rbac.py`
- [ ] Run the migration script against a DB with one legacy GCP user_tokens row; confirm a `user_connections` row appears with correct `client_email` + `accessible_project_ids`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connect and manage multiple GCP service accounts per user, with optional aliasing and a "Manage Service Accounts" UI for listing, expanding, disconnecting, or disconnecting all accounts.

* **Improvements**
  * Better GCP project discovery and credential handling across multiple accounts, including targeting or fan-out when running GCP tools.
  * Alert metadata enrichment: automatic extraction of GCP project IDs from incoming alerts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->