### PR TITLE
Artifacts: persistent agent-maintained documents in Monitor

### DIFF
--- a/client/src/app/api/artifacts/[id]/route.ts
+++ b/client/src/app/api/artifacts/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return forwardRequest(request, 'GET', `/api/artifacts/${id}`, 'Failed to fetch artifact');
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return forwardRequest(request, 'PATCH', `/api/artifacts/${id}`, 'Failed to update artifact');
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return forwardRequest(request, 'DELETE', `/api/artifacts/${id}`, 'Failed to delete artifact');
+}

--- a/client/src/app/api/artifacts/[id]/versions/[versionId]/restore/route.ts
+++ b/client/src/app/api/artifacts/[id]/versions/[versionId]/restore/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; versionId: string }> },
+) {
+  const { id, versionId } = await params;
+  return forwardRequest(
+    request,
+    'POST',
+    `/api/artifacts/${id}/versions/${versionId}/restore`,
+    'Failed to restore artifact version',
+  );
+}

--- a/client/src/app/api/artifacts/[id]/versions/[versionId]/route.ts
+++ b/client/src/app/api/artifacts/[id]/versions/[versionId]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; versionId: string }> },
+) {
+  const { id, versionId } = await params;
+  return forwardRequest(
+    request,
+    'GET',
+    `/api/artifacts/${id}/versions/${versionId}`,
+    'Failed to fetch artifact version',
+  );
+}

--- a/client/src/app/api/artifacts/[id]/versions/route.ts
+++ b/client/src/app/api/artifacts/[id]/versions/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return forwardRequest(request, 'GET', `/api/artifacts/${id}/versions`, 'Failed to fetch artifact versions');
+}

--- a/client/src/app/api/artifacts/route.ts
+++ b/client/src/app/api/artifacts/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+// GET /api/artifacts            → list summaries
+// GET /api/artifacts?title=...  → single artifact by exact title
+export async function GET(request: NextRequest) {
+  return forwardRequest(request, 'GET', '/api/artifacts', 'Failed to fetch artifacts');
+}
+
+// POST /api/artifacts → create (or replace by title)
+export async function POST(request: NextRequest) {
+  return forwardRequest(request, 'POST', '/api/artifacts', 'Failed to create artifact');
+}

--- a/client/src/app/monitor/components/artifacts-tab.tsx
+++ b/client/src/app/monitor/components/artifacts-tab.tsx
@@ -1,0 +1,472 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  BookOpen, Plus, ArrowLeft, Save, X, Trash2, History, Eye, Edit2, RotateCcw, Loader2,
+} from 'lucide-react';
+import { useQuery, jsonFetcher } from '@/lib/query';
+import { postmortemMarkdownComponents } from '@/lib/markdown-components';
+import { formatTimeAgo } from '@/lib/utils/time-format';
+import { ChartPanel, EmptyState } from './charts';
+import {
+  artifactsService,
+  type ArtifactSummary,
+  type ArtifactData,
+  type ArtifactVersion,
+  type ArtifactEditor,
+} from '@/lib/services/artifacts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function EditorBadge({ who }: { who: ArtifactEditor }) {
+  const isUser = who === 'user';
+  return (
+    <span
+      className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+        isUser ? 'bg-emerald-500/10 text-emerald-400' : 'bg-blue-500/10 text-blue-400'
+      }`}
+    >
+      {isUser ? 'You' : 'Agent'}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List view
+// ---------------------------------------------------------------------------
+
+export default function ArtifactsTab() {
+  const { data, isLoading, mutate } = useQuery<{ artifacts: ArtifactSummary[] }>(
+    '/api/artifacts', jsonFetcher, { staleTime: 15_000 },
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const artifacts = data?.artifacts ?? [];
+
+  const handleDelete = useCallback(async (id: string) => {
+    setDeletingId(id);
+    setDeleteError(null);
+    const result = await artifactsService.deleteArtifact(id);
+    setDeletingId(null);
+    if (!result.success) {
+      setDeleteError(result.error || 'Failed to delete artifact');
+      return;
+    }
+    setConfirmingId(null);
+    mutate();
+  }, [mutate]);
+
+  if (creating) {
+    return (
+      <ArtifactCreate
+        existingTitles={artifacts.map((a) => a.title)}
+        onBack={() => setCreating(false)}
+        onCreated={(id) => { setCreating(false); mutate(); setSelectedId(id); }}
+      />
+    );
+  }
+
+  if (selectedId) {
+    return (
+      <ArtifactDetail
+        id={selectedId}
+        onBack={() => { setSelectedId(null); mutate(); }}
+        onDeleted={() => { setSelectedId(null); mutate(); }}
+      />
+    );
+  }
+
+  return (
+    <ChartPanel title="Artifacts" subtitle="Living documents Aurora maintains across runs" loading={isLoading}>
+      <div className="flex justify-end mb-4">
+        <button
+          onClick={() => setCreating(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-zinc-200 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New artifact
+        </button>
+      </div>
+
+      {deleteError && <p className="text-xs text-red-400 mb-3">{deleteError}</p>}
+
+      {artifacts.length === 0 ? (
+        <EmptyState
+          icon={BookOpen}
+          message="No artifacts yet"
+          hint="Aurora keeps living documents here — findings lists, cost reports, runbooks — that update across runs. Create one or ask Aurora in an action to maintain it."
+        />
+      ) : (
+        <div className="space-y-2">
+          {artifacts.map((a) => (
+            <div
+              key={a.id}
+              className="group flex items-center justify-between border border-zinc-800 rounded-lg px-4 py-3 hover:border-zinc-700 hover:bg-zinc-800/20 transition-colors"
+            >
+              <button
+                onClick={() => setSelectedId(a.id)}
+                className="flex-1 min-w-0 text-left"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-zinc-200 truncate">{a.title}</span>
+                  <EditorBadge who={a.lastEditedBy} />
+                  <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/60 text-[10px] font-mono text-zinc-300">
+                    v{a.version}
+                  </span>
+                </div>
+                <p className="text-xs text-zinc-500 mt-1">Updated {a.updatedAt ? formatTimeAgo(a.updatedAt) : '—'}</p>
+              </button>
+
+              <div className="flex items-center gap-1.5 shrink-0 ml-3">
+                {confirmingId === a.id ? (
+                  <>
+                    <button
+                      onClick={() => handleDelete(a.id)}
+                      disabled={deletingId === a.id}
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 transition-colors disabled:opacity-50"
+                    >
+                      {deletingId === a.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => setConfirmingId(null)}
+                      className="inline-flex items-center px-2 py-1 rounded text-[11px] text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => setConfirmingId(a.id)}
+                    aria-label={`Delete ${a.title}`}
+                    className="p-1.5 rounded text-zinc-600 hover:text-red-400 hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </ChartPanel>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create view
+// ---------------------------------------------------------------------------
+
+function ArtifactCreate({ existingTitles, onBack, onCreated }: {
+  existingTitles: string[];
+  onBack: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (!title.trim() || !content.trim()) return;
+    // POST is an upsert-by-title server-side; guard here so a human creating a
+    // new doc can't silently overwrite an existing one (incl. agent-maintained).
+    const collision = existingTitles.some((t) => t.toLowerCase() === title.trim().toLowerCase());
+    if (collision) {
+      setError('An artifact with this title already exists — open it to edit instead.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const result = await artifactsService.createArtifact(title.trim(), content);
+    setSaving(false);
+    if (result.success && result.id) {
+      onCreated(result.id);
+    } else {
+      setError(result.error || 'Failed to create artifact');
+    }
+  };
+
+  return (
+    <ChartPanel title="New artifact" subtitle="Create a living document">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saving || !title.trim() || !content.trim()}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-xs text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20 border border-green-500/20 transition-colors disabled:opacity-50"
+        >
+          <Save className="h-3 w-3" />
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Artifact title"
+        aria-label="Artifact title"
+        className="w-full mb-3 px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+      />
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Document content in markdown..."
+        className="w-full h-96 px-4 py-3 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-zinc-300 font-mono focus:outline-none focus:border-zinc-500 resize-y"
+      />
+      {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+    </ChartPanel>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail view
+// ---------------------------------------------------------------------------
+
+type DetailMode = 'view' | 'edit' | 'history';
+
+function ArtifactDetail({ id, onBack, onDeleted }: {
+  id: string;
+  onBack: () => void;
+  onDeleted: () => void;
+}) {
+  const [artifact, setArtifact] = useState<ArtifactData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [mode, setMode] = useState<DetailMode>('view');
+  const [editContent, setEditContent] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const [versions, setVersions] = useState<ArtifactVersion[]>([]);
+  const [currentVersionId, setCurrentVersionId] = useState<string | null>(null);
+  const [loadingVersions, setLoadingVersions] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const data = await artifactsService.getArtifact(id);
+    setArtifact(data);
+    if (data) setEditContent(data.content);
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const loadVersions = useCallback(async () => {
+    setLoadingVersions(true);
+    const { versions: list, currentVersionId: cvId } = await artifactsService.getVersions(id);
+    setVersions(list);
+    setCurrentVersionId(cvId);
+    setLoadingVersions(false);
+  }, [id]);
+
+  useEffect(() => {
+    if (mode === 'history') loadVersions();
+  }, [mode, loadVersions]);
+
+  const handleSave = async () => {
+    if (!editContent.trim()) return;
+    setSaving(true);
+    setError(null);
+    const result = await artifactsService.updateArtifact(id, editContent);
+    setSaving(false);
+    if (result.success) {
+      await load();
+      setMode('view');
+    } else {
+      setError(result.error || 'Failed to save');
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError(null);
+    const result = await artifactsService.deleteArtifact(id);
+    setDeleting(false);
+    if (!result.success) {
+      setConfirmingDelete(false);
+      setError(result.error || 'Failed to delete artifact');
+      return;
+    }
+    onDeleted();
+  };
+
+  const handleRestore = async (versionId: string) => {
+    const result = await artifactsService.restoreVersion(id, versionId);
+    if (result.success) {
+      await load();
+      await loadVersions();
+    } else {
+      setError(result.error || 'Failed to restore version');
+    }
+  };
+
+  const segBtn = (m: DetailMode, label: string, Icon: typeof Eye) => (
+    <button
+      onClick={() => setMode(m)}
+      className={`inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+        mode === m ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-400 hover:text-zinc-200'
+      }`}
+    >
+      <Icon className="h-3 w-3" />
+      {label}
+    </button>
+  );
+
+  return (
+    <ChartPanel title={artifact?.title ?? 'Artifact'} subtitle={artifact ? `Version ${artifact.version}` : undefined} loading={loading}>
+      <div className="flex items-center mb-4 gap-3">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </button>
+
+        <div className="flex items-center gap-1 bg-zinc-800/40 rounded-lg p-0.5 ml-auto">
+          {segBtn('view', 'View', Eye)}
+          {segBtn('edit', 'Edit', Edit2)}
+          {segBtn('history', 'History', History)}
+        </div>
+
+        <div className="flex items-center gap-1.5 shrink-0">
+          {confirmingDelete ? (
+            <>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 transition-colors disabled:opacity-50"
+              >
+                {deleting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                Confirm
+              </button>
+              <button
+                onClick={() => setConfirmingDelete(false)}
+                className="inline-flex items-center px-2 py-1 rounded text-[11px] text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => setConfirmingDelete(true)}
+              aria-label="Delete artifact"
+              className="p-1.5 rounded text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="text-xs text-red-400 mb-3">{error}</p>}
+
+      {!loading && !artifact && (
+        <EmptyState icon={BookOpen} message="Artifact not found" />
+      )}
+
+      {artifact && mode === 'view' && (
+        <div className="prose prose-invert prose-sm max-w-none">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={postmortemMarkdownComponents}>
+            {artifact.content}
+          </ReactMarkdown>
+        </div>
+      )}
+
+      {artifact && mode === 'edit' && (
+        <div>
+          <textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="w-full h-96 px-4 py-3 rounded-lg bg-zinc-900 border border-zinc-700 text-sm text-zinc-300 font-mono focus:outline-none focus:border-zinc-500 resize-y"
+            placeholder="Document content in markdown..."
+          />
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              onClick={handleSave}
+              disabled={saving || !editContent.trim()}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-xs text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20 border border-green-500/20 transition-colors disabled:opacity-50"
+            >
+              <Save className="h-3 w-3" />
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+            <button
+              onClick={() => { setEditContent(artifact.content); setMode('view'); }}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+            >
+              <X className="h-3 w-3" />
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {artifact && mode === 'history' && (
+        <div>
+          {loadingVersions ? (
+            <div className="flex items-center justify-center py-8 text-zinc-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </div>
+          ) : versions.length === 0 ? (
+            <p className="text-xs text-zinc-500 py-4">No version history available.</p>
+          ) : (
+            <div className="space-y-1 max-h-[28rem] overflow-y-auto">
+              {versions.map((v) => (
+                <div
+                  key={v.id}
+                  className="flex items-center justify-between py-2 px-3 rounded-md bg-zinc-800/40 border border-zinc-800 hover:border-zinc-700 transition-colors"
+                >
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/60 text-[10px] font-mono text-zinc-300">
+                      v{v.versionNumber}
+                    </span>
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/40 text-[10px] text-zinc-400 capitalize">
+                      {v.source}
+                    </span>
+                    <span className="text-[10px] text-zinc-500">
+                      {v.createdAt
+                        ? new Date(v.createdAt).toLocaleString(undefined, {
+                            month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+                          })
+                        : '—'}
+                    </span>
+                  </div>
+                  {v.id === currentVersionId ? (
+                    <span className="inline-flex items-center px-2 py-1 rounded-md text-[11px] text-green-400 bg-green-500/10 border border-green-500/20">
+                      Current
+                    </span>
+                  ) : (
+                    <button
+                      onClick={() => handleRestore(v.id)}
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 transition-colors"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Restore
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </ChartPanel>
+  );
+}

--- a/client/src/app/monitor/components/artifacts-tab.tsx
+++ b/client/src/app/monitor/components/artifacts-tab.tsx
@@ -23,7 +23,7 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function EditorBadge({ who }: { who: ArtifactEditor }) {
+function EditorBadge({ who }: Readonly<{ who: ArtifactEditor }>) {
   const isUser = who === 'user';
   return (
     <span
@@ -36,7 +36,7 @@ function EditorBadge({ who }: { who: ArtifactEditor }) {
   );
 }
 
-function ArtifactMarkdown({ content }: { content: string }) {
+function ArtifactMarkdown({ content }: Readonly<{ content: string }>) {
   return (
     <div className="prose prose-invert prose-sm max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={postmortemMarkdownComponents}>
@@ -44,6 +44,26 @@ function ArtifactMarkdown({ content }: { content: string }) {
       </ReactMarkdown>
     </div>
   );
+}
+
+function VersionContent({ loading, version }: Readonly<{
+  loading: boolean;
+  version: ArtifactVersionDetail | null | undefined;
+}>) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-4 text-zinc-500">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    );
+  }
+  if (version == null) {
+    return <p className="text-xs text-zinc-500">Couldn&apos;t load this version&apos;s content.</p>;
+  }
+  if (version.content.trim() === '') {
+    return <p className="text-xs text-zinc-500 italic">This version is empty.</p>;
+  }
+  return <ArtifactMarkdown content={version.content} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -176,11 +196,11 @@ export default function ArtifactsTab() {
 // Create view
 // ---------------------------------------------------------------------------
 
-function ArtifactCreate({ existingTitles, onBack, onCreated }: {
+function ArtifactCreate({ existingTitles, onBack, onCreated }: Readonly<{
   existingTitles: string[];
   onBack: () => void;
   onCreated: (id: string) => void;
-}) {
+}>) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [saving, setSaving] = useState(false);
@@ -251,11 +271,11 @@ function ArtifactCreate({ existingTitles, onBack, onCreated }: {
 
 type DetailMode = 'view' | 'edit' | 'history';
 
-function ArtifactDetail({ id, onBack, onDeleted }: {
+function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   id: string;
   onBack: () => void;
   onDeleted: () => void;
-}) {
+}>) {
   const [mode, setMode] = useState<DetailMode>('view');
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
@@ -498,17 +518,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
                     </div>
                     {isExpanded && (
                       <div className="border-t border-zinc-800 px-4 py-3">
-                        {loadingVersionContent ? (
-                          <div className="flex items-center justify-center py-4 text-zinc-500">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          </div>
-                        ) : expandedVersion == null ? (
-                          <p className="text-xs text-zinc-500">Couldn&apos;t load this version&apos;s content.</p>
-                        ) : expandedVersion.content.trim() === '' ? (
-                          <p className="text-xs text-zinc-500 italic">This version is empty.</p>
-                        ) : (
-                          <ArtifactMarkdown content={expandedVersion.content} />
-                        )}
+                        <VersionContent loading={loadingVersionContent} version={expandedVersion} />
                       </div>
                     )}
                   </div>

--- a/client/src/app/monitor/components/artifacts-tab.tsx
+++ b/client/src/app/monitor/components/artifacts-tab.tsx
@@ -71,7 +71,7 @@ function VersionContent({ loading, version }: Readonly<{
 // ---------------------------------------------------------------------------
 
 export default function ArtifactsTab() {
-  const { data, isLoading, mutate } = useQuery<{ artifacts: ArtifactSummary[] }>(
+  const { data, isLoading, mutate, error } = useQuery<{ artifacts: ArtifactSummary[] }>(
     '/api/artifacts', jsonFetcher, { staleTime: 15_000 },
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -81,6 +81,10 @@ export default function ArtifactsTab() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const artifacts = data?.artifacts ?? [];
+  // Only trust an empty list once the query has actually succeeded — otherwise a
+  // failed fetch would read as "no artifacts" and let the create flow's
+  // title-collision guard pass with an empty existingTitles set.
+  const loadFailed = !!error && !data;
 
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);
@@ -112,6 +116,20 @@ export default function ArtifactsTab() {
         onBack={() => { setSelectedId(null); mutate(); }}
         onDeleted={() => { setSelectedId(null); mutate(); }}
       />
+    );
+  }
+
+  // No data + an error: show an explicit failure (and withhold the create flow,
+  // whose overwrite guard would be unsafe without the real title list).
+  if (loadFailed) {
+    return (
+      <ChartPanel title="Artifacts" subtitle="Living documents Aurora maintains across runs">
+        <EmptyState
+          icon={BookOpen}
+          message="Couldn't load artifacts"
+          hint="Something went wrong fetching your artifacts. Refresh to try again."
+        />
+      </ChartPanel>
     );
   }
 
@@ -288,7 +306,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   const fetchVersions = () => artifactsService.getVersions(id);
 
   // Cached artifact body — re-opening the same artifact is served from cache.
-  const { data: artifact = null, isLoading: loading, mutate: reloadArtifact } = useQuery<ArtifactData | null>(
+  const { data: artifact = null, isLoading: loading, mutate: reloadArtifact, error: artifactError } = useQuery<ArtifactData | null>(
     `artifact:${id}`,
     () => artifactsService.getArtifact(id),
     { staleTime: 30_000, revalidateOnFocus: false },
@@ -298,6 +316,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   const { data: versionsData, isLoading: loadingVersions } = useQuery<{
     versions: ArtifactVersion[];
     currentVersionId: string | null;
+    error?: string;
   }>(
     mode === 'history' ? versionsKey : null,
     fetchVersions,
@@ -305,6 +324,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   );
   const versions = versionsData?.versions ?? [];
   const currentVersionId = versionsData?.currentVersionId ?? null;
+  const versionsError = versionsData?.error;
 
   // Expanded version body — fetched on expand, then cached per version so
   // re-expanding is instant.
@@ -427,7 +447,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
       {error && <p className="text-xs text-red-400 mb-3">{error}</p>}
 
       {!loading && !artifact && (
-        <EmptyState icon={BookOpen} message="Artifact not found" />
+        <EmptyState icon={BookOpen} message={artifactError ? "Couldn't load artifact" : 'Artifact not found'} />
       )}
 
       {artifact && mode === 'view' && (
@@ -469,7 +489,9 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
               <Loader2 className="h-4 w-4 animate-spin" />
             </div>
           ) : versions.length === 0 ? (
-            <p className="text-xs text-zinc-500 py-4">No version history available.</p>
+            <p className="text-xs text-zinc-500 py-4">
+              {versionsError ? "Couldn't load version history." : 'No version history available.'}
+            </p>
           ) : (
             <div className="space-y-1 max-h-[28rem] overflow-y-auto">
               {versions.map((v) => {

--- a/client/src/app/monitor/components/artifacts-tab.tsx
+++ b/client/src/app/monitor/components/artifacts-tab.tsx
@@ -4,9 +4,9 @@ import { useState, useEffect, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
-  BookOpen, Plus, ArrowLeft, Save, X, Trash2, History, Eye, Edit2, RotateCcw, Loader2,
+  BookOpen, Plus, ArrowLeft, Save, X, Trash2, History, Eye, Edit2, RotateCcw, Loader2, ChevronRight,
 } from 'lucide-react';
-import { useQuery, jsonFetcher } from '@/lib/query';
+import { useQuery, jsonFetcher, queryClient } from '@/lib/query';
 import { postmortemMarkdownComponents } from '@/lib/markdown-components';
 import { formatTimeAgo } from '@/lib/utils/time-format';
 import { ChartPanel, EmptyState } from './charts';
@@ -15,6 +15,7 @@ import {
   type ArtifactSummary,
   type ArtifactData,
   type ArtifactVersion,
+  type ArtifactVersionDetail,
   type ArtifactEditor,
 } from '@/lib/services/artifacts';
 
@@ -32,6 +33,16 @@ function EditorBadge({ who }: { who: ArtifactEditor }) {
     >
       {isUser ? 'You' : 'Agent'}
     </span>
+  );
+}
+
+function ArtifactMarkdown({ content }: { content: string }) {
+  return (
+    <div className="prose prose-invert prose-sm max-w-none">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={postmortemMarkdownComponents}>
+        {content}
+      </ReactMarkdown>
+    </div>
   );
 }
 
@@ -245,40 +256,51 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
   onBack: () => void;
   onDeleted: () => void;
 }) {
-  const [artifact, setArtifact] = useState<ArtifactData | null>(null);
-  const [loading, setLoading] = useState(true);
   const [mode, setMode] = useState<DetailMode>('view');
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [expandedVersionId, setExpandedVersionId] = useState<string | null>(null);
 
-  const [versions, setVersions] = useState<ArtifactVersion[]>([]);
-  const [currentVersionId, setCurrentVersionId] = useState<string | null>(null);
-  const [loadingVersions, setLoadingVersions] = useState(false);
+  const versionsKey = `artifact-versions:${id}`;
+  const fetchVersions = () => artifactsService.getVersions(id);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    const data = await artifactsService.getArtifact(id);
-    setArtifact(data);
-    if (data) setEditContent(data.content);
-    setLoading(false);
-  }, [id]);
+  // Cached artifact body — re-opening the same artifact is served from cache.
+  const { data: artifact = null, isLoading: loading, mutate: reloadArtifact } = useQuery<ArtifactData | null>(
+    `artifact:${id}`,
+    () => artifactsService.getArtifact(id),
+    { staleTime: 30_000, revalidateOnFocus: false },
+  );
 
-  useEffect(() => { load(); }, [load]);
+  // Version list — only fetched on the History tab, then cached across visits.
+  const { data: versionsData, isLoading: loadingVersions } = useQuery<{
+    versions: ArtifactVersion[];
+    currentVersionId: string | null;
+  }>(
+    mode === 'history' ? versionsKey : null,
+    fetchVersions,
+    { staleTime: 30_000, revalidateOnFocus: false },
+  );
+  const versions = versionsData?.versions ?? [];
+  const currentVersionId = versionsData?.currentVersionId ?? null;
 
-  const loadVersions = useCallback(async () => {
-    setLoadingVersions(true);
-    const { versions: list, currentVersionId: cvId } = await artifactsService.getVersions(id);
-    setVersions(list);
-    setCurrentVersionId(cvId);
-    setLoadingVersions(false);
-  }, [id]);
+  // Expanded version body — fetched on expand, then cached per version so
+  // re-expanding is instant.
+  const { data: expandedVersion, isLoading: loadingVersionContent } = useQuery<ArtifactVersionDetail | null>(
+    expandedVersionId ? `artifact-version:${id}:${expandedVersionId}` : null,
+    () => artifactsService.getVersion(id, expandedVersionId!),
+    { staleTime: 60_000, revalidateOnFocus: false },
+  );
 
+  // Seed the edit buffer from the loaded content. The functional update also
+  // seeds when the artifact resolves *after* the user already switched to Edit
+  // (otherwise the editor stays blank), while never clobbering an in-progress edit.
   useEffect(() => {
-    if (mode === 'history') loadVersions();
-  }, [mode, loadVersions]);
+    if (!artifact) return;
+    setEditContent((prev) => (mode === 'edit' && prev !== '' ? prev : artifact.content));
+  }, [artifact, mode]);
 
   const handleSave = async () => {
     if (!editContent.trim()) return;
@@ -287,7 +309,9 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
     const result = await artifactsService.updateArtifact(id, editContent);
     setSaving(false);
     if (result.success) {
-      await load();
+      await reloadArtifact();
+      // A save creates a new version — drop the stale version-list cache.
+      queryClient.invalidate(versionsKey, fetchVersions, { staleTime: 30_000 }).catch(() => {});
       setMode('view');
     } else {
       setError(result.error || 'Failed to save');
@@ -310,11 +334,15 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
   const handleRestore = async (versionId: string) => {
     const result = await artifactsService.restoreVersion(id, versionId);
     if (result.success) {
-      await load();
-      await loadVersions();
+      await reloadArtifact();
+      await queryClient.invalidate(versionsKey, fetchVersions, { staleTime: 30_000 });
     } else {
       setError(result.error || 'Failed to restore version');
     }
+  };
+
+  const toggleVersion = (versionId: string) => {
+    setExpandedVersionId((prev) => (prev === versionId ? null : versionId));
   };
 
   const segBtn = (m: DetailMode, label: string, Icon: typeof Eye) => (
@@ -383,11 +411,7 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
       )}
 
       {artifact && mode === 'view' && (
-        <div className="prose prose-invert prose-sm max-w-none">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={postmortemMarkdownComponents}>
-            {artifact.content}
-          </ReactMarkdown>
-        </div>
+        <ArtifactMarkdown content={artifact.content} />
       )}
 
       {artifact && mode === 'edit' && (
@@ -428,41 +452,68 @@ function ArtifactDetail({ id, onBack, onDeleted }: {
             <p className="text-xs text-zinc-500 py-4">No version history available.</p>
           ) : (
             <div className="space-y-1 max-h-[28rem] overflow-y-auto">
-              {versions.map((v) => (
-                <div
-                  key={v.id}
-                  className="flex items-center justify-between py-2 px-3 rounded-md bg-zinc-800/40 border border-zinc-800 hover:border-zinc-700 transition-colors"
-                >
-                  <div className="flex items-center gap-2.5 min-w-0">
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/60 text-[10px] font-mono text-zinc-300">
-                      v{v.versionNumber}
-                    </span>
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/40 text-[10px] text-zinc-400 capitalize">
-                      {v.source}
-                    </span>
-                    <span className="text-[10px] text-zinc-500">
-                      {v.createdAt
-                        ? new Date(v.createdAt).toLocaleString(undefined, {
-                            month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
-                          })
-                        : '—'}
-                    </span>
+              {versions.map((v) => {
+                const isExpanded = expandedVersionId === v.id;
+                return (
+                  <div
+                    key={v.id}
+                    className="rounded-md bg-zinc-800/40 border border-zinc-800 hover:border-zinc-700 transition-colors overflow-hidden"
+                  >
+                    <div className="flex items-center justify-between py-2 px-3 gap-2">
+                      <button
+                        onClick={() => toggleVersion(v.id)}
+                        aria-expanded={isExpanded}
+                        className="flex items-center gap-2.5 min-w-0 flex-1 text-left"
+                      >
+                        <ChevronRight
+                          className={`h-3.5 w-3.5 text-zinc-500 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                        />
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/60 text-[10px] font-mono text-zinc-300">
+                          v{v.versionNumber}
+                        </span>
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-zinc-700/40 text-[10px] text-zinc-400 capitalize">
+                          {v.source}
+                        </span>
+                        <span className="text-[10px] text-zinc-500">
+                          {v.createdAt
+                            ? new Date(v.createdAt).toLocaleString(undefined, {
+                                month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+                              })
+                            : '—'}
+                        </span>
+                      </button>
+                      {v.id === currentVersionId ? (
+                        <span className="inline-flex items-center px-2 py-1 rounded-md text-[11px] text-green-400 bg-green-500/10 border border-green-500/20 shrink-0">
+                          Current
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => handleRestore(v.id)}
+                          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 transition-colors shrink-0"
+                        >
+                          <RotateCcw className="h-3 w-3" />
+                          Restore
+                        </button>
+                      )}
+                    </div>
+                    {isExpanded && (
+                      <div className="border-t border-zinc-800 px-4 py-3">
+                        {loadingVersionContent ? (
+                          <div className="flex items-center justify-center py-4 text-zinc-500">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          </div>
+                        ) : expandedVersion == null ? (
+                          <p className="text-xs text-zinc-500">Couldn&apos;t load this version&apos;s content.</p>
+                        ) : expandedVersion.content.trim() === '' ? (
+                          <p className="text-xs text-zinc-500 italic">This version is empty.</p>
+                        ) : (
+                          <ArtifactMarkdown content={expandedVersion.content} />
+                        )}
+                      </div>
+                    )}
                   </div>
-                  {v.id === currentVersionId ? (
-                    <span className="inline-flex items-center px-2 py-1 rounded-md text-[11px] text-green-400 bg-green-500/10 border border-green-500/20">
-                      Current
-                    </span>
-                  ) : (
-                    <button
-                      onClick={() => handleRestore(v.id)}
-                      className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 transition-colors"
-                    >
-                      <RotateCcw className="h-3 w-3" />
-                      Restore
-                    </button>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/client/src/app/monitor/components/artifacts-tab.tsx
+++ b/client/src/app/monitor/components/artifacts-tab.tsx
@@ -313,10 +313,9 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   );
 
   // Version list — only fetched on the History tab, then cached across visits.
-  const { data: versionsData, isLoading: loadingVersions } = useQuery<{
+  const { data: versionsData, isLoading: loadingVersions, error: versionsError } = useQuery<{
     versions: ArtifactVersion[];
     currentVersionId: string | null;
-    error?: string;
   }>(
     mode === 'history' ? versionsKey : null,
     fetchVersions,
@@ -324,7 +323,6 @@ function ArtifactDetail({ id, onBack, onDeleted }: Readonly<{
   );
   const versions = versionsData?.versions ?? [];
   const currentVersionId = versionsData?.currentVersionId ?? null;
-  const versionsError = versionsData?.error;
 
   // Expanded version body — fetched on expand, then cached per version so
   // re-expanding is instant.

--- a/client/src/app/monitor/page.tsx
+++ b/client/src/app/monitor/page.tsx
@@ -1,19 +1,21 @@
 'use client';
 
 import { useState } from 'react';
-import { Radar, DollarSign, HeartPulse, Timer, ShieldCheck } from 'lucide-react';
+import { Radar, DollarSign, HeartPulse, Timer, ShieldCheck, BookOpen } from 'lucide-react';
 import { PeriodSelector, type Period } from './components/charts';
 import FleetTab from './components/fleet-tab';
 import UsageTab from './components/usage-tab';
 import SreTab from './components/sre-tab';
 import WaterfallTab from './components/waterfall-tab';
 import AuditTab from './components/audit-tab';
+import ArtifactsTab from './components/artifacts-tab';
 
 const TABS = [
   { id: 'fleet', label: 'Fleet', icon: Radar },
   { id: 'usage', label: 'Usage & Cost', icon: DollarSign },
   { id: 'sre', label: 'SRE Metrics', icon: HeartPulse },
   { id: 'waterfall', label: 'Execution', icon: Timer },
+  { id: 'artifacts', label: 'Artifacts', icon: BookOpen },
   { id: 'audit', label: 'Audit Log', icon: ShieldCheck },
 ] as const;
 
@@ -62,6 +64,7 @@ export default function MonitorPage() {
         {tab === 'usage' && <UsageTab period={period} />}
         {tab === 'sre' && <SreTab period={period} />}
         {tab === 'waterfall' && <WaterfallTab period={period} />}
+        {tab === 'artifacts' && <ArtifactsTab />}
         {tab === 'audit' && <AuditTab period={period} />}
       </div>
     </div>

--- a/client/src/lib/services/artifacts.ts
+++ b/client/src/lib/services/artifacts.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { apiGet, apiPost, apiRequest, type ApiError } from '@/lib/services/api-client';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ArtifactEditor = 'agent' | 'user';
+
+export interface ArtifactSummary {
+  id: string;
+  title: string;
+  version: number;
+  lastEditedBy: ArtifactEditor;
+  updatedAt: string | null;
+  createdAt: string | null;
+}
+
+export interface ArtifactData extends ArtifactSummary {
+  content: string;
+}
+
+export interface ArtifactVersion {
+  id: string;
+  versionNumber: number;
+  source: string;
+  userId: string;
+  createdAt: string | null;
+  generationSessionId: string | null;
+}
+
+export interface ArtifactVersionDetail extends ArtifactVersion {
+  content: string;
+}
+
+// ============================================================================
+// Service
+// ============================================================================
+
+export const artifactsService = {
+  async listArtifacts(): Promise<ArtifactSummary[]> {
+    try {
+      const data = await apiGet<{ artifacts: ArtifactSummary[] }>('/api/artifacts');
+      return data.artifacts ?? [];
+    } catch (error) {
+      console.error('Error fetching artifacts:', error);
+      return [];
+    }
+  },
+
+  async getArtifact(id: string): Promise<ArtifactData | null> {
+    try {
+      const data = await apiGet<{ artifact: ArtifactData }>(`/api/artifacts/${id}`);
+      return data.artifact ?? null;
+    } catch (error) {
+      if ((error as ApiError).status === 404) return null;
+      console.error('Error fetching artifact:', error);
+      return null;
+    }
+  },
+
+  async createArtifact(title: string, content: string): Promise<{ success: boolean; id?: string; error?: string }> {
+    try {
+      const data = await apiPost<{ id: string; version: number }>('/api/artifacts', { title, content });
+      return { success: true, id: data.id };
+    } catch (error) {
+      const apiErr = error as ApiError;
+      return { success: false, error: apiErr.message || 'Failed to create artifact' };
+    }
+  },
+
+  async updateArtifact(id: string, content: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      await apiRequest(`/api/artifacts/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ content }),
+      });
+      return { success: true };
+    } catch (error) {
+      const apiErr = error as ApiError;
+      return { success: false, error: apiErr.message || 'Failed to update artifact' };
+    }
+  },
+
+  async deleteArtifact(id: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      await apiRequest(`/api/artifacts/${id}`, { method: 'DELETE' });
+      return { success: true };
+    } catch (error) {
+      const apiErr = error as ApiError;
+      return { success: false, error: apiErr.message || 'Failed to delete artifact' };
+    }
+  },
+
+  async getVersions(id: string): Promise<{ versions: ArtifactVersion[]; currentVersionId: string | null; error?: string }> {
+    try {
+      const data = await apiGet<{ versions: ArtifactVersion[]; currentVersionId: string | null }>(
+        `/api/artifacts/${id}/versions`,
+      );
+      return { versions: data.versions ?? [], currentVersionId: data.currentVersionId ?? null };
+    } catch (error) {
+      const apiErr = error as ApiError;
+      return { versions: [], currentVersionId: null, error: apiErr.message || 'Failed to load versions' };
+    }
+  },
+
+  async getVersion(id: string, versionId: string): Promise<ArtifactVersionDetail | null> {
+    try {
+      const data = await apiGet<{ version: ArtifactVersionDetail }>(
+        `/api/artifacts/${id}/versions/${versionId}`,
+      );
+      return data.version ?? null;
+    } catch (error) {
+      console.error('Error fetching artifact version:', error);
+      return null;
+    }
+  },
+
+  async restoreVersion(id: string, versionId: string): Promise<{ success: boolean; content?: string; error?: string }> {
+    try {
+      const data = await apiPost<{ success: boolean; content: string }>(
+        `/api/artifacts/${id}/versions/${versionId}/restore`,
+      );
+      return { success: true, content: data.content };
+    } catch (error) {
+      const apiErr = error as ApiError;
+      return { success: false, error: apiErr.message || 'Failed to restore version' };
+    }
+  },
+};

--- a/client/src/lib/services/artifacts.ts
+++ b/client/src/lib/services/artifacts.ts
@@ -38,16 +38,6 @@ export interface ArtifactVersionDetail extends ArtifactVersion {
 // ============================================================================
 
 export const artifactsService = {
-  async listArtifacts(): Promise<ArtifactSummary[]> {
-    try {
-      const data = await apiGet<{ artifacts: ArtifactSummary[] }>('/api/artifacts');
-      return data.artifacts ?? [];
-    } catch (error) {
-      console.error('Error fetching artifacts:', error);
-      return [];
-    }
-  },
-
   async getArtifact(id: string): Promise<ArtifactData | null> {
     try {
       const data = await apiGet<{ artifact: ArtifactData }>(`/api/artifacts/${id}`);
@@ -93,15 +83,17 @@ export const artifactsService = {
     }
   },
 
-  async getVersions(id: string): Promise<{ versions: ArtifactVersion[]; currentVersionId: string | null; error?: string }> {
+  async getVersions(id: string): Promise<{ versions: ArtifactVersion[]; currentVersionId: string | null }> {
     try {
       const data = await apiGet<{ versions: ArtifactVersion[]; currentVersionId: string | null }>(
         `/api/artifacts/${id}/versions`,
       );
       return { versions: data.versions ?? [], currentVersionId: data.currentVersionId ?? null };
     } catch (error) {
-      const apiErr = error as ApiError;
-      return { versions: [], currentVersionId: null, error: apiErr.message || 'Failed to load versions' };
+      // Match getArtifact/getVersion: 404 = empty (no versions), re-throw the
+      // rest so the caller's useQuery error field drives a consistent error state.
+      if ((error as ApiError).status === 404) return { versions: [], currentVersionId: null };
+      throw error;
     }
   },
 
@@ -118,12 +110,12 @@ export const artifactsService = {
     }
   },
 
-  async restoreVersion(id: string, versionId: string): Promise<{ success: boolean; content?: string; error?: string }> {
+  async restoreVersion(id: string, versionId: string): Promise<{ success: boolean; error?: string }> {
     try {
-      const data = await apiPost<{ success: boolean; content: string }>(
-        `/api/artifacts/${id}/versions/${versionId}/restore`,
-      );
-      return { success: true, content: data.content };
+      // The caller refetches the artifact after a restore, so the response body
+      // is unused — only success/failure matters here.
+      await apiPost(`/api/artifacts/${id}/versions/${versionId}/restore`);
+      return { success: true };
     } catch (error) {
       const apiErr = error as ApiError;
       return { success: false, error: apiErr.message || 'Failed to restore version' };

--- a/client/src/lib/services/artifacts.ts
+++ b/client/src/lib/services/artifacts.ts
@@ -25,7 +25,6 @@ export interface ArtifactVersion {
   id: string;
   versionNumber: number;
   source: string;
-  userId: string;
   createdAt: string | null;
   generationSessionId: string | null;
 }
@@ -54,9 +53,10 @@ export const artifactsService = {
       const data = await apiGet<{ artifact: ArtifactData }>(`/api/artifacts/${id}`);
       return data.artifact ?? null;
     } catch (error) {
+      // 404 means "doesn't exist" (a valid empty state); surface everything else
+      // so the UI can show a real error instead of a misleading "not found".
       if ((error as ApiError).status === 404) return null;
-      console.error('Error fetching artifact:', error);
-      return null;
+      throw error;
     }
   },
 
@@ -112,8 +112,9 @@ export const artifactsService = {
       );
       return data.version ?? null;
     } catch (error) {
-      console.error('Error fetching artifact version:', error);
-      return null;
+      // 404 = version gone; surface other errors so the panel shows a failure.
+      if ((error as ApiError).status === 404) return null;
+      throw error;
     }
   },
 

--- a/server/aurora_mcp/dispatch.py
+++ b/server/aurora_mcp/dispatch.py
@@ -44,6 +44,8 @@ def _arg_schema(entry) -> List[Dict[str, Any]]:
         out.append({"name": a, "in": "path", "required": True})
     for a in entry.body_keys:
         out.append({"name": a, "in": "body", "required": False})
+    for a in getattr(entry, "query_keys", ()):
+        out.append({"name": a, "in": "query", "required": False})
     return out
 
 

--- a/server/aurora_mcp/registry.py
+++ b/server/aurora_mcp/registry.py
@@ -171,6 +171,9 @@ class DispatchEntry:
     body_keys: Tuple[str, ...] = ()
     # Args that must be substituted into the path (e.g. {issue_key}).
     path_args: Tuple[str, ...] = ()
+    # Query-string args to advertise in the tool schema so the LLM knows to
+    # pass them (forwarding already routes any non-body/non-path arg to query).
+    query_keys: Tuple[str, ...] = ()
 
 
 # Each entry maps a stable MCP-side name to an existing Aurora REST endpoint.
@@ -523,6 +526,33 @@ DISPATCH_ALLOWLIST: Tuple[DispatchEntry, ...] = (
         enabling_skills=("notion",),
         path_args=("incident_id",),
         body_keys=("databaseId", "titleProperty", "propertyMapping", "actionItemsDatabaseId"),
+    ),
+    # ----- Artifacts (Aurora-internal — no prefix; /api/artifacts) -----
+    DispatchEntry(
+        name="artifact_list",
+        description="List persistent markdown artifacts for this workspace.",
+        category="docs",
+        method="GET",
+        path="/api/artifacts",
+        enabling_skills=(),
+    ),
+    DispatchEntry(
+        name="artifact_read",
+        description="Read one artifact's full content by exact title (pass the `title` arg).",
+        category="docs",
+        method="GET",
+        path="/api/artifacts",
+        enabling_skills=(),
+        query_keys=("title",),
+    ),
+    DispatchEntry(
+        name="artifact_write",
+        description="Create or update a persistent markdown artifact by title.",
+        category="docs",
+        method="POST",
+        path="/api/artifacts",
+        enabling_skills=(),
+        body_keys=("title", "content"),
     ),
     # ----- Incidents — Aurora-internal reads and lifecycle writes -----
     DispatchEntry(

--- a/server/aurora_mcp/registry.py
+++ b/server/aurora_mcp/registry.py
@@ -22,6 +22,9 @@ from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Aurora-internal artifacts API base path, shared by the artifact_* dispatch entries.
+_ARTIFACTS_PATH = "/api/artifacts"
+
 
 # ---------------------------------------------------------------------------
 # Connector-status cache — populated via the Flask backend API by the MCP
@@ -533,7 +536,7 @@ DISPATCH_ALLOWLIST: Tuple[DispatchEntry, ...] = (
         description="List persistent markdown artifacts for this workspace.",
         category="docs",
         method="GET",
-        path="/api/artifacts",
+        path=_ARTIFACTS_PATH,
         enabling_skills=(),
     ),
     DispatchEntry(
@@ -541,7 +544,7 @@ DISPATCH_ALLOWLIST: Tuple[DispatchEntry, ...] = (
         description="Read one artifact's full content by exact title (pass the `title` arg).",
         category="docs",
         method="GET",
-        path="/api/artifacts",
+        path=_ARTIFACTS_PATH,
         enabling_skills=(),
         query_keys=("title",),
     ),
@@ -550,7 +553,7 @@ DISPATCH_ALLOWLIST: Tuple[DispatchEntry, ...] = (
         description="Create or update a persistent markdown artifact by title.",
         category="docs",
         method="POST",
-        path="/api/artifacts",
+        path=_ARTIFACTS_PATH,
         enabling_skills=(),
         body_keys=("title", "content"),
     ),

--- a/server/chat/backend/agent/tools/artifact_tool.py
+++ b/server/chat/backend/agent/tools/artifact_tool.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 _MAX_CONTENT = 100000
 _MAX_TITLE = 500
 
+_NO_USER_CTX = json.dumps({"error": "No user context available."})
+_NO_ORG_CTX = json.dumps({"error": "No organization context available."})
+
 
 class ListArtifactsArgs(BaseModel):
     """No args -- lists every artifact in the caller's workspace."""
@@ -38,7 +41,7 @@ class WriteArtifactArgs(BaseModel):
 def list_artifacts(user_id: str | None = None, **kwargs) -> str:
     """List artifact metadata (title, version, last editor, updated time) for the org."""
     if not user_id:
-        return json.dumps({"error": "No user context available."})
+        return _NO_USER_CTX
 
     try:
         from utils.db.connection_pool import db_pool
@@ -48,7 +51,7 @@ def list_artifacts(user_id: str | None = None, **kwargs) -> str:
             with conn.cursor() as cursor:
                 org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:list]")
                 if not org_id:
-                    return json.dumps({"error": "No organization context available."})
+                    return _NO_ORG_CTX
 
                 cursor.execute(
                     """SELECT a.title, a.last_edited_by, a.updated_at,
@@ -80,7 +83,7 @@ def list_artifacts(user_id: str | None = None, **kwargs) -> str:
 def read_artifact(title: str, user_id: str | None = None, **kwargs) -> str:
     """Read one artifact's full markdown by exact title, or report it doesn't exist."""
     if not user_id:
-        return json.dumps({"error": "No user context available."})
+        return _NO_USER_CTX
 
     if not title or not title.strip():
         return json.dumps({"error": "title is required."})
@@ -95,7 +98,7 @@ def read_artifact(title: str, user_id: str | None = None, **kwargs) -> str:
             with conn.cursor() as cursor:
                 org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:read]")
                 if not org_id:
-                    return json.dumps({"error": "No organization context available."})
+                    return _NO_ORG_CTX
 
                 cursor.execute(
                     """SELECT a.content, a.last_edited_by, a.updated_at,
@@ -135,7 +138,7 @@ def write_artifact(
 ) -> str:
     """Create or update an artifact by title, recording a new version each time."""
     if not user_id:
-        return json.dumps({"error": "No user context available."})
+        return _NO_USER_CTX
 
     if not title or not title.strip():
         return json.dumps({"error": "title is required."})
@@ -158,7 +161,7 @@ def write_artifact(
             with conn.cursor() as cursor:
                 org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:write]")
                 if not org_id:
-                    return json.dumps({"error": "No organization context available."})
+                    return _NO_ORG_CTX
 
                 _artifact_id, version = upsert_artifact_by_title(
                     cursor, org_id, user_id, title.strip(), content,

--- a/server/chat/backend/agent/tools/artifact_tool.py
+++ b/server/chat/backend/agent/tools/artifact_tool.py
@@ -1,0 +1,177 @@
+"""
+Artifact Tools
+
+Agent-callable tools for listing, reading, and writing persistent markdown
+documents (artifacts) that Aurora maintains over time. Available to every agent
+surface (chat, scheduled Actions, background RCA, MCP) via get_cloud_tools().
+
+Title-based — no UUIDs are ever exposed to the LLM. Each function resolves the
+caller's org via set_rls_context() so writes are scoped to the right tenant even
+outside a Flask request context (e.g. Celery action runs).
+"""
+
+import json
+import logging
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_MAX_CONTENT = 100000
+_MAX_TITLE = 500
+
+
+class ListArtifactsArgs(BaseModel):
+    """No args -- lists every artifact in the caller's workspace."""
+    pass
+
+
+class ReadArtifactArgs(BaseModel):
+    title: str = Field(description="The exact title of the artifact to read")
+
+
+class WriteArtifactArgs(BaseModel):
+    title: str = Field(description="The exact title of the artifact to create or update")
+    content: str = Field(description="The full markdown content of the document")
+
+
+def list_artifacts(user_id: str | None = None, **kwargs) -> str:
+    """List artifact metadata (title, version, last editor, updated time) for the org."""
+    if not user_id:
+        return json.dumps({"error": "No user context available."})
+
+    try:
+        from utils.db.connection_pool import db_pool
+        from utils.auth.stateless_auth import set_rls_context
+
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:list]")
+                if not org_id:
+                    return json.dumps({"error": "No organization context available."})
+
+                cursor.execute(
+                    """SELECT a.title, a.last_edited_by, a.updated_at,
+                              COALESCE(v.version_number, 0)
+                       FROM artifacts a
+                       LEFT JOIN artifact_versions v ON a.current_version_id = v.id
+                       WHERE a.org_id = %s
+                       ORDER BY a.updated_at DESC""",
+                    (org_id,),
+                )
+                rows = cursor.fetchall()
+
+        artifacts = [
+            {
+                "title": row[0],
+                "last_edited_by": row[1],
+                "updated_at": row[2].isoformat() if row[2] else None,
+                "version": row[3],
+            }
+            for row in rows
+        ]
+        return json.dumps({"status": "ok", "artifacts": artifacts})
+
+    except Exception:
+        logger.exception("[ArtifactTool] Failed to list artifacts")
+        return json.dumps({"error": "Failed to list artifacts."})
+
+
+def read_artifact(title: str, user_id: str | None = None, **kwargs) -> str:
+    """Read one artifact's full markdown by exact title, or report it doesn't exist."""
+    if not user_id:
+        return json.dumps({"error": "No user context available."})
+
+    if not title or not title.strip():
+        return json.dumps({"error": "title is required."})
+
+    title = title.strip()
+
+    try:
+        from utils.db.connection_pool import db_pool
+        from utils.auth.stateless_auth import set_rls_context
+
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:read]")
+                if not org_id:
+                    return json.dumps({"error": "No organization context available."})
+
+                cursor.execute(
+                    """SELECT a.content, a.last_edited_by, a.updated_at,
+                              COALESCE(v.version_number, 0)
+                       FROM artifacts a
+                       LEFT JOIN artifact_versions v ON a.current_version_id = v.id
+                       WHERE a.org_id = %s AND a.title = %s""",
+                    (org_id, title),
+                )
+                row = cursor.fetchone()
+
+        if not row:
+            return json.dumps({
+                "status": "not_found",
+                "message": "No artifact with that title exists.",
+            })
+
+        return json.dumps({
+            "status": "ok",
+            "content": row[0] or "",
+            "last_edited_by": row[1],
+            "updated_at": row[2].isoformat() if row[2] else None,
+            "version": row[3],
+        })
+
+    except Exception:
+        logger.exception("[ArtifactTool] Failed to read artifact")
+        return json.dumps({"error": "Failed to read artifact."})
+
+
+def write_artifact(
+    title: str,
+    content: str,
+    user_id: str | None = None,
+    session_id: str | None = None,
+    **kwargs,
+) -> str:
+    """Create or update an artifact by title, recording a new version each time."""
+    if not user_id:
+        return json.dumps({"error": "No user context available."})
+
+    if not title or not title.strip():
+        return json.dumps({"error": "title is required."})
+
+    if len(title.strip()) > _MAX_TITLE:
+        return json.dumps({"error": "Title exceeds maximum length (500 chars)."})
+
+    if not content or not content.strip():
+        return json.dumps({"error": "content cannot be empty."})
+
+    if len(content) > _MAX_CONTENT:
+        return json.dumps({"error": "Content exceeds maximum length (100000 chars)."})
+
+    try:
+        from utils.db.connection_pool import db_pool
+        from utils.auth.stateless_auth import set_rls_context
+        from services.artifacts.store import upsert_artifact_by_title
+
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[ArtifactTool:write]")
+                if not org_id:
+                    return json.dumps({"error": "No organization context available."})
+
+                _artifact_id, version = upsert_artifact_by_title(
+                    cursor, org_id, user_id, title.strip(), content,
+                    source="agent", session_id=session_id,
+                )
+                conn.commit()
+
+        return json.dumps({
+            "status": "ok",
+            "message": f"Artifact saved (version {version}).",
+            "version": version,
+        })
+
+    except Exception:
+        logger.exception("[ArtifactTool] Failed to write artifact")
+        return json.dumps({"error": "Failed to write artifact."})

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1640,9 +1640,11 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "runbook) — not for one-off chat answers. ALWAYS read the existing artifact "
                     "first and reconcile rather than regenerate: keep items the user edited or "
                     "added, remove findings that are now resolved or no longer reproduce, do not "
-                    "re-add anything the user deleted, and avoid duplicates. If the existing doc "
-                    "was last edited by the user, treat their version as authoritative and change "
-                    "it minimally."
+                    "re-add anything the user deleted, and avoid duplicates. Honor any "
+                    "user-maintained 'False positives', 'Suppressed', or 'Won't fix' section: "
+                    "preserve it verbatim and never re-report or re-add the items it lists, even "
+                    "if a fresh scan surfaces them again. If the existing doc was last edited by "
+                    "the user, treat their version as authoritative and change it minimally."
                 ),
                 args_schema=WriteArtifactArgs,
             )

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1371,6 +1371,18 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
     except ImportError:
         logger.warning("Postmortem tools not available — import failed")
 
+    # Artifacts: persistent markdown documents Aurora maintains across runs.
+    # Unconditional (no connector gating) so any agent surface — chat, scheduled
+    # Actions, background RCA, MCP — can list/read/write them. Steering lives
+    # entirely in the tool descriptions below; never in a system prompt.
+    try:
+        from .artifact_tool import list_artifacts, read_artifact, write_artifact
+        tool_functions.append((list_artifacts, "list_artifacts"))
+        tool_functions.append((read_artifact, "read_artifact"))
+        tool_functions.append((write_artifact, "write_artifact"))
+    except ImportError:
+        logger.warning("Artifact tools not available — import failed")
+
     # Process Aurora native tools
     for func, name in tool_functions:
         # For github_rca, inject the authoritative incident timestamp before any
@@ -1587,6 +1599,52 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "structured markdown (Summary, Timeline, Root Cause, Impact, etc.)."
                 ),
                 args_schema=SavePostmortemArgs,
+            )
+        elif name == 'list_artifacts':
+            from .artifact_tool import ListArtifactsArgs
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "List all persistent documents (artifacts) maintained for this workspace, "
+                    "with titles, versions, and last-updated times. Call this to discover what "
+                    "documents already exist before deciding whether to read, update, or create "
+                    "one — especially when instructions reference maintaining/updating a document "
+                    "but don't say it's new. Metadata only, not content."
+                ),
+                args_schema=ListArtifactsArgs,
+            )
+        elif name == 'read_artifact':
+            from .artifact_tool import ReadArtifactArgs
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Read the full current markdown of one artifact by exact title. Call after "
+                    "list_artifacts to get a document's current state — e.g. to see what you "
+                    "reported last run before producing an update, or to respect a user's edits. "
+                    "Returns content, version, and last-updated time, or that it doesn't exist."
+                ),
+                args_schema=ReadArtifactArgs,
+            )
+        elif name == 'write_artifact':
+            from .artifact_tool import WriteArtifactArgs
+            tool = StructuredTool.from_function(
+                func=final_func,
+                name=name,
+                description=(
+                    "Create or update a persistent markdown document by title. If the title "
+                    "exists, its content is replaced and a new version recorded; otherwise it's "
+                    "created. Use when instructions ask you to maintain/update/record findings in "
+                    "a document that persists across runs (a living findings list, cost report, "
+                    "runbook) — not for one-off chat answers. ALWAYS read the existing artifact "
+                    "first and reconcile rather than regenerate: keep items the user edited or "
+                    "added, remove findings that are now resolved or no longer reproduce, do not "
+                    "re-add anything the user deleted, and avoid duplicates. If the existing doc "
+                    "was last edited by the user, treat their version as authoritative and change "
+                    "it minimally."
+                ),
+                args_schema=WriteArtifactArgs,
             )
         elif name == 'list_slack_channels':
             from .slack_tool import ListSlackChannelsArgs

--- a/server/main_compute.py
+++ b/server/main_compute.py
@@ -513,6 +513,9 @@ app.register_blueprint(actions_bp, url_prefix="/api/actions")
 from routes.postmortem_routes import postmortem_bp
 app.register_blueprint(postmortem_bp)
 
+from routes.artifact_routes import artifact_bp
+app.register_blueprint(artifact_bp)
+
 # --- SRE Metrics Routes ---
 from routes.metrics_routes import metrics_bp
 app.register_blueprint(metrics_bp)

--- a/server/routes/artifact_routes.py
+++ b/server/routes/artifact_routes.py
@@ -128,7 +128,7 @@ def list_or_get_artifacts(user_id):
                     return jsonify({"artifact": _serialize_artifact(row, include_content=True)})
 
                 cursor.execute(
-                    """SELECT a.id, a.title, a.content, a.last_edited_by,
+                    """SELECT a.id, a.title, NULL, a.last_edited_by,
                               a.created_at, a.updated_at, COALESCE(v.version_number, 0)
                        FROM artifacts a
                        LEFT JOIN artifact_versions v ON a.current_version_id = v.id
@@ -261,7 +261,7 @@ def delete_artifact(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
 @with_artifact
 def list_artifact_versions(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
     cursor.execute(
-        """SELECT v.id, v.version_number, v.source, v.user_id, v.created_at,
+        """SELECT v.id, v.version_number, v.source, v.created_at,
                   v.generation_session_id, a.current_version_id
            FROM artifact_versions v
            JOIN artifacts a ON v.artifact_id = a.id
@@ -271,15 +271,14 @@ def list_artifact_versions(user_id, artifact_id, *, org_id, conn, cursor, **kwar
     )
     rows = cursor.fetchall()
 
-    current_version_id = str(rows[0][6]) if rows and rows[0][6] else None
+    current_version_id = str(rows[0][5]) if rows and rows[0][5] else None
     versions = [
         {
             "id": str(row[0]),
             "versionNumber": row[1],
             "source": row[2],
-            "userId": row[3],
-            "createdAt": _format_timestamp(row[4]),
-            "generationSessionId": str(row[5]) if row[5] else None,
+            "createdAt": _format_timestamp(row[3]),
+            "generationSessionId": str(row[4]) if row[4] else None,
         }
         for row in rows
     ]
@@ -294,7 +293,7 @@ def get_artifact_version(user_id, artifact_id, version_id, *, org_id, conn, curs
         return jsonify({"error": "Invalid version ID"}), 400
 
     cursor.execute(
-        """SELECT v.id, v.version_number, v.source, v.user_id, v.content, v.created_at
+        """SELECT v.id, v.version_number, v.source, v.content, v.created_at
            FROM artifact_versions v
            JOIN artifacts a ON v.artifact_id = a.id
            WHERE v.id = %s AND a.id = %s AND a.org_id = %s""",
@@ -309,9 +308,8 @@ def get_artifact_version(user_id, artifact_id, version_id, *, org_id, conn, curs
             "id": str(row[0]),
             "versionNumber": row[1],
             "source": row[2],
-            "userId": row[3],
-            "content": row[4],
-            "createdAt": _format_timestamp(row[5]),
+            "content": row[3],
+            "createdAt": _format_timestamp(row[4]),
         }
     })
 

--- a/server/routes/artifact_routes.py
+++ b/server/routes/artifact_routes.py
@@ -28,6 +28,7 @@ artifact_bp = Blueprint("artifact", __name__)
 _LOG_PREFIX = "[Artifact]"
 _MAX_CONTENT = 100000
 _MAX_TITLE = 500
+_ARTIFACT_NOT_FOUND = "Artifact not found"
 
 
 def _validate_uuid(value: str) -> bool:
@@ -87,14 +88,14 @@ def with_artifact(fn):
                         (artifact_id, org_id),
                     )
                     if not cursor.fetchone():
-                        return jsonify({"error": "Artifact not found"}), 404
+                        return jsonify({"error": _ARTIFACT_NOT_FOUND}), 404
 
                     return fn(
                         user_id, artifact_id, *args,
                         org_id=org_id, conn=conn, cursor=cursor, **kwargs,
                     )
-        except Exception as e:
-            logger.error("%s %s failed for artifact %s: %s", _LOG_PREFIX, fn.__name__, artifact_id, e)
+        except Exception:
+            logger.exception("%s %s failed for artifact %s", _LOG_PREFIX, fn.__name__, artifact_id)
             return jsonify({"error": f"Failed to {fn.__name__.replace('_', ' ')}"}), 500
 
     return wrapper
@@ -123,7 +124,7 @@ def list_or_get_artifacts(user_id):
                     )
                     row = cursor.fetchone()
                     if not row:
-                        return jsonify({"error": "Artifact not found"}), 404
+                        return jsonify({"error": _ARTIFACT_NOT_FOUND}), 404
                     return jsonify({"artifact": _serialize_artifact(row, include_content=True)})
 
                 cursor.execute(
@@ -140,8 +141,8 @@ def list_or_get_artifacts(user_id):
         artifacts = [_serialize_artifact(r, include_content=False) for r in rows]
         return jsonify({"artifacts": artifacts})
 
-    except Exception as e:
-        logger.error("%s Failed to list artifacts for user %s: %s", _LOG_PREFIX, user_id, e)
+    except Exception:
+        logger.exception("%s Failed to list artifacts for user %s", _LOG_PREFIX, user_id)
         return jsonify({"error": "Failed to fetch artifacts"}), 500
 
 
@@ -173,8 +174,8 @@ def create_artifact(user_id):
                     cursor, org_id, user_id, title, content, source="manual",
                 )
                 conn.commit()
-    except Exception as e:
-        logger.error("%s Failed to create artifact for user %s: %s", _LOG_PREFIX, user_id, e)
+    except Exception:
+        logger.exception("%s Failed to create artifact for user %s", _LOG_PREFIX, user_id)
         return jsonify({"error": "Failed to create artifact"}), 500
 
     record_audit_event(org_id, user_id, "create_artifact", "artifact", artifact_id,
@@ -196,7 +197,7 @@ def get_artifact(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
     )
     row = cursor.fetchone()
     if not row:
-        return jsonify({"error": "Artifact not found"}), 404
+        return jsonify({"error": _ARTIFACT_NOT_FOUND}), 404
     return jsonify({"artifact": _serialize_artifact(row, include_content=True)})
 
 

--- a/server/routes/artifact_routes.py
+++ b/server/routes/artifact_routes.py
@@ -1,0 +1,348 @@
+"""API routes for artifact CRUD, version history, and restore.
+
+Artifacts are persistent markdown documents Aurora maintains over time (living
+findings lists, cost reports, runbooks). The agent writes them by title via
+artifact_tool; this blueprint backs the Monitor → Artifacts UI and the MCP
+docs tools. Both write paths share services.artifacts.store so versioning
+never drifts between them.
+"""
+
+import logging
+from datetime import timezone
+from functools import wraps
+from typing import Optional
+from uuid import UUID
+
+import psycopg2.errors
+from flask import Blueprint, jsonify, request
+
+from routes.audit_routes import record_audit_event
+from services.artifacts.store import create_version, upsert_artifact_by_title
+from utils.auth.rbac_decorators import require_permission
+from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.db.connection_pool import db_pool
+
+logger = logging.getLogger(__name__)
+
+artifact_bp = Blueprint("artifact", __name__)
+_LOG_PREFIX = "[Artifact]"
+_MAX_CONTENT = 100000
+_MAX_TITLE = 500
+
+
+def _validate_uuid(value: str) -> bool:
+    try:
+        UUID(value)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _format_timestamp(ts) -> Optional[str]:
+    if not ts:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.isoformat()
+
+
+def _serialize_artifact(row, *, include_content: bool) -> dict:
+    """Build a camelCase artifact dict from a row of
+    (id, title, content, last_edited_by, created_at, updated_at, version_number).
+    """
+    data = {
+        "id": str(row[0]),
+        "title": row[1],
+        "lastEditedBy": row[3],
+        "createdAt": _format_timestamp(row[4]),
+        "updatedAt": _format_timestamp(row[5]),
+        "version": row[6] or 0,
+    }
+    if include_content:
+        data["content"] = row[2] or ""
+    return data
+
+
+def with_artifact(fn):
+    """Validate artifact_id, resolve org_id, open DB, set RLS, confirm the
+    artifact exists. Injects org_id, conn, cursor as keyword args. 404 if absent.
+    """
+    @wraps(fn)
+    def wrapper(user_id, artifact_id, *args, **kwargs):
+        if not _validate_uuid(artifact_id):
+            return jsonify({"error": "Invalid artifact ID"}), 400
+
+        org_id = get_org_id_from_request()
+
+        try:
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cursor:
+                    if set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX) is None:
+                        # Org couldn't be resolved → RLS unset → every query would
+                        # default-deny. Surface that rather than a misleading 404.
+                        return jsonify({"error": "Unable to resolve organization context"}), 500
+
+                    cursor.execute(
+                        "SELECT id FROM artifacts WHERE id = %s AND org_id = %s",
+                        (artifact_id, org_id),
+                    )
+                    if not cursor.fetchone():
+                        return jsonify({"error": "Artifact not found"}), 404
+
+                    return fn(
+                        user_id, artifact_id, *args,
+                        org_id=org_id, conn=conn, cursor=cursor, **kwargs,
+                    )
+        except Exception as e:
+            logger.error("%s %s failed for artifact %s: %s", _LOG_PREFIX, fn.__name__, artifact_id, e)
+            return jsonify({"error": f"Failed to {fn.__name__.replace('_', ' ')}"}), 500
+
+    return wrapper
+
+
+@artifact_bp.route("/api/artifacts", methods=["GET"])
+@require_permission("artifacts", "read")
+def list_or_get_artifacts(user_id):
+    """List artifacts (no ?title) or fetch one by exact title (?title=)."""
+    org_id = get_org_id_from_request()
+    title = request.args.get("title")
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
+
+                if title:
+                    cursor.execute(
+                        """SELECT a.id, a.title, a.content, a.last_edited_by,
+                                  a.created_at, a.updated_at, COALESCE(v.version_number, 0)
+                           FROM artifacts a
+                           LEFT JOIN artifact_versions v ON a.current_version_id = v.id
+                           WHERE a.org_id = %s AND a.title = %s""",
+                        (org_id, title.strip()),
+                    )
+                    row = cursor.fetchone()
+                    if not row:
+                        return jsonify({"error": "Artifact not found"}), 404
+                    return jsonify({"artifact": _serialize_artifact(row, include_content=True)})
+
+                cursor.execute(
+                    """SELECT a.id, a.title, a.content, a.last_edited_by,
+                              a.created_at, a.updated_at, COALESCE(v.version_number, 0)
+                       FROM artifacts a
+                       LEFT JOIN artifact_versions v ON a.current_version_id = v.id
+                       WHERE a.org_id = %s
+                       ORDER BY a.updated_at DESC""",
+                    (org_id,),
+                )
+                rows = cursor.fetchall()
+
+        artifacts = [_serialize_artifact(r, include_content=False) for r in rows]
+        return jsonify({"artifacts": artifacts})
+
+    except Exception as e:
+        logger.error("%s Failed to list artifacts for user %s: %s", _LOG_PREFIX, user_id, e)
+        return jsonify({"error": "Failed to fetch artifacts"}), 500
+
+
+@artifact_bp.route("/api/artifacts", methods=["POST"])
+@require_permission("artifacts", "write")
+def create_artifact(user_id):
+    """Create (or replace by title) an artifact from the UI / MCP. Marked as a
+    user edit so the agent treats it as human-authored."""
+    data = request.get_json(force=True, silent=True) or {}
+
+    title = (data.get("title") or "").strip()
+    content = data.get("content")
+    if not title:
+        return jsonify({"error": "Title is required"}), 400
+    if len(title) > _MAX_TITLE:
+        return jsonify({"error": f"Title exceeds maximum length of {_MAX_TITLE} characters"}), 400
+    if not isinstance(content, str) or not content.strip():
+        return jsonify({"error": "Content is required"}), 400
+    if len(content) > _MAX_CONTENT:
+        return jsonify({"error": f"Content exceeds maximum length of {_MAX_CONTENT} characters"}), 400
+
+    org_id = get_org_id_from_request()
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
+                artifact_id, version = upsert_artifact_by_title(
+                    cursor, org_id, user_id, title, content, source="manual",
+                )
+                conn.commit()
+    except Exception as e:
+        logger.error("%s Failed to create artifact for user %s: %s", _LOG_PREFIX, user_id, e)
+        return jsonify({"error": "Failed to create artifact"}), 500
+
+    record_audit_event(org_id, user_id, "create_artifact", "artifact", artifact_id,
+                       {"title": title}, request)
+    return jsonify({"id": artifact_id, "version": version}), 201
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>", methods=["GET"])
+@require_permission("artifacts", "read")
+@with_artifact
+def get_artifact(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
+    cursor.execute(
+        """SELECT a.id, a.title, a.content, a.last_edited_by,
+                  a.created_at, a.updated_at, COALESCE(v.version_number, 0)
+           FROM artifacts a
+           LEFT JOIN artifact_versions v ON a.current_version_id = v.id
+           WHERE a.id = %s AND a.org_id = %s""",
+        (artifact_id, org_id),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return jsonify({"error": "Artifact not found"}), 404
+    return jsonify({"artifact": _serialize_artifact(row, include_content=True)})
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>", methods=["PATCH"])
+@require_permission("artifacts", "write")
+@with_artifact
+def update_artifact(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
+    data = request.get_json(force=True, silent=True) or {}
+
+    content = data.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return jsonify({"error": "Content is required"}), 400
+    if len(content) > _MAX_CONTENT:
+        return jsonify({"error": f"Content exceeds maximum length of {_MAX_CONTENT} characters"}), 400
+
+    new_title = data.get("title")
+    new_title = new_title.strip() if isinstance(new_title, str) and new_title.strip() else None
+    if new_title and len(new_title) > _MAX_TITLE:
+        return jsonify({"error": f"Title exceeds maximum length of {_MAX_TITLE} characters"}), 400
+
+    # No pre-edit snapshot needed: the prior content is already the current
+    # version row, so create_version below records this edit as the new
+    # current version and the previous one remains restorable.
+    try:
+        cursor.execute(
+            """UPDATE artifacts
+               SET content = %s,
+                   title = COALESCE(%s, title),
+                   last_edited_by = 'user',
+                   user_id = %s,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE id = %s""",
+            (content, new_title, user_id, artifact_id),
+        )
+    except psycopg2.errors.UniqueViolation:
+        conn.rollback()
+        return jsonify({"error": "An artifact with that title already exists"}), 409
+
+    # New current version reflecting the manual edit.
+    version = create_version(cursor, artifact_id, org_id, user_id, content, source="manual")
+    conn.commit()
+
+    record_audit_event(org_id, user_id, "update_artifact", "artifact", artifact_id, {}, request)
+    return jsonify({"success": True, "version": version})
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>", methods=["DELETE"])
+@require_permission("artifacts", "write")
+@with_artifact
+def delete_artifact(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
+    # Versions cascade via the artifact_versions FK (ON DELETE CASCADE).
+    cursor.execute("DELETE FROM artifacts WHERE id = %s AND org_id = %s", (artifact_id, org_id))
+    conn.commit()
+
+    record_audit_event(org_id, user_id, "delete_artifact", "artifact", artifact_id, {}, request)
+    return jsonify({"success": True})
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>/versions", methods=["GET"])
+@require_permission("artifacts", "read")
+@with_artifact
+def list_artifact_versions(user_id, artifact_id, *, org_id, conn, cursor, **kwargs):
+    cursor.execute(
+        """SELECT v.id, v.version_number, v.source, v.user_id, v.created_at,
+                  v.generation_session_id, a.current_version_id
+           FROM artifact_versions v
+           JOIN artifacts a ON v.artifact_id = a.id
+           WHERE a.id = %s AND a.org_id = %s
+           ORDER BY v.version_number DESC""",
+        (artifact_id, org_id),
+    )
+    rows = cursor.fetchall()
+
+    current_version_id = str(rows[0][6]) if rows and rows[0][6] else None
+    versions = [
+        {
+            "id": str(row[0]),
+            "versionNumber": row[1],
+            "source": row[2],
+            "userId": row[3],
+            "createdAt": _format_timestamp(row[4]),
+            "generationSessionId": str(row[5]) if row[5] else None,
+        }
+        for row in rows
+    ]
+    return jsonify({"versions": versions, "currentVersionId": current_version_id})
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>/versions/<version_id>", methods=["GET"])
+@require_permission("artifacts", "read")
+@with_artifact
+def get_artifact_version(user_id, artifact_id, version_id, *, org_id, conn, cursor, **kwargs):
+    if not _validate_uuid(version_id):
+        return jsonify({"error": "Invalid version ID"}), 400
+
+    cursor.execute(
+        """SELECT v.id, v.version_number, v.source, v.user_id, v.content, v.created_at
+           FROM artifact_versions v
+           JOIN artifacts a ON v.artifact_id = a.id
+           WHERE v.id = %s AND a.id = %s AND a.org_id = %s""",
+        (version_id, artifact_id, org_id),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return jsonify({"error": "Version not found"}), 404
+
+    return jsonify({
+        "version": {
+            "id": str(row[0]),
+            "versionNumber": row[1],
+            "source": row[2],
+            "userId": row[3],
+            "content": row[4],
+            "createdAt": _format_timestamp(row[5]),
+        }
+    })
+
+
+@artifact_bp.route("/api/artifacts/<artifact_id>/versions/<version_id>/restore", methods=["POST"])
+@require_permission("artifacts", "write")
+@with_artifact
+def restore_artifact_version(user_id, artifact_id, version_id, *, org_id, conn, cursor, **kwargs):
+    if not _validate_uuid(version_id):
+        return jsonify({"error": "Invalid version ID"}), 400
+
+    cursor.execute(
+        """SELECT v.content
+           FROM artifact_versions v
+           JOIN artifacts a ON v.artifact_id = a.id
+           WHERE v.id = %s AND a.id = %s AND a.org_id = %s""",
+        (version_id, artifact_id, org_id),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return jsonify({"error": "Version not found"}), 404
+
+    restored_content = row[0]
+    cursor.execute(
+        """UPDATE artifacts
+           SET content = %s, current_version_id = %s,
+               last_edited_by = 'user', updated_at = CURRENT_TIMESTAMP
+           WHERE id = %s""",
+        (restored_content, version_id, artifact_id),
+    )
+    conn.commit()
+
+    record_audit_event(org_id, user_id, "restore_artifact_version", "artifact", artifact_id,
+                       {"version_id": version_id}, request)
+    return jsonify({"success": True, "content": restored_content})

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -173,20 +173,22 @@ def build_action_prompt(
     ]
 
     # Auto-maintain a living artifact for every action so results accumulate
-    # across runs without the user having to ask for it. Skip when the user
-    # already wrote their own artifact instructions — their steering wins.
-    if "artifact" not in action["instructions"].lower():
+    # across runs without the user having to ask for it. Skip when the user's
+    # own instructions already steer a persistent doc — their steering wins.
+    # ("artifact" also matches read_artifact / write_artifact mentions.)
+    instructions_lc = action["instructions"].lower()
+    user_steers_doc = any(
+        kw in instructions_lc
+        for kw in ("artifact", "living document", "living doc", "persist across runs")
+    )
+    if not user_steers_doc:
         title = action["name"]
         parts += [
             "",
             "## Maintain a Living Document",
-            f'Keep a persistent Aurora artifact titled "{title}" so this Action\'s results '
-            "accumulate across runs instead of being lost in chat.",
-            f'- First call read_artifact with title "{title}" to load the prior version, then '
-            f'write_artifact with that same exact title.',
-            "- Reconcile rather than regenerate: add new findings, remove anything now resolved, "
-            "keep items the user edited or added, and never re-add anything the user deleted or "
-            'listed under a "False positives" / "Won\'t fix" section.',
+            f'Keep a persistent Aurora artifact titled "{title}" so this Action\'s results accumulate across runs instead of being lost in chat.',
+            f'- First call read_artifact with title "{title}" to load the prior version, then write_artifact with that same exact title.',
+            '- Reconcile rather than regenerate: add new findings, remove anything now resolved, keep items the user edited or added, and never re-add anything the user deleted or listed under a "False positives" / "Won\'t fix" section.',
             "- If there is nothing new to record, leave the document unchanged.",
         ]
 

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -172,6 +172,24 @@ def build_action_prompt(
         "- Report what you did and any issues encountered.",
     ]
 
+    # Auto-maintain a living artifact for every action so results accumulate
+    # across runs without the user having to ask for it. Skip when the user
+    # already wrote their own artifact instructions — their steering wins.
+    if "artifact" not in action["instructions"].lower():
+        title = action["name"]
+        parts += [
+            "",
+            "## Maintain a Living Document",
+            f'Keep a persistent Aurora artifact titled "{title}" so this Action\'s results '
+            "accumulate across runs instead of being lost in chat.",
+            f'- First call read_artifact with title "{title}" to load the prior version, then '
+            f'write_artifact with that same exact title.',
+            "- Reconcile rather than regenerate: add new findings, remove anything now resolved, "
+            "keep items the user edited or added, and never re-add anything the user deleted or "
+            'listed under a "False positives" / "Won\'t fix" section.',
+            "- If there is nothing new to record, leave the document unchanged.",
+        ]
+
     return "\n".join(parts), rail_text
 
 

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -172,25 +172,19 @@ def build_action_prompt(
         "- Report what you did and any issues encountered.",
     ]
 
-    # Auto-maintain a living artifact for every action so results accumulate
-    # across runs without the user having to ask for it. Skip when the user's
-    # own instructions already steer a persistent doc — their steering wins.
-    # ("artifact" also matches read_artifact / write_artifact mentions.)
-    instructions_lc = action["instructions"].lower()
-    user_steers_doc = any(
-        kw in instructions_lc
-        for kw in ("artifact", "living document", "living doc", "persist across runs")
-    )
-    if not user_steers_doc:
-        title = action["name"]
-        parts += [
-            "",
-            "## Maintain a Living Document",
-            f'Keep a persistent Aurora artifact titled "{title}" so this Action\'s results accumulate across runs instead of being lost in chat.',
-            f'- First call read_artifact with title "{title}" to load the prior version, then write_artifact with that same exact title.',
-            '- Reconcile rather than regenerate: add new findings, remove anything now resolved, keep items the user edited or added, and never re-add anything the user deleted or listed under a "False positives" / "Won\'t fix" section.',
-            "- If there is nothing new to record, leave the document unchanged.",
-        ]
+    # Auto-maintain a living artifact on every action so results accumulate
+    # across runs without the user having to ask for it. Always applied; if the
+    # user's instructions already name a document to keep, the agent reuses that
+    # title instead of the default below (handled in prose, not by parsing).
+    title = action["name"]
+    parts += [
+        "",
+        "## Maintain a Living Document",
+        f'Keep a persistent Aurora artifact so this Action\'s results accumulate across runs instead of being lost in chat. Title it "{title}", unless your instructions above already name a specific document to maintain — then use that title.',
+        "- First read_artifact to load the prior version, then write_artifact with that same exact title every run.",
+        '- Reconcile rather than regenerate: add new findings, remove anything now resolved, keep items the user edited or added, and never re-add anything the user deleted or listed under a "False positives" / "Won\'t fix" section.',
+        "- If there is nothing new to record, leave the document unchanged.",
+    ]
 
     return "\n".join(parts), rail_text
 

--- a/server/services/artifacts/store.py
+++ b/server/services/artifacts/store.py
@@ -23,9 +23,14 @@ def create_version(
     """Insert a new version row for an artifact and return its number.
 
     The next version number is computed inline via a subquery (MAX+1) at insert
-    time, matching the postmortem versioning pattern. When set_current=True
-    (default), also advances the artifact's current_version_id pointer.
+    time. The artifact row is locked FOR UPDATE first so concurrent writers to
+    the same artifact serialize here and can't both read the same MAX and
+    collide on version_number. When set_current=True (default), also advances
+    the artifact's current_version_id pointer.
     """
+    # Serialize concurrent version allocation for this artifact (see docstring).
+    cursor.execute("SELECT id FROM artifacts WHERE id = %s FOR UPDATE", (artifact_id,))
+
     cursor.execute(
         """INSERT INTO artifact_versions
            (artifact_id, org_id, user_id, content, version_number, source, generation_session_id)

--- a/server/services/artifacts/store.py
+++ b/server/services/artifacts/store.py
@@ -1,0 +1,87 @@
+"""Shared artifact persistence helpers.
+
+Flask-free so the agent tool (title-based) and the REST routes (id + title)
+share identical upsert + versioning logic, avoiding version-bump drift between
+the two write paths. Every function operates on a caller-supplied cursor — the
+caller owns the connection, RLS context, and commit/rollback.
+"""
+
+from typing import Optional, Tuple
+
+
+def create_version(
+    cursor,
+    artifact_id: str,
+    org_id: str,
+    user_id: str,
+    content: str,
+    *,
+    source: str,
+    session_id: Optional[str] = None,
+    set_current: bool = True,
+) -> int:
+    """Insert a new version row for an artifact and return its number.
+
+    The next version number is computed inline via a subquery (MAX+1) at insert
+    time, matching the postmortem versioning pattern. When set_current=True
+    (default), also advances the artifact's current_version_id pointer.
+    """
+    cursor.execute(
+        """INSERT INTO artifact_versions
+           (artifact_id, org_id, user_id, content, version_number, source, generation_session_id)
+           VALUES (%s, %s, %s, %s,
+                   (SELECT COALESCE(MAX(version_number), 0) + 1
+                    FROM artifact_versions WHERE artifact_id = %s),
+                   %s, %s)
+           RETURNING id, version_number""",
+        (artifact_id, org_id, user_id, content, artifact_id, source, session_id),
+    )
+    row = cursor.fetchone()
+    version_id, version_number = row[0], row[1]
+    if set_current:
+        cursor.execute(
+            "UPDATE artifacts SET current_version_id = %s WHERE id = %s",
+            (str(version_id), artifact_id),
+        )
+    return version_number
+
+
+def upsert_artifact_by_title(
+    cursor,
+    org_id: str,
+    user_id: str,
+    title: str,
+    content: str,
+    *,
+    source: str,
+    session_id: Optional[str] = None,
+) -> Tuple[str, int]:
+    """Create or replace an artifact addressed by (org_id, title) and version it.
+
+    Relies on the unique index idx_artifacts_org_title for an atomic upsert.
+    last_edited_by is derived from source: a 'manual' write came from a human
+    (the UI), anything else from the agent. Returns (artifact_id, version_number).
+    """
+    last_edited_by = "user" if source == "manual" else "agent"
+
+    cursor.execute(
+        """INSERT INTO artifacts (org_id, user_id, title, content, last_edited_by, updated_at)
+           VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
+           ON CONFLICT (org_id, title)
+           DO UPDATE SET content = EXCLUDED.content,
+                         user_id = EXCLUDED.user_id,
+                         last_edited_by = EXCLUDED.last_edited_by,
+                         updated_at = CURRENT_TIMESTAMP
+           RETURNING id""",
+        (org_id, user_id, title, content, last_edited_by),
+    )
+    row = cursor.fetchone()
+    if not row:
+        raise RuntimeError("Artifact upsert failed — access denied or conflict.")
+    artifact_id = str(row[0])
+
+    version_number = create_version(
+        cursor, artifact_id, org_id, user_id, content,
+        source=source, session_id=session_id, set_current=True,
+    )
+    return artifact_id, version_number

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -32,6 +32,7 @@ _DEFAULT_POLICIES = [
     # --- viewer permissions (read-only) ---
     ("viewer", "*", "incidents", "read"),
     ("viewer", "*", "postmortems", "read"),
+    ("viewer", "*", "artifacts", "read"),
     ("viewer", "*", "dashboards", "read"),
     ("viewer", "*", "connectors", "read"),
     ("viewer", "*", "chat", "read"),
@@ -50,6 +51,7 @@ _DEFAULT_POLICIES = [
     ("editor", "*", "connectors", "write"),
     ("editor", "*", "incidents", "write"),
     ("editor", "*", "postmortems", "write"),
+    ("editor", "*", "artifacts", "write"),
     ("editor", "*", "knowledge_base", "write"),
     ("editor", "*", "ssh_keys", "write"),
     ("editor", "*", "vms", "write"),

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1238,6 +1238,38 @@ def initialize_tables():
                     CREATE UNIQUE INDEX IF NOT EXISTS postmortems_incident_id_unique ON postmortems(incident_id);
                     CREATE INDEX IF NOT EXISTS idx_postmortems_user_id ON postmortems(user_id);
                 """,
+                "artifacts": """
+                    CREATE TABLE IF NOT EXISTS artifacts (
+                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        org_id VARCHAR(255) NOT NULL,
+                        user_id VARCHAR(255) NOT NULL,
+                        title VARCHAR(500) NOT NULL,
+                        content TEXT,
+                        last_edited_by VARCHAR(20) NOT NULL DEFAULT 'agent',
+                        current_version_id UUID,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_org_title ON artifacts(org_id, title);
+                """,
+                "artifact_versions": """
+                    CREATE TABLE IF NOT EXISTS artifact_versions (
+                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        artifact_id UUID NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+                        org_id VARCHAR(255) NOT NULL,
+                        user_id VARCHAR(255) NOT NULL,
+                        content TEXT NOT NULL,
+                        version_number INTEGER NOT NULL DEFAULT 1,
+                        source VARCHAR(50) NOT NULL DEFAULT 'agent',
+                        generation_session_id VARCHAR(255),
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_artifact_versions_artifact
+                        ON artifact_versions(artifact_id, version_number DESC);
+                    CREATE INDEX IF NOT EXISTS idx_artifact_versions_org ON artifact_versions(org_id);
+                """,
                 "incident_lifecycle_events": """
                     CREATE TABLE IF NOT EXISTS incident_lifecycle_events (
                         id SERIAL PRIMARY KEY,
@@ -1413,6 +1445,8 @@ def initialize_tables():
             rls_tables.append("actions")
             rls_tables.append("action_runs")
             rls_tables.append("postmortem_versions")
+            rls_tables.append("artifacts")
+            rls_tables.append("artifact_versions")
 
 
             # Migration: Add rca_celery_task_id column to incidents table if it doesn't exist

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -1266,7 +1266,7 @@ def initialize_tables():
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     );
 
-                    CREATE INDEX IF NOT EXISTS idx_artifact_versions_artifact
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_artifact_versions_artifact
                         ON artifact_versions(artifact_id, version_number DESC);
                     CREATE INDEX IF NOT EXISTS idx_artifact_versions_org ON artifact_versions(org_id);
                 """,


### PR DESCRIPTION
## Summary

Adds **Artifacts** — living markdown documents Aurora maintains across runs (findings lists, cost reports, runbooks), surfaced in a new **Monitor → Artifacts** tab. Scheduled Actions and chat create/update them through agent tools; users can view, edit, and browse version history in the UI.

## Backend

- `artifacts` + `artifact_versions` tables with per-org RLS policies
- Shared, Flask-free store helper for title-based upsert + versioning (reused by REST routes and agent tools so they never drift)
- REST routes: CRUD, version history, and restore — RBAC-gated (`artifacts` read/write)
- Agent tools (list / read / write) on the cloud toolbelt, plus MCP dispatch exposure
- Discoverability is via tool descriptions only — nothing added to any system prompt

## Frontend

- Artifacts tab: master/detail with View / Edit / History modes, plus create and delete
- Expandable per-version dropdown to read exactly what each version wrote
- Detail and history reads cached via `useQuery` — re-opening an artifact and re-expanding a version are served from cache instead of refetching

## Testing

- REST CRUD full cycle; cross-org access returns 403
- Agent tools end-to-end, including same-title re-write producing a version bump (proves cross-run persistence)
- Architectural RBAC tests pass; `tsc` and ESLint clean for the changed frontend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent markdown artifacts: create, view, edit, delete, per-version viewing, and restore from history.
  * Artifacts tab in Monitor with creation UI, edit/history modes, title-collision blocking, and per-item delete confirmation.
  * Client-side service and API routes for listing, fetching, creating, updating, deleting, versioning, and restoring artifacts.
  * Agent-accessible artifact tools and registry integration for programmatic list/read/write operations.

* **Chores**
  * Database schema, row-level security, and RBAC updates to support tenant-scoped artifact storage and versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->