### PR TITLE
fix: exclude github_fix tool from action-triggered background chats

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -978,6 +978,25 @@ from .mcp_tools import (
     LANGCHAIN_TOOLS_CACHE_DURATION
 )
 
+
+_NON_RCA_SOURCES = frozenset(('action', 'prediscovery'))
+
+
+def _is_background_rca(state_context, is_background: bool) -> bool:
+    """True when the session is a background RCA investigating a real incident.
+
+    Used to gate tools like github_fix that only make sense during incident
+    investigation (where the user will see the incident card afterwards).
+    """
+    if not state_context or not is_background:
+        return False
+    incident_id = getattr(state_context, 'incident_id', None)
+    if not incident_id:
+        return False
+    rca_source = ((getattr(state_context, 'rca_context', None) or {}).get('source', '') or '').lower()
+    return bool(rca_source) and rca_source not in _NON_RCA_SOURCES
+
+
 def get_cloud_tools():
     """Get all cloud management tools including both Aurora native tools and REAL MCP tools."""
     # Import required classes at function start to avoid scope issues
@@ -1009,10 +1028,11 @@ def get_cloud_tools():
     rca_flag = getattr(state_context, 'trigger_rca_requested', False) if state_context else False
     is_background = getattr(state_context, 'is_background', False) if state_context else False
     is_postmortem_action = getattr(state_context, 'is_postmortem_action', False) if state_context else False
+    is_rca_context = _is_background_rca(state_context, is_background)
     if tool_capture is None:
-        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
+        cache_key = f"{user_id}:nocapture:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}:is_rca_ctx={is_rca_context}"
     else:
-        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}"
+        cache_key = f"{user_id}:capture:{id(tool_capture)}:{mode_suffix}:background={is_background}:rca={rca_flag}:postmortem={is_postmortem_action}:is_rca_ctx={is_rca_context}"
     
     current_time = time.time()
     if (
@@ -1323,8 +1343,13 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         tool_functions.append((github_commit, "github_commit"))
         tool_functions.append((get_connected_repos, "get_connected_repos"))
         tool_functions.append((github_rca, "github_rca"))
-        tool_functions.append((github_fix, "github_fix"))
-        logging.info(f"Added GitHub tools for user {user_id}")
+        # github_fix saves suggestions for user review in the incident card UI.
+        # Only include during background RCA (real incident investigation) where
+        # the user will see the incident card. Exclude from actions (autonomous,
+        # should use MCP create_pull_request), prediscovery, and interactive chat.
+        if is_rca_context:
+            tool_functions.append((github_fix, "github_fix"))
+        logging.info(f"Added GitHub tools for user {user_id} (github_fix={'included' if is_rca_context else 'excluded (not RCA)'})")
 
     if _safe_connected(is_tailscale_connected, "Tailscale"):
         tool_functions.append((tailscale_ssh, "tailscale_ssh"))


### PR DESCRIPTION
## Summary
- `github_fix` saves fix suggestions to `incident_suggestions` for user review in the incident card UI
- In Actions (which run autonomously after RCA completes), no user is actively viewing the incident card — suggestions dead-end silently
- This PR gates `github_fix` to only be available during actual RCA sessions (`source != 'action'`), so actions will instead use the GitHub MCP tools (`create_pull_request`, `push_files`) that produce visible artifacts like PRs

## Context
The "Mute noisy alerts" action was calling `github_fix` repeatedly, generating code suggestions that no one ever sees or acts on. With `github_fix` excluded from actions, the agent will fall through to the MCP tools which can create branches and PRs directly.

## Test plan
- [x] Trigger a background RCA (via Datadog/PagerDuty webhook) — verify `github_fix` is still available
- [x] Trigger an action (on_incident after_rca) — verify `github_fix` is NOT in the tool list and the agent uses MCP tools instead
- [x] Verify cache key differentiates action vs RCA contexts (no stale tool list served)
- [x] Chat-triggered RCA (trigger_rca tool) — verify `github_fix` is available in the spawned background session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool caching now considers investigation context type to ensure appropriate tool sets are available.
  * GitHub integration tool availability is now contextually determined based on the current investigation mode, improving tool accuracy and preventing incompatible tool combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->