### PR TITLE
Add file-size guard on artifact creation via MCP GitHub tools

### DIFF
--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -66,6 +66,113 @@ def is_destructive_mcp_tool(tool_name: str) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# File-size guard for GitHub write MCP tools (issue #521)
+# ---------------------------------------------------------------------------
+# When the LLM's output is silently truncated, create_or_update_file pushes
+# a partial file to GitHub, destroying the original.  The guard rejects
+# writes where the new content is suspiciously small relative to the
+# existing file or exceeds a hard size cap.
+_FILE_SIZE_GUARD_ABS_CAP = 50_000       # reject content > 50 KB outright
+_FILE_SIZE_GUARD_MIN_ORIGINAL = 10_000   # only compare ratio when original > 10 KB
+_FILE_SIZE_GUARD_MIN_RATIO = 0.50        # new must be >= 50% of original
+
+
+def _check_file_size_guard(
+    original_tool_name: str,
+    kwargs: dict,
+    manager: "RealMCPServerManager",
+    run_async,
+) -> str | None:
+    """Return an error string if the write should be blocked, else ``None``.
+
+    For ``create_or_update_file``: if the file already exists on GitHub
+    (``sha`` is present), fetches the current size via ``get_file_contents``.
+    Rejects when the new content is < 50% of the original (and the original
+    exceeds 10 KB) -- the signature of a truncated LLM output.
+
+    For ``push_files``: applies only the absolute 50 KB cap per file entry.
+    """
+    if original_tool_name == "create_or_update_file":
+        content = kwargs.get("content", "")
+        new_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
+
+        # Hard cap
+        if new_size > _FILE_SIZE_GUARD_ABS_CAP:
+            return (
+                f"Blocked: content is {new_size:,} bytes which exceeds the "
+                f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for create_or_update_file. "
+                "Use push_files with git or incremental edits for large files."
+            )
+
+        # Ratio check -- only when updating an existing file (sha present)
+        owner = kwargs.get("owner")
+        repo = kwargs.get("repo")
+        path = kwargs.get("path")
+        branch = kwargs.get("branch")
+        sha = kwargs.get("sha")
+
+        if sha and owner and repo and path:
+            try:
+                get_kwargs: dict = {"owner": owner, "repo": repo, "path": path}
+                if branch:
+                    get_kwargs["branch"] = branch
+                result = run_async(
+                    manager.call_mcp_tool("github", "get_file_contents", get_kwargs)
+                )
+                existing_size = _extract_github_file_size(result)
+                if (
+                    existing_size is not None
+                    and existing_size > _FILE_SIZE_GUARD_MIN_ORIGINAL
+                    and new_size < existing_size * _FILE_SIZE_GUARD_MIN_RATIO
+                ):
+                    return (
+                        f"Blocked: new content ({new_size:,} bytes) is less than "
+                        f"{int(_FILE_SIZE_GUARD_MIN_RATIO * 100)}% of the existing "
+                        f"file ({existing_size:,} bytes).  This looks like a "
+                        "truncated LLM output.  Use incremental (line-level) edits "
+                        "or push_files with the complete file content instead."
+                    )
+            except Exception as exc:
+                logging.warning(
+                    "[FileGuard] Could not fetch existing file for %s/%s/%s -- "
+                    "skipping ratio check: %s", owner, repo, path, exc,
+                )
+
+    elif original_tool_name == "push_files":
+        files = kwargs.get("files") or []
+        for entry in files:
+            if isinstance(entry, dict):
+                content = entry.get("content", "")
+                entry_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
+                if entry_size > _FILE_SIZE_GUARD_ABS_CAP:
+                    return (
+                        f"Blocked: file entry '{entry.get('path', '?')}' is "
+                        f"{entry_size:,} bytes, exceeding the "
+                        f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for push_files. "
+                        "Split large file changes into smaller commits."
+                    )
+
+    return None
+
+
+def _extract_github_file_size(mcp_result: dict | None) -> int | None:
+    """Best-effort extraction of a file's byte size from a ``get_file_contents`` response."""
+    if not mcp_result:
+        return None
+    try:
+        content_items = mcp_result.get("content") or []
+        for item in content_items:
+            if isinstance(item, dict) and "text" in item:
+                import json as _json
+                data = _json.loads(item["text"])
+                if isinstance(data, dict) and "size" in data:
+                    return int(data["size"])
+    except Exception:
+        pass
+    return None
+
+
 def summarize_mcp_tool_action(tool_name: str, kwargs: dict) -> str:
     """Generate a human-readable summary of what the MCP tool will do."""
     action = tool_name.replace("_", " ")
@@ -1320,7 +1427,30 @@ def create_mcp_langchain_tools(real_mcp_tools: List, tool_capture=None, send_too
                     except Exception as confirm_err:
                         logging.warning(f"Failed to get confirmation for {tool_name}: {confirm_err}")
                         # Continue without confirmation if there's an error
-                
+
+                # File-size guard (issue #521) -- reject writes that look like
+                # truncated LLM output before they reach the GitHub Contents API.
+                if server_type == "github" and original_tool_name in (
+                    "create_or_update_file", "push_files",
+                ):
+                    try:
+                        guard_msg = _check_file_size_guard(
+                            original_tool_name, kwargs, _mcp_manager, run_async_in_thread,
+                        )
+                        if guard_msg:
+                            logging.warning("[FileGuard] Blocked %s: %s", original_tool_name, guard_msg)
+                            try:
+                                if send_tool_completion:
+                                    send_tool_completion(tool_name, guard_msg, "blocked", tool_call_id)
+                            except Exception:
+                                pass
+                            return guard_msg
+                    except Exception as guard_exc:
+                        logging.warning(
+                            "[FileGuard] Guard check failed for %s, allowing through: %s",
+                            original_tool_name, guard_exc,
+                        )
+
                 try:
                     # Handle both old 'command' and new 'cli_command' parameters
                     if 'kwargs' in kwargs:

--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -84,75 +84,87 @@ def _check_file_size_guard(
     manager: "RealMCPServerManager",
     run_async,
 ) -> str | None:
-    """Return an error string if the write should be blocked, else ``None``.
-
-    For ``create_or_update_file``: if the file already exists on GitHub
-    (``sha`` is present), fetches the current size via ``get_file_contents``.
-    Rejects when the new content is < 50% of the original (and the original
-    exceeds 10 KB) -- the signature of a truncated LLM output.
-
-    For ``push_files``: applies only the absolute 50 KB cap per file entry.
-    """
+    """Return an error string if the write should be blocked, else ``None``."""
     if original_tool_name == "create_or_update_file":
-        content = kwargs.get("content", "")
-        new_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
+        return _guard_create_or_update_file(kwargs, manager, run_async)
+    if original_tool_name == "push_files":
+        return _guard_push_files(kwargs)
+    return None
 
-        # Hard cap
-        if new_size > _FILE_SIZE_GUARD_ABS_CAP:
+
+def _guard_create_or_update_file(
+    kwargs: dict,
+    manager: "RealMCPServerManager",
+    run_async,
+) -> str | None:
+    """Size guard for ``create_or_update_file``.
+
+    Applies the absolute cap and, when updating an existing file (``sha``
+    is present), checks that the new content is not suspiciously smaller
+    than the existing file (truncated LLM output heuristic).
+    """
+    content = kwargs.get("content", "")
+    new_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
+
+    if new_size > _FILE_SIZE_GUARD_ABS_CAP:
+        return (
+            f"Blocked: content is {new_size:,} bytes which exceeds the "
+            f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for create_or_update_file. "
+            "Use push_files with git or incremental edits for large files."
+        )
+
+    owner = kwargs.get("owner")
+    repo = kwargs.get("repo")
+    path = kwargs.get("path")
+    branch = kwargs.get("branch")
+    sha = kwargs.get("sha")
+
+    if not (sha and owner and repo and path):
+        return None
+
+    try:
+        get_kwargs: dict = {"owner": owner, "repo": repo, "path": path}
+        if branch:
+            get_kwargs["branch"] = branch
+        result = run_async(
+            manager.call_mcp_tool("github", "get_file_contents", get_kwargs)
+        )
+        existing_size = _extract_github_file_size(result)
+        if (
+            existing_size is not None
+            and existing_size > _FILE_SIZE_GUARD_MIN_ORIGINAL
+            and new_size < existing_size * _FILE_SIZE_GUARD_MIN_RATIO
+        ):
             return (
-                f"Blocked: content is {new_size:,} bytes which exceeds the "
-                f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for create_or_update_file. "
-                "Use push_files with git or incremental edits for large files."
+                f"Blocked: new content ({new_size:,} bytes) is less than "
+                f"{int(_FILE_SIZE_GUARD_MIN_RATIO * 100)}% of the existing "
+                f"file ({existing_size:,} bytes).  This looks like a "
+                "truncated LLM output.  Use incremental (line-level) edits "
+                "or push_files with the complete file content instead."
             )
+    except Exception as exc:
+        logging.warning(
+            "[FileGuard] Could not fetch existing file for %s/%s/%s -- "
+            "skipping ratio check: %s", owner, repo, path, exc,
+        )
 
-        # Ratio check -- only when updating an existing file (sha present)
-        owner = kwargs.get("owner")
-        repo = kwargs.get("repo")
-        path = kwargs.get("path")
-        branch = kwargs.get("branch")
-        sha = kwargs.get("sha")
+    return None
 
-        if sha and owner and repo and path:
-            try:
-                get_kwargs: dict = {"owner": owner, "repo": repo, "path": path}
-                if branch:
-                    get_kwargs["branch"] = branch
-                result = run_async(
-                    manager.call_mcp_tool("github", "get_file_contents", get_kwargs)
+
+def _guard_push_files(kwargs: dict) -> str | None:
+    """Size guard for ``push_files``: absolute cap per file entry."""
+    files = kwargs.get("files") or []
+    for entry in files:
+        if isinstance(entry, dict):
+            content = entry.get("content", "")
+            entry_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
+            if entry_size > _FILE_SIZE_GUARD_ABS_CAP:
+                return (
+                    f"Blocked: file entry '{entry.get('path', '?')}' is "
+                    f"{entry_size:,} bytes, exceeding the "
+                    f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for push_files. "
+                    "Split large file changes into smaller commits."
                 )
-                existing_size = _extract_github_file_size(result)
-                if (
-                    existing_size is not None
-                    and existing_size > _FILE_SIZE_GUARD_MIN_ORIGINAL
-                    and new_size < existing_size * _FILE_SIZE_GUARD_MIN_RATIO
-                ):
-                    return (
-                        f"Blocked: new content ({new_size:,} bytes) is less than "
-                        f"{int(_FILE_SIZE_GUARD_MIN_RATIO * 100)}% of the existing "
-                        f"file ({existing_size:,} bytes).  This looks like a "
-                        "truncated LLM output.  Use incremental (line-level) edits "
-                        "or push_files with the complete file content instead."
-                    )
-            except Exception as exc:
-                logging.warning(
-                    "[FileGuard] Could not fetch existing file for %s/%s/%s -- "
-                    "skipping ratio check: %s", owner, repo, path, exc,
-                )
-
-    elif original_tool_name == "push_files":
-        files = kwargs.get("files") or []
-        for entry in files:
-            if isinstance(entry, dict):
-                content = entry.get("content", "")
-                entry_size = len(content.encode("utf-8", errors="replace")) if isinstance(content, str) else 0
-                if entry_size > _FILE_SIZE_GUARD_ABS_CAP:
-                    return (
-                        f"Blocked: file entry '{entry.get('path', '?')}' is "
-                        f"{entry_size:,} bytes, exceeding the "
-                        f"{_FILE_SIZE_GUARD_ABS_CAP:,}-byte safety cap for push_files. "
-                        "Split large file changes into smaller commits."
-                    )
-
     return None
 
 

--- a/server/chat/backend/agent/tools/mcp_tools.py
+++ b/server/chat/backend/agent/tools/mcp_tools.py
@@ -160,16 +160,16 @@ def _extract_github_file_size(mcp_result: dict | None) -> int | None:
     """Best-effort extraction of a file's byte size from a ``get_file_contents`` response."""
     if not mcp_result:
         return None
-    try:
-        content_items = mcp_result.get("content") or []
-        for item in content_items:
-            if isinstance(item, dict) and "text" in item:
-                import json as _json
+    import json as _json
+    content_items = mcp_result.get("content") or []
+    for item in content_items:
+        if isinstance(item, dict) and "text" in item:
+            try:
                 data = _json.loads(item["text"])
                 if isinstance(data, dict) and "size" in data:
                     return int(data["size"])
-    except Exception:
-        pass
+            except Exception:
+                pass
     return None
 
 


### PR DESCRIPTION
## Summary

When the LLM hits its output token limit, `create_or_update_file` silently pushes a truncated stub to GitHub, destroying the original file (the pattern that caused PR #513 on staging). This adds a pre-flight guard inside the MCP tool wrapper that:

- Rejects content exceeding a 50 KB absolute cap for both `create_or_update_file` and `push_files` (per-entry)
- For file updates (`sha` present), fetches the existing file size via `get_file_contents` and rejects writes smaller than 50% of the original when the original exceeds 10 KB
- Fail-open: guard failures are logged and the write proceeds

The guard runs after the HITL confirmation gate but before the MCP server call, so it catches both foreground and background writes.

## Test plan
- [ ] Verify `create_or_update_file` with content > 50 KB is rejected
- [ ] Verify `create_or_update_file` updating a 20 KB file with 5 KB content (`sha` present) is rejected with ratio error
- [ ] Verify `create_or_update_file` creating a new file (no `sha`) is not subject to ratio check
- [ ] Verify `push_files` with a per-entry > 50 KB is rejected
- [ ] Verify guard failure (e.g., `get_file_contents` timeout) allows the write through

Closes #521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file size safety check for GitHub repository write operations to help prevent truncated or suspiciously sized content from overwriting existing files.
  * When a write is flagged, the operation is blocked and a notification is returned instead of executing the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->