### PR TITLE
Expand Vertex AI support for Gemini models

### DIFF
--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -41,10 +41,8 @@ const modelPricing: Record<string, string> = {
   'openai/gpt-5.5': 'Premium Cost ($5/$30 per 1M)',
   'anthropic/claude-sonnet-4.6': 'Medium Cost ($3/$15 per 1M)',
   'anthropic/claude-opus-4.7': 'High Cost ($5/$25 per 1M)',
+  'vertex/gemini-3.5-flash': 'Low Cost ($0.50/$3 per 1M)',
   'vertex/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
-  'vertex/gemini-3-flash': 'Low Cost ($0.50/$3 per 1M)',
-  'vertex/gemini-2.5-pro': 'Medium Cost ($1.25/$10 per 1M)',
-  'vertex/gemini-2.5-flash': 'Low Cost ($0.30/$2.50 per 1M)',
 };
 
 const modelOptions: ModelOption[] = [
@@ -77,38 +75,20 @@ const modelOptions: ModelOption[] = [
     isSlow: true
   },
   {
+    id: 'vertex/gemini-3.5-flash',
+    name: 'gemini-3.5-flash',
+    displayName: 'Gemini 3.5 Flash',
+    provider: 'Vertex AI',
+    tier: 'free',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
     id: 'vertex/gemini-3.1-pro-preview',
     name: 'gemini-3.1-pro-preview',
     displayName: 'Gemini 3.1 Pro',
     provider: 'Vertex AI',
     tier: 'pro',
-    contextLength: '1M',
-    hasReasoning: true
-  },
-  {
-    id: 'vertex/gemini-3-flash',
-    name: 'gemini-3-flash',
-    displayName: 'Gemini 3 Flash',
-    provider: 'Vertex AI',
-    tier: 'free',
-    contextLength: '1M',
-    hasReasoning: true
-  },
-  {
-    id: 'vertex/gemini-2.5-pro',
-    name: 'gemini-2.5-pro',
-    displayName: 'Gemini 2.5 Pro',
-    provider: 'Vertex AI',
-    tier: 'pro',
-    contextLength: '1M',
-    hasReasoning: true
-  },
-  {
-    id: 'vertex/gemini-2.5-flash',
-    name: 'gemini-2.5-flash',
-    displayName: 'Gemini 2.5 Flash',
-    provider: 'Vertex AI',
-    tier: 'free',
     contextLength: '1M',
     hasReasoning: true
   },

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -41,8 +41,10 @@ const modelPricing: Record<string, string> = {
   'openai/gpt-5.5': 'Premium Cost ($5/$30 per 1M)',
   'anthropic/claude-sonnet-4.6': 'Medium Cost ($3/$15 per 1M)',
   'anthropic/claude-opus-4.7': 'High Cost ($5/$25 per 1M)',
-  'vertex/gemini-3.5-flash': 'Low Cost ($0.50/$3 per 1M)',
-  'vertex/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
+  'google/gemini-3.5-flash': 'Low Cost ($0.50/$3 per 1M)',
+  'google/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
+  'google/gemini-2.5-pro': 'Medium Cost ($1.25/$10 per 1M)',
+  'google/gemini-2.5-flash': 'Low Cost ($0.30/$2.50 per 1M)',
 };
 
 const modelOptions: ModelOption[] = [
@@ -75,20 +77,38 @@ const modelOptions: ModelOption[] = [
     isSlow: true
   },
   {
-    id: 'vertex/gemini-3.5-flash',
+    id: 'google/gemini-3.5-flash',
     name: 'gemini-3.5-flash',
     displayName: 'Gemini 3.5 Flash',
-    provider: 'Vertex AI',
+    provider: 'Google',
     tier: 'free',
     contextLength: '1M',
     hasReasoning: true
   },
   {
-    id: 'vertex/gemini-3.1-pro-preview',
+    id: 'google/gemini-3.1-pro-preview',
     name: 'gemini-3.1-pro-preview',
     displayName: 'Gemini 3.1 Pro',
-    provider: 'Vertex AI',
+    provider: 'Google',
     tier: 'pro',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
+    id: 'google/gemini-2.5-pro',
+    name: 'gemini-2.5-pro',
+    displayName: 'Gemini 2.5 Pro',
+    provider: 'Google',
+    tier: 'pro',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
+    id: 'google/gemini-2.5-flash',
+    name: 'gemini-2.5-flash',
+    displayName: 'Gemini 2.5 Flash',
+    provider: 'Google',
+    tier: 'free',
     contextLength: '1M',
     hasReasoning: true
   },

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -132,7 +132,10 @@ export default function ModelSelector({
       onModelChange(savedModel);
     } else if (!isValidModel) {
       localStorage.removeItem('selectedModel');
-      onModelChange(modelOptions[0].id);
+      const currentIsValid = modelOptions.some((model) => model.id === selectedModel);
+      if (!currentIsValid) {
+        onModelChange(modelOptions[0].id);
+      }
     }
   }, []);
 

--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -41,7 +41,10 @@ const modelPricing: Record<string, string> = {
   'openai/gpt-5.5': 'Premium Cost ($5/$30 per 1M)',
   'anthropic/claude-sonnet-4.6': 'Medium Cost ($3/$15 per 1M)',
   'anthropic/claude-opus-4.7': 'High Cost ($5/$25 per 1M)',
-  'google/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
+  'vertex/gemini-3.1-pro-preview': 'Medium Cost ($2/$12 per 1M)',
+  'vertex/gemini-3-flash': 'Low Cost ($0.50/$3 per 1M)',
+  'vertex/gemini-2.5-pro': 'Medium Cost ($1.25/$10 per 1M)',
+  'vertex/gemini-2.5-flash': 'Low Cost ($0.30/$2.50 per 1M)',
 };
 
 const modelOptions: ModelOption[] = [
@@ -74,11 +77,38 @@ const modelOptions: ModelOption[] = [
     isSlow: true
   },
   {
-    id: 'google/gemini-3.1-pro-preview',
+    id: 'vertex/gemini-3.1-pro-preview',
     name: 'gemini-3.1-pro-preview',
     displayName: 'Gemini 3.1 Pro',
-    provider: 'Google',
+    provider: 'Vertex AI',
     tier: 'pro',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
+    id: 'vertex/gemini-3-flash',
+    name: 'gemini-3-flash',
+    displayName: 'Gemini 3 Flash',
+    provider: 'Vertex AI',
+    tier: 'free',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
+    id: 'vertex/gemini-2.5-pro',
+    name: 'gemini-2.5-pro',
+    displayName: 'Gemini 2.5 Pro',
+    provider: 'Vertex AI',
+    tier: 'pro',
+    contextLength: '1M',
+    hasReasoning: true
+  },
+  {
+    id: 'vertex/gemini-2.5-flash',
+    name: 'gemini-2.5-flash',
+    displayName: 'Gemini 2.5 Flash',
+    provider: 'Vertex AI',
+    tier: 'free',
     contextLength: '1M',
     hasReasoning: true
   },
@@ -102,6 +132,7 @@ export default function ModelSelector({
       onModelChange(savedModel);
     } else if (!isValidModel) {
       localStorage.removeItem('selectedModel');
+      onModelChange(modelOptions[0].id);
     }
   }, []);
 

--- a/server/chat/backend/agent/model_mapper.py
+++ b/server/chat/backend/agent/model_mapper.py
@@ -55,37 +55,15 @@ MODEL_MAPPINGS = {
         "vertex": "gemini-3.1-pro-preview",
         "provider": "vertex",
     },
-    "google/gemini-3-flash": {
-        "openrouter": "google/gemini-3-flash",
-        "google": "gemini-3-flash",
-        "vertex": "gemini-3-flash",
+    "google/gemini-3.5-flash": {
+        "openrouter": "google/gemini-3.5-flash",
+        "google": "gemini-3.5-flash",
+        "vertex": "gemini-3.5-flash",
         "provider": "google",
     },
-    "vertex/gemini-3-flash": {
-        "openrouter": "google/gemini-3-flash",
-        "vertex": "gemini-3-flash",
-        "provider": "vertex",
-    },
-    "google/gemini-2.5-pro": {
-        "openrouter": "google/gemini-2.5-pro",
-        "google": "gemini-2.5-pro",
-        "vertex": "gemini-2.5-pro",
-        "provider": "google",
-    },
-    "vertex/gemini-2.5-pro": {
-        "openrouter": "google/gemini-2.5-pro",
-        "vertex": "gemini-2.5-pro",
-        "provider": "vertex",
-    },
-    "google/gemini-2.5-flash": {
-        "openrouter": "google/gemini-2.5-flash",
-        "google": "gemini-2.5-flash",
-        "vertex": "gemini-2.5-flash",
-        "provider": "google",
-    },
-    "vertex/gemini-2.5-flash": {
-        "openrouter": "google/gemini-2.5-flash",
-        "vertex": "gemini-2.5-flash",
+    "vertex/gemini-3.5-flash": {
+        "openrouter": "google/gemini-3.5-flash",
+        "vertex": "gemini-3.5-flash",
         "provider": "vertex",
     },
     "anthropic/claude-sonnet-4.6": {

--- a/server/chat/backend/agent/model_mapper.py
+++ b/server/chat/backend/agent/model_mapper.py
@@ -47,7 +47,46 @@ MODEL_MAPPINGS = {
     "google/gemini-3.1-pro-preview": {
         "openrouter": "google/gemini-3.1-pro-preview",
         "google": "gemini-3.1-pro-preview",
+        "vertex": "gemini-3.1-pro-preview",
         "provider": "google",
+    },
+    "vertex/gemini-3.1-pro-preview": {
+        "openrouter": "google/gemini-3.1-pro-preview",
+        "vertex": "gemini-3.1-pro-preview",
+        "provider": "vertex",
+    },
+    "google/gemini-3-flash": {
+        "openrouter": "google/gemini-3-flash",
+        "google": "gemini-3-flash",
+        "vertex": "gemini-3-flash",
+        "provider": "google",
+    },
+    "vertex/gemini-3-flash": {
+        "openrouter": "google/gemini-3-flash",
+        "vertex": "gemini-3-flash",
+        "provider": "vertex",
+    },
+    "google/gemini-2.5-pro": {
+        "openrouter": "google/gemini-2.5-pro",
+        "google": "gemini-2.5-pro",
+        "vertex": "gemini-2.5-pro",
+        "provider": "google",
+    },
+    "vertex/gemini-2.5-pro": {
+        "openrouter": "google/gemini-2.5-pro",
+        "vertex": "gemini-2.5-pro",
+        "provider": "vertex",
+    },
+    "google/gemini-2.5-flash": {
+        "openrouter": "google/gemini-2.5-flash",
+        "google": "gemini-2.5-flash",
+        "vertex": "gemini-2.5-flash",
+        "provider": "google",
+    },
+    "vertex/gemini-2.5-flash": {
+        "openrouter": "google/gemini-2.5-flash",
+        "vertex": "gemini-2.5-flash",
+        "provider": "vertex",
     },
     "anthropic/claude-sonnet-4.6": {
         "openrouter": "anthropic/claude-sonnet-4.6",

--- a/server/chat/backend/agent/model_mapper.py
+++ b/server/chat/backend/agent/model_mapper.py
@@ -66,6 +66,28 @@ MODEL_MAPPINGS = {
         "vertex": "gemini-3.5-flash",
         "provider": "vertex",
     },
+    "google/gemini-2.5-pro": {
+        "openrouter": "google/gemini-2.5-pro",
+        "google": "gemini-2.5-pro",
+        "vertex": "gemini-2.5-pro",
+        "provider": "google",
+    },
+    "vertex/gemini-2.5-pro": {
+        "openrouter": "google/gemini-2.5-pro",
+        "vertex": "gemini-2.5-pro",
+        "provider": "vertex",
+    },
+    "google/gemini-2.5-flash": {
+        "openrouter": "google/gemini-2.5-flash",
+        "google": "gemini-2.5-flash",
+        "vertex": "gemini-2.5-flash",
+        "provider": "google",
+    },
+    "vertex/gemini-2.5-flash": {
+        "openrouter": "google/gemini-2.5-flash",
+        "vertex": "gemini-2.5-flash",
+        "provider": "vertex",
+    },
     "anthropic/claude-sonnet-4.6": {
         "openrouter": "anthropic/claude-sonnet-4.6",
         "anthropic": "claude-sonnet-4-6",

--- a/server/chat/backend/agent/providers/vertex_provider.py
+++ b/server/chat/backend/agent/providers/vertex_provider.py
@@ -106,8 +106,8 @@ class VertexAIProvider(BaseLLMProvider):
 
     def get_supported_models(self) -> list[str]:
         return [
+            "vertex/gemini-3.5-flash",
             "vertex/gemini-3.1-pro-preview",
-            "vertex/gemini-3-flash",
             "vertex/gemini-2.5-pro",
             "vertex/gemini-2.5-flash",
         ]

--- a/server/chat/backend/agent/providers/vertex_provider.py
+++ b/server/chat/backend/agent/providers/vertex_provider.py
@@ -105,4 +105,9 @@ class VertexAIProvider(BaseLLMProvider):
         return model
 
     def get_supported_models(self) -> list[str]:
-        return []
+        return [
+            "vertex/gemini-3.1-pro-preview",
+            "vertex/gemini-3-flash",
+            "vertex/gemini-2.5-pro",
+            "vertex/gemini-2.5-flash",
+        ]

--- a/server/chat/backend/agent/utils/chat_context_manager.py
+++ b/server/chat/backend/agent/utils/chat_context_manager.py
@@ -37,6 +37,13 @@ class ChatContextManager:
         "anthropic/claude-opus-4.5": 180000,  # 200K - 20K buffer
         "anthropic/claude-3-haiku": 180000,  # 200K - 20K buffer
         "google/gemini-3.1-pro-preview": 1000000,  # 1M context
+        "google/gemini-3-flash": 1000000,  # 1M context
+        "google/gemini-2.5-pro": 1000000,  # 1M context
+        "google/gemini-2.5-flash": 1000000,  # 1M context
+        "vertex/gemini-3.1-pro-preview": 1000000,  # 1M context
+        "vertex/gemini-3-flash": 1000000,  # 1M context
+        "vertex/gemini-2.5-pro": 1000000,  # 1M context
+        "vertex/gemini-2.5-flash": 1000000,  # 1M context
         # Bedrock-hosted Claude (same models/windows as the direct Anthropic entries above)
         "bedrock/us.anthropic.claude-sonnet-4-6": 950000,  # 1M - 50K buffer
         "bedrock/us.anthropic.claude-opus-4-6-v1": 950000,  # 1M - 50K buffer

--- a/server/chat/backend/agent/utils/model_cutoff_manager.py
+++ b/server/chat/backend/agent/utils/model_cutoff_manager.py
@@ -66,11 +66,11 @@ class ModelCutoffManager:
 
         # Google / Vertex AI Models
         google_models = {
+            "google/gemini-3.5-flash": ModelInfo(
+                "gemini-3.5-flash", "google", cutoff_date(2025, 4, 1), True, True
+            ),
             "google/gemini-3.1-pro-preview": ModelInfo(
                 "gemini-3.1-pro-preview", "google", cutoff_date(2025, 4, 1), True, True
-            ),
-            "google/gemini-3-flash": ModelInfo(
-                "gemini-3-flash", "google", cutoff_date(2025, 4, 1), True, True
             ),
             "google/gemini-2.5-pro": ModelInfo(
                 "gemini-2.5-pro", "google", cutoff_date(2025, 3, 1), True, True
@@ -78,11 +78,11 @@ class ModelCutoffManager:
             "google/gemini-2.5-flash": ModelInfo(
                 "gemini-2.5-flash", "google", cutoff_date(2025, 3, 1), True, True
             ),
+            "vertex/gemini-3.5-flash": ModelInfo(
+                "gemini-3.5-flash", "vertex", cutoff_date(2025, 4, 1), True, True
+            ),
             "vertex/gemini-3.1-pro-preview": ModelInfo(
                 "gemini-3.1-pro-preview", "vertex", cutoff_date(2025, 4, 1), True, True
-            ),
-            "vertex/gemini-3-flash": ModelInfo(
-                "gemini-3-flash", "vertex", cutoff_date(2025, 4, 1), True, True
             ),
             "vertex/gemini-2.5-pro": ModelInfo(
                 "gemini-2.5-pro", "vertex", cutoff_date(2025, 3, 1), True, True

--- a/server/chat/backend/agent/utils/model_cutoff_manager.py
+++ b/server/chat/backend/agent/utils/model_cutoff_manager.py
@@ -64,10 +64,31 @@ class ModelCutoffManager:
             ),
         }
 
-        # Google Models (via OpenRouter)
+        # Google / Vertex AI Models
         google_models = {
             "google/gemini-3.1-pro-preview": ModelInfo(
                 "gemini-3.1-pro-preview", "google", cutoff_date(2025, 4, 1), True, True
+            ),
+            "google/gemini-3-flash": ModelInfo(
+                "gemini-3-flash", "google", cutoff_date(2025, 4, 1), True, True
+            ),
+            "google/gemini-2.5-pro": ModelInfo(
+                "gemini-2.5-pro", "google", cutoff_date(2025, 3, 1), True, True
+            ),
+            "google/gemini-2.5-flash": ModelInfo(
+                "gemini-2.5-flash", "google", cutoff_date(2025, 3, 1), True, True
+            ),
+            "vertex/gemini-3.1-pro-preview": ModelInfo(
+                "gemini-3.1-pro-preview", "vertex", cutoff_date(2025, 4, 1), True, True
+            ),
+            "vertex/gemini-3-flash": ModelInfo(
+                "gemini-3-flash", "vertex", cutoff_date(2025, 4, 1), True, True
+            ),
+            "vertex/gemini-2.5-pro": ModelInfo(
+                "gemini-2.5-pro", "vertex", cutoff_date(2025, 3, 1), True, True
+            ),
+            "vertex/gemini-2.5-flash": ModelInfo(
+                "gemini-2.5-flash", "vertex", cutoff_date(2025, 3, 1), True, True
             ),
         }
 

--- a/server/guardrails/input_rail.py
+++ b/server/guardrails/input_rail.py
@@ -150,11 +150,14 @@ def _build_llm() -> BaseChatModel:
     model_name = gc.llm_model or ModelConfig.MAIN_MODEL
     llm = create_chat_model(model_name, temperature=0.0, streaming=False)
 
-    provider, _ = ModelMapper.split_provider_model(model_name)
-    if provider in ("google", "vertex"):
-        return _GuardrailsLLMCompat(inner=llm, rename_max_tokens=True)
     provider_mode = os.getenv("LLM_PROVIDER_MODE", "direct").lower()
-    if provider == "openai" and provider_mode == "direct":
+
+    from chat.backend.agent.providers import get_registry
+    serving_provider = get_registry().resolve_provider_name(model_name, mode=provider_mode)
+
+    if serving_provider in ("google", "vertex"):
+        return _GuardrailsLLMCompat(inner=llm, rename_max_tokens=True)
+    if serving_provider == "openai":
         native = ModelMapper.get_native_name(model_name, "openai")
         if OpenAIProvider._supports_reasoning(native):
             return _GuardrailsLLMCompat(inner=llm, rename_max_tokens=False)

--- a/server/guardrails/input_rail.py
+++ b/server/guardrails/input_rail.py
@@ -151,9 +151,9 @@ def _build_llm() -> BaseChatModel:
     llm = create_chat_model(model_name, temperature=0.0, streaming=False)
 
     provider, _ = ModelMapper.split_provider_model(model_name)
-    provider_mode = os.getenv("LLM_PROVIDER_MODE", "direct").lower()
-    if provider == "google" and provider_mode == "direct":
+    if provider in ("google", "vertex"):
         return _GuardrailsLLMCompat(inner=llm, rename_max_tokens=True)
+    provider_mode = os.getenv("LLM_PROVIDER_MODE", "direct").lower()
     if provider == "openai" and provider_mode == "direct":
         native = ModelMapper.get_native_name(model_name, "openai")
         if OpenAIProvider._supports_reasoning(native):

--- a/website/docs/integrations/llm-providers.md
+++ b/website/docs/integrations/llm-providers.md
@@ -75,8 +75,12 @@ A clean pick like **Claude Opus 4.7** is then translated to that provider's nati
 | | `anthropic/claude-3-haiku` | Cheapest (default RCA model) |
 | **Google Gemini** | `google/gemini-3.5-flash` | Fast, cost-effective with thinking |
 | | `google/gemini-3.1-pro-preview` | Latest flagship with thinking |
+| | `google/gemini-2.5-pro` | Strong for complex tasks |
+| | `google/gemini-2.5-flash` | Cost-effective |
 | **Vertex AI** | `vertex/gemini-3.5-flash` | Fast, cost-effective with thinking |
 | | `vertex/gemini-3.1-pro-preview` | Latest flagship with thinking |
+| | `vertex/gemini-2.5-pro` | Strong for complex tasks |
+| | `vertex/gemini-2.5-flash` | Cost-effective with IAM auth |
 | **Ollama** | `ollama/llama3.1` | Meta's Llama 3.1 (8B/70B) |
 | | `ollama/qwen2.5` | Alibaba's Qwen 2.5 (various sizes) |
 | | Any model via `ollama pull` | |

--- a/website/docs/integrations/llm-providers.md
+++ b/website/docs/integrations/llm-providers.md
@@ -41,7 +41,7 @@ Connects directly to each provider's native API. Use this when running models lo
 LLM_PROVIDER_MODE=direct
 ```
 
-In direct mode, Aurora auto-detects the provider from the model name prefix (e.g., `anthropic/claude-3-haiku` routes to Anthropic, `google/gemini-2.5-flash` routes to Google AI).
+In direct mode, Aurora auto-detects the provider from the model name prefix (e.g., `anthropic/claude-3-haiku` routes to Anthropic, `google/gemini-3.5-flash` routes to Google AI).
 
 ### Provider Mode (route everything through one provider)
 
@@ -73,16 +73,10 @@ A clean pick like **Claude Opus 4.7** is then translated to that provider's nati
 | | `anthropic/claude-haiku-4.5` | Fast, affordable |
 | | `anthropic/claude-3.5-sonnet` | Widely used, reliable |
 | | `anthropic/claude-3-haiku` | Cheapest (default RCA model) |
-| **Google Gemini** | `google/gemini-3.1-pro-preview` | Latest flagship with thinking |
-| | `google/gemini-3-flash-preview` | Fast, outperforms 2.5 Pro |
-| | `google/gemini-2.5-pro` | Strong for complex tasks |
-| | `google/gemini-2.5-flash` | Cost-effective |
-| | `google/gemini-2.5-flash-lite` | Cheapest Gemini option |
-| **Vertex AI** | `vertex/gemini-3.1-pro-preview` | Latest flagship with thinking |
-| | `vertex/gemini-3-flash-preview` | Fast, enterprise-grade |
-| | `vertex/gemini-2.5-pro` | Strong for complex tasks |
-| | `vertex/gemini-2.5-flash` | Cost-effective with IAM auth |
-| | `vertex/gemini-2.5-flash-lite` | Cheapest Vertex option |
+| **Google Gemini** | `google/gemini-3.5-flash` | Fast, cost-effective with thinking |
+| | `google/gemini-3.1-pro-preview` | Latest flagship with thinking |
+| **Vertex AI** | `vertex/gemini-3.5-flash` | Fast, cost-effective with thinking |
+| | `vertex/gemini-3.1-pro-preview` | Latest flagship with thinking |
 | **Ollama** | `ollama/llama3.1` | Meta's Llama 3.1 (8B/70B) |
 | | `ollama/qwen2.5` | Alibaba's Qwen 2.5 (various sizes) |
 | | Any model via `ollama pull` | |
@@ -157,6 +151,13 @@ LLM_PROVIDER_MODE=direct
 :::tip
 The project ID is automatically extracted from the service account JSON if `VERTEX_AI_PROJECT` is not set.
 :::
+
+**Optional configuration:**
+
+```bash
+# Disable thinking mode for Gemini models (reduces latency, lowers token usage)
+GEMINI_DISABLE_THINKING=true
+```
 
 ### Ollama (Local Models)
 
@@ -265,10 +266,10 @@ RCA_MODEL=anthropic/claude-haiku-4.5
 RCA_MODEL=openai/gpt-4o
 
 # Google AI
-RCA_MODEL=google/gemini-2.5-flash
+RCA_MODEL=google/gemini-3.5-flash
 
 # Vertex AI
-RCA_MODEL=vertex/gemini-2.5-flash
+RCA_MODEL=vertex/gemini-3.5-flash
 
 # Ollama (local)
 RCA_MODEL=ollama/llama3.1


### PR DESCRIPTION
## Summary
- Add Vertex-routed Gemini models (3.1 Pro, 3 Flash, 2.5 Pro, 2.5 Flash) to model registry, UI selector, pricing, and context managers
- Fix guardrails crash when `LLM_PROVIDER_MODE=vertex` — NeMo calls `.bind(max_tokens=3)` but Gemini only accepts `max_output_tokens`, now properly wrapped
- Pass `GOOGLE_APPLICATION_CREDENTIALS` through docker-compose for file-based Vertex auth

## Test plan
- [x] Model mapper: reverse mapping collision fixed (vertex entries no longer overwrite google entries)
- [x] Provider routing: vertex/gemini-* routes through VertexAIProvider, anthropic/* falls back to direct
- [x] Guardrails: wrapper correctly applied to google/vertex models, NOT applied to anthropic/openai under vertex mode
- [x] End-to-end: invoked `vertex/gemini-2.5-flash` via Vertex AI on `sublime-flux-414616` — response received
- [x] Guardrails e2e: `_GuardrailsLLMCompat` with `rename_max_tokens=True` + `.bind(max_tokens=50)` returns plain string (thinking blocks stripped)
- [x] Existing test suite: 191/191 pass (1 pre-existing RBAC failure unrelated)

Closes DEV-1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Vertex AI provider support with Gemini 3.5 Flash and 3.1 Pro Preview model options
  * Enhanced model selection and provider switching capabilities
  * Improved model compatibility across multiple providers

* **Documentation**
  * Updated LLM provider documentation with latest model examples and configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->