### PR TITLE
fix: set RLS context in _action_is_generate_postmortem to ungate save_postmortem tool

### DIFF
--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1193,13 +1193,14 @@ async def _run_jira_action(
     logger.info(f"[JiraAction] Completed for {session_id}")
 
 
-def _action_is_generate_postmortem(action_id: Optional[str]) -> bool:
+def _action_is_generate_postmortem(action_id: Optional[str], user_id: Optional[str] = None) -> bool:
     """Return True when action_id belongs to the built-in 'generate_postmortem' system action."""
     if not action_id:
         return False
     try:
         with db_pool.get_connection() as conn:
             with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[BackgroundChat:PostmortemCheck]")
                 cur.execute(
                     "SELECT 1 FROM actions WHERE id = %s AND system_key = 'generate_postmortem'",
                     (action_id,),
@@ -1329,7 +1330,7 @@ async def _execute_background_chat(
         _tm_source = (trigger_metadata or {}).get("source", "")
         _is_postmortem_action = _tm_source == "postmortem_generation" or (
             _tm_source == "action"
-            and _action_is_generate_postmortem((trigger_metadata or {}).get("action_id"))
+            and _action_is_generate_postmortem((trigger_metadata or {}).get("action_id"), user_id)
         )
 
         # Create state with is_background=True and rca_context for system prompt


### PR DESCRIPTION
## Summary
- `_action_is_generate_postmortem()` queries the RLS-protected `actions` table without setting RLS context, causing it to silently return 0 rows in Celery workers (no Flask request context)
- This results in `is_postmortem_action` always being `False` for orgs that have a `generate_postmortem` system action row, so `save_postmortem` is never registered as an available tool
- Fix passes `user_id` through and calls `set_rls_context()` before the query

## Root Cause
When an org has the `generate_postmortem` action in the DB, `dispatch_postmortem_action` sets `trigger_metadata["source"] = "action"`. The background task then calls `_action_is_generate_postmortem(action_id)` to verify — but that function queries `actions` (RLS-protected) without context, gets 0 rows, and returns `False`. The `save_postmortem` tool gate never opens.

Orgs without the system action row still work because `source` stays as `"postmortem_generation"`, which bypasses the DB lookup entirely.

## Test plan
- [ ] Trigger "Generate Postmortem" on an incident for an org that has a `generate_postmortem` system action row
- [ ] Verify `save_postmortem` appears in the tool list (check logs for `postmortem=True` in the cache key)
- [ ] Verify the postmortem is saved successfully


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced permission enforcement for background chat operations to ensure user access controls are properly applied during postmortem generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->