### PR TITLE
fix(helm): block celery-worker eviction during node scale-down

### DIFF
--- a/deploy/helm/aurora/templates/pdb.yaml
+++ b/deploy/helm/aurora/templates/pdb.yaml
@@ -53,7 +53,7 @@ metadata:
   labels:
     {{- include "aurora.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "aurora.name" . }}-celery-worker


### PR DESCRIPTION
## Summary

- Changes celery-worker PDB from `minAvailable: 1` to `maxUnavailable: 0`
- With 2 replicas and `minAvailable: 1`, GKE was still allowed to evict 1 pod — which killed active 30-min RCA tasks
- `maxUnavailable: 0` fully blocks voluntary eviction (node scale-down, drain) for celery workers
- Other services (server, frontend, chatbot, mcp) remain at `minAvailable: 1`

## Context

Automatic RCA sessions were failing because the GKE node autoscaler evicted celery worker pods mid-investigation. The stale session cleanup then marked them as `failed`. Evidence: incidents had execution steps stuck in `running` state with no error, and sessions were marked failed 12-22 minutes after the last activity (matching the stale cleanup threshold).

## Trade-off

`maxUnavailable: 0` will delay node drains/upgrades if a celery worker is on the target node (max 30 min wait). This is acceptable — losing customer RCA investigations is worse than a delayed node upgrade.

## Test plan

- [ ] `helm template` renders correctly
- [ ] After deploy, `kubectl get pdb -n aurora` shows celery-worker with `MAX UNAVAILABLE: 0`
- [ ] Node scale-down no longer evicts celery workers