### PR TITLE
fix: show specific message when repo metadata generation is blocked by usage limit

### DIFF
--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1067,7 +1067,8 @@ export default function GitHubProviderIntegration() {
                 const isEditing = editingMetadata[repo.repo_full_name] !== undefined;
                 const isReady = repo.metadata_status === 'ready';
                 const isPending = repo.metadata_status === 'pending' || repo.metadata_status === 'generating';
-                const isError = repo.metadata_status === 'error';
+                const isError = repo.metadata_status === 'error' || repo.metadata_status === 'limit_reached';
+                const isLimitReached = repo.metadata_status === 'limit_reached';
                 return (
                   <div key={repo.repo_full_name} className="p-2 rounded-md border border-border space-y-1">
                     <div className="flex items-center justify-between gap-2">
@@ -1130,7 +1131,7 @@ export default function GitHubProviderIntegration() {
                       </div>
                     )}
                     {isError && (
-                      <p className="text-xs text-red-500">Failed to generate description</p>
+                      <p className="text-xs text-red-500">{isLimitReached ? 'Usage limit reached — upgrade to continue.' : 'Failed to generate description'}</p>
                     )}
                     {isReady && isEditing && (
                       <div className="space-y-1">

--- a/server/routes/github/github_repo_metadata.py
+++ b/server/routes/github/github_repo_metadata.py
@@ -124,7 +124,7 @@ def generate_repo_metadata(self, user_id: str, repo_full_name: str):
     hook_allowed, hook_message = get_hook("before_llm_call")(_hook_org_id, user_id)
     if not hook_allowed:
         logger.warning("Hook blocked for user %s: %s", user_id, hook_message)
-        _update_metadata(user_id, repo_full_name, None, "error")
+        _update_metadata(user_id, repo_full_name, None, "limit_reached")
         return
 
     _update_metadata(user_id, repo_full_name, None, "generating")


### PR DESCRIPTION
When a user hits their usage limit and tries to generate a GitHub repo description, they currently see 'failed to generate description' with no explanation. Now stores status `limit_reached` so the frontend can show 'Usage limit reached' instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for repository metadata generation: the system now distinguishes between usage limit errors and other failures. When a usage limit is reached, users receive a targeted upgrade prompt with clear next steps instead of a generic error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->