### PR TITLE
fix: RCA button navigating to action chat + show actions on incident page

### DIFF
--- a/client/src/app/api/incidents/[id]/action-runs/route.ts
+++ b/client/src/app/api/incidents/[id]/action-runs/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '@/lib/backend-proxy';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = await params;
+  return forwardRequest(
+    request,
+    'GET',
+    `/api/incidents/${id}/action-runs`,
+    'get incident action runs',
+  );
+}

--- a/client/src/app/api/incidents/[id]/action-runs/route.ts
+++ b/client/src/app/api/incidents/[id]/action-runs/route.ts
@@ -3,7 +3,7 @@ import { forwardRequest } from '@/lib/backend-proxy';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
   return forwardRequest(

--- a/client/src/app/incidents/components/IncidentActionRuns.tsx
+++ b/client/src/app/incidents/components/IncidentActionRuns.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ExternalLink, CheckCircle2, AlertCircle, Clock } from 'lucide-react';
+
+interface ActionRun {
+  id: string;
+  action_id: string;
+  action_name: string;
+  status: string;
+  chat_session_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  duration_ms?: number;
+  error: string | null;
+}
+
+interface IncidentActionRunsProps {
+  readonly incidentId: string;
+}
+
+function StatusIcon({ status }: { readonly status: string }) {
+  switch (status) {
+    case 'success':
+      return <CheckCircle2 className="w-3.5 h-3.5 text-green-400" />;
+    case 'error':
+      return <AlertCircle className="w-3.5 h-3.5 text-red-400" />;
+    case 'running':
+      return (
+        <span className="relative flex h-3.5 w-3.5">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75"></span>
+          <span className="relative inline-flex rounded-full h-3.5 w-3.5 bg-orange-500"></span>
+        </span>
+      );
+    default:
+      return <Clock className="w-3.5 h-3.5 text-zinc-500" />;
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function IncidentActionRuns({ incidentId }: IncidentActionRunsProps) {
+  const [runs, setRuns] = useState<ActionRun[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchRuns() {
+      try {
+        const res = await fetch(`/api/incidents/${incidentId}/action-runs`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setRuns(data.runs || []);
+      } catch {
+        // Silently fail
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchRuns();
+    return () => { cancelled = true; };
+  }, [incidentId]);
+
+  if (loading) {
+    return (
+      <div className="py-4 text-center text-xs text-zinc-500">Loading actions...</div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="py-4 text-center text-xs text-zinc-500">No actions have run for this incident.</div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {runs.map((run) => (
+        <div
+          key={run.id}
+          className="flex items-center justify-between gap-3 px-3 py-2 rounded-md bg-zinc-900/50 border border-zinc-800/50"
+        >
+          <div className="flex items-center gap-2.5 min-w-0">
+            <StatusIcon status={run.status} />
+            <span className="text-sm text-zinc-200 truncate">{run.action_name}</span>
+            {run.duration_ms != null && (
+              <span className="text-[11px] text-zinc-500 shrink-0">
+                {formatDuration(run.duration_ms)}
+              </span>
+            )}
+            {run.started_at && (
+              <span className="text-[11px] text-zinc-600 shrink-0">
+                {formatTime(run.started_at)}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {run.error && (
+              <span className="text-[11px] text-red-400 max-w-[150px] truncate" title={run.error}>
+                {run.error}
+              </span>
+            )}
+            {run.chat_session_id && (
+              <Link
+                href={`/chat?sessionId=${run.chat_session_id}`}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+              >
+                View
+                <ExternalLink className="w-2.5 h-2.5" />
+              </Link>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/app/incidents/components/IncidentActionRuns.tsx
+++ b/client/src/app/incidents/components/IncidentActionRuns.tsx
@@ -55,28 +55,54 @@ function formatTime(isoString: string): string {
 export default function IncidentActionRuns({ incidentId }: IncidentActionRunsProps) {
   const [runs, setRuns] = useState<ActionRun[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
     async function fetchRuns() {
       try {
         const res = await fetch(`/api/incidents/${incidentId}/action-runs`);
-        if (!res.ok) return;
+        if (!res.ok) {
+          if (!cancelled) setError(true);
+          return;
+        }
         const data = await res.json();
-        if (!cancelled) setRuns(data.runs || []);
+        if (!cancelled) {
+          setRuns(data.runs || []);
+          setError(false);
+
+          // Poll every 5s while any run is still in progress
+          const hasInProgress = (data.runs || []).some(
+            (r: ActionRun) => r.status === 'pending' || r.status === 'running'
+          );
+          if (hasInProgress) {
+            pollTimer = setTimeout(fetchRuns, 5000);
+          }
+        }
       } catch {
-        // Silently fail
+        if (!cancelled) setError(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
     fetchRuns();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (pollTimer) clearTimeout(pollTimer);
+    };
   }, [incidentId]);
 
   if (loading) {
     return (
       <div className="py-4 text-center text-xs text-zinc-500">Loading actions...</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-4 text-center text-xs text-red-400">Failed to load action runs.</div>
     );
   }
 

--- a/client/src/app/incidents/components/IncidentActionRuns.tsx
+++ b/client/src/app/incidents/components/IncidentActionRuns.tsx
@@ -115,7 +115,7 @@ export default function IncidentActionRuns({ incidentId }: IncidentActionRunsPro
             )}
             {run.chat_session_id && (
               <Link
-                href={`/chat?sessionId=${run.chat_session_id}`}
+                href={`/chat?sessionId=${encodeURIComponent(run.chat_session_id)}`}
                 className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
               >
                 View

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -35,6 +35,7 @@ import CorrelatedAlertsSection from './CorrelatedAlertsSection';
 import RecentAlertsSection from './RecentAlertsSection';
 import PostmortemPanel from './PostmortemPanel';
 import InfrastructureVisualization from '@/components/incidents/InfrastructureVisualization';
+import IncidentActionRuns from './IncidentActionRuns';
 import ExecutionWaterfall from './ExecutionWaterfall';
 import { ReactFlowProvider } from '@xyflow/react';
 import { connectorRegistry } from '@/components/connectors/ConnectorRegistry';
@@ -114,6 +115,7 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
   const [showPostmortem, setShowPostmortem] = useState(false);
   const [showTokenUsage, setShowTokenUsage] = useState(false);
   const [showWaterfall, setShowWaterfall] = useState(false);
+  const [showActions, setShowActions] = useState(false);
   const [resolvingIncident, setResolvingIncident] = useState(false);
   const alert = incident.alert;
   const router = useRouter();
@@ -744,6 +746,20 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
             </button>
           )}
 
+          {/* Actions button */}
+          <button
+            onClick={() => setShowActions(!showActions)}
+            className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors ${
+              showActions
+                ? 'text-orange-300 bg-orange-500/10'
+                : 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800'
+            }`}
+          >
+            <Play className="w-3 h-3" />
+            Actions
+            <ChevronRight className={`w-3 h-3 transition-transform ${showActions ? 'rotate-90' : ''}`} />
+          </button>
+
       </div>
 
       {/* Feedback Section - only show when analysis is complete */}
@@ -752,6 +768,16 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
           <IncidentFeedback incidentId={incident.id} readOnly={!canWrite} />
         </div>
       )}
+
+      {/* Action Runs linked to this incident (collapsible, lazy-loaded) */}
+      <div className="collapsible-panel" data-open={showActions}>
+        <div>
+          <div className="border-t border-zinc-800 mt-4" />
+          <div className="mt-4">
+            {showActions && <IncidentActionRuns incidentId={incident.id} />}
+          </div>
+        </div>
+      </div>
 
       {/* Token Usage Panel (collapsible) */}
       {incident.tokenUsage && (

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -566,13 +566,13 @@ export const incidentsService = {
 export const postmortemService = {
   async getPostmortem(incidentId: string): Promise<{ data: PostmortemData | null; generating?: boolean; error?: string }> {
     try {
-      const data = await apiGet<{ postmortem: PostmortemData }>(`/api/incidents/${incidentId}/postmortem`);
+      const data = await apiGet<{ postmortem?: PostmortemData; status?: string; generationSessionId?: string }>(`/api/incidents/${incidentId}/postmortem`);
+      if (data.status === 'generating') {
+        return { data: null, generating: true };
+      }
       return { data: data.postmortem || null };
     } catch (error) {
       const apiErr = error as ApiError;
-      if (apiErr.status === 202) {
-        return { data: null, generating: true };
-      }
       if (apiErr.status === 404) {
         return { data: null };
       }

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -496,6 +496,7 @@ def run_background_chat(
     
     try:
         # Link session and Celery task ID to incident if provided
+        is_action_source = (trigger_metadata or {}).get('source') == 'action'
         if incident_id:
             try:
                 with db_pool.get_admin_connection() as conn:
@@ -513,103 +514,109 @@ def run_background_chat(
                         )
                     conn.commit()
 
-                    # Store session ID and Celery task ID (if not already set by webhook handler)
-                    # RLS already set on this conn at line above
-                    with conn.cursor() as cursor:
-                        # First check if there's already a task ID set
-                        cursor.execute(
-                            "SELECT rca_celery_task_id FROM incidents WHERE id = %s",
-                            (incident_id,)
-                        )
-                        row = cursor.fetchone()
-                        existing_task_id = row[0] if row and row[0] else None
-                        
-                        if existing_task_id and existing_task_id != self.request.id:
-                            logger.warning(
-                                f"[BackgroundChat] Incident {incident_id} already has task ID {existing_task_id}, "
-                                f"but this task is {self.request.id}. This may indicate a race condition or duplicate RCA start."
+                    # Action-triggered chats must not overwrite the RCA session on the incident
+                    if not is_action_source:
+                        # Store session ID and Celery task ID (if not already set by webhook handler)
+                        # RLS already set on this conn at line above
+                        with conn.cursor() as cursor:
+                            # First check if there's already a task ID set
+                            cursor.execute(
+                                "SELECT rca_celery_task_id FROM incidents WHERE id = %s",
+                                (incident_id,)
                             )
-                        
-                        cursor.execute(
-                            """UPDATE incidents 
-                               SET aurora_chat_session_id = %s, 
-                                   rca_celery_task_id = COALESCE(rca_celery_task_id, %s)
-                               WHERE id = %s""",
-                            (session_id, self.request.id, incident_id)
-                        )
-                        conn.commit()
-                        
-                        if existing_task_id:
-                            logger.info(
-                                f"[BackgroundChat] Linked session {session_id} to incident {incident_id} "
-                                f"(task ID already set to {existing_task_id})"
-                            )
-                        else:
-                            logger.info(
-                                f"[BackgroundChat] Linked session {session_id} and task {self.request.id} to incident {incident_id}"
-                            )
-                    
-                    # Set incident aurora_status to running and stamp the moment
-                    # the worker actually picked up the task. Used by the SRE
-                    # metrics dashboard to compute pickup latency (MTTD as
-                    # "time from webhook arrival to investigation start"). We
-                    # COALESCE so a retry doesn't overwrite the original pickup.
-                    pickup_at = datetime.now()
-                    # RLS already set on this conn at line above
-                    with conn.cursor() as cursor:
-                        cursor.execute(
-                            """UPDATE incidents
-                               SET aurora_status = %s,
-                                   investigation_started_at = COALESCE(investigation_started_at, %s),
-                                   updated_at = %s
-                               WHERE id = %s""",
-                            ("running", pickup_at, pickup_at, incident_id),
-                        )
-                        conn.commit()
-                        logger.info(f"[BackgroundChat] Set incident {incident_id} aurora_status to 'running' at start of RCA")
+                            row = cursor.fetchone()
+                            existing_task_id = row[0] if row and row[0] else None
 
-                    # Record lifecycle event for RCA start
-                    try:
+                            if existing_task_id and existing_task_id != self.request.id:
+                                logger.warning(
+                                    f"[BackgroundChat] Incident {incident_id} already has task ID {existing_task_id}, "
+                                    f"but this task is {self.request.id}. This may indicate a race condition or duplicate RCA start."
+                                )
+
+                            cursor.execute(
+                                """UPDATE incidents 
+                                   SET aurora_chat_session_id = %s, 
+                                       rca_celery_task_id = COALESCE(rca_celery_task_id, %s)
+                                   WHERE id = %s""",
+                                (session_id, self.request.id, incident_id)
+                            )
+                            conn.commit()
+
+                            if existing_task_id:
+                                logger.info(
+                                    f"[BackgroundChat] Linked session {session_id} to incident {incident_id} "
+                                    f"(task ID already set to {existing_task_id})"
+                                )
+                            else:
+                                logger.info(
+                                    f"[BackgroundChat] Linked session {session_id} and task {self.request.id} to incident {incident_id}"
+                                )
+                    else:
+                        logger.info(f"[BackgroundChat] Action session {session_id} linked to incident {incident_id} (aurora_chat_session_id not overwritten)")
+
+                    # Actions should not touch incident status or dispatch further on_incident actions
+                    if not is_action_source:
+                        # Set incident aurora_status to running and stamp the moment
+                        # the worker actually picked up the task. Used by the SRE
+                        # metrics dashboard to compute pickup latency (MTTD as
+                        # "time from webhook arrival to investigation start"). We
+                        # COALESCE so a retry doesn't overwrite the original pickup.
+                        pickup_at = datetime.now()
                         # RLS already set on this conn at line above
                         with conn.cursor() as cursor:
                             cursor.execute(
-                                """INSERT INTO incident_lifecycle_events
-                                   (incident_id, user_id, org_id, event_type, new_value)
-                                   VALUES (%s, %s, %s, %s, %s)""",
-                                (incident_id, user_id, rls_org_id, 'rca_started', 'running')
+                                """UPDATE incidents
+                                   SET aurora_status = %s,
+                                       investigation_started_at = COALESCE(investigation_started_at, %s),
+                                       updated_at = %s
+                                   WHERE id = %s""",
+                                ("running", pickup_at, pickup_at, incident_id),
                             )
                             conn.commit()
-                            logger.info(f"[BackgroundChat] Recorded lifecycle event 'rca_started' for incident {incident_id}")
-                    except Exception as le:
-                        logger.error(f"[BackgroundChat] Failed to record lifecycle event 'rca_started' for incident {incident_id}: {le}")
+                            logger.info(f"[BackgroundChat] Set incident {incident_id} aurora_status to 'running' at start of RCA")
 
-                    # Dispatch on_incident actions for this incident (fire-and-forget)
-                    source = trigger_metadata.get('source', '') if trigger_metadata else ''
-                    # Prevent infinite loops: actions must not trigger other on_incident actions
-                    if source and source != 'action':
+                        # Record lifecycle event for RCA start
                         try:
-                            from services.actions.executor import dispatch_on_incident_actions
-                            dispatch_on_incident_actions(user_id, str(incident_id), timing='immediate')
-                        except Exception:
-                            logger.debug("[BackgroundChat] Failed to dispatch on_incident actions")
-                    
-                    # Send investigation started notifications (if enabled)
-                    # Skip notifications if explicitly disabled (e.g., for Slack @mentions)
-                    # For email: need both general notifications AND start notifications enabled
-                    # For Slack: only need general notifications (no separate start preference since start message is overwritten by end message)
-                    email_general_enabled = _is_rca_email_notification_enabled(user_id)
-                    email_start_enabled = _is_rca_email_start_notification_enabled(user_id)
-                    email_start_notification_enabled = email_general_enabled and email_start_enabled
-                    
-                    slack_notification_enabled = get_slack_client_for_user(user_id) is not None
-                    google_chat_notification_enabled = _has_google_chat_connected(user_id)
-                    
-                    if send_notifications and (email_start_notification_enabled or slack_notification_enabled or google_chat_notification_enabled):
-                        _send_rca_notification(user_id, incident_id, 'started', 
-                            email_enabled=email_start_notification_enabled,
-                            slack_enabled=slack_notification_enabled,
-                            google_chat_enabled=google_chat_notification_enabled
-                        )
+                            # RLS already set on this conn at line above
+                            with conn.cursor() as cursor:
+                                cursor.execute(
+                                    """INSERT INTO incident_lifecycle_events
+                                       (incident_id, user_id, org_id, event_type, new_value)
+                                       VALUES (%s, %s, %s, %s, %s)""",
+                                    (incident_id, user_id, rls_org_id, 'rca_started', 'running')
+                                )
+                                conn.commit()
+                                logger.info(f"[BackgroundChat] Recorded lifecycle event 'rca_started' for incident {incident_id}")
+                        except Exception as le:
+                            logger.error(f"[BackgroundChat] Failed to record lifecycle event 'rca_started' for incident {incident_id}: {le}")
+
+                        # Dispatch on_incident actions for this incident (fire-and-forget)
+                        source = trigger_metadata.get('source', '') if trigger_metadata else ''
+                        # Prevent infinite loops: actions must not trigger other on_incident actions
+                        if source and source != 'action':
+                            try:
+                                from services.actions.executor import dispatch_on_incident_actions
+                                dispatch_on_incident_actions(user_id, str(incident_id), timing='immediate')
+                            except Exception:
+                                logger.debug("[BackgroundChat] Failed to dispatch on_incident actions")
+
+                        # Send investigation started notifications (if enabled)
+                        # Skip notifications if explicitly disabled (e.g., for Slack @mentions)
+                        # For email: need both general notifications AND start notifications enabled
+                        # For Slack: only need general notifications (no separate start preference since start message is overwritten by end message)
+                        email_general_enabled = _is_rca_email_notification_enabled(user_id)
+                        email_start_enabled = _is_rca_email_start_notification_enabled(user_id)
+                        email_start_notification_enabled = email_general_enabled and email_start_enabled
+
+                        slack_notification_enabled = get_slack_client_for_user(user_id) is not None
+                        google_chat_notification_enabled = _has_google_chat_connected(user_id)
+
+                        if send_notifications and (email_start_notification_enabled or slack_notification_enabled or google_chat_notification_enabled):
+                            _send_rca_notification(user_id, incident_id, 'started', 
+                                email_enabled=email_start_notification_enabled,
+                                slack_enabled=slack_notification_enabled,
+                                google_chat_enabled=google_chat_notification_enabled
+                            )
             except Exception as e:
                 logger.error(f"[BackgroundChat] Failed to link session to incident: {e}")
         
@@ -1280,6 +1287,7 @@ async def _execute_background_chat(
         # Create the initial message; tag it so the UI layer can skip the
         # synthesized RCA scaffold (internal instructions, not user input).
         # Slack/Google Chat messages are user-authored and should NOT be hidden.
+        # Action messages follow the same display logic as RCA (controlled by DISPLAY__RCA_USER_MSG).
         source = trigger_metadata.get("source", "") if trigger_metadata else ""
         is_scaffold = source in _RCA_SOURCES and source not in ('slack', 'google_chat', 'chat')
         human_message = HumanMessage(

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1295,9 +1295,9 @@ async def _execute_background_chat(
         # Create the initial message; tag it so the UI layer can skip the
         # synthesized RCA scaffold (internal instructions, not user input).
         # Slack/Google Chat messages are user-authored and should NOT be hidden.
-        # Action messages follow the same display logic as RCA (controlled by DISPLAY__RCA_USER_MSG).
+        # Action prompts should also be visible to the user in the chat UI.
         source = trigger_metadata.get("source", "") if trigger_metadata else ""
-        is_scaffold = source in _RCA_SOURCES and source not in ('slack', 'google_chat', 'chat')
+        is_scaffold = source in _RCA_SOURCES and source not in ('slack', 'google_chat', 'chat', 'action')
         human_message = HumanMessage(
             content=initial_message,
             additional_kwargs={"is_rca_scaffold": is_scaffold},
@@ -1441,7 +1441,8 @@ async def _execute_background_chat(
 
         # Also finalize the incident and enqueue post-RCA tasks here (inside the
         # async function) because asyncio.run() may never return to the caller.
-        if incident_id:
+        is_action_source = (trigger_metadata or {}).get('source') == 'action'
+        if incident_id and not is_action_source:
             try:
                 with db_pool.get_admin_connection() as conn:
                     with conn.cursor() as cursor:

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -455,16 +455,6 @@ def run_background_chat(
     logger.info(f"[BackgroundChat] Starting for user {user_id}, session {session_id}")
     logger.info(f"[BackgroundChat] Trigger: {trigger_metadata}")
 
-    # Skip re-delivered tasks (acks_late means Redis can re-queue before completion)
-    try:
-        redis_client = get_redis_client()
-        lock_key = f"bgchat:lock:{session_id}"
-        acquired = redis_client.set(lock_key, self.request.id, nx=True, ex=1800)
-        if not acquired:
-            logger.warning("[BackgroundChat] DUPLICATE DELIVERY: session %s already running — skipping.", session_id)
-            return {"session_id": session_id, "status": "skipped", "skipped": "duplicate_delivery"}
-    except Exception:
-        pass
 
     # Eagerly persist the initial user message so it's visible in the UI immediately (opt-in)
     if os.environ.get("DISPLAY__RCA_USER_MSG", "").lower() in ("1", "true", "yes"):

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -533,13 +533,21 @@ def run_background_chat(
                                     f"but this task is {self.request.id}. This may indicate a race condition or duplicate RCA start."
                                 )
 
-                            cursor.execute(
-                                """UPDATE incidents 
-                                   SET aurora_chat_session_id = %s, 
-                                       rca_celery_task_id = COALESCE(rca_celery_task_id, %s)
-                                   WHERE id = %s""",
-                                (session_id, self.request.id, incident_id)
-                            )
+                            # Only update aurora_chat_session_id when this task owns the RCA
+                            if not existing_task_id or existing_task_id == self.request.id:
+                                cursor.execute(
+                                    """UPDATE incidents 
+                                       SET aurora_chat_session_id = %s, 
+                                           rca_celery_task_id = COALESCE(rca_celery_task_id, %s)
+                                       WHERE id = %s""",
+                                    (session_id, self.request.id, incident_id)
+                                )
+                            else:
+                                logger.warning(
+                                    "[BackgroundChat] Skipping aurora_chat_session_id overwrite for incident %s; RCA task %s already owns it",
+                                    incident_id,
+                                    existing_task_id,
+                                )
                             conn.commit()
 
                             if existing_task_id:
@@ -627,7 +635,7 @@ def run_background_chat(
         hook_allowed, hook_message = get_hook("before_llm_call")(_hook_org_id, user_id)
         if not hook_allowed:
             logger.warning(f"[BackgroundChat] Hook blocked for user {user_id}: {hook_message}")
-            if incident_id:
+            if incident_id and not is_action_source:
                 try:
                     with db_pool.get_admin_connection() as conn:
                         with conn.cursor() as cursor:
@@ -667,7 +675,7 @@ def run_background_chat(
         
         # Update incident status to analyzed if incident_id provided
         # (may already be done inside _execute_background_chat as crash protection)
-        if incident_id:
+        if incident_id and not is_action_source:
             # Clear the Celery task ID since we're done
             try:
                 with db_pool.get_admin_connection() as conn:
@@ -823,7 +831,7 @@ def run_background_chat(
     except SoftTimeLimitExceeded:
         logger.error(f"[BackgroundChat] Timeout after 30 minutes for session {session_id}")
         _update_session_status(session_id, "failed", user_id=user_id)
-        if incident_id:
+        if incident_id and not is_action_source:
             _update_incident_aurora_status(incident_id, "error", user_id=user_id)
             _mark_inflight_findings_failed(incident_id, user_id, "parent task timed out after 30 minutes")
         if trigger_metadata and trigger_metadata.get('source') == 'action':
@@ -843,7 +851,7 @@ def run_background_chat(
     except Exception as e:
         logger.exception(f"[BackgroundChat] Failed for session {session_id}: {e}")
         _update_session_status(session_id, "failed", user_id=user_id)
-        if incident_id:
+        if incident_id and not is_action_source:
             _update_incident_aurora_status(incident_id, "error", user_id=user_id)
             _mark_inflight_findings_failed(incident_id, user_id, f"parent task failed: {e}")
         if trigger_metadata and trigger_metadata.get('source') == 'action':

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -455,6 +455,17 @@ def run_background_chat(
     logger.info(f"[BackgroundChat] Starting for user {user_id}, session {session_id}")
     logger.info(f"[BackgroundChat] Trigger: {trigger_metadata}")
 
+    # Skip re-delivered tasks (acks_late means Redis can re-queue before completion)
+    try:
+        redis_client = get_redis_client()
+        lock_key = f"bgchat:lock:{session_id}"
+        acquired = redis_client.set(lock_key, self.request.id, nx=True, ex=1800)
+        if not acquired:
+            logger.warning("[BackgroundChat] DUPLICATE DELIVERY: session %s already running — skipping.", session_id)
+            return {"session_id": session_id, "status": "skipped", "skipped": "duplicate_delivery"}
+    except Exception:
+        pass
+
     # Eagerly persist the initial user message so it's visible in the UI immediately (opt-in)
     if os.environ.get("DISPLAY__RCA_USER_MSG", "").lower() in ("1", "true", "yes"):
         try:

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -2037,21 +2037,20 @@ def get_incident_action_runs(user_id, incident_id: str):
     org_id = get_org_id_from_request()
 
     try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
-                cursor.execute(
-                    """SELECT r.id, r.action_id, r.status, r.chat_session_id,
-                              r.started_at, r.completed_at, r.error,
-                              a.name AS action_name
-                       FROM action_runs r
-                       JOIN actions a ON a.id = r.action_id
-                       WHERE r.incident_id = %s AND r.org_id = %s
-                       ORDER BY r.started_at DESC""",
-                    (incident_id, org_id),
-                )
-                cols = [d[0] for d in cursor.description]
-                rows = [dict(zip(cols, row)) for row in cursor.fetchall()]
+        with db_pool.get_admin_connection() as conn, conn.cursor() as cursor:
+            set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
+            cursor.execute(
+                """SELECT r.id, r.action_id, r.status, r.chat_session_id,
+                          r.started_at, r.completed_at, r.error,
+                          a.name AS action_name
+                   FROM action_runs r
+                   JOIN actions a ON a.id = r.action_id
+                   WHERE r.incident_id = %s AND r.org_id = %s
+                   ORDER BY r.started_at DESC""",
+                (incident_id, org_id),
+            )
+            cols = [d[0] for d in cursor.description]
+            rows = [dict(zip(cols, row, strict=False)) for row in cursor.fetchall()]
 
         for r in rows:
             r["id"] = str(r["id"])

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -2027,6 +2027,47 @@ def get_recent_unlinked_incidents(user_id):
 _ALLOWED_SEVERITIES = {"critical", "high", "medium", "low"}
 
 
+@incidents_bp.route("/api/incidents/<incident_id>/action-runs", methods=["GET"])
+@require_permission("incidents", "read")
+def get_incident_action_runs(user_id, incident_id: str):
+    """Return action runs linked to a specific incident."""
+    if not _validate_uuid(incident_id):
+        return jsonify({"error": "Invalid incident ID"}), 400
+
+    org_id = get_org_id_from_request()
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
+                cursor.execute(
+                    """SELECT r.id, r.action_id, r.status, r.chat_session_id,
+                              r.started_at, r.completed_at, r.error,
+                              a.name AS action_name
+                       FROM action_runs r
+                       JOIN actions a ON a.id = r.action_id
+                       WHERE r.incident_id = %s AND r.org_id = %s
+                       ORDER BY r.started_at DESC""",
+                    (incident_id, org_id),
+                )
+                cols = [d[0] for d in cursor.description]
+                rows = [dict(zip(cols, row)) for row in cursor.fetchall()]
+
+        for r in rows:
+            r["id"] = str(r["id"])
+            r["action_id"] = str(r["action_id"])
+            r["chat_session_id"] = str(r["chat_session_id"]) if r["chat_session_id"] else None
+            if r["started_at"] and r["completed_at"]:
+                r["duration_ms"] = max(0, int((r["completed_at"] - r["started_at"]).total_seconds() * 1000))
+            r["started_at"] = _format_timestamp(r["started_at"])
+            r["completed_at"] = _format_timestamp(r["completed_at"])
+
+        return jsonify({"runs": rows})
+    except Exception:
+        logger.exception("[INCIDENTS] Failed to get action runs for incident %s", sanitize(incident_id))
+        return jsonify({"error": "Failed to retrieve action runs"}), 500
+
+
 @incidents_bp.route("/api/incidents/trigger-rca", methods=["POST"])
 @require_permission("incidents", "write")
 def trigger_rca_from_chat(user_id):

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -117,11 +117,26 @@ def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "
             )
             rows = cur.fetchall()
 
+            # Dedup: skip actions already running for this incident
+            action_ids = [str(r[0]) for r in rows]
+            already_running = set()
+            if action_ids:
+                cur.execute(
+                    """SELECT DISTINCT action_id FROM action_runs
+                       WHERE action_id = ANY(%s::uuid[]) AND incident_id = %s::uuid
+                         AND status IN ('pending', 'running')""",
+                    (action_ids, incident_id),
+                )
+                already_running = {str(r[0]) for r in cur.fetchall()}
+
     for action_id, trigger_config, system_key in rows:
         cfg = trigger_config or {}
         action_timing = cfg.get("timing", "immediate")
 
         if action_timing != timing:
+            continue
+
+        if str(action_id) in already_running:
             continue
 
         try:

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -1,4 +1,5 @@
 """Actions executor -- dispatches action runs as background chat sessions."""
+import hashlib
 import json
 import logging
 import os
@@ -117,37 +118,45 @@ def dispatch_on_incident_actions(user_id: str, incident_id: str, timing: str = "
             )
             rows = cur.fetchall()
 
-            # Dedup: skip actions already running for this incident
-            action_ids = [str(r[0]) for r in rows]
-            already_running = set()
-            if action_ids:
-                cur.execute(
-                    """SELECT DISTINCT action_id FROM action_runs
-                       WHERE action_id = ANY(%s::uuid[]) AND incident_id = %s::uuid
-                         AND status IN ('pending', 'running')""",
-                    (action_ids, incident_id),
-                )
-                already_running = {str(r[0]) for r in cur.fetchall()}
-
     for action_id, trigger_config, system_key in rows:
         cfg = trigger_config or {}
         action_timing = cfg.get("timing", "immediate")
 
+        # Wrong timing for this dispatch cycle
         if action_timing != timing:
             continue
 
-        if str(action_id) in already_running:
-            continue
+        # Atomic dedup: advisory lock serializes concurrent dispatchers for the
+        # same (action, incident) pair so the SELECT+INSERT is race-free.
+        lock_key = int.from_bytes(
+            hashlib.sha256(f"{action_id}:{incident_id}".encode()).digest()[:7],
+            byteorder="big", signed=False,
+        ) & 0x7FFFFFFFFFFFFFFF  # pg_advisory_xact_lock takes a bigint
 
         try:
-            if system_key == "generate_postmortem":
-                _dispatch_postmortem_via_action(user_id, incident_id)
-            else:
-                dispatch_action(
-                    action_id=str(action_id),
-                    user_id=user_id,
-                    trigger_context={"source": "on_incident", "incident_id": incident_id},
-                )
+            with db_pool.get_connection() as conn:
+                with conn.cursor() as cur:
+                    set_rls_context(cur, conn, user_id, log_prefix="[Actions:dedup]")
+                    cur.execute("SELECT pg_advisory_xact_lock(%s)", (lock_key,))
+                    cur.execute(
+                        """SELECT 1 FROM action_runs
+                           WHERE action_id = %s::uuid AND incident_id = %s::uuid
+                             AND status IN ('pending', 'running')
+                           LIMIT 1""",
+                        (str(action_id), incident_id),
+                    )
+                    # Already has a pending/running run — skip
+                    if cur.fetchone():
+                        continue
+
+                    if system_key == "generate_postmortem":
+                        _dispatch_postmortem_via_action(user_id, incident_id)
+                    else:
+                        dispatch_action(
+                            action_id=str(action_id),
+                            user_id=user_id,
+                            trigger_context={"source": "on_incident", "incident_id": incident_id},
+                        )
         except Exception:
             logger.debug("[Actions] Failed to dispatch on_incident action %s", action_id)
 


### PR DESCRIPTION
## What this fixes

1. **RCA button was broken** — clicking "Root Cause Analysis" on an incident took you to the action chat instead of the actual RCA. Actions were overwriting `aurora_chat_session_id` on the incident.
   - `server/chat/background/task.py` — guard the session/status writes with `if not is_action_source`

2. **Actions visible on incident page** — added an "Actions" tab (like Waterfall) so you can see all actions that ran for an incident and jump to their chat.
   - `server/routes/incidents_routes.py` — new `GET /api/incidents/<id>/action-runs` endpoint
   - `client/src/app/incidents/components/IncidentActionRuns.tsx` — new component
   - `client/src/app/incidents/components/IncidentCard.tsx` — added the tab button + collapsible panel
   - `client/src/app/api/incidents/[id]/action-runs/route.ts` — Next.js proxy route

3. **Postmortem generation spinner was broken** — resolving an incident triggered postmortem gen but the UI would stop spinning and show "Generate Postmortem" button while it was still generating in the background.
   - Root cause: backend returns HTTP 202 with `{status: "generating"}`, but `apiGet` treats 202 as success (not an error). The catch block checking `apiErr.status === 202` was dead code.
   - `client/src/lib/services/incidents.ts` — check `data.status === 'generating'` in the success path

4. **Actions dispatching was broken** — `dispatch_on_incident_actions` had a UUID type mismatch (`uuid = text`) in the dedup query that crashed the entire function silently, preventing all on-incident actions (including postmortem gen on resolve) from firing.
   - `server/services/actions/executor.py` — cast to `::uuid[]` / `::uuid` in the dedup query


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsible "Actions" panel on incident cards with animated chevron.
  * Action runs list showing status (live indicator when running), action name, duration, start time, truncated error tooltip, and "View" link to related chat sessions.
  * Loading and empty states ("Loading actions..." / "No actions have run for this incident.").

* **New API**
  * Endpoint to fetch action runs for an incident.

* **Bug Fixes**
  * Prevent duplicate action deliveries and avoid triggering incident-side workflows for action-originated runs.
  * Avoid dispatching duplicate action runs; postmortem generation state correctly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->