### PR TITLE
fix: enforce seat limits in admin create_user route

### DIFF
--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -123,6 +123,15 @@ def create_user(user_id):
                     (org_id, target_email),
                 )
 
+                from utils.hooks import get_hook
+                cur.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (org_id,))
+                _cnt = cur.fetchone()[0]
+                cur.execute("SELECT COUNT(*) FROM org_invitations WHERE org_id = %s AND status = 'pending'", (org_id,))
+                _cnt += cur.fetchone()[0]
+                allowed, msg = get_hook("before_add_member")(org_id, _cnt)
+                if not allowed:
+                    return jsonify({"error": msg or "Seat limit reached"}), 403
+
                 invitation_id = str(_uuid.uuid4())
                 expires_at = datetime.now(timezone.utc) + timedelta(days=7)
 

--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -162,7 +162,6 @@ def create_user(user_id):
             _cnt += cur.fetchone()[0]
             allowed, msg = get_hook("before_add_member")(org_id, _cnt)
             if not allowed:
-                conn.close()
                 return jsonify({"error": msg or "Seat limit reached"}), 403
 
             password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")

--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -155,6 +155,16 @@ def create_user(user_id):
             if len(password) < 8:
                 return jsonify({"error": "Password must be at least 8 characters"}), 400
 
+            from utils.hooks import get_hook
+            cur.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (org_id,))
+            _cnt = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM org_invitations WHERE org_id = %s AND status = 'pending'", (org_id,))
+            _cnt += cur.fetchone()[0]
+            allowed, msg = get_hook("before_add_member")(org_id, _cnt)
+            if not allowed:
+                conn.close()
+                return jsonify({"error": msg or "Seat limit reached"}), 403
+
             password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
             try:

--- a/server/routes/org_routes.py
+++ b/server/routes/org_routes.py
@@ -849,6 +849,15 @@ def join_org(user_id):
                         conn.commit()
                     return jsonify({"error": "You are already a member of this organization"}), 409
 
+                from utils.hooks import get_hook
+                cursor.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (new_org_id,))
+                _cnt = cursor.fetchone()[0]
+                cursor.execute("SELECT COUNT(*) FROM org_invitations WHERE org_id = %s AND status = 'pending'", (new_org_id,))
+                _cnt += cursor.fetchone()[0]
+                allowed, msg = get_hook("before_add_member")(new_org_id, _cnt)
+                if not allowed:
+                    return jsonify({"error": msg or "Seat limit reached"}), 403
+
                 set_rls_context(cursor, conn, user_id, log_prefix="[OrgJoin]")
                 _transfer_user_to_org(cursor, user_id, old_org_id, new_org_id, new_role)
 

--- a/server/routes/org_routes.py
+++ b/server/routes/org_routes.py
@@ -853,7 +853,11 @@ def join_org(user_id):
                 from utils.hooks import get_hook
                 cursor.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (new_org_id,))
                 _cnt = cursor.fetchone()[0]
-                cursor.execute("SELECT COUNT(*) FROM org_invitations WHERE org_id = %s AND status = 'pending'", (new_org_id,))
+                cursor.execute(
+                    """SELECT COUNT(*) FROM org_invitations
+                       WHERE org_id = %s AND status = 'pending' AND id IS DISTINCT FROM %s""",
+                    (new_org_id, invitation_id),
+                )
                 _cnt += cursor.fetchone()[0]
                 allowed, msg = get_hook("before_add_member")(new_org_id, _cnt)
                 if not allowed:

--- a/server/routes/org_routes.py
+++ b/server/routes/org_routes.py
@@ -849,6 +849,7 @@ def join_org(user_id):
                         conn.commit()
                     return jsonify({"error": "You are already a member of this organization"}), 409
 
+                # Best-effort seat enforcement (not serialised — concurrent requests can overshoot by 1)
                 from utils.hooks import get_hook
                 cursor.execute("SELECT COUNT(*) FROM users WHERE org_id = %s", (new_org_id,))
                 _cnt = cursor.fetchone()[0]


### PR DESCRIPTION
## Summary
- The `before_add_member` hook from #474 was only wired into `org_routes.py` (add_member + create_invitation)
- The admin panel uses `admin_routes.py:create_user()` which bypassed the seat check entirely
- Adds the same hook check before the INSERT in create_user

## Test plan
- Try adding a member via admin panel when at seat limit — should get 403
- Adding members under the limit should still work

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seat limit enforcement when admins create new users or invitations.
  * Seat limit enforcement when users move to a different organization.
  * Limit checks include current members and pending invitations; displays "Seat limit reached" (or a provided message) when denied.
  * Best-effort enforcement for org joins; concurrent requests may temporarily exceed the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->