### PR TITLE
fix(mcp): remove broken JSON truncation from tool responses

### DIFF
--- a/server/aurora_mcp/response.py
+++ b/server/aurora_mcp/response.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-def truncate_payload(payload: Any, *, tool_name: str = "mcp") -> Dict[str, Any]:
+def truncate_payload(payload: Any, **_kwargs: Any) -> Dict[str, Any]:
     """Guarantee a dict return shape for MCP tool responses.
 
     MCP tools are declared with a `Dict[str, Any]` return type. FastMCP
@@ -39,11 +39,10 @@ def paginate(
 
 
 def wrap_listing(
-    items: List[Any], *, cursor: Optional[str] = None, limit: int = 20, tool_name: str = "mcp"
+    items: List[Any], *, cursor: Optional[str] = None, limit: int = 20,
 ) -> Dict[str, Any]:
     """Standard envelope for list-returning tools: {items, next_cursor, total}."""
     page, next_cursor = paginate(items, cursor=cursor, limit=limit)
     return truncate_payload(
         {"items": page, "next_cursor": next_cursor, "total": len(items)},
-        tool_name=tool_name,
     )

--- a/server/aurora_mcp/response.py
+++ b/server/aurora_mcp/response.py
@@ -1,22 +1,12 @@
-"""Shared response helpers for MCP tools.
-
-Wraps `utils.tool_output_cap` so list-returning tools enforce the 15k-token
-cap consistently, plus a small cursor-paginate helper.
-"""
+"""Shared response helpers for MCP tools."""
 
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-
-# Roughly 15k tokens at 4 chars/token; aligned with PASS_THROUGH_CHARS in
-# chat.backend.agent.utils.tool_output_cap (40_000 chars ≈ 10–12k tokens; we
-# go slightly higher because MCP doesn't run an LLM summarizer in-process).
-RESPONSE_HARD_CHAR_CAP = 60_000
 
 
 def truncate_payload(payload: Any, *, tool_name: str = "mcp") -> Dict[str, Any]:
-    """Cap a tool response and guarantee a dict return shape.
+    """Guarantee a dict return shape for MCP tool responses.
 
     MCP tools are declared with a `Dict[str, Any]` return type. FastMCP
     validates that contract — if a backend route returns a bare JSON array
@@ -26,28 +16,7 @@ def truncate_payload(payload: Any, *, tool_name: str = "mcp") -> Dict[str, Any]:
     """
     if not isinstance(payload, dict):
         payload = {"items": payload}
-
-    try:
-        encoded = json.dumps(payload, default=str)
-    except (TypeError, ValueError):
-        encoded = str(payload)
-
-    if len(encoded) <= RESPONSE_HARD_CHAR_CAP:
-        return payload
-
-    head = encoded[: RESPONSE_HARD_CHAR_CAP - 200]
-    return {
-        "truncated": True,
-        "tool": tool_name,
-        "original_size_chars": len(encoded),
-        "max_size_chars": RESPONSE_HARD_CHAR_CAP,
-        "summary": head + "\n...[truncated]",
-        "hint": (
-            "Result exceeded the MCP per-call size cap. Narrow your query "
-            "(shorter time range, smaller limit) or use a resource URI to "
-            "fetch the full payload."
-        ),
-    }
+    return payload
 
 
 def paginate(

--- a/server/aurora_mcp/tools_always_on.py
+++ b/server/aurora_mcp/tools_always_on.py
@@ -304,6 +304,9 @@ def register_tier1_tools(mcp, api_call: ApiCall) -> None:
           status: Filter by incident status (optional).
           limit: Max incidents to return (1-100, default 20).
           offset: Paging offset (>= 0, default 0).
+
+        Returns {incidents: [...], total: N}. Use total to know when to
+        stop paging (e.g. offset + limit >= total means last page).
         """
         return await _do_list_incidents(api_call, status, limit, offset)
 

--- a/server/aurora_mcp/tools_always_on.py
+++ b/server/aurora_mcp/tools_always_on.py
@@ -298,8 +298,13 @@ def register_tier1_tools(mcp, api_call: ApiCall) -> None:
     @mcp.tool()
     async def list_incidents(status: Optional[str] = None, limit: int = 20, offset: int = 0) -> Dict[str, Any]:
         """List Aurora incidents. Optionally filter by status
-        (investigating/analyzed/merged/resolved). Use offset to paginate
-        through results (max 100 per page)."""
+        (investigating/analyzed/merged/resolved).
+
+        Args:
+          status: Filter by incident status (optional).
+          limit: Max incidents to return (1-100, default 20).
+          offset: Paging offset (>= 0, default 0).
+        """
         return await _do_list_incidents(api_call, status, limit, offset)
 
     @mcp.tool()

--- a/server/aurora_mcp/tools_always_on.py
+++ b/server/aurora_mcp/tools_always_on.py
@@ -46,10 +46,12 @@ def _slim_incident(incident: Any) -> Any:
     return incident
 
 
-async def _do_list_incidents(api_call: ApiCall, status: Optional[str], limit: int) -> Dict[str, Any]:
+async def _do_list_incidents(api_call: ApiCall, status: Optional[str], limit: int, offset: int) -> Dict[str, Any]:
     params: Dict[str, Any] = {"limit": limit}
     if status:
         params["status"] = status
+    if offset > 0:
+        params["offset"] = offset
     return truncate_payload(
         await api_call("GET", "/api/incidents", params=params),
         tool_name="list_incidents",
@@ -294,10 +296,11 @@ def register_tier1_tools(mcp, api_call: ApiCall) -> None:
         return truncate_payload(result, tool_name="chat_with_aurora")
 
     @mcp.tool()
-    async def list_incidents(status: Optional[str] = None, limit: int = 20) -> Dict[str, Any]:
+    async def list_incidents(status: Optional[str] = None, limit: int = 20, offset: int = 0) -> Dict[str, Any]:
         """List Aurora incidents. Optionally filter by status
-        (investigating/analyzed/merged/resolved)."""
-        return await _do_list_incidents(api_call, status, limit)
+        (investigating/analyzed/merged/resolved). Use offset to paginate
+        through results (max 100 per page)."""
+        return await _do_list_incidents(api_call, status, limit, offset)
 
     @mcp.tool()
     async def get_incident(incident_id: str) -> Dict[str, Any]:

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -308,6 +308,15 @@ def get_incidents(user_id):
 
                 query += " ORDER BY i.started_at DESC"
 
+                # Get total count for pagination before applying LIMIT/OFFSET
+                count_query = "SELECT COUNT(*) FROM incidents i WHERE i.org_id = %s AND i.status != 'merged'"
+                count_params = [org_id]
+                if status_filter:
+                    count_query += " AND i.status = %s"
+                    count_params.append(status_filter)
+                cursor.execute(count_query, tuple(count_params))
+                total_count = cursor.fetchone()[0]
+
                 limit = request.args.get("limit", 100, type=int)
                 limit = max(1, min(limit, 100))
                 query += " LIMIT %s"
@@ -334,7 +343,7 @@ def get_incidents(user_id):
                     len(incidents),
                     user_id,
                 )
-                return jsonify({"incidents": incidents}), 200
+                return jsonify({"incidents": incidents, "total": total_count}), 200
 
     except Exception as exc:
         logger.exception(

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -313,6 +313,12 @@ def get_incidents(user_id):
                 query += " LIMIT %s"
                 params.append(limit)
 
+                offset = request.args.get("offset", 0, type=int)
+                offset = max(0, offset)
+                if offset > 0:
+                    query += " OFFSET %s"
+                    params.append(offset)
+
                 cursor.execute(query, tuple(params))
                 rows = cursor.fetchall()
 

--- a/server/tests/mcp/test_response.py
+++ b/server/tests/mcp/test_response.py
@@ -10,13 +10,11 @@ def test_small_payload_passes_through():
     assert response.truncate_payload(payload) == payload
 
 
-def test_large_payload_returns_truncation_envelope():
-    big = "x" * (response.RESPONSE_HARD_CHAR_CAP + 1000)
+def test_large_payload_passes_through_unchanged():
+    """Large payloads are returned as-is — no truncation, no broken JSON."""
+    big = "x" * 100_000
     out = response.truncate_payload({"blob": big}, tool_name="t1")
-    assert out["truncated"] is True
-    assert out["tool"] == "t1"
-    assert out["original_size_chars"] > response.RESPONSE_HARD_CHAR_CAP
-    assert "summary" in out
+    assert out == {"blob": big}
 
 
 def test_paginate_returns_next_cursor_when_more_remain():
@@ -47,12 +45,9 @@ def test_paginate_handles_invalid_cursor():
 
 def test_wrap_listing_shape():
     out = response.wrap_listing([1, 2, 3], limit=2)
-    # Either returns the envelope directly, or wraps it in the truncation
-    # shape if too big — the items list should be 2 long either way.
-    if "items" in out:
-        assert out["items"] == [1, 2]
-        assert out["next_cursor"] == "2"
-        assert out["total"] == 3
+    assert out["items"] == [1, 2]
+    assert out["next_cursor"] == "2"
+    assert out["total"] == 3
 
 
 def test_list_payload_is_coerced_to_dict():


### PR DESCRIPTION
## Summary

- Removes the naive `encoded[:60000]` character-slice truncation from `truncate_payload()` in `server/aurora_mcp/response.py` that was producing broken/unparseable JSON for LLMs
- `truncate_payload()` now just ensures the response is a dict (FastMCP contract) and returns it unmodified
- Modern LLMs have 100K-200K token context windows; a full `list_incidents` response (~106K chars / ~26K tokens) is well within capacity

## Test plan

- [x] All 9 MCP response tests pass
- [ ] Verify `list_incidents` via MCP returns full valid JSON with 74 incidents (localhost)
- [ ] Confirm LLM clients (Cursor, Claude) can parse the full response without issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offset-based pagination for incident listing (API and listing tool accept offset).

* **Refactor**
  * Removed hard response-size cap and simplified responses to always use a consistent dictionary shape.

* **Tests**
  * Updated tests to expect large payloads to pass through unchanged and to enforce a consistent wrapped listing envelope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->