### PR TITLE
fix: use connection pool in health endpoint to prevent DB connection leak (INC-440)

### DIFF
--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -21,34 +21,26 @@ logger = logging.getLogger(__name__)
 health_bp = Blueprint('health', __name__)
 
 def check_database_health():
-    """Check PostgreSQL database connectivity."""
+    """Check PostgreSQL database connectivity using the shared connection pool.
+
+    Previously this function opened a brand-new psycopg2 connection on every
+    call.  The /health/readiness endpoint is polled by Kubernetes probes at
+    ~6 req/min per pod, so two server pods together were creating ~12 new
+    backend connections per minute against Cloud SQL — even under normal load.
+    Under I/O pressure (escalating checkpoint write times, high autovacuum
+    activity) those extra connections amplified latency for all
+    database-touching requests.
+
+    Using db_pool.get_connection() borrows an already-open connection from the
+    pool and returns it immediately after the SELECT 1, keeping the backend
+    connection count stable.
+    """
     try:
-        # Connect using unified POSTGRES_* variables
-        user = os.getenv('POSTGRES_USER')
-        password = os.getenv('POSTGRES_PASSWORD')
-        host = os.getenv('POSTGRES_HOST')
-        port = os.getenv('POSTGRES_PORT')
-        dbname = os.getenv('POSTGRES_DB')
-
-        if not user or not password:
-            return {"status": "unhealthy", "error": "Database credentials not configured"}
-
-        conn = psycopg2.connect(
-            host=host,
-            port=port,
-            dbname=dbname,
-            user=user,
-            password=password,
-            sslmode=os.getenv('POSTGRES_SSLMODE', 'prefer') or None,
-            sslrootcert=os.getenv('POSTGRES_SSLROOTCERT') or None,
-        )
-
-        cursor = conn.cursor()
-        # No RLS needed — infrastructure health check
-        cursor.execute("SELECT 1")
-        cursor.close()
-        conn.close()
-
+        from utils.db.connection_pool import db_pool
+        with db_pool.get_connection() as conn:
+            with conn.cursor() as cursor:
+                # No RLS needed — infrastructure health check
+                cursor.execute("SELECT 1")
         return {"status": "healthy", "message": "Database connection successful"}
     except Exception as e:
         logger.warning(f"Database health check failed: {e}", exc_info=True)


### PR DESCRIPTION
## Problem

During INC-440 (2026-06-10 ~15:34–16:18 UTC), Aurora production served an elevated number of slow requests (>5s). One of the confirmed amplifying factors was the `/health/readiness` Kubernetes probe calling `check_database_health()`, which opened a **brand-new raw `psycopg2` connection on every invocation** rather than borrowing from the shared connection pool.

With Kubernetes probing at ~6 req/min per pod × 2 server pods = **~12 new backend connections per minute** being created against Cloud SQL. Under the already-stressed database conditions at the time (checkpoint write times escalating from 35.6s → 41.9s → 47.4s, high-frequency auto-analyze on `chat_sessions`, two client connection resets), these extra connections amplified latency for all database-touching requests.

## Fix

Replace the ad-hoc `psycopg2.connect(...)` call in `check_database_health()` with `db_pool.get_connection()` — the existing `DatabaseConnectionPool` singleton already used everywhere else in the server.

**Before:**
```python
conn = psycopg2.connect(host=host, port=port, dbname=dbname, user=user, password=password, ...)
cursor = conn.cursor()
cursor.execute("SELECT 1")
cursor.close()
conn.close()
```

**After:**
```python
from utils.db.connection_pool import db_pool
with db_pool.get_connection() as conn:
    with conn.cursor() as cursor:
        cursor.execute("SELECT 1")
```

The pooled connection is borrowed for the duration of the `SELECT 1` and immediately returned. No new backend connection is created; the pool's existing idle connections are reused.

## Expected outcome

- Health endpoint response time drops from ~1s (observed in nginx logs at 16:17 UTC) to <50ms under normal load
- Cloud SQL backend connection count stays stable regardless of probe frequency
- No change to health check semantics — the endpoint still returns `healthy`/`unhealthy` based on whether a query can execute

## Related

- **Incident:** INC-440 — Aurora Prod Slow Requests (>5s), triggered 2026-06-10 16:10:26 UTC
- **Also recommended (separate PRs):** Deploy `sha-8ee506e8` (Casbin Redis fix), resolve cert-manager ACME challenge routing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced database health check efficiency through improved connection management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->