### PR TITLE
Strip GitHub write MCP tools from non-RCA chat sessions

### DIFF
--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -981,6 +981,23 @@ from .mcp_tools import (
 
 _NON_RCA_SOURCES = frozenset(('action', 'prediscovery'))
 
+# GitHub write MCP tools that MUST be restricted to RCA sessions (issue #522).
+# Non-RCA sessions (interactive chat, ask, actions) should never have these
+# loaded -- they bypass ModeAccessController (which only gates "ask" mode) and
+# can push destructive changes without the structured github_fix guardrails.
+# Tool names match the StructuredTool naming: "mcp_{original_tool_name}".
+_GITHUB_MCP_WRITE_TOOLS = frozenset({
+    "mcp_create_or_update_file",
+    "mcp_push_files",
+    "mcp_create_branch",
+    "mcp_create_pull_request",
+    "mcp_merge_pull_request",
+    "mcp_delete_file",
+    "mcp_create_repository",
+    "mcp_fork_repository",
+    "mcp_update_pull_request_branch",
+})
+
 
 def _is_background_rca(state_context, is_background: bool) -> bool:
     """True when the session is a background RCA investigating a real incident.
@@ -2560,13 +2577,31 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
         
         if real_mcp_tools:
             mcp_tools = create_mcp_langchain_tools(
-                real_mcp_tools, 
+                real_mcp_tools,
                 tool_capture=tool_capture,
                 send_tool_start=send_tool_start,
                 send_tool_completion=send_tool_completion,
                 send_tool_error=send_tool_error,
                 run_async_in_thread=run_async_in_thread
             )
+
+            # Issue #522: strip GitHub write MCP tools from non-RCA sessions.
+            # RCA sessions use the structured github_fix -> github_apply_fix
+            # flow with line-level edits.  Non-RCA sessions must not have raw
+            # write tools that bypass ModeAccessController and github_fix.
+            if not is_rca_context:
+                before_count = len(mcp_tools)
+                mcp_tools = [
+                    t for t in mcp_tools
+                    if getattr(t, "name", "") not in _GITHUB_MCP_WRITE_TOOLS
+                ]
+                dropped = before_count - len(mcp_tools)
+                if dropped:
+                    logging.info(
+                        "Stripped %d GitHub write MCP tools from non-RCA session (user=%s)",
+                        dropped, user_id,
+                    )
+
             tools.extend(mcp_tools)
             logging.info(f"Added {len(mcp_tools)} MCP tools for user {user_id}")
         else:


### PR DESCRIPTION
## Summary

`ModeAccessController.filter_tools()` only gates tools in `"ask"` mode. Non-RCA sessions running in `"agent"` or default mode were getting raw GitHub write MCP tools (`create_or_update_file`, `push_files`, `create_branch`, etc.) without the structured `github_fix` guardrails that RCA sessions use. This was a contributing factor in the staging incident (PR #513).

The fix adds a `_GITHUB_MCP_WRITE_TOOLS` frozenset (defined alongside the existing `_NON_RCA_SOURCES` constant) and strips those tools in `get_cloud_tools()` when `is_rca_context is False`. RCA sessions continue to receive all tools.

## Test plan
- [ ] Verify non-RCA interactive chat session does not have `mcp_create_or_update_file`, `mcp_push_files`, or `mcp_create_branch` in its tool list
- [ ] Verify RCA background session retains all MCP tools including write tools
- [ ] Verify log message `"Stripped N GitHub write MCP tools from non-RCA session"` appears for non-RCA sessions with GitHub connected
- [ ] Verify read-only MCP tools (`mcp_get_file_contents`, `mcp_list_commits`, etc.) are still available in non-RCA sessions

Closes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted certain GitHub write operations to Root Cause Analysis (RCA) sessions only. Non-RCA users will no longer have access to these tools, with enhanced logging showing how many tools are filtered per session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->