### PR TITLE
feat: extensibility hooks for LLM call gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -376,3 +376,6 @@ NGROK_URL=
 
 # Show the initial user RCA message (the auto-generated prompt) in the chat UI.
 DISPLAY__RCA_USER_MSG=false
+
+# Extensibility hooks — optional, set to a Python module path to load custom hook implementations
+AURORA_HOOKS_MODULE=

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -200,9 +200,13 @@ def run_prediscovery(
 
     logger.info(f"[Prediscovery] Starting for user {user_id} (trigger={trigger})")
 
+    from utils.auth.stateless_auth import get_org_id_for_user
+    from datetime import datetime, timezone
+    org_id = get_org_id_for_user(user_id)
+
     # Hook: check if LLM call is allowed
     from utils.hooks import get_hook
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    hook_allowed, hook_message = get_hook("before_llm_call")(org_id, user_id)
     if not hook_allowed:
         logger.warning(f"[Prediscovery] Hook blocked for user {user_id}: {hook_message}")
         return {"status": "hook_blocked", "error": hook_message}
@@ -215,10 +219,6 @@ def run_prediscovery(
         if connected_count == 0:
             logger.info(f"[Prediscovery] No integrations for user {user_id}, skipping")
             return {"status": "skipped", "reason": "no_integrations"}
-
-        from utils.auth.stateless_auth import get_org_id_for_user
-        from datetime import datetime, timezone
-        org_id = get_org_id_for_user(user_id)
         run_started_at = datetime.now(timezone.utc).isoformat()
 
         prompt = build_prediscovery_prompt(user_id, providers, integrations)

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -200,6 +200,13 @@ def run_prediscovery(
 
     logger.info(f"[Prediscovery] Starting for user {user_id} (trigger={trigger})")
 
+    # Hook: check if LLM call is allowed
+    from utils.hooks import get_hook
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning(f"[Prediscovery] Hook blocked for user {user_id}: {hook_message}")
+        return {"status": "hook_blocked", "error": hook_message}
+
     try:
         providers = get_user_providers(user_id)
         integrations = _get_connected_integrations(user_id)

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -524,6 +524,13 @@ def generate_incident_summary(
         f"{_LOG_PREFIX} Generating summary for incident {incident_id} (user={user_id}, source={source_type})"
     )
 
+    # Hook: check if LLM call is allowed
+    from utils.hooks import get_hook
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
+        return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}
+
     try:
         # Build the prompt
         prompt = _build_summary_prompt(
@@ -634,6 +641,13 @@ def generate_incident_summary_from_chat(
     logger.info(
         f"{_LOG_PREFIX} Regenerating summary from chat for incident {incident_id} (user={user_id}, session={session_id})"
     )
+
+    # Hook: check if LLM call is allowed
+    from utils.hooks import get_hook
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
+        return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}
 
     try:
         basics = _fetch_incident_basics(incident_id, user_id=user_id)

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -526,7 +526,8 @@ def generate_incident_summary(
 
     # Hook: check if LLM call is allowed
     from utils.hooks import get_hook
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    from utils.auth.stateless_auth import get_org_id_for_user
+    hook_allowed, hook_message = get_hook("before_llm_call")(get_org_id_for_user(user_id), user_id)
     if not hook_allowed:
         logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
         return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}
@@ -644,7 +645,8 @@ def generate_incident_summary_from_chat(
 
     # Hook: check if LLM call is allowed
     from utils.hooks import get_hook
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    from utils.auth.stateless_auth import get_org_id_for_user
+    hook_allowed, hook_message = get_hook("before_llm_call")(get_org_id_for_user(user_id), user_id)
     if not hook_allowed:
         logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
         return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -613,7 +613,9 @@ def run_background_chat(
         
         # Hook: check if LLM call is allowed
         from utils.hooks import get_hook
-        hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+        from utils.auth.stateless_auth import get_org_id_for_user as _get_org
+        _hook_org_id = _get_org(user_id) if user_id else None
+        hook_allowed, hook_message = get_hook("before_llm_call")(_hook_org_id, user_id)
         if not hook_allowed:
             logger.warning(f"[BackgroundChat] Hook blocked for user {user_id}: {hook_message}")
             if incident_id:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -611,6 +611,13 @@ def run_background_chat(
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to link session to incident: {e}")
         
+        # Hook: check if LLM call is allowed (billing, rate limiting, etc.)
+        from utils.hooks import get_hook
+        hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+        if not hook_allowed:
+            logger.warning(f"[BackgroundChat] Hook blocked for user {user_id}: {hook_message}")
+            return {"session_id": session_id, "status": "hook_blocked", "error": hook_message}
+
         # Run the async workflow in the sync Celery context
         logger.info(f"[BackgroundChat] Starting workflow execution for session {session_id}, incident {incident_id}")
         try:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -625,7 +625,7 @@ def run_background_chat(
                             set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:HookBlocked]")
                             cursor.execute(
                                 "UPDATE incidents SET aurora_status = %s, updated_at = %s WHERE id = %s",
-                                ('hook_blocked', datetime.now(), incident_id),
+                                ('hook_blocked', datetime.now(timezone.utc), incident_id),
                             )
                         conn.commit()
                         logger.info(f"[BackgroundChat] Set incident {incident_id} aurora_status to 'hook_blocked'")

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -611,11 +611,24 @@ def run_background_chat(
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to link session to incident: {e}")
         
-        # Hook: check if LLM call is allowed (billing, rate limiting, etc.)
+        # Hook: check if LLM call is allowed
         from utils.hooks import get_hook
         hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
         if not hook_allowed:
             logger.warning(f"[BackgroundChat] Hook blocked for user {user_id}: {hook_message}")
+            if incident_id:
+                try:
+                    with db_pool.get_admin_connection() as conn:
+                        with conn.cursor() as cursor:
+                            set_rls_context(cursor, conn, user_id, log_prefix="[BackgroundChat:HookBlocked]")
+                            cursor.execute(
+                                "UPDATE incidents SET aurora_status = %s, updated_at = %s WHERE id = %s",
+                                ('hook_blocked', datetime.now(), incident_id),
+                            )
+                        conn.commit()
+                        logger.info(f"[BackgroundChat] Set incident {incident_id} aurora_status to 'hook_blocked'")
+                except Exception as hb_err:
+                    logger.error(f"[BackgroundChat] Failed to set hook_blocked status for incident {incident_id}: {hb_err}")
             return {"session_id": session_id, "status": "hook_blocked", "error": hook_message}
 
         # Run the async workflow in the sync Celery context

--- a/server/chat/background/visualization_generator.py
+++ b/server/chat/background/visualization_generator.py
@@ -54,7 +54,14 @@ def update_visualization(
         tool_calls_json: JSON string of recent tool calls to process
     """
     logger.info(f"{_LOG_PREFIX} Starting update for incident {incident_id} (force_full={force_full})")
-    
+
+    # Hook: check if LLM call is allowed
+    from utils.hooks import get_hook
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
+        return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}
+
     try:
         # Get recent tool calls
         if tool_calls_json:

--- a/server/chat/background/visualization_generator.py
+++ b/server/chat/background/visualization_generator.py
@@ -57,7 +57,8 @@ def update_visualization(
 
     # Hook: check if LLM call is allowed
     from utils.hooks import get_hook
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    from utils.auth.stateless_auth import get_org_id_for_user
+    hook_allowed, hook_message = get_hook("before_llm_call")(get_org_id_for_user(user_id), user_id)
     if not hook_allowed:
         logger.warning(f"{_LOG_PREFIX} Hook blocked for user {user_id}: {hook_message}")
         return {"incident_id": incident_id, "status": "hook_blocked", "error": hook_message}

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1221,19 +1221,6 @@ async def handle_connection(websocket) -> None:
                 except Exception as e:
                     logger.error("Error checking incident session RBAC: %s", e)
             
-            # Hook: check if LLM call is allowed
-            if user_id:
-                from utils.hooks import get_hook
-                hook_allowed, hook_message = get_hook("before_llm_call")(org_id, user_id)
-                if not hook_allowed:
-                    logger.warning("Hook blocked LLM call for user=%s org=%s: %s", user_id, org_id, hook_message)
-                    await websocket.send(json.dumps({
-                        "type": "error",
-                        "session_id": session_id,
-                        "data": {"text": hook_message, "code": "HOOK_BLOCKED"}
-                    }))
-                    continue
-
             # Get verified providers (cloud + SkillRegistry-validated integrations)
             from chat.background.rca_prompt_builder import get_user_providers
             if user_id:
@@ -1505,6 +1492,19 @@ async def handle_connection(websocket) -> None:
                 agent = Agent(weaviate_client=weaviate_client, postgres_client=postgres_client, websocket_sender=websocket_sender, event_loop=asyncio.get_event_loop())
                 logger.info(f"Created agent with websocket sender")
             
+            # Hook: check if LLM call is allowed
+            if user_id:
+                from utils.hooks import get_hook
+                hook_allowed, hook_message = get_hook("before_llm_call")(org_id, user_id)
+                if not hook_allowed:
+                    logger.warning("Hook blocked LLM call for user=%s org=%s: %s", user_id, org_id, hook_message)
+                    await websocket.send(json.dumps({
+                        "type": "error",
+                        "session_id": session_id,
+                        "data": {"text": hook_message, "code": "HOOK_BLOCKED"}
+                    }))
+                    continue
+
             # Create session-specific workflow instance to allow resumption while preventing cross-session leakage
             # Generate a temporary session_id if none provided (for new chats)
             effective_session_id = session_id or f"temp_{user_id}_{uuid.uuid4().hex[:8]}"

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1221,6 +1221,19 @@ async def handle_connection(websocket) -> None:
                 except Exception as e:
                     logger.error("Error checking incident session RBAC: %s", e)
             
+            # Hook: check if LLM call is allowed (billing, rate limiting, etc.)
+            if user_id:
+                from utils.hooks import get_hook
+                hook_allowed, hook_message = get_hook("before_llm_call")(org_id, user_id)
+                if not hook_allowed:
+                    logger.warning("Hook blocked LLM call for user=%s org=%s: %s", user_id, org_id, hook_message)
+                    await websocket.send(json.dumps({
+                        "type": "error",
+                        "session_id": session_id,
+                        "data": {"text": hook_message, "code": "BUDGET_EXCEEDED"}
+                    }))
+                    continue
+
             # Get verified providers (cloud + SkillRegistry-validated integrations)
             from chat.background.rca_prompt_builder import get_user_providers
             if user_id:

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -1221,7 +1221,7 @@ async def handle_connection(websocket) -> None:
                 except Exception as e:
                     logger.error("Error checking incident session RBAC: %s", e)
             
-            # Hook: check if LLM call is allowed (billing, rate limiting, etc.)
+            # Hook: check if LLM call is allowed
             if user_id:
                 from utils.hooks import get_hook
                 hook_allowed, hook_message = get_hook("before_llm_call")(org_id, user_id)
@@ -1230,7 +1230,7 @@ async def handle_connection(websocket) -> None:
                     await websocket.send(json.dumps({
                         "type": "error",
                         "session_id": session_id,
-                        "data": {"text": hook_message, "code": "BUDGET_EXCEEDED"}
+                        "data": {"text": hook_message, "code": "HOOK_BLOCKED"}
                     }))
                     continue
 

--- a/server/routes/github/github_repo_metadata.py
+++ b/server/routes/github/github_repo_metadata.py
@@ -119,9 +119,11 @@ def generate_repo_metadata(self, user_id: str, repo_full_name: str):
 
     # Hook: check if LLM call is allowed
     from utils.hooks import get_hook
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    from utils.auth.stateless_auth import get_org_id_for_user
+    _hook_org_id = get_org_id_for_user(user_id) if user_id else None
+    hook_allowed, hook_message = get_hook("before_llm_call")(_hook_org_id, user_id)
     if not hook_allowed:
-        logger.warning(f"Hook blocked for user {user_id}: {hook_message}")
+        logger.warning("Hook blocked for user %s: %s", user_id, hook_message)
         _update_metadata(user_id, repo_full_name, None, "error")
         return
 

--- a/server/routes/github/github_repo_metadata.py
+++ b/server/routes/github/github_repo_metadata.py
@@ -116,6 +116,15 @@ def generate_repo_metadata(self, user_id: str, repo_full_name: str):
     )
 
     logger.info(f"Generating metadata for {repo_full_name} (user {user_id})")
+
+    # Hook: check if LLM call is allowed
+    from utils.hooks import get_hook
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning(f"Hook blocked for user {user_id}: {hook_message}")
+        _update_metadata(user_id, repo_full_name, None, "error")
+        return
+
     _update_metadata(user_id, repo_full_name, None, "generating")
 
     try:

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -19,8 +19,8 @@ from typing import Optional, Tuple
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
-_hooks_module = None
-_hooks_loaded = False
+_hooks_module: object = None
+_hooks_loaded: bool = False
 _hook_cache: dict = {}
 
 

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -2,9 +2,9 @@
 Extensibility hooks for Aurora server.
 
 Default implementations are no-ops. To provide custom implementations
-(e.g., billing enforcement), set AURORA_HOOKS_MODULE to a Python module:
+(e.g., custom enforcement), set AURORA_HOOKS_MODULE to a Python module:
 
-    AURORA_HOOKS_MODULE=utils.hooks_billing
+    AURORA_HOOKS_MODULE=utils.hooks_custom
 
 The module must define functions matching the signatures below.
 Missing functions fall back to the defaults.
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 _lock = threading.Lock()
 _hooks_module = None
 _hooks_loaded = False
+_hook_cache: dict = {}
 
 
 # --- Default no-op implementations ---
@@ -30,13 +31,8 @@ def _default_before_llm_call(org_id: Optional[str], user_id: str) -> Tuple[bool,
     return True, None
 
 
-def _default_after_llm_call(org_id: Optional[str], user_id: str, cost_usd: float) -> None:
-    """Called after an LLM call completes with known cost."""
-    pass
-
-
-def _default_on_plan_change(org_id: str, new_plan: str) -> None:
-    """Called when an organization's plan changes."""
+def _default_after_llm_call(org_id: Optional[str], user_id: str, metadata: dict) -> None:
+    """Called after an LLM call completes with metadata about the call."""
     pass
 
 
@@ -44,7 +40,6 @@ def _default_on_plan_change(org_id: str, new_plan: str) -> None:
 _HOOK_REGISTRY = {
     "before_llm_call": _default_before_llm_call,
     "after_llm_call": _default_after_llm_call,
-    "on_plan_change": _default_on_plan_change,
 }
 
 
@@ -57,10 +52,10 @@ def _load_hooks():
     with _lock:
         if _hooks_loaded:
             return
-        _hooks_loaded = True
 
         module_path = os.environ.get("AURORA_HOOKS_MODULE")
         if not module_path:
+            _hooks_loaded = True
             return
 
         try:
@@ -69,8 +64,9 @@ def _load_hooks():
         except Exception as e:
             logger.critical(
                 "AURORA_HOOKS_MODULE='%s' failed to import: %s — "
-                "billing enforcement may be inactive!", module_path, e
+                "custom hooks may be inactive!", module_path, e
             )
+        _hooks_loaded = True
 
 
 def get_hook(name: str):
@@ -80,6 +76,10 @@ def get_hook(name: str):
     if name not in _HOOK_REGISTRY:
         logger.error("Unknown hook '%s' requested", name)
         return _HOOK_REGISTRY.get("before_llm_call", _default_before_llm_call)
+
+    # Return cached closure if available
+    if name in _hook_cache:
+        return _hook_cache[name]
 
     # Try custom module first
     if _hooks_module and hasattr(_hooks_module, name):
@@ -95,4 +95,5 @@ def get_hook(name: str):
             logger.error("Hook '%s' raised: %s — failing open", name, e)
             return _HOOK_REGISTRY[name](*args, **kwargs)
 
+    _hook_cache[name] = _safe_hook
     return _safe_hook

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -1,0 +1,98 @@
+"""
+Extensibility hooks for Aurora server.
+
+Default implementations are no-ops. To provide custom implementations
+(e.g., billing enforcement), set AURORA_HOOKS_MODULE to a Python module:
+
+    AURORA_HOOKS_MODULE=utils.hooks_billing
+
+The module must define functions matching the signatures below.
+Missing functions fall back to the defaults.
+"""
+
+import importlib
+import logging
+import os
+import threading
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_hooks_module = None
+_hooks_loaded = False
+
+
+# --- Default no-op implementations ---
+
+def _default_before_llm_call(org_id: Optional[str], user_id: str) -> Tuple[bool, Optional[str]]:
+    """Called before any LLM API call. Return (False, message) to block."""
+    return True, None
+
+
+def _default_after_llm_call(org_id: Optional[str], user_id: str, cost_usd: float) -> None:
+    """Called after an LLM call completes with known cost."""
+    pass
+
+
+def _default_on_plan_change(org_id: str, new_plan: str) -> None:
+    """Called when an organization's plan changes."""
+    pass
+
+
+# Explicit registry — only these names are valid hook points
+_HOOK_REGISTRY = {
+    "before_llm_call": _default_before_llm_call,
+    "after_llm_call": _default_after_llm_call,
+    "on_plan_change": _default_on_plan_change,
+}
+
+
+# --- Hook loader ---
+
+def _load_hooks():
+    global _hooks_module, _hooks_loaded
+    if _hooks_loaded:
+        return
+    with _lock:
+        if _hooks_loaded:
+            return
+        _hooks_loaded = True
+
+        module_path = os.environ.get("AURORA_HOOKS_MODULE")
+        if not module_path:
+            return
+
+        try:
+            _hooks_module = importlib.import_module(module_path)
+            logger.info("Loaded custom hooks from %s", module_path)
+        except Exception as e:
+            logger.critical(
+                "AURORA_HOOKS_MODULE='%s' failed to import: %s — "
+                "billing enforcement may be inactive!", module_path, e
+            )
+
+
+def get_hook(name: str):
+    """Get a hook function by name. Returns a safe callable that never raises."""
+    _load_hooks()
+
+    if name not in _HOOK_REGISTRY:
+        logger.error("Unknown hook '%s' requested", name)
+        return _HOOK_REGISTRY.get("before_llm_call", _default_before_llm_call)
+
+    # Try custom module first
+    if _hooks_module and hasattr(_hooks_module, name):
+        fn = getattr(_hooks_module, name)
+    else:
+        fn = _HOOK_REGISTRY[name]
+
+    # Wrap in safety net so a broken hook never crashes the caller
+    def _safe_hook(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            logger.error("Hook '%s' raised: %s — failing open", name, e)
+            return _HOOK_REGISTRY[name](*args, **kwargs)
+
+    return _safe_hook

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -74,8 +74,7 @@ def get_hook(name: str):
     _load_hooks()
 
     if name not in _HOOK_REGISTRY:
-        logger.error("Unknown hook '%s' requested", name)
-        return _HOOK_REGISTRY.get("before_llm_call", _default_before_llm_call)
+        raise ValueError(f"Unknown hook '{name}' — valid hooks: {list(_HOOK_REGISTRY.keys())}")
 
     # Return cached closure if available
     if name in _hook_cache:

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -144,7 +144,8 @@ def _generate_summary(user_id: str, context: str) -> str:
     from utils.hooks import get_hook
 
     # Hook: check if LLM call is allowed
-    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    from utils.auth.stateless_auth import get_org_id_for_user
+    hook_allowed, hook_message = get_hook("before_llm_call")(get_org_id_for_user(user_id), user_id)
     if not hook_allowed:
         logger.warning("Hook blocked repo metadata LLM call for user=%s: %s", user_id, hook_message)
         raise RuntimeError(f"hook_blocked: {hook_message}")

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -147,7 +147,7 @@ def _generate_summary(user_id: str, context: str) -> str:
     hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
     if not hook_allowed:
         logger.warning("Hook blocked repo metadata LLM call for user=%s: %s", user_id, hook_message)
-        return "Summary generation blocked by policy"
+        raise RuntimeError(f"hook_blocked: {hook_message}")
 
     llm = create_chat_model(
         ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -141,6 +141,13 @@ def _generate_summary(user_id: str, context: str) -> str:
     from chat.backend.agent.llm import ModelConfig
     from chat.backend.agent.utils.llm_usage_tracker import tracked_invoke
     from langchain_core.messages import HumanMessage
+    from utils.hooks import get_hook
+
+    # Hook: check if LLM call is allowed
+    hook_allowed, hook_message = get_hook("before_llm_call")(None, user_id)
+    if not hook_allowed:
+        logger.warning("Hook blocked repo metadata LLM call for user=%s: %s", user_id, hook_message)
+        return "Summary generation blocked by policy"
 
     llm = create_chat_model(
         ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,


### PR DESCRIPTION
## Summary

Adds a plugin hook system that allows custom modules to intercept LLM calls before they execute. Default behavior is a no-op — zero functional change for existing deployments.

## Motivation

Enables downstream deployments to add billing enforcement, rate limiting, usage metering, or audit logging without forking or patching the core codebase. Custom implementations are loaded via a single env var.

## How it works

```bash
# No env var = all hooks are no-ops (current behavior, unchanged)
# With custom module:
AURORA_HOOKS_MODULE=my_custom.hooks
```

The module must define:
```python
def before_llm_call(org_id: str | None, user_id: str) -> tuple[bool, str | None]:
    # Return (False, "reason") to block, (True, None) to allow
```

## Files changed

| File | Change |
|------|--------|
| `server/utils/hooks.py` | New — hook registry, loader, safe wrapper |
| `server/main_chatbot.py` | +11 lines — hook check before chat LLM call |
| `server/chat/background/task.py` | +6 lines — hook check before background RCA |
| `server/chat/background/summarization.py` | +12 lines — hook check at both summary paths |
| `server/chat/background/visualization_generator.py` | +7 lines — hook check before viz extraction |
| `server/chat/background/prediscovery_task.py` | +7 lines — hook check before prediscovery |
| `server/routes/github/github_repo_metadata.py` | +8 lines — hook check before repo summary |

## Design decisions

- **Explicit registry** — only defined hook names are valid (no `globals()` leakage)
- **Safe wrapper** — exceptions in hook implementations are caught and logged, never crash the caller
- **Thread-safe** — module loading uses a lock for Celery worker thread pools
- **CRITICAL log** — if `AURORA_HOOKS_MODULE` is set but fails to import, ops gets alerted
- **Fail-open** — if hook module is unavailable, all calls proceed (same as no hook)

## Test plan

- [x] Without `AURORA_HOOKS_MODULE`: all 7 hook call sites return `(True, None)`, zero behavior change
- [x] With valid module: hook is called, can block or allow
- [x] With broken module (import error): logs CRITICAL, falls back to no-op
- [ ] Verify no performance regression on chat message latency (import is cached after first call)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced policy enforcement for LLM-based operations across the platform, including chat sessions, incident summaries, visualization generation, and repository metadata creation. When policies restrict an operation, users receive error responses with clear status codes and messages explaining the policy-based restriction. This enables administrators to control access to LLM features based on organizational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->