### PR TITLE
Add KCP (Knowledge Context Protocol) connector for knowledge base

### DIFF
--- a/server/connectors/kcp_connector/__init__.py
+++ b/server/connectors/kcp_connector/__init__.py
@@ -1,0 +1,7 @@
+"""KCP (Knowledge Context Protocol) connector for Aurora's knowledge base.
+
+Reads a KCP ``knowledge.yaml`` manifest and ingests its units into
+Aurora's Weaviate-backed KB, preserving structured metadata (intent,
+triggers, audience, temporal validity) that would otherwise be lost
+in a flat document upload.
+"""

--- a/server/connectors/kcp_connector/__main__.py
+++ b/server/connectors/kcp_connector/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m connectors.kcp_connector`` as a CLI entry point."""
+
+from connectors.kcp_connector.ingest import main
+
+main()

--- a/server/connectors/kcp_connector/ingest.py
+++ b/server/connectors/kcp_connector/ingest.py
@@ -96,9 +96,9 @@ def ingest_kcp_manifest(
         try:
             from utils.auth.stateless_auth import get_org_id_for_user
             org_id = get_org_id_for_user(user_id)
-        except Exception:
+        except Exception as e:
             logger.warning(
-                "%s Could not resolve org_id for user %s", _LOG_PREFIX, user_id,
+                "%s Could not resolve org_id for user %s: %s", _LOG_PREFIX, user_id, e,
             )
 
     for unit in manifest.units:

--- a/server/connectors/kcp_connector/ingest.py
+++ b/server/connectors/kcp_connector/ingest.py
@@ -1,0 +1,371 @@
+"""KCP -> Aurora KB ingestion pipeline.
+
+Reads a KCP manifest, resolves each unit's content file, processes it
+through Aurora's existing document chunker, and uploads chunks to
+Weaviate with KCP metadata preserved as additional properties.
+
+Usage (CLI)::
+
+    python -m connectors.kcp_connector \\
+        --manifest /path/to/knowledge.yaml \\
+        --user-id <aurora-user-id> \\
+        [--org-id <org-id>] \\
+        [--dry-run]
+
+Usage (programmatic)::
+
+    from connectors.kcp_connector.ingest import ingest_kcp_manifest
+    result = ingest_kcp_manifest(
+        manifest_path="/path/to/knowledge.yaml",
+        user_id="<aurora-user-id>",
+    )
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_LOG_PREFIX = "[KCP Ingest]"
+
+
+@dataclass
+class IngestResult:
+    """Summary of a KCP ingestion run."""
+
+    manifest_path: str = ""
+    kcp_version: str = ""
+    project: str = ""
+    units_found: int = 0
+    units_ingested: int = 0
+    units_skipped: int = 0
+    total_chunks: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def ingest_kcp_manifest(
+    manifest_path: str | Path,
+    user_id: str,
+    org_id: Optional[str] = None,
+    *,
+    dry_run: bool = False,
+) -> IngestResult:
+    """Parse a KCP manifest and ingest all units into Aurora's KB.
+
+    Each unit is treated as a virtual document:
+
+    - Content is read from the resolved path (relative to manifest dir).
+    - Chunks are produced by Aurora's ``DocumentProcessor``.
+    - Chunks are uploaded to Weaviate via ``insert_chunks`` (or the
+      extended ``insert_chunks_with_metadata`` when available), with KCP
+      metadata (intent, triggers, audience, not_for, temporal) injected
+      as additional properties on each chunk.
+
+    Args:
+        manifest_path: Path to the ``knowledge.yaml`` file.
+        user_id: Aurora user ID for ownership and Weaviate scoping.
+        org_id: Aurora org ID.  If ``None``, derived from ``user_id``.
+        dry_run: Parse and validate but do not write to Weaviate.
+
+    Returns:
+        An :class:`IngestResult` summarising the run.
+    """
+    from connectors.kcp_connector.manifest import parse_manifest
+
+    result = IngestResult(manifest_path=str(manifest_path))
+
+    try:
+        manifest = parse_manifest(manifest_path)
+    except Exception as e:
+        result.errors.append(f"Manifest parse failed: {e}")
+        logger.error("%s %s", _LOG_PREFIX, result.errors[-1])
+        return result
+
+    result.kcp_version = manifest.kcp_version
+    result.project = manifest.project or manifest.entity_name
+    result.units_found = len(manifest.units)
+
+    if org_id is None:
+        try:
+            from utils.auth.stateless_auth import get_org_id_for_user
+            org_id = get_org_id_for_user(user_id)
+        except Exception:
+            logger.warning(
+                "%s Could not resolve org_id for user %s", _LOG_PREFIX, user_id,
+            )
+
+    for unit in manifest.units:
+        if not unit.resolved_path:
+            msg = f"Unit '{unit.id}': content file not found ({unit.path})"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.warning("%s %s", _LOG_PREFIX, msg)
+            continue
+
+        try:
+            content_bytes = unit.resolved_path.read_bytes()
+        except Exception as e:
+            msg = f"Unit '{unit.id}': failed to read {unit.resolved_path}: {e}"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.error("%s %s", _LOG_PREFIX, msg)
+            continue
+
+        if not content_bytes.strip():
+            msg = f"Unit '{unit.id}': content file is empty"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.warning("%s %s", _LOG_PREFIX, msg)
+            continue
+
+        # Stable document ID derived from project + unit ID so
+        # re-ingesting the same manifest replaces rather than duplicates.
+        doc_id = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"kcp:{result.project}:{unit.id}")
+        )
+
+        file_type = _kcp_format_to_aurora_type(unit.format, unit.path)
+
+        logger.info(
+            "%s Processing unit '%s' (%s, %d bytes, type=%s)",
+            _LOG_PREFIX, unit.id, unit.path, len(content_bytes), file_type,
+        )
+
+        if dry_run:
+            result.units_ingested += 1
+            logger.info("%s [dry-run] Would ingest unit '%s'", _LOG_PREFIX, unit.id)
+            continue
+
+        try:
+            chunks = _chunk_unit(user_id, doc_id, unit.path, content_bytes, file_type)
+        except Exception as e:
+            msg = f"Unit '{unit.id}': chunking failed: {e}"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.error("%s %s", _LOG_PREFIX, msg)
+            continue
+
+        if not chunks:
+            msg = f"Unit '{unit.id}': no chunks produced"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.warning("%s %s", _LOG_PREFIX, msg)
+            continue
+
+        # Inject KCP metadata into each chunk's properties
+        _enrich_chunks_with_kcp_metadata(chunks, unit, manifest)
+
+        try:
+            inserted = _upload_chunks(
+                user_id=user_id,
+                document_id=doc_id,
+                source_filename=unit.path,
+                chunks=chunks,
+                org_id=org_id,
+            )
+            result.total_chunks += inserted
+            result.units_ingested += 1
+            logger.info(
+                "%s Unit '%s': inserted %d chunks", _LOG_PREFIX, unit.id, inserted,
+            )
+        except Exception as e:
+            msg = f"Unit '{unit.id}': Weaviate upload failed: {e}"
+            result.errors.append(msg)
+            result.units_skipped += 1
+            logger.error("%s %s", _LOG_PREFIX, msg)
+
+    logger.info(
+        "%s Finished: %d/%d units ingested, %d chunks total, %d errors",
+        _LOG_PREFIX,
+        result.units_ingested,
+        result.units_found,
+        result.total_chunks,
+        len(result.errors),
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _kcp_format_to_aurora_type(kcp_format: str, path: str) -> str:
+    """Map KCP ``format`` field to Aurora's file_type enum."""
+    fmt = kcp_format.lower()
+    if fmt in ("markdown", "md"):
+        return "markdown"
+    if fmt == "pdf":
+        return "pdf"
+    # Fallback: derive from file extension
+    ext = Path(path).suffix.lower().lstrip(".")
+    if ext == "md":
+        return "markdown"
+    if ext == "pdf":
+        return "pdf"
+    return "plaintext"
+
+
+def _chunk_unit(
+    user_id: str,
+    document_id: str,
+    filename: str,
+    content: bytes,
+    file_type: str,
+) -> list[dict]:
+    """Chunk content using Aurora's existing DocumentProcessor."""
+    from routes.knowledge_base.document_processor import DocumentProcessor
+
+    processor = DocumentProcessor(user_id, document_id, filename)
+    return processor.process(content, file_type)
+
+
+def _enrich_chunks_with_kcp_metadata(
+    chunks: list[dict],
+    unit,
+    manifest,
+) -> None:
+    """Inject KCP-specific metadata into each chunk dict.
+
+    These extra keys are stored alongside the standard Weaviate properties
+    by ``insert_chunks_with_metadata``.  Even if Weaviate's schema has not
+    been extended yet, the standard ``insert_chunks`` call will simply
+    ignore unknown keys -- so this is safe against an unmodified Aurora.
+    """
+    for chunk in chunks:
+        chunk["kcp_unit_id"] = unit.id
+        chunk["kcp_intent"] = unit.intent
+        chunk["kcp_triggers"] = unit.triggers
+        chunk["kcp_audience"] = unit.audience
+        chunk["kcp_not_for"] = unit.not_for
+        chunk["kcp_scope"] = unit.scope
+        chunk["kcp_kind"] = unit.kind
+        chunk["kcp_depends_on"] = unit.depends_on
+
+        # Temporal validity
+        chunk["kcp_valid_from"] = unit.temporal.valid_from or ""
+        chunk["kcp_valid_until"] = unit.temporal.valid_until or ""
+        chunk["kcp_review_by"] = unit.temporal.review_by or ""
+
+        # Project-level context
+        chunk["kcp_project"] = manifest.project or manifest.entity_name
+        chunk["kcp_version"] = manifest.kcp_version
+
+        # Prepend intent to heading_context so it appears in search
+        # results without changing the search pipeline.
+        existing_heading = chunk.get("heading_context", "")
+        if unit.intent:
+            intent_prefix = f"[KCP:{unit.id}] {unit.intent}"
+            chunk["heading_context"] = (
+                f"{intent_prefix} > {existing_heading}" if existing_heading
+                else intent_prefix
+            )
+
+
+def _upload_chunks(
+    user_id: str,
+    document_id: str,
+    source_filename: str,
+    chunks: list[dict],
+    org_id: Optional[str],
+) -> int:
+    """Upload chunks to Weaviate.
+
+    Tries ``insert_chunks_with_metadata`` (extended schema) first.  If
+    that import fails (module not yet deployed), falls back to the
+    standard ``insert_chunks`` which ignores the extra KCP keys.
+    """
+    try:
+        from connectors.kcp_connector.weaviate_ext import insert_chunks_with_metadata
+        return insert_chunks_with_metadata(
+            user_id=user_id,
+            document_id=document_id,
+            source_filename=source_filename,
+            chunks=chunks,
+            org_id=org_id,
+        )
+    except ImportError:
+        logger.info(
+            "%s Extended Weaviate schema not available, using standard insert_chunks",
+            _LOG_PREFIX,
+        )
+    except Exception as e:
+        logger.warning(
+            "%s insert_chunks_with_metadata failed (%s), falling back to standard",
+            _LOG_PREFIX, e,
+        )
+
+    # Fallback: standard insert (KCP metadata keys are silently ignored)
+    from routes.knowledge_base.weaviate_client import insert_chunks
+    return insert_chunks(
+        user_id=user_id,
+        document_id=document_id,
+        source_filename=source_filename,
+        chunks=chunks,
+        org_id=org_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Ingest a KCP knowledge.yaml manifest into Aurora's knowledge base.",
+    )
+    parser.add_argument(
+        "--manifest", required=True, help="Path to the knowledge.yaml file",
+    )
+    parser.add_argument(
+        "--user-id", required=True, help="Aurora user ID for ownership",
+    )
+    parser.add_argument(
+        "--org-id", default=None, help="Aurora org ID (auto-resolved if omitted)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Parse and validate without writing to Weaviate",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
+    )
+
+    result = ingest_kcp_manifest(
+        manifest_path=args.manifest,
+        user_id=args.user_id,
+        org_id=args.org_id,
+        dry_run=args.dry_run,
+    )
+
+    print(f"\n{'=' * 60}")
+    print(f"KCP Ingestion {'(dry run) ' if args.dry_run else ''}Summary")
+    print(f"{'=' * 60}")
+    print(f"  Manifest:   {result.manifest_path}")
+    print(f"  Project:    {result.project}")
+    print(f"  KCP ver:    {result.kcp_version}")
+    print(f"  Units:      {result.units_found} found, {result.units_ingested} ingested, {result.units_skipped} skipped")
+    print(f"  Chunks:     {result.total_chunks}")
+    if result.errors:
+        print(f"  Errors ({len(result.errors)}):")
+        for err in result.errors:
+            print(f"    - {err}")
+    print()
+
+    sys.exit(1 if result.errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/connectors/kcp_connector/ingest.py
+++ b/server/connectors/kcp_connector/ingest.py
@@ -102,84 +102,7 @@ def ingest_kcp_manifest(
             )
 
     for unit in manifest.units:
-        if not unit.resolved_path:
-            msg = f"Unit '{unit.id}': content file not found ({unit.path})"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.warning("%s %s", _LOG_PREFIX, msg)
-            continue
-
-        try:
-            content_bytes = unit.resolved_path.read_bytes()
-        except Exception as e:
-            msg = f"Unit '{unit.id}': failed to read {unit.resolved_path}: {e}"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.error("%s %s", _LOG_PREFIX, msg)
-            continue
-
-        if not content_bytes.strip():
-            msg = f"Unit '{unit.id}': content file is empty"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.warning("%s %s", _LOG_PREFIX, msg)
-            continue
-
-        # Stable document ID derived from project + unit ID so
-        # re-ingesting the same manifest replaces rather than duplicates.
-        doc_id = str(
-            uuid.uuid5(uuid.NAMESPACE_URL, f"kcp:{result.project}:{unit.id}")
-        )
-
-        file_type = _kcp_format_to_aurora_type(unit.format, unit.path)
-
-        logger.info(
-            "%s Processing unit '%s' (%s, %d bytes, type=%s)",
-            _LOG_PREFIX, unit.id, unit.path, len(content_bytes), file_type,
-        )
-
-        if dry_run:
-            result.units_ingested += 1
-            logger.info("%s [dry-run] Would ingest unit '%s'", _LOG_PREFIX, unit.id)
-            continue
-
-        try:
-            chunks = _chunk_unit(user_id, doc_id, unit.path, content_bytes, file_type)
-        except Exception as e:
-            msg = f"Unit '{unit.id}': chunking failed: {e}"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.error("%s %s", _LOG_PREFIX, msg)
-            continue
-
-        if not chunks:
-            msg = f"Unit '{unit.id}': no chunks produced"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.warning("%s %s", _LOG_PREFIX, msg)
-            continue
-
-        # Inject KCP metadata into each chunk's properties
-        _enrich_chunks_with_kcp_metadata(chunks, unit, manifest)
-
-        try:
-            inserted = _upload_chunks(
-                user_id=user_id,
-                document_id=doc_id,
-                source_filename=unit.path,
-                chunks=chunks,
-                org_id=org_id,
-            )
-            result.total_chunks += inserted
-            result.units_ingested += 1
-            logger.info(
-                "%s Unit '%s': inserted %d chunks", _LOG_PREFIX, unit.id, inserted,
-            )
-        except Exception as e:
-            msg = f"Unit '{unit.id}': Weaviate upload failed: {e}"
-            result.errors.append(msg)
-            result.units_skipped += 1
-            logger.error("%s %s", _LOG_PREFIX, msg)
+        _ingest_unit(unit, manifest, result.project, user_id, org_id, dry_run, result)
 
     logger.info(
         "%s Finished: %d/%d units ingested, %d chunks total, %d errors",
@@ -195,6 +118,92 @@ def ingest_kcp_manifest(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+def _ingest_unit(
+    unit,
+    manifest,
+    project: str,
+    user_id: str,
+    org_id: Optional[str],
+    dry_run: bool,
+    result: IngestResult,
+) -> None:
+    """Process a single KCP unit and update *result* in place."""
+    if not unit.resolved_path:
+        msg = f"Unit '{unit.id}': content file not found ({unit.path})"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.warning("%s %s", _LOG_PREFIX, msg)
+        return
+
+    try:
+        content_bytes = unit.resolved_path.read_bytes()
+    except Exception as e:
+        msg = f"Unit '{unit.id}': failed to read {unit.resolved_path}: {e}"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.error("%s %s", _LOG_PREFIX, msg)
+        return
+
+    if not content_bytes.strip():
+        msg = f"Unit '{unit.id}': content file is empty"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.warning("%s %s", _LOG_PREFIX, msg)
+        return
+
+    # Stable document ID derived from project + unit ID so
+    # re-ingesting the same manifest replaces rather than duplicates.
+    doc_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"kcp:{project}:{unit.id}"))
+    file_type = _kcp_format_to_aurora_type(unit.format, unit.path)
+
+    logger.info(
+        "%s Processing unit '%s' (%s, %d bytes, type=%s)",
+        _LOG_PREFIX, unit.id, unit.path, len(content_bytes), file_type,
+    )
+
+    if dry_run:
+        result.units_ingested += 1
+        logger.info("%s [dry-run] Would ingest unit '%s'", _LOG_PREFIX, unit.id)
+        return
+
+    try:
+        chunks = _chunk_unit(user_id, doc_id, unit.path, content_bytes, file_type)
+    except Exception as e:
+        msg = f"Unit '{unit.id}': chunking failed: {e}"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.error("%s %s", _LOG_PREFIX, msg)
+        return
+
+    if not chunks:
+        msg = f"Unit '{unit.id}': no chunks produced"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.warning("%s %s", _LOG_PREFIX, msg)
+        return
+
+    _enrich_chunks_with_kcp_metadata(chunks, unit, manifest)
+
+    try:
+        inserted = _upload_chunks(
+            user_id=user_id,
+            document_id=doc_id,
+            source_filename=unit.path,
+            chunks=chunks,
+            org_id=org_id,
+        )
+        result.total_chunks += inserted
+        result.units_ingested += 1
+        logger.info(
+            "%s Unit '%s': inserted %d chunks", _LOG_PREFIX, unit.id, inserted,
+        )
+    except Exception as e:
+        msg = f"Unit '{unit.id}': Weaviate upload failed: {e}"
+        result.errors.append(msg)
+        result.units_skipped += 1
+        logger.error("%s %s", _LOG_PREFIX, msg)
+
 
 def _kcp_format_to_aurora_type(kcp_format: str, path: str) -> str:
     """Map KCP ``format`` field to Aurora's file_type enum."""

--- a/server/connectors/kcp_connector/manifest.py
+++ b/server/connectors/kcp_connector/manifest.py
@@ -1,0 +1,152 @@
+"""KCP manifest parser -- reads and validates ``knowledge.yaml`` files.
+
+Handles both KCP 0.6+ (``kcp_version`` at top level) and 0.20+
+(``version`` at top level with an ``entity`` block) manifests.
+Resolves each unit's ``path`` relative to the manifest directory so
+content files can be read during ingestion.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TemporalMetadata:
+    """Temporal validity window for a knowledge unit."""
+
+    valid_from: Optional[str] = None
+    valid_until: Optional[str] = None
+    review_by: Optional[str] = None
+
+
+@dataclass
+class KCPUnit:
+    """One knowledge unit from a KCP manifest."""
+
+    id: str
+    path: str
+    intent: str = ""
+    triggers: list[str] = field(default_factory=list)
+    audience: list[str] = field(default_factory=list)
+    not_for: list[str] = field(default_factory=list)
+    scope: str = ""
+    kind: str = "knowledge"
+    format: str = "markdown"
+    depends_on: list[str] = field(default_factory=list)
+    validated: Optional[str] = None
+    temporal: TemporalMetadata = field(default_factory=TemporalMetadata)
+
+    # Resolved at parse time -- absolute path to the content file.
+    resolved_path: Optional[Path] = field(default=None, repr=False)
+
+
+@dataclass
+class KCPManifest:
+    """Parsed KCP ``knowledge.yaml``."""
+
+    kcp_version: str = ""
+    project: str = ""
+    entity_name: str = ""
+    entity_domain: str = ""
+    language: str = "en"
+    units: list[KCPUnit] = field(default_factory=list)
+    raw: dict = field(default_factory=dict, repr=False)
+
+
+def parse_manifest(manifest_path: str | Path) -> KCPManifest:
+    """Parse a ``knowledge.yaml`` file and resolve unit paths.
+
+    Args:
+        manifest_path: Path to the ``knowledge.yaml`` file.
+
+    Returns:
+        A populated :class:`KCPManifest` with resolved unit paths.
+
+    Raises:
+        FileNotFoundError: If the manifest file does not exist.
+        yaml.YAMLError: If the YAML is malformed.
+        ValueError: If the manifest has no ``units`` list.
+    """
+    manifest_path = Path(manifest_path)
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"KCP manifest not found: {manifest_path}")
+
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        raw: dict[str, Any] = yaml.safe_load(fh) or {}
+
+    manifest_dir = manifest_path.parent
+
+    # Version: prefer top-level ``version`` (0.20+), fall back to ``kcp_version``
+    kcp_version = str(raw.get("version", raw.get("kcp_version", "")))
+
+    # Entity block (0.20+) or flat ``project`` field (0.6+)
+    entity = raw.get("entity") or {}
+    entity_name = entity.get("name", raw.get("project", ""))
+    entity_domain = entity.get("domain", "")
+
+    units_raw: list[dict[str, Any]] = raw.get("units") or []
+    if not units_raw:
+        raise ValueError(f"KCP manifest has no units: {manifest_path}")
+
+    units: list[KCPUnit] = []
+    for u in units_raw:
+        temporal_raw = u.get("temporal") or {}
+        temporal = TemporalMetadata(
+            valid_from=temporal_raw.get("valid_from"),
+            valid_until=temporal_raw.get("valid_until"),
+            review_by=temporal_raw.get("review_by"),
+        )
+
+        unit = KCPUnit(
+            id=u.get("id", ""),
+            path=u.get("path", ""),
+            intent=u.get("intent", ""),
+            triggers=_as_list(u.get("triggers")),
+            audience=_as_list(u.get("audience")),
+            not_for=_as_list(u.get("not_for")),
+            scope=u.get("scope", ""),
+            kind=u.get("kind", "knowledge"),
+            format=u.get("format", "markdown"),
+            depends_on=_as_list(u.get("depends_on")),
+            validated=u.get("validated"),
+            temporal=temporal,
+        )
+
+        # Resolve the content file path relative to the manifest directory
+        if unit.path:
+            resolved = manifest_dir / unit.path
+            if resolved.is_file():
+                unit.resolved_path = resolved
+            else:
+                logger.warning(
+                    "[KCP] Unit '%s' path does not exist: %s", unit.id, resolved,
+                )
+
+        units.append(unit)
+
+    return KCPManifest(
+        kcp_version=kcp_version,
+        project=raw.get("project", ""),
+        entity_name=entity_name,
+        entity_domain=entity_domain,
+        language=raw.get("language", "en"),
+        units=units,
+        raw=raw,
+    )
+
+
+def _as_list(value: Any) -> list[str]:
+    """Coerce a value to a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return [str(value)]

--- a/server/connectors/kcp_connector/weaviate_ext.py
+++ b/server/connectors/kcp_connector/weaviate_ext.py
@@ -144,10 +144,10 @@ def insert_chunks_with_metadata(
                 batch.add_object(properties=properties, uuid=uuid)
                 success_count += 1
 
-            except Exception as e:
-                logger.error(
-                    "[KCP Weaviate] Error adding chunk %s: %s",
-                    chunk.get("chunk_index", "?"), e,
+            except Exception:
+                logger.exception(
+                    "[KCP Weaviate] Error adding chunk %s",
+                    chunk.get("chunk_index", "?"),
                 )
 
     # Report batch failures

--- a/server/connectors/kcp_connector/weaviate_ext.py
+++ b/server/connectors/kcp_connector/weaviate_ext.py
@@ -55,7 +55,7 @@ def ensure_kcp_properties() -> bool:
         "DATE": DataType.DATE,
     }
 
-    _client, collection = _get_weaviate_client()
+    _, collection = _get_weaviate_client()
 
     existing_config = collection.config.get()
     existing_names = {p.name for p in existing_config.properties}

--- a/server/connectors/kcp_connector/weaviate_ext.py
+++ b/server/connectors/kcp_connector/weaviate_ext.py
@@ -1,0 +1,168 @@
+"""Extended Weaviate schema and insert for KCP metadata.
+
+Adds KCP-specific properties (intent, triggers, audience, temporal, etc.)
+to the existing ``KnowledgeBaseChunk`` collection and provides an
+``insert_chunks_with_metadata`` function that stores them alongside the
+standard Aurora chunk fields.
+
+The schema migration is idempotent -- calling ``ensure_kcp_properties``
+multiple times is safe and skips properties that already exist.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# KCP-specific properties to add to KnowledgeBaseChunk.
+# Maps property name -> Weaviate DataType string.
+_KCP_PROPERTIES: dict[str, str] = {
+    "kcp_unit_id": "TEXT",
+    "kcp_intent": "TEXT",
+    "kcp_triggers": "TEXT_ARRAY",
+    "kcp_audience": "TEXT_ARRAY",
+    "kcp_not_for": "TEXT_ARRAY",
+    "kcp_scope": "TEXT",
+    "kcp_kind": "TEXT",
+    "kcp_depends_on": "TEXT_ARRAY",
+    "kcp_valid_from": "TEXT",
+    "kcp_valid_until": "TEXT",
+    "kcp_review_by": "TEXT",
+    "kcp_project": "TEXT",
+    "kcp_version": "TEXT",
+}
+
+
+def ensure_kcp_properties() -> bool:
+    """Add KCP properties to the ``KnowledgeBaseChunk`` collection if missing.
+
+    Returns ``True`` if the schema was modified, ``False`` if already
+    up to date.  Raises on connection or schema errors.
+    """
+    from routes.knowledge_base.weaviate_client import (
+        _get_weaviate_client,
+        COLLECTION_NAME,
+    )
+    from weaviate.classes.config import DataType, Property
+
+    _type_map = {
+        "TEXT": DataType.TEXT,
+        "TEXT_ARRAY": DataType.TEXT_ARRAY,
+        "INT": DataType.INT,
+        "DATE": DataType.DATE,
+    }
+
+    _client, collection = _get_weaviate_client()
+
+    existing_config = collection.config.get()
+    existing_names = {p.name for p in existing_config.properties}
+
+    to_add = []
+    for prop_name, dtype_str in _KCP_PROPERTIES.items():
+        if prop_name not in existing_names:
+            to_add.append(
+                Property(name=prop_name, data_type=_type_map[dtype_str])
+            )
+
+    if not to_add:
+        logger.info(
+            "[KCP Weaviate] All KCP properties already present on %s",
+            COLLECTION_NAME,
+        )
+        return False
+
+    for prop in to_add:
+        collection.config.add_property(prop)
+        logger.info(
+            "[KCP Weaviate] Added property '%s' to %s", prop.name, COLLECTION_NAME,
+        )
+
+    logger.info(
+        "[KCP Weaviate] Extended %s with %d KCP properties",
+        COLLECTION_NAME, len(to_add),
+    )
+    return True
+
+
+def insert_chunks_with_metadata(
+    user_id: str,
+    document_id: str,
+    source_filename: str,
+    chunks: list[dict[str, Any]],
+    org_id: Optional[str] = None,
+) -> int:
+    """Insert chunks with KCP metadata into Weaviate.
+
+    Works like ``weaviate_client.insert_chunks`` but also stores the
+    ``kcp_*`` keys present in each chunk dict.  Automatically extends
+    the collection schema on first call.
+    """
+    if not chunks:
+        return 0
+
+    from routes.knowledge_base.weaviate_client import _get_weaviate_client
+    from weaviate.util import generate_uuid5
+
+    # Ensure schema has KCP properties (idempotent)
+    try:
+        ensure_kcp_properties()
+    except Exception as e:
+        logger.warning("[KCP Weaviate] Could not ensure KCP properties: %s", e)
+        # Continue anyway -- unknown keys are silently ignored by Weaviate batch.
+
+    _, collection = _get_weaviate_client()
+    success_count = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    with collection.batch.dynamic() as batch:
+        for chunk in chunks:
+            try:
+                chunk_index = chunk.get("chunk_index", 0)
+                uuid = generate_uuid5(f"{user_id}:{document_id}:{chunk_index}")
+
+                properties: dict[str, Any] = {
+                    "user_id": user_id,
+                    "document_id": document_id,
+                    "chunk_index": chunk_index,
+                    "content": chunk.get("content", ""),
+                    "heading_context": chunk.get("heading_context", ""),
+                    "source_filename": source_filename,
+                    "created_at": now,
+                }
+                if org_id:
+                    properties["org_id"] = org_id
+
+                # Copy KCP metadata properties from the enriched chunk dict
+                for key in _KCP_PROPERTIES:
+                    value = chunk.get(key)
+                    if value is not None:
+                        properties[key] = value
+
+                batch.add_object(properties=properties, uuid=uuid)
+                success_count += 1
+
+            except Exception as e:
+                logger.error(
+                    "[KCP Weaviate] Error adding chunk %s: %s",
+                    chunk.get("chunk_index", "?"), e,
+                )
+
+    # Report batch failures
+    if collection.batch.failed_objects:
+        fail_count = len(collection.batch.failed_objects)
+        logger.error(
+            "[KCP Weaviate] Batch had %d failures out of %d",
+            fail_count, success_count,
+        )
+        for i, failed in enumerate(collection.batch.failed_objects[:5]):
+            logger.error("[KCP Weaviate] Failed object %d: %s", i + 1, failed)
+        return max(0, success_count - fail_count)
+
+    logger.info(
+        "[KCP Weaviate] Inserted %d chunks (with KCP metadata) for doc %s",
+        success_count, document_id,
+    )
+    return success_count


### PR DESCRIPTION
## Summary

Aurora's current KB ingestion flattens all documents into unstructured Weaviate chunks, losing the structured metadata that makes operational knowledge navigable: *why* a runbook exists, *who* it's for, *when* it's valid, and *what* it depends on.

This adds a KCP connector (`server/connectors/kcp_connector/`) that ingests [KCP knowledge.yaml manifests](https://github.com/cantara/knowledge-context-protocol) into Aurora's KB, preserving that structure:

```yaml
- id: k8s-oom-recovery
  intent: "Steps to recover from OOM kill on production pods"
  triggers: [OOMKilled, memory pressure, pod eviction]
  audience: [sre, platform-eng]
  not_for: [frontend-devs]
  temporal:
    valid_from: "2025-01-01"
    review_by: "2026-06-01"
  depends_on: [k8s-resource-quotas]
```

### What's included

- **`manifest.py`** — KCP YAML parser (handles 0.6+ and 0.20+ formats), resolves unit paths, produces typed dataclasses
- **`ingest.py`** — Orchestrator: chunks via Aurora's existing `DocumentProcessor`, enriches with KCP metadata, uploads to Weaviate. CLI: `python -m connectors.kcp_connector --manifest knowledge.yaml --user-id <id>`
- **`weaviate_ext.py`** — Idempotent schema migration adding 13 KCP-specific properties + `insert_chunks_with_metadata`

### Design decisions

- **`uuid5(project:unit_id)`** for stable document IDs — re-ingesting a manifest replaces rather than duplicates
- **Intent in `heading_context`** — appears in existing `knowledge_base_search` / `search_runbooks` results immediately, no search pipeline changes needed
- **Graceful fallback** — works against unmodified Aurora (standard Weaviate schema) by falling back to `insert_chunks` which ignores unknown keys

## Test plan
- [ ] Parse a KCP 0.6 manifest (`kcp_version` field)
- [ ] Parse a KCP 0.20+ manifest (`version` field, `entity` block)
- [ ] Dry-run mode validates without writing to Weaviate
- [ ] Units with missing content files are skipped with warnings
- [ ] Re-ingesting the same manifest replaces existing chunks (same UUIDs)
- [ ] `heading_context` includes `[KCP:unit-id] intent` prefix in search results
- [ ] Extended schema adds 13 `kcp_*` properties to `KnowledgeBaseChunk`
- [ ] Fallback to standard `insert_chunks` when `weaviate_ext` schema migration is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added KCP (Knowledge Context Protocol) connector to process knowledge manifests with structured metadata support (intent, triggers, audience, temporal validity)
* Introduced command-line interface for knowledge manifest operations with user ID and organization configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->