### PR TITLE
fix(actions): move action_run update and after_rca dispatch inside async fn

### DIFF
--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1460,6 +1460,7 @@ async def _execute_background_chat(
             try:
                 from services.actions.executor import update_action_run_status
                 if guardrail_blocked:
+                    _append_block_message(session_id, user_id, "This action was blocked by safety guardrails. The instructions may need to be rephrased to pass input validation.")
                     update_action_run_status(
                         run_id=trigger_metadata['run_id'], status='error',
                         user_id=user_id, error_message='Action blocked by safety guardrails',

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1451,13 +1451,38 @@ async def _execute_background_chat(
         llm_context = _ensure_llm_context_history(session_id, user_id)
         tool_calls = _extract_tool_calls_for_viz(session_id, user_id, llm_context)
         logger.info(f"[BackgroundChat] Extracted {len(tool_calls)} tool calls for visualization")
-        
+
+        # Mark action run as success INSIDE the async function. asyncio.run() may
+        # never return to the caller (worker process exits during event loop teardown
+        # due to MCP subprocess cleanup), so this must happen before we return.
+        guardrail_blocked = getattr(state, "guardrail_blocked", False)
+        if trigger_metadata and trigger_metadata.get('source') == 'action':
+            try:
+                from services.actions.executor import update_action_run_status
+                if guardrail_blocked:
+                    update_action_run_status(
+                        run_id=trigger_metadata['run_id'], status='error',
+                        user_id=user_id, error_message='Action blocked by safety guardrails',
+                    )
+                else:
+                    update_action_run_status(run_id=trigger_metadata['run_id'], status='success', user_id=user_id)
+            except Exception as e:
+                logger.error(f"[BackgroundChat] Failed to update action run status: {e}")
+
+        # Dispatch after_rca actions before returning (same reason as above).
+        if incident_id and trigger_metadata and trigger_metadata.get('source') != 'action':
+            try:
+                from services.actions.executor import dispatch_on_incident_actions
+                dispatch_on_incident_actions(user_id, str(incident_id), timing='after_rca')
+            except Exception:
+                logger.debug("[BackgroundChat] Failed to dispatch after_rca actions")
+
         return {
             "session_id": session_id,
             "status": "completed",
             "trigger_metadata": trigger_metadata,
             "tool_calls": tool_calls,
-            "guardrail_blocked": getattr(state, "guardrail_blocked", False),
+            "guardrail_blocked": guardrail_blocked,
         }
         
     except Exception as e:


### PR DESCRIPTION
## Summary

- Moves action_run status update (`success`/`error`) and `dispatch_on_incident_actions(timing='after_rca')` into `_execute_background_chat`, where they execute before `asyncio.run()` tears down the event loop.
- Same root cause as #439 (`722bc5c8`): the worker process exits cleanly (exitcode 0) during event loop teardown when MCP subprocess cleanup triggers `sys.exit`. Code after `asyncio.run()` in the outer celery task never executes.
- Action runs were left stuck in `running` state until the cleanup task marked them as `error` ("Background chat did not complete successfully"). After_rca actions were never dispatched for those incidents.

## Test plan

- [ ] Deploy to prod and observe that action_runs transition to `success` immediately after RCA completes (no more `WorkerLostError` leaving them stranded)
- [ ] Verify `after_rca` actions dispatch reliably by checking `action_runs` table after next RCA completion
- [ ] Confirm the outer task code (lines 777-808) still works as harmless fallback if `asyncio.run()` returns normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal background chat workflow restructured: status updates for action-triggered runs and incident action dispatching for non-action triggers now occur earlier within the async flow. Returned results now use computed local state for guardrail blocking, improving consistency and reliability of background chat processing. No user-facing APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->