### PR TITLE
fix: GitHub not appearing in Action Tool Permissions UI

### DIFF
--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -23,6 +23,15 @@ def _validate_provider_connection(provider: str, token_data: dict) -> bool:
     """
     from routes.connector_status import PROVIDER_CHECKERS
 
+    if provider == "github":
+        from routes.connector_status import _check_github
+        user_id = token_data.get("_user_id", "")
+        try:
+            result = _check_github(user_id, app_runtime_ready=True)
+            return result.get("connected", False)
+        except Exception:
+            return False
+
     checker = PROVIDER_CHECKERS.get(provider)
     if checker is None:
         return True
@@ -176,7 +185,16 @@ def get_connected_accounts(user_id, target_user_id):
                 }
 
         # ------------------------------
-        # 4) Kubectl agent connections
+        # 4) GitHub fallback (App installs may not have user_tokens rows)
+        # ------------------------------
+        if "github" not in accounts:
+            from routes.connector_status import _check_github
+            result = _check_github(user_id, app_runtime_ready=True)
+            if result.get("connected"):
+                accounts["github"] = {"isConnected": True, "name": "GitHub", "displayText": "GitHub"}
+
+        # ------------------------------
+        # 5) Kubectl agent connections
         # ------------------------------
         if "kubectl" not in accounts:
             result = _check_kubectl(user_id, org_id)
@@ -184,7 +202,7 @@ def get_connected_accounts(user_id, target_user_id):
                 accounts["kubectl"] = {"isConnected": True, "name": "Kubernetes", "displayText": "Kubernetes Cluster"}
 
         # ------------------------------
-        # 5) On-prem VM connections
+        # 6) On-prem VM connections
         # ------------------------------
         if "onprem" not in accounts:
             result = _check_onprem(user_id, org_id)

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -23,15 +23,6 @@ def _validate_provider_connection(provider: str, token_data: dict) -> bool:
     """
     from routes.connector_status import PROVIDER_CHECKERS
 
-    if provider == "github":
-        from routes.connector_status import _check_github
-        user_id = token_data.get("_user_id", "")
-        try:
-            result = _check_github(user_id, app_runtime_ready=True)
-            return result.get("connected", False)
-        except Exception:
-            return False
-
     checker = PROVIDER_CHECKERS.get(provider)
     if checker is None:
         return True

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -176,19 +176,7 @@ def get_connected_accounts(user_id, target_user_id):
                 }
 
         # ------------------------------
-        # 4) GitHub fallback (App installs may not have user_tokens rows)
-        # ------------------------------
-        if "github" not in accounts:
-            try:
-                from routes.connector_status import _check_github
-                result = _check_github(user_id, app_runtime_ready=True)
-                if result.get("connected"):
-                    accounts["github"] = {"isConnected": True, "name": "GitHub", "displayText": "GitHub"}
-            except Exception:
-                pass
-
-        # ------------------------------
-        # 5) Kubectl agent connections
+        # 4) Kubectl agent connections
         # ------------------------------
         if "kubectl" not in accounts:
             result = _check_kubectl(user_id, org_id)
@@ -196,7 +184,7 @@ def get_connected_accounts(user_id, target_user_id):
                 accounts["kubectl"] = {"isConnected": True, "name": "Kubernetes", "displayText": "Kubernetes Cluster"}
 
         # ------------------------------
-        # 6) On-prem VM connections
+        # 5) On-prem VM connections
         # ------------------------------
         if "onprem" not in accounts:
             result = _check_onprem(user_id, org_id)

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -188,10 +188,13 @@ def get_connected_accounts(user_id, target_user_id):
         # 4) GitHub fallback (App installs may not have user_tokens rows)
         # ------------------------------
         if "github" not in accounts:
-            from routes.connector_status import _check_github
-            result = _check_github(user_id, app_runtime_ready=True)
-            if result.get("connected"):
-                accounts["github"] = {"isConnected": True, "name": "GitHub", "displayText": "GitHub"}
+            try:
+                from routes.connector_status import _check_github
+                result = _check_github(user_id, app_runtime_ready=True)
+                if result.get("connected"):
+                    accounts["github"] = {"isConnected": True, "name": "GitHub", "displayText": "GitHub"}
+            except Exception:
+                pass
 
         # ------------------------------
         # 5) Kubectl agent connections

--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -270,9 +270,18 @@ def _check_google_chat(creds: Dict[str, Any]) -> Dict[str, Any]:
         return {"connected": False}
 
 
-def _check_github(user_id: str, app_runtime_ready: bool) -> Dict[str, Any]:
-    """Mirrors /github/status — App-aware AND OAuth-aware (hybrid mode)."""
+def _check_github(creds_or_user_id, app_runtime_ready: bool = True) -> Dict[str, Any]:
+    """Mirrors /github/status — App-aware AND OAuth-aware (hybrid mode).
+
+    Accepts either a credentials dict (with ``_user_id``) for generic
+    PROVIDER_CHECKERS dispatch, or a plain user_id string for direct callers.
+    """
     from utils.auth.github_auth_mode import is_app_enabled, is_oauth_enabled
+
+    if isinstance(creds_or_user_id, dict):
+        user_id = creds_or_user_id.get("_user_id", "")
+    else:
+        user_id = creds_or_user_id
 
     if is_app_enabled() and app_runtime_ready:
         try:


### PR DESCRIPTION
## Summary

GitHub was not appearing in the Action Tool Permissions section (Settings > Security), even when connected via OAuth.

**Root cause:** Every checker in `PROVIDER_CHECKERS` accepts a single `token_data` dict — except `_check_github`, which had the signature `(user_id: str, app_runtime_ready: bool)`. When `_validate_provider_connection` called `checker(token_data)`, Python raised `TypeError: missing 1 required positional argument: 'app_runtime_ready'`. The `except Exception: return False` swallowed it, so GitHub silently failed validation and was excluded from `/api/connected-accounts`.

The frontend filters the tool permissions panel by connected providers, so GitHub was hidden.

**Fix:** Made `_check_github` accept either a credentials dict (with `_user_id` key) or a plain user_id string, matching the `PROVIDER_CHECKERS` calling convention. Single file change in `connector_status.py`.

## Test plan
- [ ] Connect GitHub via OAuth, verify GitHub appears in Action Tool Permissions
- [ ] Toggle a GitHub tool permission off, verify it persists on reload
- [ ] Verify other connectors still render correctly