### PR TITLE
fix: seed tool permissions on connector connect (bitbucket, gitlab, notion, spinnaker)

### DIFF
--- a/server/routes/bitbucket/bitbucket.py
+++ b/server/routes/bitbucket/bitbucket.py
@@ -218,6 +218,15 @@ def bitbucket_callback():
                 frontend_url=FRONTEND_URL,
             )
 
+        try:
+            from utils.auth.tool_registry import seed_org_tool_permissions
+            from utils.auth.stateless_auth import get_org_id_for_user
+            org_id = get_org_id_for_user(user_id)
+            if org_id:
+                seed_org_tool_permissions(org_id, user_id)
+        except Exception:
+            logger.warning("[BITBUCKET-CALLBACK] failed to seed tool permissions", exc_info=True)
+
         return render_template(
             "bitbucket_callback_success.html",
             bitbucket_username=username,

--- a/server/routes/gitlab/gitlab_routes.py
+++ b/server/routes/gitlab/gitlab_routes.py
@@ -252,6 +252,15 @@ def gitlab_connect(user_id):
         store_tokens_in_db(user_id, gitlab_token_data, "gitlab")
         logger.info("Stored GitLab credentials for user %s (org-level)", user_id)
 
+        try:
+            from utils.auth.tool_registry import seed_org_tool_permissions
+            from utils.auth.stateless_auth import get_org_id_for_user
+            org_id = get_org_id_for_user(user_id)
+            if org_id:
+                seed_org_tool_permissions(org_id, user_id)
+        except Exception:
+            logger.warning("[GITLAB-CONNECT] failed to seed tool permissions", exc_info=True)
+
         project_count, connect_warning = _auto_connect_projects(user_id, base_url, access_token)
 
         response = {

--- a/server/routes/notion/notion_routes.py
+++ b/server/routes/notion/notion_routes.py
@@ -87,6 +87,15 @@ def _handle_oauth_callback(
         logger.exception("[NOTION] Failed to persist OAuth credentials: %s", exc)
         return jsonify({"error": "Failed to persist Notion credentials"}), 500
 
+    try:
+        from utils.auth.tool_registry import seed_org_tool_permissions
+        from utils.auth.stateless_auth import get_org_id_for_user
+        org_id = get_org_id_for_user(user_id)
+        if org_id:
+            seed_org_tool_permissions(org_id, user_id)
+    except Exception:
+        logger.warning("[NOTION] failed to seed tool permissions", exc_info=True)
+
     return jsonify(
         {
             "success": True,
@@ -162,6 +171,15 @@ def connect(user_id):
         rc = get_redis_client()
         if rc:
             rc.delete(f"notion:status:{user_id}")
+
+        try:
+            from utils.auth.tool_registry import seed_org_tool_permissions
+            from utils.auth.stateless_auth import get_org_id_for_user
+            org_id = get_org_id_for_user(user_id)
+            if org_id:
+                seed_org_tool_permissions(org_id, user_id)
+        except Exception:
+            logger.warning("[NOTION] failed to seed tool permissions", exc_info=True)
 
         return jsonify(
             {

--- a/server/routes/spinnaker/spinnaker_routes.py
+++ b/server/routes/spinnaker/spinnaker_routes.py
@@ -126,6 +126,15 @@ def connect(user_id):
         logger.exception("[SPINNAKER] Failed to store credentials for user %s", user_id)
         return jsonify({"error": "Failed to store Spinnaker credentials"}), 500
 
+    try:
+        from utils.auth.tool_registry import seed_org_tool_permissions
+        from utils.auth.stateless_auth import get_org_id_for_user
+        org_id = get_org_id_for_user(user_id)
+        if org_id:
+            seed_org_tool_permissions(org_id, user_id)
+    except Exception:
+        logger.warning("[SPINNAKER] failed to seed tool permissions", exc_info=True)
+
     return jsonify({
         "connected": True,
         "baseUrl": base_url,


### PR DESCRIPTION
## Summary
- Adds `seed_org_tool_permissions` call to the connect/callback success path for all connectors that have entries in the tool registry: Bitbucket, GitLab, Notion, Spinnaker
- Ensures tool permissions rows exist in the DB immediately upon connecting, so background RCA can use the tools without requiring the user to visit Security Settings first
- Idempotent (`ON CONFLICT DO NOTHING`) — existing user choices are preserved

Companion to #535 which covers GitHub (App + OAuth).

## Test plan
- [ ] Connect each connector and verify `org_tool_permissions` has rows for its tools
- [ ] Verify existing orgs with pre-set permissions are not overwritten on reconnect