### PR TITLE
fix: remove noisy cloud provider warning on chat send

### DIFF
--- a/client/src/app/chat/components/useChatSendHandlers.ts
+++ b/client/src/app/chat/components/useChatSendHandlers.ts
@@ -1,9 +1,8 @@
 "use client";
 
-import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState, startTransition } from "react";
+import { MutableRefObject, useCallback, useEffect, useRef, useState, startTransition } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { providerPreferencesService } from "@/lib/services/providerPreferences";
-import { useConnectedAccounts } from "@/hooks/useConnectedAccounts";
 import { Message } from "../types";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
@@ -69,23 +68,12 @@ export function useChatSendHandlers({
   clearSelectedAction,
 }: ChatSendHandlerParams): ChatSendHandlerResult {
   const { toast } = useToast();
-  const { providerIds, isProviderConnected } = useConnectedAccounts();
 
   const [selectedModel, setSelectedModel] = useState("openai/gpt-5.5");
   const [selectedMode, setSelectedMode] = useState("agent");
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
   const [isSending, setIsSending] = useState(false);
   const isSyncingRef = useRef(false);
-
-  const getConnectedProviders = useCallback(() => {
-    const infra = ['gcp', 'aws', 'azure', 'ovh', 'scaleway', 'tailscale', 'kubectl', 'onprem'];
-    return infra.filter(id => isProviderConnected(id));
-  }, [providerIds, isProviderConnected]);
-
-  const anyProviderConnected = useMemo(
-    () => getConnectedProviders().length > 0,
-    [getConnectedProviders],
-  );
 
   const syncProvidersWithMode = useCallback((modeValue: string, providers: string[]) => {
     // Prevent infinite loop - if we're already syncing, skip
@@ -306,17 +294,10 @@ export function useChatSendHandlers({
     if (!trimmed && !selectedAction) return false;
 
     const targetMode = modeOverride || selectedMode;
-    // Show warning if no providers connected
-    if (!anyProviderConnected) {
-      toast({
-        description: "No cloud provider selected. Connect a provider for reliable execution.",
-        variant: "default",
-      });
-    }
 
     // Let sendMessage handle provider enforcement and normalization
     return await sendMessage(messageText, socket, targetMode, undefined, options);
-  }, [anyProviderConnected, selectedMode, sendMessage, toast, selectedAction]);
+  }, [selectedMode, sendMessage, selectedAction]);
 
   const handleSend = useCallback(async (messageText: string, socket: ChatWebSocket, overrideMode?: string, options?: { triggerRca?: boolean }) => {
     return await initiateSend(messageText, socket, overrideMode, options);


### PR DESCRIPTION
## Summary
- Remove the repeated “No cloud provider selected” toast from the general chat send flow.
- Drop the connected-accounts lookup that was only used to decide whether to show that warning.
- Keep normal message sending, provider preferences, and existing error toasts unchanged.

## Context
Issue #518 reports that the provider warning fires on every message send. The issue discussion points toward deleting this notification rather than changing connected-account key matching, so this keeps the fix limited to the chat send warning path.

## Testing
- ✅ `python3` regression check: confirmed the warning string, `anyProviderConnected`, and `useConnectedAccounts` are absent from `client/src/app/chat/components/useChatSendHandlers.ts`
- ✅ `git diff --check`
- ✅ `npm run build`

Attempted but currently blocked by existing baseline/tooling issues:
- ⚠️ `npm run lint` fails with `The requested module 'minimatch' does not provide an export named 'default'`
- ⚠️ `npx tsc --noEmit` fails on existing Next/type errors, including generated `.next/types` route context errors and pre-existing nullability errors in `useChatSendHandlers.ts`

Fixes #518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified provider handling in chat messaging. Provider warnings have been consolidated, and logic has been streamlined for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->