### PR TITLE
feat: Add get_recent_incidents tool for RCA agent

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -2547,6 +2547,21 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         except Exception as e:
             logging.warning(f"Failed to add get_alert_field tool: {e}")
 
+        try:
+            from .recent_incidents_tool import get_recent_incidents, GetRecentIncidentsArgs, GET_RECENT_INCIDENTS_DESCRIPTION
+            _ctx = with_forced_context(get_recent_incidents)
+            _notif = with_completion_notification(_ctx)
+            _final = wrap_func_with_capture(_notif, "get_recent_incidents") if tool_capture else _notif
+            tools.append(StructuredTool.from_function(
+                func=_final,
+                name="get_recent_incidents",
+                description=GET_RECENT_INCIDENTS_DESCRIPTION,
+                args_schema=GetRecentIncidentsArgs,
+            ))
+            logging.info(f"Added get_recent_incidents tool for incident {incident_id}")
+        except Exception as e:
+            logging.warning(f"Failed to add get_recent_incidents tool: {e}")
+
     logging.info(f"Created {len(tools)} Aurora native tools")
     
     # Add real MCP tools if available

--- a/server/chat/backend/agent/tools/recent_incidents_tool.py
+++ b/server/chat/backend/agent/tools/recent_incidents_tool.py
@@ -20,10 +20,14 @@ _SUMMARY_TRUNCATION_CHARS = 500
 class GetRecentIncidentsArgs(BaseModel):
     time_window_hours: int = Field(
         default=72,
+        ge=1,
+        le=168,
         description="How far back to look in hours (default: 72h / 3 days)",
     )
     limit: int = Field(
         default=20,
+        ge=1,
+        le=50,
         description="Maximum number of incidents to return",
     )
     service_filter: Optional[str] = Field(

--- a/server/chat/backend/agent/tools/recent_incidents_tool.py
+++ b/server/chat/backend/agent/tools/recent_incidents_tool.py
@@ -1,0 +1,120 @@
+"""
+Recent Incidents Tool
+
+Retrieves recent completed incident investigations for situational awareness
+during RCA. Lets the agent see what Aurora has already investigated recently,
+enabling it to independently notice overlapping root causes.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_TRUNCATION_CHARS = 500
+
+
+class GetRecentIncidentsArgs(BaseModel):
+    time_window_hours: int = Field(
+        default=72,
+        description="How far back to look in hours (default: 72h / 3 days)",
+    )
+    limit: int = Field(
+        default=20,
+        description="Maximum number of incidents to return",
+    )
+    service_filter: Optional[str] = Field(
+        default=None,
+        description="Optional service name to filter by (matches alert_service or affected_services)",
+    )
+
+
+GET_RECENT_INCIDENTS_DESCRIPTION = (
+    "List recent incidents that Aurora has already investigated. "
+    "Returns alert titles, affected services, severity, and root cause summaries. "
+    "Available for situational awareness during investigation."
+)
+
+
+def get_recent_incidents(
+    time_window_hours: int = 72,
+    limit: int = 20,
+    service_filter: Optional[str] = None,
+    user_id: Optional[str] = None,
+    incident_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    """Retrieve recent analyzed incidents for situational awareness."""
+    if not user_id:
+        return json.dumps({"error": "User authentication required."})
+
+    if not incident_id:
+        return json.dumps({"error": "No incident context. This tool is only available during RCA investigations."})
+
+    from utils.db.connection_pool import db_pool
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                from utils.auth.stateless_auth import set_rls_context
+
+                set_rls_context(cursor, conn, user_id, log_prefix="[GetRecentIncidents]")
+
+                params = []
+                conditions = [
+                    "status = 'analyzed'",
+                    "id != %s",
+                    "started_at >= NOW() - INTERVAL '%s hours'",
+                ]
+                params.append(incident_id)
+                params.append(time_window_hours)
+
+                if service_filter:
+                    conditions.append(
+                        "(alert_service ILIKE %s OR %s = ANY(affected_services))"
+                    )
+                    params.append(f"%{service_filter}%")
+                    params.append(service_filter)
+
+                query = f"""
+                    SELECT id, alert_title, alert_service, severity,
+                           aurora_summary, started_at, affected_services,
+                           correlated_alert_count
+                    FROM incidents
+                    WHERE {' AND '.join(conditions)}
+                    ORDER BY started_at DESC
+                    LIMIT %s
+                """
+                params.append(limit)
+
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
+
+                if not rows:
+                    return json.dumps({"incidents": [], "count": 0})
+
+                incidents = []
+                for row in rows:
+                    summary = row[4] or ""
+                    if len(summary) > _SUMMARY_TRUNCATION_CHARS:
+                        summary = summary[:_SUMMARY_TRUNCATION_CHARS] + "..."
+
+                    incidents.append({
+                        "id": str(row[0]),
+                        "alert_title": row[1],
+                        "alert_service": row[2],
+                        "severity": row[3],
+                        "aurora_summary": summary,
+                        "started_at": row[5].isoformat() if row[5] else None,
+                        "affected_services": row[6] or [],
+                        "correlated_alert_count": row[7] or 0,
+                    })
+
+                return json.dumps({"incidents": incidents, "count": len(incidents)})
+
+    except Exception as e:
+        logger.exception("[GetRecentIncidents] Error retrieving recent incidents: %s", e)
+        return json.dumps({"error": f"Error retrieving recent incidents: {e}"})

--- a/server/chat/backend/agent/tools/recent_incidents_tool.py
+++ b/server/chat/backend/agent/tools/recent_incidents_tool.py
@@ -8,9 +8,11 @@ enabling it to independently notice overlapping root causes.
 
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
+
+from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +51,7 @@ def get_recent_incidents(
     service_filter: Optional[str] = None,
     user_id: Optional[str] = None,
     incident_id: Optional[str] = None,
-    **kwargs,
+    **kwargs: Any,  # Accepted for LangChain tool injection compatibility
 ) -> str:
     """Retrieve recent analyzed incidents for situational awareness."""
     if not user_id:
@@ -65,7 +67,9 @@ def get_recent_incidents(
             with conn.cursor() as cursor:
                 from utils.auth.stateless_auth import set_rls_context
 
-                set_rls_context(cursor, conn, user_id, log_prefix="[GetRecentIncidents]")
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[GetRecentIncidents]")
+                if not org_id:
+                    return json.dumps({"error": "Failed to resolve organization context."})
 
                 params = []
                 conditions = [
@@ -120,5 +124,5 @@ def get_recent_incidents(
                 return json.dumps({"incidents": incidents, "count": len(incidents)})
 
     except Exception as e:
-        logger.exception("[GetRecentIncidents] Error retrieving recent incidents: %s", e)
-        return json.dumps({"error": f"Error retrieving recent incidents: {e}"})
+        logger.exception("[GetRecentIncidents] Error retrieving recent incidents: %s", sanitize(e))
+        return json.dumps({"error": f"Error retrieving recent incidents: {sanitize(e)}"})


### PR DESCRIPTION
Rca tool that lets the RCA agent view recently investigated incidents for situational awareness. The default is 3 days with a max of one week (these can be changed later)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During background RCA sessions, users can fetch a list of recently analyzed incidents (excluding the current incident).
  * Results include key fields (id, title, service, severity, started_at, affected services, correlated count) and a truncated summary, ordered newest first, with configurable time window and limit.
  * Optional service filter supported; errors return a safe JSON error payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->