### PR TITLE
Fix GitHubCommitTool crash on lost WebSocket

### DIFF
--- a/client/src/components/GitHubCommitTool.tsx
+++ b/client/src/components/GitHubCommitTool.tsx
@@ -10,6 +10,7 @@ interface GitHubCommitToolProps {
   repo?: string
   branch?: string
   defaultMessage?: string
+  disabled?: boolean
   onCommit?: (message: string) => Promise<void>
   onPush?: () => Promise<void>
   onClose?: () => void
@@ -19,6 +20,7 @@ export function GitHubCommitTool({
   repo = "user/repository",
   branch = "main",
   defaultMessage = "Update files",
+  disabled = false,
   onCommit,
   onPush,
   onClose,
@@ -28,16 +30,18 @@ export function GitHubCommitTool({
   const [isPushing, setIsPushing] = useState(false)
   const [isCommitted, setIsCommitted] = useState(false)
   const [isPushed, setIsPushed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const handleCommit = async () => {
     if (!commitMessage.trim()) return
 
     setIsCommitting(true)
+    setError(null)
     try {
       await onCommit?.(commitMessage)
       setIsCommitted(true)
-    } catch (error) {
-      console.error("Commit failed:", error)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Commit failed")
     } finally {
       setIsCommitting(false)
     }
@@ -83,13 +87,17 @@ export function GitHubCommitTool({
 
       {/* Commit Message Input */}
       <div className="flex-1 min-w-0">
+
         <Input
           value={commitMessage}
           onChange={(e) => setCommitMessage(e.target.value)}
           placeholder="Commit message..."
           className="bg-gray-50 dark:bg-gray-900/50 border-gray-300 dark:border-gray-700/50 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-500 h-8 text-sm"
-          disabled={isCommitting || isPushing}
+          disabled={disabled || isCommitting || isPushing}
         />
+        {error && (
+          <p className="text-xs text-red-600 dark:text-red-400 mt-1">{error}</p>
+        )}
       </div>
 
       {/* Action Buttons */}
@@ -98,7 +106,7 @@ export function GitHubCommitTool({
           size="sm"
           variant="outline"
           onClick={handleCommit}
-          disabled={!commitMessage.trim() || isCommitting || isPushing || isCommitted}
+          disabled={disabled || !commitMessage.trim() || isCommitting || isPushing || isCommitted}
           className="bg-white dark:bg-gray-900/50 border-gray-300 dark:border-gray-700/50 text-gray-900 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 h-8 px-3"
         >
           {isCommitting ? (
@@ -114,7 +122,7 @@ export function GitHubCommitTool({
         <Button
           size="sm"
           onClick={handlePush}
-          disabled={!isCommitted || isPushing || isPushed}
+          disabled={disabled || !isCommitted || isPushing || isPushed}
           className="bg-blue-600 hover:bg-blue-700 text-white h-8 px-3 shadow-sm"
         >
           {isPushing ? (

--- a/client/src/components/tool-calls/ToolExecutionWidget.tsx
+++ b/client/src/components/tool-calls/ToolExecutionWidget.tsx
@@ -291,30 +291,30 @@ const ToolExecutionWidget = ({ tool, className, sendMessage, sendRaw, onToolUpda
               repo={repo}
               branch={branch}
               defaultMessage={commitMessage}
+              disabled={!sendMessage || !userId}
               onCommit={async (message) => {
-                if (sendMessage && userId) {
-                  const success = sendMessage(
-                    `Please use the github_commit tool with these exact parameters: repo="${repo}", commit_message="${message}", branch="${branch}", push=true`,
-                    userId,
-                    { 
-                      tool_suggestion: 'github_commit',
-                      session_id: 'current',
-                      direct_tool_call: {
-                        tool_name: 'github_commit',
-                        parameters: {
-                          repo: repo,
-                          commit_message: message,
-                          branch: branch,
-                          push: true
-                        }
+                if (!sendMessage || !userId) {
+                  throw new Error('Connection lost. Please refresh the page and try again.')
+                }
+                const success = sendMessage(
+                  `Please use the github_commit tool with these exact parameters: repo="${repo}", commit_message="${message}", branch="${branch}", push=true`,
+                  userId,
+                  {
+                    tool_suggestion: 'github_commit',
+                    session_id: 'current',
+                    direct_tool_call: {
+                      tool_name: 'github_commit',
+                      parameters: {
+                        repo: repo,
+                        commit_message: message,
+                        branch: branch,
+                        push: true
                       }
                     }
-                  )
-                  if (!success) {
-                    throw new Error('Failed to send commit request to backend')
                   }
-                } else {
-                  throw new Error('Unable to send commit request - no WebSocket connection')
+                )
+                if (!success) {
+                  throw new Error('Failed to send commit request. Please try again.')
                 }
               }}
               onPush={async () => {


### PR DESCRIPTION
## Summary
- Disable commit/push buttons when the WebSocket connection is unavailable (`sendMessage` or `userId` undefined)
- Show inline error message instead of throwing an unhandled exception to the console
- Prevents the `Unable to send commit request - no WebSocket connection` error that shows as a Next.js error overlay

## Context
The `GitHubCommitTool` widget renders after the agent calls `github_commit`. If the user clicks the button after the WS connection drops (e.g. agent turn ended, timeout, navigation), it threw an unhandled error. Now it gracefully disables and shows a "Connection lost" message.

## Test plan
- [ ] Trigger a Terraform IaC write that shows the commit widget
- [ ] Wait for the agent turn to end (WS disconnects)
- [ ] Verify commit button is disabled, not throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Commit operations now display clear, user-visible error messages when failures occur
  * Commit and push buttons automatically disable when connection requirements are unavailable
  * Improved error handling with clearer, more user-friendly messages for failed commit requests
  * Enhanced state management to prevent invalid operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->