### PR TITLE
fix: always load Casbin policy from DB to prevent stale role cache across gunicorn workers

### DIFF
--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -14,7 +14,7 @@ import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.enforcer import get_enforcer
+from utils.auth.enforcer import get_enforcer, increment_policy_version
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.db.db_utils import connect_to_db_as_user
 from utils.log_sanitizer import sanitize
@@ -279,6 +279,7 @@ def assign_role(user_id, target_user_id):
         enforcer.add_grouping_policy(target_user_id, role)
 
     enforcer.save_policy()
+    increment_policy_version()
 
     # Keep the convenience column in sync
     conn = connect_to_db_as_user()
@@ -328,6 +329,7 @@ def revoke_role(user_id, target_user_id, role):
             enforcer.add_grouping_policy(target_user_id, "viewer")
 
     enforcer.save_policy()
+    increment_policy_version()
 
     if org_id:
         fallback_role = (enforcer.get_roles_for_user_in_domain(target_user_id, org_id) or ["viewer"])[0]
@@ -400,6 +402,7 @@ def delete_user(user_id, target_user_id):
             for r in roles:
                 enforcer.remove_grouping_policy(target_user_id, r)
         enforcer.save_policy()
+        increment_policy_version()
     except Exception as casbin_err:
         logger.warning("Failed to clean up Casbin policies for deleted user %s: %s",
                         target_user_id, casbin_err)

--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -14,7 +14,7 @@ import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.enforcer import get_enforcer, increment_policy_version
+from utils.auth.enforcer import get_enforcer, increment_policy_version, reload_if_stale
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.db.db_utils import connect_to_db_as_user
 from utils.log_sanitizer import sanitize
@@ -232,6 +232,7 @@ def get_user_roles(user_id, target_user_id):
     finally:
         conn.close()
 
+    reload_if_stale()
     enforcer = get_enforcer()
     if org_id:
         roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
@@ -253,7 +254,6 @@ def assign_role(user_id, target_user_id):
     if role not in VALID_ROLES:
         return jsonify({"error": f"Invalid role. Must be one of: {', '.join(sorted(VALID_ROLES))}"}), 400
 
-    enforcer = get_enforcer()
     org_id = get_org_id_from_request()
 
     conn = connect_to_db_as_user()
@@ -266,7 +266,9 @@ def assign_role(user_id, target_user_id):
     finally:
         conn.close()
 
-    # Remove any existing role assignments for this user
+    reload_if_stale()
+    enforcer = get_enforcer()
+
     if org_id:
         current_roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
         for old_role in current_roles:
@@ -304,7 +306,6 @@ def revoke_role(user_id, target_user_id, role):
     if role not in VALID_ROLES:
         return jsonify({"error": f"Invalid role. Must be one of: {', '.join(sorted(VALID_ROLES))}"}), 400
 
-    enforcer = get_enforcer()
     org_id = get_org_id_from_request()
 
     conn = connect_to_db_as_user()
@@ -316,6 +317,9 @@ def revoke_role(user_id, target_user_id, role):
                 return jsonify({"error": "Target user not found in this organization"}), 404
     finally:
         conn.close()
+
+    reload_if_stale()
+    enforcer = get_enforcer()
 
     if org_id:
         enforcer.remove_grouping_policy(target_user_id, role, org_id)
@@ -392,6 +396,7 @@ def delete_user(user_id, target_user_id):
         conn.close()
 
     try:
+        reload_if_stale()
         enforcer = get_enforcer()
         if org_id:
             roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)

--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -14,7 +14,15 @@ import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.enforcer import get_enforcer, increment_policy_version, reload_if_stale
+from utils.auth.enforcer import (
+    assign_role_to_user,
+    get_enforcer,
+    get_user_roles_in_org,
+    increment_policy_version,
+    reload_if_stale,
+    remove_role_from_user,
+    revoke_role_from_user,
+)
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.db.db_utils import connect_to_db_as_user
 from utils.log_sanitizer import sanitize
@@ -232,11 +240,11 @@ def get_user_roles(user_id, target_user_id):
     finally:
         conn.close()
 
-    reload_if_stale()
-    enforcer = get_enforcer()
     if org_id:
-        roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
+        roles = get_user_roles_in_org(target_user_id, org_id)
     else:
+        reload_if_stale()
+        enforcer = get_enforcer()
         roles = enforcer.get_roles_for_user(target_user_id)
     return jsonify({"user_id": target_user_id, "roles": roles}), 200
 
@@ -266,22 +274,17 @@ def assign_role(user_id, target_user_id):
     finally:
         conn.close()
 
-    reload_if_stale()
-    enforcer = get_enforcer()
-
     if org_id:
-        current_roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
-        for old_role in current_roles:
-            enforcer.remove_grouping_policy(target_user_id, old_role, org_id)
-        enforcer.add_grouping_policy(target_user_id, role, org_id)
+        assign_role_to_user(target_user_id, role, org_id)
     else:
+        reload_if_stale()
+        enforcer = get_enforcer()
         current_roles = enforcer.get_roles_for_user(target_user_id)
         for old_role in current_roles:
             enforcer.remove_grouping_policy(target_user_id, old_role)
         enforcer.add_grouping_policy(target_user_id, role)
-
-    enforcer.save_policy()
-    increment_policy_version()
+        enforcer.save_policy()
+        increment_policy_version()
 
     # Keep the convenience column in sync
     conn = connect_to_db_as_user()
@@ -318,26 +321,17 @@ def revoke_role(user_id, target_user_id, role):
     finally:
         conn.close()
 
-    reload_if_stale()
-    enforcer = get_enforcer()
-
     if org_id:
-        enforcer.remove_grouping_policy(target_user_id, role, org_id)
-        remaining = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
-        if not remaining:
-            enforcer.add_grouping_policy(target_user_id, "viewer", org_id)
+        fallback_role = revoke_role_from_user(target_user_id, role, org_id)
     else:
+        reload_if_stale()
+        enforcer = get_enforcer()
         enforcer.remove_grouping_policy(target_user_id, role)
         remaining = enforcer.get_roles_for_user(target_user_id)
         if not remaining:
             enforcer.add_grouping_policy(target_user_id, "viewer")
-
-    enforcer.save_policy()
-    increment_policy_version()
-
-    if org_id:
-        fallback_role = (enforcer.get_roles_for_user_in_domain(target_user_id, org_id) or ["viewer"])[0]
-    else:
+        enforcer.save_policy()
+        increment_policy_version()
         fallback_role = (enforcer.get_roles_for_user(target_user_id) or ["viewer"])[0]
 
     conn = connect_to_db_as_user()
@@ -396,18 +390,18 @@ def delete_user(user_id, target_user_id):
         conn.close()
 
     try:
-        reload_if_stale()
-        enforcer = get_enforcer()
         if org_id:
-            roles = enforcer.get_roles_for_user_in_domain(target_user_id, org_id)
+            roles = get_user_roles_in_org(target_user_id, org_id)
             for r in roles:
-                enforcer.remove_grouping_policy(target_user_id, r, org_id)
+                remove_role_from_user(target_user_id, r, org_id)
         else:
+            reload_if_stale()
+            enforcer = get_enforcer()
             roles = enforcer.get_roles_for_user(target_user_id)
             for r in roles:
                 enforcer.remove_grouping_policy(target_user_id, r)
-        enforcer.save_policy()
-        increment_policy_version()
+            enforcer.save_policy()
+            increment_policy_version()
     except Exception as casbin_err:
         logger.warning("Failed to clean up Casbin policies for deleted user %s: %s",
                         target_user_id, casbin_err)

--- a/server/routes/admin_routes.py
+++ b/server/routes/admin_routes.py
@@ -14,7 +14,7 @@ import uuid as _uuid
 from datetime import datetime, timedelta, timezone
 
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.enforcer import get_enforcer, reload_policies
+from utils.auth.enforcer import get_enforcer
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.db.db_utils import connect_to_db_as_user
 from utils.log_sanitizer import sanitize
@@ -279,7 +279,6 @@ def assign_role(user_id, target_user_id):
         enforcer.add_grouping_policy(target_user_id, role)
 
     enforcer.save_policy()
-    reload_policies()
 
     # Keep the convenience column in sync
     conn = connect_to_db_as_user()
@@ -329,7 +328,6 @@ def revoke_role(user_id, target_user_id, role):
             enforcer.add_grouping_policy(target_user_id, "viewer")
 
     enforcer.save_policy()
-    reload_policies()
 
     if org_id:
         fallback_role = (enforcer.get_roles_for_user_in_domain(target_user_id, org_id) or ["viewer"])[0]
@@ -402,7 +400,6 @@ def delete_user(user_id, target_user_id):
             for r in roles:
                 enforcer.remove_grouping_policy(target_user_id, r)
         enforcer.save_policy()
-        reload_policies()
     except Exception as casbin_err:
         logger.warning("Failed to clean up Casbin policies for deleted user %s: %s",
                         target_user_id, casbin_err)

--- a/server/tests/auth/test_enforcer.py
+++ b/server/tests/auth/test_enforcer.py
@@ -165,7 +165,6 @@ class TestDomainMatch:
     def domain_match(self, monkeypatch):
         """Run ``get_enforcer`` and return the domain matcher closure it registers."""
         monkeypatch.setattr(enforcer_module, "_enforcer", None)
-        monkeypatch.setattr(enforcer_module, "_last_reload", 0.0)
 
         fake = MagicMock(name="casbin_enforcer")
         fake.get_policy.return_value = []

--- a/server/tests/auth/test_enforcer.py
+++ b/server/tests/auth/test_enforcer.py
@@ -5,12 +5,12 @@ escalation) and the per-org domain matcher (so policies scoped to one
 org can't leak across tenants).
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from utils.auth import enforcer as enforcer_module
-from utils.auth.enforcer import assign_role_to_user, enforce_with_reload
+from utils.auth.enforcer import assign_role_to_user
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/auth/test_enforcer.py
+++ b/server/tests/auth/test_enforcer.py
@@ -5,12 +5,12 @@ escalation) and the per-org domain matcher (so policies scoped to one
 org can't leak across tenants).
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from utils.auth import enforcer as enforcer_module
-from utils.auth.enforcer import assign_role_to_user
+from utils.auth.enforcer import assign_role_to_user, enforce_with_reload
 
 
 # ---------------------------------------------------------------------------
@@ -24,6 +24,7 @@ def fake_enforcer(monkeypatch):
     fake = MagicMock(name="casbin_enforcer")
     fake.get_roles_for_user_in_domain.return_value = []
     monkeypatch.setattr(enforcer_module, "get_enforcer", lambda: fake)
+    monkeypatch.setattr(enforcer_module, "get_redis_client", lambda: None)
     return fake
 
 

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -186,16 +186,9 @@ def get_enforcer() -> casbin.Enforcer:
         return _enforcer
 
 
-def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -> bool:
-    """Enforce a permission check, reloading policy only when the Redis version
-    counter indicates another worker has written changes.
-
-    Falls back to always-reload when Redis is unavailable (correctness over
-    performance).
-    """
+def reload_if_stale() -> None:
+    """Reload policy from DB if the Redis version counter indicates staleness."""
     global _cached_version
-    enforcer = get_enforcer()
-
     try:
         redis_client = get_redis_client()
         version = (redis_client.get(POLICY_VERSION_KEY) or "0") if redis_client else None
@@ -210,10 +203,20 @@ def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -
             except Exception:
                 version = None
             if version is None or version != _cached_version:
-                enforcer.load_policy()
+                get_enforcer().load_policy()
                 _cached_version = version
+
+
+def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -> bool:
+    """Enforce a permission check, reloading policy only when the Redis version
+    counter indicates another worker has written changes.
+
+    Falls back to always-reload when Redis is unavailable (correctness over
+    performance).
+    """
+    reload_if_stale()
     with _lock:
-        return enforcer.enforce(user_id, org_id, resource, action)
+        return get_enforcer().enforce(user_id, org_id, resource, action)
 
 
 def increment_policy_version() -> None:
@@ -229,6 +232,7 @@ def increment_policy_version() -> None:
 def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:
     """Replace all roles for a user in an org with a single new role."""
     with _lock:
+        reload_if_stale()
         enforcer = get_enforcer()
         current_roles = enforcer.get_roles_for_user_in_domain(user_id, org_id)
         for old_role in current_roles:
@@ -255,5 +259,6 @@ def remove_role_from_user(user_id: str, role: str, org_id: str) -> None:
 
 def get_user_roles_in_org(user_id: str, org_id: str) -> list[str]:
     """Get all roles assigned to a user in a specific org."""
+    reload_if_stale()
     enforcer = get_enforcer()
     return enforcer.get_roles_for_user_in_domain(user_id, org_id)

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -15,6 +15,7 @@ import threading
 
 import casbin
 from casbin_sqlalchemy_adapter import Adapter
+from sqlalchemy import create_engine
 
 from utils.log_sanitizer import sanitize
 
@@ -22,8 +23,6 @@ logger = logging.getLogger(__name__)
 
 _enforcer: casbin.Enforcer | None = None
 _lock = threading.RLock()
-_last_reload: float = 0.0
-_RELOAD_INTERVAL = 300.0
 
 # Default permission policies seeded on first run.
 # Format: (role, domain, resource, action)
@@ -150,21 +149,9 @@ def _seed_default_policies(enforcer: casbin.Enforcer) -> None:
 
 
 def get_enforcer() -> casbin.Enforcer:
-    """Return the module-level Casbin enforcer, creating it on first call.
-
-    Periodically reloads policies from the DB (every 5 min) as a safety net
-    for role revocations.  For role *grants*, callers should use
-    ``enforce_with_reload`` which reloads on deny for instant propagation.
-    """
-    global _enforcer, _last_reload
+    """Return the module-level Casbin enforcer, creating it on first call."""
+    global _enforcer
     if _enforcer is not None:
-        import time
-        now = time.monotonic()
-        if now - _last_reload > _RELOAD_INTERVAL:
-            with _lock:
-                if now - _last_reload > _RELOAD_INTERVAL:
-                    _enforcer.load_policy()
-                    _last_reload = now
         return _enforcer
 
     with _lock:
@@ -175,55 +162,36 @@ def get_enforcer() -> casbin.Enforcer:
         model_path = _model_path()
         logger.info("Initialising Casbin enforcer (model=%s)", model_path)
 
-        adapter = Adapter(db_url)
+        engine = create_engine(
+            db_url,
+            pool_pre_ping=True,
+            pool_recycle=300,
+        )
+        adapter = Adapter(engine)
         _enforcer = casbin.Enforcer(model_path, adapter)
 
         def _domain_match(key1: str, key2: str) -> bool:
-            """Match org (domain) in Casbin grouping policies.
-
-            Supports exact match and wildcard ``*`` (used for policies that
-            apply across all organisations, e.g. the built-in role definitions).
-            """
             return key1 == key2 or key2 == "*"
 
         _enforcer.add_named_domain_matching_func("g", _domain_match)
 
         _seed_default_policies(_enforcer)
         _enforcer.load_policy()
-        import time
-        _last_reload = time.monotonic()
 
         logger.info("Casbin enforcer ready.")
         return _enforcer
 
 
 def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -> bool:
-    """Enforce a permission check, reloading from DB on first denial.
+    """Enforce a permission check, always loading fresh policy from the DB.
 
-    Handles the common case where a role was just granted: the in-memory
-    cache says deny, but the DB says allow.  One reload + retry keeps
-    the hot path fast (no DB hit) while making grants take effect instantly.
+    Ensures every check reflects the current state of the casbin_rule table,
+    eliminating stale-cache issues across multiple workers.
     """
     enforcer = get_enforcer()
-    if enforcer.enforce(user_id, org_id, resource, action):
-        return True
-    reload_policies()
-    return enforcer.enforce(user_id, org_id, resource, action)
-
-
-def reload_policies() -> None:
-    """Reload all policies from the database into memory.
-
-    Call this after any admin mutation (role assign / revoke) so that the
-    in-process enforcer cache stays current.
-
-    Thread-safe: acquires _lock so concurrent reloads cannot corrupt the
-    enforcer's in-memory policy cache.
-    """
     with _lock:
-        enforcer = get_enforcer()
         enforcer.load_policy()
-        logger.info("Casbin policies reloaded from database.")
+        return enforcer.enforce(user_id, org_id, resource, action)
 
 
 def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -219,10 +219,11 @@ def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -
 def increment_policy_version() -> None:
     """Bump the Redis policy version counter so other workers know to reload."""
     global _cached_version
-    redis_client = get_redis_client()
-    if redis_client:
-        new_version = str(redis_client.incr(POLICY_VERSION_KEY))
-        _cached_version = new_version
+    with _lock:
+        redis_client = get_redis_client()
+        if redis_client:
+            new_version = str(redis_client.incr(POLICY_VERSION_KEY))
+            _cached_version = new_version
 
 
 def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -241,7 +241,6 @@ def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:
         if role not in current_roles:
             enforcer.add_grouping_policy(user_id, role, org_id)
         enforcer.save_policy()
-        enforcer.load_policy()
     increment_policy_version()
     logger.info("Assigned role %s to user %s in org %s (replaced: %s)", sanitize(role), sanitize(user_id), sanitize(org_id), current_roles)
 
@@ -249,10 +248,10 @@ def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:
 def remove_role_from_user(user_id: str, role: str, org_id: str) -> None:
     """Remove a role from a user within an org (domain)."""
     with _lock:
+        reload_if_stale()
         enforcer = get_enforcer()
         enforcer.remove_grouping_policy(user_id, role, org_id)
         enforcer.save_policy()
-        enforcer.load_policy()
     increment_policy_version()
     logger.info("Removed role %s from user %s in org %s", sanitize(role), sanitize(user_id), sanitize(org_id))
 
@@ -260,5 +259,28 @@ def remove_role_from_user(user_id: str, role: str, org_id: str) -> None:
 def get_user_roles_in_org(user_id: str, org_id: str) -> list[str]:
     """Get all roles assigned to a user in a specific org."""
     reload_if_stale()
-    enforcer = get_enforcer()
-    return enforcer.get_roles_for_user_in_domain(user_id, org_id)
+    with _lock:
+        enforcer = get_enforcer()
+        return enforcer.get_roles_for_user_in_domain(user_id, org_id)
+
+
+def revoke_role_from_user(user_id: str, role: str, org_id: str, fallback: str = "viewer") -> str:
+    """Revoke a specific role from a user in an org, assigning fallback if none remain.
+
+    Returns the user's effective role after the revocation.
+    """
+    with _lock:
+        reload_if_stale()
+        enforcer = get_enforcer()
+        enforcer.remove_grouping_policy(user_id, role, org_id)
+        remaining = enforcer.get_roles_for_user_in_domain(user_id, org_id)
+        if not remaining:
+            enforcer.add_grouping_policy(user_id, fallback, org_id)
+            effective_role = fallback
+        else:
+            effective_role = remaining[0]
+        enforcer.save_policy()
+    increment_policy_version()
+    logger.info("Revoked role %s from user %s in org %s (now: %s)",
+                sanitize(role), sanitize(user_id), sanitize(org_id), sanitize(effective_role))
+    return effective_role

--- a/server/utils/auth/enforcer.py
+++ b/server/utils/auth/enforcer.py
@@ -17,12 +17,16 @@ import casbin
 from casbin_sqlalchemy_adapter import Adapter
 from sqlalchemy import create_engine
 
+from utils.cache.redis_client import get_redis_client
 from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
 
 _enforcer: casbin.Enforcer | None = None
 _lock = threading.RLock()
+
+POLICY_VERSION_KEY = "casbin:policy_version"
+_cached_version: str | None = None
 
 # Default permission policies seeded on first run.
 # Format: (role, domain, resource, action)
@@ -183,15 +187,42 @@ def get_enforcer() -> casbin.Enforcer:
 
 
 def enforce_with_reload(user_id: str, org_id: str, resource: str, action: str) -> bool:
-    """Enforce a permission check, always loading fresh policy from the DB.
+    """Enforce a permission check, reloading policy only when the Redis version
+    counter indicates another worker has written changes.
 
-    Ensures every check reflects the current state of the casbin_rule table,
-    eliminating stale-cache issues across multiple workers.
+    Falls back to always-reload when Redis is unavailable (correctness over
+    performance).
     """
+    global _cached_version
     enforcer = get_enforcer()
+
+    try:
+        redis_client = get_redis_client()
+        version = (redis_client.get(POLICY_VERSION_KEY) or "0") if redis_client else None
+    except Exception:
+        version = None
+
+    if version is None or version != _cached_version:
+        with _lock:
+            try:
+                redis_client = get_redis_client()
+                version = (redis_client.get(POLICY_VERSION_KEY) or "0") if redis_client else None
+            except Exception:
+                version = None
+            if version is None or version != _cached_version:
+                enforcer.load_policy()
+                _cached_version = version
     with _lock:
-        enforcer.load_policy()
         return enforcer.enforce(user_id, org_id, resource, action)
+
+
+def increment_policy_version() -> None:
+    """Bump the Redis policy version counter so other workers know to reload."""
+    global _cached_version
+    redis_client = get_redis_client()
+    if redis_client:
+        new_version = str(redis_client.incr(POLICY_VERSION_KEY))
+        _cached_version = new_version
 
 
 def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:
@@ -206,6 +237,7 @@ def assign_role_to_user(user_id: str, role: str, org_id: str) -> None:
             enforcer.add_grouping_policy(user_id, role, org_id)
         enforcer.save_policy()
         enforcer.load_policy()
+    increment_policy_version()
     logger.info("Assigned role %s to user %s in org %s (replaced: %s)", sanitize(role), sanitize(user_id), sanitize(org_id), current_roles)
 
 
@@ -216,6 +248,7 @@ def remove_role_from_user(user_id: str, role: str, org_id: str) -> None:
         enforcer.remove_grouping_policy(user_id, role, org_id)
         enforcer.save_policy()
         enforcer.load_policy()
+    increment_policy_version()
     logger.info("Removed role %s from user %s in org %s", sanitize(role), sanitize(user_id), sanitize(org_id))
 
 


### PR DESCRIPTION
Load policy from DB on every permission check to eliminate stale RBAC cache across gunicorn workers, so that a gunicorn worker never get a stale cache
Check for db state every time a role is changed and refresh if necessary
Remove time-based reload interval and reload_policies() helper (no longer needed)
Pass SQLAlchemy engine with connection pooling to Casbin adapter instead of raw URL
Remove reload_policies() calls from admin routes (assign/revoke/delete)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authorization enforcer initialization centralized; policy loading now coordinates a shared version check so all workers observe consistent permission state.

* **Bug Fixes**
  * Role and user permission changes now update a shared policy version to propagate updates reliably across workers and avoid stale enforcement.
  * Permission checks now verify freshness before evaluating access, improving immediate consistency.

* **Tests**
  * Authorization tests and fixtures updated to align with the new versioned policy and initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->