### PR TITLE
fix: skip incident creation on auto-connect test alerts

### DIFF
--- a/server/routes/grafana/tasks.py
+++ b/server/routes/grafana/tasks.py
@@ -511,7 +511,7 @@ def process_grafana_alert(
                                 logger.warning("[GRAFANA][ALERT] Failed to enqueue summary for incident %s (%s): %s", incident_id, per_alert_title, summary_exc)
 
                             # Trigger full RCA background chat
-                            if not skip_rca and _should_trigger_background_chat(user_id, alert_payload):
+                            if _should_trigger_background_chat(user_id, alert_payload):
                                 try:
                                     from chat.background.task import (
                                         run_background_chat, create_background_chat_session, is_background_chat_allowed,

--- a/server/routes/grafana/tasks.py
+++ b/server/routes/grafana/tasks.py
@@ -321,6 +321,13 @@ def process_grafana_alert(
                                 continue
 
                             # -- Firing: create incident and trigger RCA --
+                            if skip_rca:
+                                logger.info(
+                                    "[GRAFANA][ALERT] skip_rca=True (auto-connect webhook), skipping incident creation for user %s (fp=%s)",
+                                    user_id, fingerprint,
+                                )
+                                continue
+
                             severity = _extract_severity(alert_payload)
                             service = _extract_service(alert_payload)
 


### PR DESCRIPTION
Fixed bug where the auto-connect webhooks created a stale incident the first time they were connected. Moved the guard before the incident creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alert incident creation logic to fully respect configuration flags, preventing unintended incident creation in specific scenarios.
  * Adjusted background chat triggering mechanism for improved alert handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->