### PR TITLE
fix: disable aggressive GitHub polling (causes frontend OOM)

### DIFF
--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -316,22 +316,9 @@ export default function GitHubProviderIntegration() {
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
-    const hasPending = repos.some(r => r.metadata_status === 'pending' || r.metadata_status === 'generating');
-    if (!hasPending || !userId) return;
-    pollingRef.current = setInterval(async () => {
-      try {
-        const response = await fetch('/api/proxy/github/repo-selections');
-        if (!response.ok) return; // transient; keep polling
-        const data = await response.json();
-        const updated: ConnectedRepo[] = data.repositories || [];
-        setSavedRepos(updated);
-        const stillPending = updated.some(r => r.metadata_status === 'pending' || r.metadata_status === 'generating');
-        if (!stillPending && pollingRef.current) {
-          clearInterval(pollingRef.current);
-          pollingRef.current = null;
-        }
-      } catch { /* keep polling; transient failure */ }
-    }, 3000);
+    // Polling disabled — 3s interval causes frontend OOM in dev mode (see #471).
+    // Metadata status updates on manual page refresh instead.
+    return;
   }, [userId]);
 
   const loadSavedRepos = useCallback(async () => {

--- a/client/src/hooks/use-github-status.ts
+++ b/client/src/hooks/use-github-status.ts
@@ -108,18 +108,11 @@ export function useGitHubStatus(userId: string | null) {
         checkStatus();
       }
     };
-    const handleVisibility = () => {
-      if (document.visibilityState === 'visible') checkStatus();
-    };
     window.addEventListener('providerStateChanged', handleProviderChange);
     window.addEventListener('message', handleAuthMessage);
-    window.addEventListener('focus', checkStatus);
-    document.addEventListener('visibilitychange', handleVisibility);
     return () => {
       window.removeEventListener('providerStateChanged', handleProviderChange);
       window.removeEventListener('message', handleAuthMessage);
-      window.removeEventListener('focus', checkStatus);
-      document.removeEventListener('visibilitychange', handleVisibility);
     };
   }, [userId, checkStatus]);
 


### PR DESCRIPTION
## Problem

The GitHub connector polls `/api/proxy/github/repo-selections` every 3 seconds and re-checks status on every tab focus/visibility change. In Docker dev mode this causes the frontend container to OOM and crash repeatedly.

## Fix

- Disabled the `setInterval` polling for repo metadata status (was 3s)
- Removed `focus` and `visibilitychange` event listeners that re-triggered status checks
- Status is still checked once on mount and on `providerStateChanged` events

## Impact

- Metadata generation status won't auto-update (user refreshes manually)
- GitHub OAuth callback still works (fires `providerStateChanged`)
- No functional regression for normal usage

Refs #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)