### PR TITLE
feat: add marketplace metering hooks and extraEnv Helm support

### DIFF
--- a/deploy/helm/aurora/templates/celery-beat-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-beat-deployment.yaml
@@ -64,6 +64,10 @@ spec:
                 name: {{ include "aurora.secretName.backend" . }}
             - secretRef:
                 name: {{ include "aurora.secretName.app" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.celeryBeat | nindent 12 }}
           {{- if .Values.ssl.caCertSecret }}

--- a/deploy/helm/aurora/templates/celery-worker-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-worker-deployment.yaml
@@ -66,6 +66,10 @@ spec:
                 name: {{ include "aurora.secretName.app" . }}
             - secretRef:
                 name: {{ include "aurora.secretName.llm" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: terraform-workdir
               mountPath: /app/terraform_workdir

--- a/deploy/helm/aurora/templates/chatbot-deployment.yaml
+++ b/deploy/helm/aurora/templates/chatbot-deployment.yaml
@@ -64,6 +64,10 @@ spec:
                 name: {{ include "aurora.secretName.app" . }}
             - secretRef:
                 name: {{ include "aurora.secretName.llm" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: terraform-workdir
               mountPath: /app/terraform_workdir

--- a/deploy/helm/aurora/templates/server-deployment.yaml
+++ b/deploy/helm/aurora/templates/server-deployment.yaml
@@ -61,6 +61,10 @@ spec:
                 name: {{ include "aurora.secretName.backend" . }}
             - secretRef:
                 name: {{ include "aurora.secretName.app" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: terraform-workdir
               mountPath: /app/terraform_workdir

--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -108,6 +108,17 @@ autoscaling:
     targetCPU: 70
 
 # ------------------------------------------------------------------------------
+# Extra environment variables (for marketplace metering, custom integrations, etc.)
+# ------------------------------------------------------------------------------
+extraEnv: []
+# Example:
+#   extraEnv:
+#     - name: AWS_MP_PRODUCT_CODE
+#       value: "prod-abc123"
+#     - name: GCP_MP_SERVICE_NAME
+#       value: "aurora-marketplace.endpoints.project.cloud.goog"
+
+# ------------------------------------------------------------------------------
 # Celery worker pod settings
 # ------------------------------------------------------------------------------
 celeryWorker:

--- a/server/chat/backend/agent/utils/llm_usage_tracker.py
+++ b/server/chat/backend/agent/utils/llm_usage_tracker.py
@@ -331,7 +331,19 @@ class LLMUsageTracker:
                     logger.debug(f"Cleared API cost cache for user {usage.user_id} after new usage record")
                 except Exception as cache_error:
                     logger.warning(f"Failed to clear API cost cache after usage store: {cache_error}")
-                
+
+                # Report usage to marketplace metering (no-op unless hooks are configured)
+                try:
+                    from utils.hooks import get_hook
+                    get_hook("report_usage")(usage.org_id, usage.estimated_cost, {
+                        "user_id": usage.user_id,
+                        "model": usage.model_name,
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                    })
+                except Exception as hook_err:
+                    logger.debug(f"report_usage hook error (non-fatal): {hook_err}")
+
                 return True
 
         except Exception as e:

--- a/server/chat/backend/agent/utils/llm_usage_tracker.py
+++ b/server/chat/backend/agent/utils/llm_usage_tracker.py
@@ -341,8 +341,8 @@ class LLMUsageTracker:
                         "input_tokens": usage.input_tokens,
                         "output_tokens": usage.output_tokens,
                     })
-                except Exception:
-                    pass
+                except Exception as hook_err:
+                    logger.debug("report_usage hook error (non-fatal): %s", hook_err)
 
                 return True
 

--- a/server/chat/backend/agent/utils/llm_usage_tracker.py
+++ b/server/chat/backend/agent/utils/llm_usage_tracker.py
@@ -332,17 +332,17 @@ class LLMUsageTracker:
                 except Exception as cache_error:
                     logger.warning(f"Failed to clear API cost cache after usage store: {cache_error}")
 
-                # Report usage to marketplace metering (no-op unless hooks are configured)
+                # Report usage to marketplace metering (no-op unless hooks are configured).
+                # Implementations must be non-blocking (buffer + flush pattern).
                 try:
                     from utils.hooks import get_hook
                     get_hook("report_usage")(usage.org_id, usage.estimated_cost, {
-                        "user_id": usage.user_id,
                         "model": usage.model_name,
                         "input_tokens": usage.input_tokens,
                         "output_tokens": usage.output_tokens,
                     })
-                except Exception as hook_err:
-                    logger.debug(f"report_usage hook error (non-fatal): {hook_err}")
+                except Exception:
+                    pass
 
                 return True
 

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -104,11 +104,16 @@ def get_hook(name: str):
     else:
         fn = _HOOK_REGISTRY[name]
 
-    # Wrap in safety net so a broken hook never crashes the caller
+    # Hooks that gate access must fail closed; all others fail open.
+    _fail_closed_hooks = {"verify_entitlement"}
+
     def _safe_hook(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
         except Exception as e:
+            if name in _fail_closed_hooks:
+                logger.error("Hook '%s' raised: %s — failing closed", name, e)
+                return False, "Entitlement verification unavailable"
             logger.error("Hook '%s' raised: %s — failing open", name, e)
             return _HOOK_REGISTRY[name](*args, **kwargs)
 

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -41,11 +41,23 @@ def _default_before_add_member(org_id: str, current_member_count: int) -> Tuple[
     return True, None
 
 
+def _default_report_usage(org_id: Optional[str], usage_usd: float, metadata: dict) -> None:
+    """Called after LLM usage is recorded. For marketplace metering integration."""
+    pass
+
+
+def _default_verify_entitlement(org_id: Optional[str]) -> Tuple[bool, Optional[str]]:
+    """Verify the org has a valid marketplace entitlement. Return (False, message) to block."""
+    return True, None
+
+
 # Explicit registry — only these names are valid hook points
 _HOOK_REGISTRY = {
     "before_llm_call": _default_before_llm_call,
     "after_llm_call": _default_after_llm_call,
     "before_add_member": _default_before_add_member,
+    "report_usage": _default_report_usage,
+    "verify_entitlement": _default_verify_entitlement,
 }
 
 

--- a/server/utils/hooks.py
+++ b/server/utils/hooks.py
@@ -110,11 +110,11 @@ def get_hook(name: str):
     def _safe_hook(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except Exception as e:
+        except Exception:
             if name in _fail_closed_hooks:
-                logger.error("Hook '%s' raised: %s — failing closed", name, e)
+                logger.exception("Hook '%s' raised — failing closed", name)
                 return False, "Entitlement verification unavailable"
-            logger.error("Hook '%s' raised: %s — failing open", name, e)
+            logger.exception("Hook '%s' raised — failing open", name)
             return _HOOK_REGISTRY[name](*args, **kwargs)
 
     _hook_cache[name] = _safe_hook


### PR DESCRIPTION
## Summary
- Add `report_usage` and `verify_entitlement` hook points to `utils/hooks.py` (no-ops by default, same pattern as `before_llm_call`)
- Fire `report_usage` from `LLMUsageTracker.store_usage()` after every LLM call is persisted
- Add `extraEnv` field to all backend Helm deployment templates (server, chatbot, celery-worker, celery-beat) so marketplace-specific env vars can be injected via values overlays

## Context
Preparing for AWS and GCP Marketplace listings. The marketplace overlays (in `aurora-saas-prod`) will implement these hooks to report usage to AWS MeterUsage / GCP Service Control APIs and verify entitlements. This PR adds only the generic hook points — no marketplace-specific code touches OSS.

## Test plan
- [ ] `helm template` renders correctly with `extraEnv` set and unset
- [ ] Python syntax validation passes on modified files
- [ ] Existing hook behavior unchanged (no-ops when `AURORA_HOOKS_MODULE` is unset)
- [ ] `before_llm_call` budget gating still works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart now supports injecting additional environment variables via `extraEnv` across all deployed services (server, chatbot, Celery worker, Celery beat).
  * Marketplace metering is enabled with new hook points to report LLM usage and verify entitlements.

* **Behavior Changes**
  * Usage reporting invokes a metering hook after tracking new LLM usage (errors won’t break normal processing).
  * Entitlement verification now fails closed when hook evaluation errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->