### PR TITLE
fix(gate): fall back to registry defaults when org has no seeded permissions

### DIFF
--- a/server/utils/auth/command_gate.py
+++ b/server/utils/auth/command_gate.py
@@ -174,18 +174,25 @@ def _maybe_refresh_permitted_tools(state) -> None:
     try:
         from utils.cache.redis_client import get_redis_client
         rc = get_redis_client()
-        if not rc:
-            return
         org_id = getattr(state, "org_id", None)
         if not org_id:
             return
+
         version_key = f"tool_perms_version:{org_id}"
-        current_version = rc.get(version_key)
-        if not current_version:
+        current_version = rc.get(version_key) if rc else None
+
+        if current_version:
+            cached_version = getattr(state, "_perms_version", None)
+            if cached_version == current_version:
+                return
+
+        # No Redis version means permissions were never seeded via the UI.
+        # Still load from DB (may have been seeded manually), and if empty,
+        # fall back to TOOL_REGISTRY defaults so background actions work
+        # without requiring a Security Settings visit.
+        if getattr(state, "permitted_tools", None) is not None and not current_version:
             return
-        cached_version = getattr(state, "_perms_version", None)
-        if cached_version == current_version:
-            return
+
         from utils.db.connection_pool import db_pool
         from utils.auth.stateless_auth import set_rls_context
         user_id = getattr(state, "user_id", None)
@@ -198,8 +205,14 @@ def _maybe_refresh_permitted_tools(state) -> None:
                     "SELECT tool_key FROM org_tool_permissions WHERE org_id = %s AND enabled = true",
                     (org_id,),
                 )
-                state.permitted_tools = {row[0] for row in cur.fetchall()}
-        state._perms_version = current_version
+                rows = cur.fetchall()
+                if rows:
+                    state.permitted_tools = {row[0] for row in rows}
+                else:
+                    from utils.auth.tool_registry import get_default_enabled_tools
+                    state.permitted_tools = get_default_enabled_tools()
+        if current_version:
+            state._perms_version = current_version
     except Exception as e:
         logger.debug("Could not refresh tool permissions: %s", e)
         state.permitted_tools = None


### PR DESCRIPTION
## Summary

- When an org has never visited Security Settings, the `org_tool_permissions` table is empty and no Redis version key exists for them.
- `_maybe_refresh_permitted_tools` previously returned early when no Redis version key was found, leaving `permitted_tools = None`, which caused `_is_org_tool_permitted` to return `False`.
- This blocked all destructive MCP tools (GitHub branch/file/PR creation) in background mode, producing "MCP tool X cancelled by user" errors for actions.
- 21 out of 32 production orgs were affected (empty `org_tool_permissions`).
- Fix: load permissions from DB even without a Redis version key, and fall back to `TOOL_REGISTRY` defaults if the DB is also empty. This matches what the UI displays.

## Test plan

- [ ] Verify a background action using destructive MCP tools succeeds for an org that has never visited Security Settings
- [ ] Verify an org that HAS explicitly disabled a tool via Security Settings still has it blocked
- [ ] Verify no redundant DB queries on every tool call (the `permitted_tools is not None` guard prevents repeated loads)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the tool permissions system with enhanced fallback handling and more resilient caching logic, enabling better reliability for background operations and scenarios where certain infrastructure components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->