### PR TITLE
fix: seed tool permissions on org creation

### DIFF
--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -146,6 +146,12 @@ def register():
                 except Exception as policy_err:
                     logging.warning("Failed to seed command policy for org %s", org_id, exc_info=policy_err)
 
+                try:
+                    from utils.auth.tool_registry import seed_org_tool_permissions
+                    seed_org_tool_permissions(org_id, user_id)
+                except Exception as tool_perm_err:
+                    logging.warning("Failed to seed tool permissions for org %s: %s", org_id, tool_perm_err)
+
                 record_audit_event(org_id, user_id, "register", "organization", org_id,
                                    {"email": email}, request)
 
@@ -262,6 +268,12 @@ def setup_org(user_id):
                     seed_default_command_policy(org_id, user_id)
                 except Exception as policy_err:
                     logging.warning("Failed to seed command policy for org %s", org_id, exc_info=policy_err)
+
+                try:
+                    from utils.auth.tool_registry import seed_org_tool_permissions
+                    seed_org_tool_permissions(org_id, user_id)
+                except Exception as tool_perm_err:
+                    logging.warning("Failed to seed tool permissions for org %s: %s", org_id, tool_perm_err)
 
                 logging.info(f"User {user_id} created org {org_id} ({org_name})")
 

--- a/server/routes/auth_routes.py
+++ b/server/routes/auth_routes.py
@@ -150,7 +150,7 @@ def register():
                     from utils.auth.tool_registry import seed_org_tool_permissions
                     seed_org_tool_permissions(org_id, user_id)
                 except Exception as tool_perm_err:
-                    logging.warning("Failed to seed tool permissions for org %s: %s", org_id, tool_perm_err)
+                    logging.warning("Failed to seed tool permissions for org %s", org_id, exc_info=tool_perm_err)
 
                 record_audit_event(org_id, user_id, "register", "organization", org_id,
                                    {"email": email}, request)
@@ -273,7 +273,7 @@ def setup_org(user_id):
                     from utils.auth.tool_registry import seed_org_tool_permissions
                     seed_org_tool_permissions(org_id, user_id)
                 except Exception as tool_perm_err:
-                    logging.warning("Failed to seed tool permissions for org %s: %s", org_id, tool_perm_err)
+                    logging.warning("Failed to seed tool permissions for org %s", org_id, exc_info=tool_perm_err)
 
                 logging.info(f"User {user_id} created org {org_id} ({org_name})")
 

--- a/server/routes/tool_permissions.py
+++ b/server/routes/tool_permissions.py
@@ -11,7 +11,7 @@ from flask import Blueprint, jsonify, request
 
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
-from utils.auth.tool_registry import TOOL_REGISTRY, get_default_enabled_tools, get_tools_by_connector
+from utils.auth.tool_registry import TOOL_REGISTRY, get_tools_by_connector
 from utils.db.connection_pool import db_pool
 
 logger = logging.getLogger(__name__)
@@ -98,25 +98,13 @@ def toggle_permission(user_id: str, tool_key: str):
 @require_permission("admin", "access")
 def seed_defaults(user_id: str):
     """Seed default tool permissions for this org (idempotent)."""
+    from utils.auth.tool_registry import seed_org_tool_permissions
+
     org_id = get_org_id_from_request()
     if not org_id:
         return jsonify({"error": _ERR_NO_ORG}), 400
 
-    defaults = get_default_enabled_tools()
-    now = datetime.now(timezone.utc)
-
-    with db_pool.get_connection() as conn:
-        with conn.cursor() as cur:
-            set_rls_context(cur, conn, user_id, log_prefix="[ToolPerms:seed]")
-            for tool_key in TOOL_REGISTRY:
-                enabled = tool_key in defaults
-                cur.execute(
-                    """INSERT INTO org_tool_permissions (org_id, tool_key, enabled, updated_by, updated_at)
-                       VALUES (%s, %s, %s, %s, %s)
-                       ON CONFLICT (org_id, tool_key) DO NOTHING""",
-                    (org_id, tool_key, enabled, user_id, now),
-                )
-            conn.commit()
+    count = seed_org_tool_permissions(org_id, user_id)
 
     _invalidate_permissions_cache(org_id)
-    return jsonify({"seeded": len(TOOL_REGISTRY)})
+    return jsonify({"seeded": count})

--- a/server/utils/auth/tool_registry.py
+++ b/server/utils/auth/tool_registry.py
@@ -68,6 +68,30 @@ def get_default_enabled_tools() -> set:
     return {k for k, v in TOOL_REGISTRY.items() if v.get("default")}
 
 
+def seed_org_tool_permissions(org_id: str, user_id: str) -> int:
+    """Seed default tool permissions for org. Idempotent (DO NOTHING on conflict)."""
+    from datetime import datetime, timezone
+    from utils.db.connection_pool import db_pool
+    from utils.auth.stateless_auth import set_rls_context
+
+    defaults = get_default_enabled_tools()
+    now = datetime.now(timezone.utc)
+
+    with db_pool.get_connection() as conn:
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[seed_tool_perms]")
+            for tool_key in TOOL_REGISTRY:
+                enabled = tool_key in defaults
+                cur.execute(
+                    """INSERT INTO org_tool_permissions (org_id, tool_key, enabled, updated_by, updated_at)
+                       VALUES (%s, %s, %s, %s, %s)
+                       ON CONFLICT (org_id, tool_key) DO NOTHING""",
+                    (org_id, tool_key, enabled, user_id, now),
+                )
+            conn.commit()
+    return len(TOOL_REGISTRY)
+
+
 def get_tools_by_connector() -> dict:
     """Group registry entries by connector for UI rendering."""
     grouped: dict = {}

--- a/server/utils/auth/tool_registry.py
+++ b/server/utils/auth/tool_registry.py
@@ -72,14 +72,15 @@ def seed_org_tool_permissions(org_id: str, user_id: str) -> int:
     """Seed default tool permissions for org. Idempotent (DO NOTHING on conflict)."""
     from datetime import datetime, timezone
     from utils.db.connection_pool import db_pool
-    from utils.auth.stateless_auth import set_rls_context
 
     defaults = get_default_enabled_tools()
     now = datetime.now(timezone.utc)
 
     with db_pool.get_connection() as conn:
         with conn.cursor() as cur:
-            set_rls_context(cur, conn, user_id, log_prefix="[seed_tool_perms]")
+            cur.execute("SET myapp.current_user_id = %s;", (user_id,))
+            cur.execute("SET myapp.current_org_id = %s;", (org_id,))
+            conn.commit()
             for tool_key in TOOL_REGISTRY:
                 enabled = tool_key in defaults
                 cur.execute(


### PR DESCRIPTION
New orgs had 0 rows in org_tool_permissions, causing all gated tools to be blocked in background chats
Seed default tool permissions at org creation (both /register and /setup-org), matching existing seed_default_command_policy pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool permissions are now automatically initialized during organization setup and user registration; the system reports how many permissions were seeded.

* **Bug Fixes**
  * Seeding is idempotent and now uses robust logic that won’t fail the registration or setup if individual permission entries can’t be created; failures are handled gracefully and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->