### PR TITLE
fix: use connection pool in health endpoint to prevent DB connection leak (re-fires after INC-440)

### DIFF
--- a/server/routes/health_routes.py
+++ b/server/routes/health_routes.py
@@ -10,7 +10,6 @@ import requests
 import socket
 from datetime import datetime, timezone
 from flask import Blueprint, jsonify
-import psycopg2
 import redis
 from celery_config import celery_app
 
@@ -21,33 +20,19 @@ logger = logging.getLogger(__name__)
 health_bp = Blueprint('health', __name__)
 
 def check_database_health():
-    """Check PostgreSQL database connectivity."""
+    """Check PostgreSQL database connectivity using the shared connection pool."""
     try:
-        # Connect using unified POSTGRES_* variables
         user = os.getenv('POSTGRES_USER')
         password = os.getenv('POSTGRES_PASSWORD')
-        host = os.getenv('POSTGRES_HOST')
-        port = os.getenv('POSTGRES_PORT')
-        dbname = os.getenv('POSTGRES_DB')
 
         if not user or not password:
             return {"status": "unhealthy", "error": "Database credentials not configured"}
 
-        conn = psycopg2.connect(
-            host=host,
-            port=port,
-            dbname=dbname,
-            user=user,
-            password=password,
-            sslmode=os.getenv('POSTGRES_SSLMODE', 'prefer') or None,
-            sslrootcert=os.getenv('POSTGRES_SSLROOTCERT') or None,
-        )
-
-        cursor = conn.cursor()
-        # No RLS needed — infrastructure health check
-        cursor.execute("SELECT 1")
-        cursor.close()
-        conn.close()
+        from utils.db.connection_pool import db_pool
+        with db_pool.get_connection() as conn:
+            with conn.cursor() as cursor:
+                # No RLS needed — infrastructure health check
+                cursor.execute("SELECT 1")
 
         return {"status": "healthy", "message": "Database connection successful"}
     except Exception as e:


### PR DESCRIPTION
## Problem

The `/health/readiness` Kubernetes probe calls `check_database_health()`, which opens a **brand-new raw `psycopg2` connection on every invocation** rather than borrowing from the shared `DatabaseConnectionPool`.

With Kubernetes probing at ~6 req/min per pod × 2 server pods, this continuously generates **~12 new Cloud SQL backend connections per minute**. Under any DB stress (checkpoint writes, autovacuum, client resets), these extra connections amplify latency for all DB-touching requests — causing the >5s slow request threshold to be breached.

### History
- **INC-440** (2026-06-10 ~15:34–16:18 UTC): First occurrence. PR [#494](https://github.com/Arvo-AI/aurora/pull/494) was created with this exact fix but was **closed without merging**.
- **This incident** (2026-06-12): Same root cause re-fires. The unfixed connection leak continues to amplify DB latency under load.

## Fix

Replace the ad-hoc `psycopg2.connect(...)` call in `check_database_health()` with `db_pool.get_connection()` — the existing `DatabaseConnectionPool` singleton already used everywhere else in the server.

**Before:**
```python
import psycopg2
conn = psycopg2.connect(host=host, port=port, dbname=dbname, user=user, password=password, ...)
cursor = conn.cursor()
cursor.execute("SELECT 1")
cursor.close()
conn.close()
```

**After:**
```python
from utils.db.connection_pool import db_pool
with db_pool.get_connection() as conn:
    with conn.cursor() as cursor:
        cursor.execute("SELECT 1")
```

The pooled connection is borrowed for the duration of the `SELECT 1` and immediately returned. No new backend connection is created; the pool's existing idle connections are reused.

Also removes the now-unused `import psycopg2` from the module.

## Expected outcome

- Health endpoint stops creating new DB connections on every probe
- Cloud SQL backend connection count stays stable regardless of probe frequency
- No change to health check semantics — endpoint still returns `healthy`/`unhealthy` based on query execution
- Slow request alert stops firing due to this cause

## Related

- **Incident:** Aurora Prod - User-Facing Slow Requests (>5s) > 10 in 5 min — https://infrapoo.org/incidents/6034a011-4836-4e7c-a638-e164e6667675
- **Previous incident:** INC-440 — https://infrapoo.org/incidents/ (2026-06-10)
- **Previous PR (closed without merge):** #494


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database health check endpoint's connection management approach for enhanced resource efficiency while preserving existing validation and response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->