### PR TITLE
fix: GitHub App connections missing from connected-accounts endpoint

### DIFF
--- a/server/chat/backend/agent/tools/iac/iac_user_flows.py
+++ b/server/chat/backend/agent/tools/iac/iac_user_flows.py
@@ -21,12 +21,14 @@ def check_github_connection(user_id: str) -> bool:
 
         credentials = get_user_cloud_credentials(user_id)
         if credentials and credentials.get("github", {}).get("access_token"):
-            logger.info(f"GitHub is connected for user {user_id}")
             return True
-        logger.info(f"GitHub is not connected for user {user_id}")
-        return False
-    except Exception as e:
-        logger.warning(f"Error checking GitHub connection: {e}")
+        from utils.auth.github_auth_router import (
+            NoGitHubAuthError,
+            get_any_auth_for_user,
+        )
+        get_any_auth_for_user(user_id)
+        return True
+    except Exception:
         return False
 
 

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -186,7 +186,30 @@ def get_connected_accounts(user_id, target_user_id):
                 }
 
         # ------------------------------
-        # 4) Kubectl agent connections
+        # 4) GitHub App installations (no user_tokens row)
+        # ------------------------------
+        if "github" not in accounts:
+            cursor.execute(
+                """SELECT gi.account_login
+                     FROM user_github_installations ugi
+                     JOIN github_installations gi
+                          ON gi.installation_id = ugi.installation_id
+                    WHERE ugi.user_id = %s
+                      AND ugi.disconnected_at IS NULL
+                      AND gi.suspended_at IS NULL
+                    LIMIT 1""",
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            if row:
+                accounts["github"] = {
+                    "isConnected": True,
+                    "name": "GitHub",
+                    "displayText": row[0] or "GitHub App",
+                }
+
+        # ------------------------------
+        # 5) Kubectl agent connections
         # ------------------------------
         if "kubectl" not in accounts:
             result = _check_kubectl(user_id, org_id)
@@ -194,7 +217,7 @@ def get_connected_accounts(user_id, target_user_id):
                 accounts["kubectl"] = {"isConnected": True, "name": "Kubernetes", "displayText": "Kubernetes Cluster"}
 
         # ------------------------------
-        # 5) On-prem VM connections
+        # 6) On-prem VM connections
         # ------------------------------
         if "onprem" not in accounts:
             result = _check_onprem(user_id, org_id)

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -197,6 +197,7 @@ def get_connected_accounts(user_id, target_user_id):
                     WHERE ugi.user_id = %s
                       AND ugi.disconnected_at IS NULL
                       AND gi.suspended_at IS NULL
+                    ORDER BY gi.account_login
                     LIMIT 1""",
                 (user_id,),
             )

--- a/server/routes/github/github_app.py
+++ b/server/routes/github/github_app.py
@@ -529,6 +529,16 @@ def github_app_install_callback():
             exc_info=True,
         )
 
+    # Ensure tool permissions include GitHub tools for this org (idempotent).
+    try:
+        from utils.auth.tool_registry import seed_org_tool_permissions
+        seed_org_tool_permissions(org_id, user_id)
+    except Exception:
+        logger.warning(
+            "[GITHUB-APP-CALLBACK] failed to seed tool permissions",
+            exc_info=True,
+        )
+
     # Reuse the OAuth success template. App-mode has no user token to relay,
     # so token is empty; account_login takes the github_username slot so the
     # postMessage to the parent window still carries a useful identifier.

--- a/server/routes/github/github_oauth.py
+++ b/server/routes/github/github_oauth.py
@@ -333,6 +333,15 @@ def github_callback():
             cache_err,
         )
 
+    try:
+        from utils.auth.tool_registry import seed_org_tool_permissions
+        from utils.auth.stateless_auth import get_org_id_for_user
+        org_id = get_org_id_for_user(aurora_user_id)
+        if org_id:
+            seed_org_tool_permissions(org_id, aurora_user_id)
+    except Exception:
+        logger.warning("[GITHUB-OAUTH] failed to seed tool permissions", exc_info=True)
+
     return flask.render_template(
         "github_callback_success.html",
         token="",


### PR DESCRIPTION
## Summary
- In App mode, GitHub installations are stored in `user_github_installations` (not `user_tokens`), so the `/api/connected-accounts` endpoint never returned GitHub as connected
- This caused the Actions tool permissions section to be hidden in Security Settings since the UI filters by connected providers
- Adds a check for `user_github_installations` in the connected-accounts endpoint (section 4, between webhooks and kubectl)
- Also fixes docs to clarify Setup URL targets the API host (`/github/app/install/callback`), not the frontend

## Test plan
- [ ] Connect GitHub via App mode
- [ ] Verify `/api/connected-accounts` returns `github` in the response
- [ ] Verify tool permissions section shows GitHub actions in Security Settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connected accounts reporting now includes GitHub connection status based on GitHub App installation state, displaying account login information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->