### PR TITLE
chore: bump version to 1.2.16

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.15
-appVersion: "1.2.15"
+version: 1.2.16
+appVersion: "1.2.16"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps Helm chart version and appVersion from 1.2.15 to 1.2.16

## Release steps
After merging this PR:
```bash
git checkout main && git pull
git tag v1.2.16
git push origin v1.2.16
```

This triggers `publish-images`, `publish-helm`, and `publish-airtight` workflows automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 1.2.16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->