### PR TITLE
feat: hook for seat limit enforcement

### DIFF
--- a/server/routes/org_routes.py
+++ b/server/routes/org_routes.py
@@ -382,6 +382,16 @@ def add_member(user_id):
     if role not in VALID_ROLES:
         return jsonify({"error": "Invalid role"}), 400
 
+    # Hook: check if org can add more members (seat limit enforcement)
+    from utils.hooks import get_hook
+    with db_pool.get_admin_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (org_id,))
+            member_count = cur.fetchone()[0]
+    hook_allowed, hook_message = get_hook("before_add_member")(org_id, member_count)
+    if not hook_allowed:
+        return jsonify({"error": hook_message or "Seat limit reached for your plan. Upgrade to add more members."}), 403
+
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
@@ -688,6 +698,18 @@ def _create_invitation(org_id: str, user_id: str):
 
     if role not in VALID_ROLES:
         return jsonify({"error": "Invalid role"}), 400
+
+    # Hook: check if org can add more members (seat limit enforcement)
+    from utils.hooks import get_hook
+    with db_pool.get_admin_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (org_id,))
+            member_count = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM org_invitations WHERE org_id = %s AND status = 'pending'", (org_id,))
+            pending_count = cur.fetchone()[0]
+    hook_allowed, hook_message = get_hook("before_add_member")(org_id, member_count + pending_count)
+    if not hook_allowed:
+        return jsonify({"error": hook_message or "Seat limit reached for your plan. Upgrade to add more members."}), 403
 
     try:
         with db_pool.get_admin_connection() as conn:

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -36,10 +36,16 @@ def _default_after_llm_call(org_id: Optional[str], user_id: str, metadata: dict)
     pass
 
 
+def _default_before_add_member(org_id: str, current_member_count: int) -> Tuple[bool, Optional[str]]:
+    """Called before adding a member to an org. Return (False, message) to block."""
+    return True, None
+
+
 # Explicit registry — only these names are valid hook points
 _HOOK_REGISTRY = {
     "before_llm_call": _default_before_llm_call,
     "after_llm_call": _default_after_llm_call,
+    "before_add_member": _default_before_add_member,
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `before_add_member(org_id, current_member_count)` hook to `server/utils/hooks.py` with a no-op default (OSS has no seat limits)
- Calls the hook in both the `add_member()` endpoint and `_create_invitation()` (counting pending invitations toward the total)
- SaaS overlay implements enforcement based on plan tier via the hooks module

## Test plan

- [ ] Verify existing add-member and invite flows still work without `AURORA_HOOKS_MODULE` set (default no-op returns allow)
- [ ] Set `AURORA_HOOKS_MODULE` to a module that returns `(False, "blocked")` and confirm 403 is returned
- [ ] Confirm pending invitations are counted in the seat total for the invite path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Seat limit enforcement added for organization members. The system now validates and rejects member additions or invitation creation if the organization has reached its maximum seat capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->