### PR TITLE
fix: route google/ prefixed models through Vertex AI provider

### DIFF
--- a/server/chat/backend/agent/providers/vertex_provider.py
+++ b/server/chat/backend/agent/providers/vertex_provider.py
@@ -95,11 +95,12 @@ class VertexAIProvider(BaseLLMProvider):
 
     def supports_model(self, model: str) -> bool:
         if "/" in model:
-            return model.split("/")[0] == "vertex"
+            prefix = model.split("/")[0]
+            return prefix in ("vertex", "google")
         return False
 
     def get_native_model_name(self, model: str) -> str:
-        if "/" in model and model.split("/")[0] == "vertex":
+        if "/" in model and model.split("/")[0] in ("vertex", "google"):
             return model.split("/", 1)[1]
         return model
 


### PR DESCRIPTION
## Summary

- When `LLM_PROVIDER_MODE=vertex`, models with a `google/` prefix (e.g. `google/gemini-3.1-pro-preview`) now route through the Vertex AI provider instead of failing with "Provider 'google' is not available"
- The vertex provider's `supports_model` and `get_native_model_name` now accept both `vertex/` and `google/` prefixes since Vertex AI serves the same underlying Gemini models

## Test plan

- [ ] Set `LLM_PROVIDER_MODE=vertex` with valid Vertex credentials
- [ ] Select a `google/` prefixed model in the chat UI
- [ ] Verify the request routes through Vertex AI successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended model identifier support to accept `google/` prefixed identifiers in addition to `vertex/` prefixes for Vertex AI provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->