### PR TITLE
Move Actions nav item under Incidents

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -188,6 +188,24 @@ export default function Navigation({
               </Link>
             </li>
 
+          {/* Actions Navigation Item */}
+          <li>
+            <Link
+              href="/actions"
+              className={cn(
+                "w-full flex items-center justify-between px-2.5 py-1.5 rounded-md hover:bg-primary/10 transition-colors text-sm border border-transparent hover:border-border/50",
+                pathname?.startsWith("/actions")
+                  ? "bg-card rounded-lg border border-border shadow-sm"
+                  : "text-muted-foreground"
+              )}
+            >
+              <div className="flex items-center">
+                <Workflow size={16} />
+                <span className="ml-2">Actions</span>
+              </div>
+            </Link>
+          </li>
+
           {/* Monitor Navigation Item */}
           <li>
             <Link
@@ -220,24 +238,6 @@ export default function Navigation({
               <div className="flex items-center">
                 <Plug size={16} />
                 <span className="ml-2">Connectors</span>
-              </div>
-            </Link>
-          </li>
-
-          {/* Actions Navigation Item */}
-          <li>
-            <Link
-              href="/actions"
-              className={cn(
-                "w-full flex items-center justify-between px-2.5 py-1.5 rounded-md hover:bg-primary/10 transition-colors text-sm border border-transparent hover:border-border/50",
-                pathname?.startsWith("/actions")
-                  ? "bg-card rounded-lg border border-border shadow-sm"
-                  : "text-muted-foreground"
-              )}
-            >
-              <div className="flex items-center">
-                <Workflow size={16} />
-                <span className="ml-2">Actions</span>
               </div>
             </Link>
           </li>


### PR DESCRIPTION
Reorders the sidebar navigation so Actions sits directly under Incidents.

Before: New Chat -> Incidents -> Monitor -> Connectors -> Actions
After:  New Chat -> Incidents -> Actions -> Monitor -> Connectors

Pure reorder of the existing Actions list item in `navigation.tsx`. No behavior or styling change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered sidebar navigation items with Actions now appearing before Monitor and Connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->