### PR TITLE
fix(notion): update connect UI copy to Notion's new connection flow

### DIFF
--- a/client/src/app/notion/connect/page.tsx
+++ b/client/src/app/notion/connect/page.tsx
@@ -371,7 +371,7 @@ export default function NotionConnectPage() {
             <CardDescription>
               {showTabs
                 ? "Choose how Aurora should authenticate with Notion. You can always switch later by disconnecting and reconnecting."
-                : "Aurora authenticates with your Notion workspace via an Internal Integration Token."}
+                : "Aurora authenticates with your Notion workspace via an Integration Token (Access token)."}
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/client/src/components/connectors/NotionIntegrationTokenForm.tsx
+++ b/client/src/components/connectors/NotionIntegrationTokenForm.tsx
@@ -178,21 +178,30 @@ export function NotionIntegrationTokenForm({
             >
               notion.so/my-integrations
             </a>{" "}
-            &rarr; New integration &rarr; name it &ldquo;Aurora&rdquo; &rarr; copy the
-            Internal Integration Secret.
+            &rarr; <strong>+ New connection</strong> &rarr; name it &ldquo;Aurora&rdquo;
+            &rarr; set Authentication method to <strong>Access token</strong> &rarr;{" "}
+            <strong>Create connection</strong>.
           </p>
           <p>
-            2. Open any page or database you want Aurora to see &rarr; &hellip; menu
-            &rarr; Connect to &rarr; Aurora.
+            2. On the <strong>Configuration</strong> tab, reveal the{" "}
+            <strong>Integration token</strong> (Access token) and copy it. Enable
+            the <strong>Read</strong>, <strong>Update</strong>, and{" "}
+            <strong>Insert content</strong> capabilities.
           </p>
-          <p>3. Paste the secret below.</p>
+          <p>
+            3. Share content with the connection: open each page or database you
+            want Aurora to see &rarr; &hellip; menu &rarr; <strong>Connections</strong>{" "}
+            &rarr; <strong>+ Add connections</strong> &rarr; Aurora (or use the
+            connection&rsquo;s <strong>Content access</strong> tab).
+          </p>
+          <p>4. Paste the token below.</p>
         </AlertDescription>
       </Alert>
 
       <div className="grid gap-1.5">
         <div className="flex items-center justify-between">
           <Label htmlFor="notion-iit" className="text-sm font-medium">
-            Internal Integration Secret
+            Integration Token (Access token)
           </Label>
           <Button
             type="button"


### PR DESCRIPTION
## What

Updates the Notion connector connect-screen copy to match Notion's redesigned developer UI. The previous instructions referenced the old "New integration" / "Connect to → Aurora" labels, which no longer exist.

## Changes

- Step 1: `New integration` → **+ New connection**, with explicit `Access token` auth-method selection.
- Step 2: Reveal/copy the **Integration token** on the **Configuration** tab; enable Read/Update/Insert content capabilities.
- Step 3: Share content via **••• → Connections → + Add connections**, or the connection's **Content access** tab (replaces the old "Connect to → Aurora").
- Field label: `Internal Integration Secret` → **Integration Token (Access token)**.
- Card description: "via an Internal Integration Token" → "via an Integration Token (Access token)".

No backend changes — `token_type: "iit"` flow is unchanged (an Access token is the renamed internal integration token).

## Why

A live test against a stored token confirmed the token authenticates fine; the stale UI copy was the only mismatch. Verified the new labels against the current Notion developer UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Notion authentication terminology from "Internal Integration Token" to "Integration Token (Access token)" across connection setup UI.

* **Documentation**
  * Updated Notion integration setup instructions to reflect current authentication workflow, including connection configuration and capability enablement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arvo-AI/aurora/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->