### PR TITLE
Update GitHub skill docs with file-size constraints

### DIFF
--- a/server/chat/backend/agent/skills/integrations/github/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/github/SKILL.md
@@ -44,10 +44,12 @@ Connected account: {username}
    - Pass `incident_time` (ISO 8601) for automatic time window correlation
 3. `github_fix(file_path=..., edits=[{old_string, new_string, replace_all?}, ...], fix_description=..., root_cause_summary=...)` — Suggest a code fix via anchored search-and-replace edits (stored for user review, not auto-applied). First call `get_file_contents` to read the current file so you can copy the exact `old_string` (with enough surrounding context to be unique).
 4. `github_apply_fix(suggestion_id=...)` — Create a PR from an approved fix (only after user reviews)
-5. `github_commit(repo=..., commit_message=...)` — Push Terraform files to GitHub
+5. `github_commit(repo=..., commit_message=...)` — Push generated Terraform (.tf) files from the IaC workflow to GitHub. This is NOT a general-purpose commit tool — it only pushes .tf files from the terraform working directory.
 
 ### MCP Tools (for direct GitHub API operations beyond RCA)
 - Files: `get_file_contents`, `create_or_update_file`, `push_files`, `get_repository_tree`
+- **Size limit:** `create_or_update_file` and `push_files` enforce a 50 KB per-file cap. Files exceeding this limit will be rejected. Do NOT attempt to work around this via terminal commands or other tools — the limit is intentional.
+- **Updates:** When updating an existing file, the new content must be at least 50% of the original file size (for files over 10 KB). This prevents accidental truncation.
 - Branches: `create_branch`, `list_branches`, `list_commits`, `get_commit`
 - PRs: `create_pull_request`, `list_pull_requests`, `merge_pull_request`, `get_pull_request_files`
 - Issues: `create_issue`, `list_issues`, `search_issues`, `add_issue_comment`


### PR DESCRIPTION
## Summary
- Clarify that `github_commit` is only for Terraform `.tf` files from the IaC workflow, not a general-purpose push tool
- Document the 50KB per-file cap on `create_or_update_file` and `push_files`
- Document the 50% minimum ratio guard for updates to existing files >10KB
- Explicitly tell the agent not to attempt workarounds via terminal when blocked

## Context
During integration testing of PR #523 (file-size guard), the agent was:
1. Correctly blocked by the guard on `create_or_update_file`
2. Then trying to use `github_commit` as a workaround (which only handles .tf files anyway)
3. Then trying to steal credentials from Vault/env to push via terminal

This updates the skill instructions so the agent understands the constraints upfront.

## Test plan
- [ ] Rebuild chatbot, ask it to create a >50KB file — it should acknowledge the limit instead of attempting workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub integration documentation with clearer tool usage instructions.
  * Clarified commit tool usage is restricted to Terraform files.
  * Added specific operating constraints: 50 KB per-file size limit and update-size requirements (new content must be at least 50% of original for files over 10 KB).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->