### PR TITLE
Fix Slack shared workspace returning wrong user's token

### DIFF
--- a/server/routes/slack/slack_events_helpers.py
+++ b/server/routes/slack/slack_events_helpers.py
@@ -75,11 +75,13 @@ def _lookup_slack_token(team_id: str, include_secret_ref: bool = False) -> list:
     """
     Query user_tokens for Slack entries matching team_id, iterating orgs to
     bypass FORCE ROW LEVEL SECURITY (which blocks even superuser without context).
+    Returns all matching tokens across all orgs (multiple users may share a workspace).
     """
     org_ids = _get_all_org_ids()
     if not org_ids:
         return []
 
+    all_results = []
     errors = 0
     for org_id in org_ids:
         try:
@@ -110,7 +112,7 @@ def _lookup_slack_token(team_id: str, include_secret_ref: bool = False) -> list:
                         )
                     results = cursor.fetchall()
                     if results:
-                        return results
+                        all_results.extend(results)
         except Exception as e:
             errors += 1
             logger.debug(f"Error querying slack tokens for org {org_id}: {e}")
@@ -118,7 +120,7 @@ def _lookup_slack_token(team_id: str, include_secret_ref: bool = False) -> list:
 
     if errors == len(org_ids):
         logger.warning(f"All org lookups failed for Slack team {sanitize(team_id)} ({errors} errors)")
-    return []
+    return all_results
 
 
 def get_user_id_from_slack_team(team_id: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- When multiple Aurora orgs share a Slack workspace, `_lookup_slack_token` was short-circuiting on the first org with a match
- If user A (org 1) and user B (org 2) both connected the same Slack workspace, and the iteration found org 1 first, user B would always get "not authenticated"
- Fix: collect all matching tokens across all orgs instead of returning the first match

## Root Cause
`_lookup_slack_token` had `if results: return results` inside the org loop, so it never checked subsequent orgs for the same team_id.

## Test plan
- [ ] Deploy and verify @Aurora mention works for users in shared workspaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced Slack integration's token lookup functionality to properly aggregate matching tokens across all organizations instead of stopping at the first result, significantly improving support for users managing multi-organization environments.
- Improved error handling to return accumulated results when available, rather than discarding partial matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->