### PR TITLE
Add frontendImage override to Helm chart

### DIFF
--- a/deploy/helm/aurora/templates/frontend-deployment.yaml
+++ b/deploy/helm/aurora/templates/frontend-deployment.yaml
@@ -26,14 +26,18 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- include "aurora.podSecurityContext" (dict "service" "frontend" "global" $ "defaults" (dict "runAsUser" 1000 "runAsGroup" 1000 "fsGroup" 1000)) | nindent 8 }}
-      {{- if .Values.image.pullSecrets }}
+      {{- if or .Values.image.pullSecrets (and .Values.frontendImage .Values.frontendImage.pullSecrets) }}
       imagePullSecrets:
+        {{- if and .Values.frontendImage .Values.frontendImage.pullSecrets }}
+        {{- toYaml .Values.frontendImage.pullSecrets | nindent 8 }}
+        {{- else }}
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- include "aurora.scheduling" (dict "service" "frontend" "global" $) | nindent 6 }}
       containers:
         - name: aurora-frontend
-          image: "{{ .Values.image.registry }}/aurora-frontend:{{ .Values.image.tag }}"
+          image: "{{ if and .Values.frontendImage .Values.frontendImage.tag }}{{ .Values.frontendImage.registry }}/{{ .Values.frontendImage.repository }}:{{ .Values.frontendImage.tag }}{{ else }}{{ .Values.image.registry }}/aurora-frontend:{{ .Values.image.tag }}{{ end }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             {{- include "aurora.containerSecurityContext" (dict "service" "frontend" "global" $ "defaults" (dict)) | nindent 12 }}

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -78,6 +78,20 @@ image:
   #   - name: regcred
 
 # ------------------------------------------------------------------------------
+# Frontend image override
+# ------------------------------------------------------------------------------
+# When set, the frontend deployment uses this image instead of the default
+# aurora-frontend from image.registry. Useful for custom frontend builds
+# (e.g. with additional analytics or SaaS overlay features).
+# Deploy with: helm upgrade --reuse-values --set frontendImage.tag=sha-abc1234
+frontendImage: {}
+  # registry: "ghcr.io/your-org"
+  # repository: "aurora-frontend-custom"
+  # tag: "sha-abc1234"
+  # pullSecrets:
+  #   - name: ghcr-pull
+
+# ------------------------------------------------------------------------------
 # Autoscaling (HPA)
 # ------------------------------------------------------------------------------
 autoscaling:


### PR DESCRIPTION
## Summary
- Adds `frontendImage` section to values.yaml for deploying a custom frontend image independently of the shared `image.registry`/`image.tag`
- Template falls back to `image.registry/aurora-frontend:image.tag` when `frontendImage.tag` is unset (no change for existing deployments)
- Supports its own `pullSecrets` for private registries, falls back to `image.pullSecrets` otherwise

## Usage
```bash
helm upgrade --reuse-values \
  --set frontendImage.registry=ghcr.io/org \
  --set frontendImage.repository=aurora-frontend-custom \
  --set frontendImage.tag=sha-abc1234
```

## Test plan
- [ ] `helm template` with no `frontendImage` set — uses default `image.registry/aurora-frontend:image.tag`
- [ ] `helm template` with `frontendImage.tag` set — uses override image
- [ ] `helm template` with `frontendImage.pullSecrets` — uses frontend-specific pull secret
- [ ] `helm template` with only `image.pullSecrets` — frontend falls back to global pull secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend-specific image configuration in Helm values, enabling independent customization of registry, repository, tag, and pull secrets while maintaining backward compatibility with global defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->