### PR TITLE
fix: Improve Slack action notifications with result summaries and reduced noise

### DIFF
--- a/server/connectors/slack_connector/client.py
+++ b/server/connectors/slack_connector/client.py
@@ -96,6 +96,11 @@ class SlackClient:
         if blocks:
             data["blocks"] = blocks
         return self._make_request("POST", "chat.update", data)
+
+    def delete_message(self, channel: str, ts: str) -> bool:
+        """Delete a message from a Slack channel. Returns True if successful."""
+        result = self._make_request("POST", "chat.delete", {"channel": channel, "ts": ts})
+        return result.get("ok", False)
     
     def set_channel_topic(self, channel: str, topic: str) -> Dict[str, Any]:
         """Set channel topic/description."""

--- a/server/connectors/slack_connector/client.py
+++ b/server/connectors/slack_connector/client.py
@@ -97,10 +97,9 @@ class SlackClient:
             data["blocks"] = blocks
         return self._make_request("POST", "chat.update", data)
 
-    def delete_message(self, channel: str, ts: str) -> bool:
-        """Delete a message from a Slack channel. Returns True if successful."""
-        result = self._make_request("POST", "chat.delete", {"channel": channel, "ts": ts})
-        return result.get("ok", False)
+    def delete_message(self, channel: str, ts: str) -> None:
+        """Delete a message from a Slack channel. Raises ValueError on failure."""
+        self._make_request("POST", "chat.delete", {"channel": channel, "ts": ts})
     
     def set_channel_topic(self, channel: str, topic: str) -> Dict[str, Any]:
         """Set channel topic/description."""

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -201,7 +201,7 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
     if run_id:
         action_name, started_at = _fetch_action_run_details(run_id, user_id)
 
-    if session_id and status != 'running':
+    if session_id and status == 'success' and not error_message:
         last_bot_text = _fetch_last_bot_message(session_id, user_id)
         if last_bot_text:
             result_summary = _summarize_action_result(action_name, last_bot_text, user_id)

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -27,6 +27,8 @@ from utils.db.connection_pool import db_pool
 
 logger = logging.getLogger(__name__)
 
+_UNKNOWN_ACTION = "Unknown Action"
+
 
 def _get_org_email_recipients(org_id: str, user_id: str) -> list:
     """Fetch verified and enabled email recipients for an org."""
@@ -154,7 +156,7 @@ def _fetch_action_run_details(run_id: str, user_id: str) -> tuple:
                 )
                 row = cur.fetchone()
                 if not row:
-                    return "Unknown Action", None
+                    return _UNKNOWN_ACTION, None
                 started = row[1]
                 if started and not started.tzinfo:
                     started = started.replace(tzinfo=timezone.utc)
@@ -163,7 +165,7 @@ def _fetch_action_run_details(run_id: str, user_id: str) -> tuple:
                 return row[0], started
     except Exception as e:
         logger.warning("[Dispatcher] Failed to fetch action run details: %s", e)
-    return "Unknown Action", None
+    return _UNKNOWN_ACTION, None
 
 
 def _fetch_last_bot_message(session_id: str, user_id: str) -> Optional[str]:
@@ -192,7 +194,7 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
                      status: str = 'running', error_message: Optional[str] = None) -> Dict[str, Any]:
     """Build action data dict from trigger metadata and optional DB lookup."""
     run_id = trigger_metadata.get('run_id')
-    action_name = "Unknown Action"
+    action_name = _UNKNOWN_ACTION
     result_summary = None
     started_at = None
 

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -241,6 +241,7 @@ One-line summary:"""
             ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,
             temperature=0.1,
             streaming=False,
+            request_timeout=25,
         )
 
         response = tracked_invoke(

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -144,6 +144,7 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
     """Build action data dict from trigger metadata and optional DB lookup."""
     run_id = trigger_metadata.get('run_id')
     action_name = "Unknown Action"
+    result_summary = None
     started_at = None
 
     if run_id:
@@ -168,8 +169,32 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
         except Exception as e:
             logger.warning("[Dispatcher] Failed to fetch action run details: %s", e)
 
+    # Fetch the last assistant message and summarize into key results
+    if session_id and status != 'running':
+        try:
+            with db_pool.get_admin_connection() as conn:
+                with conn.cursor() as cur:
+                    set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:ActionResult]")
+                    cur.execute(
+                        "SELECT messages FROM chat_sessions WHERE id = %s",
+                        (session_id,),
+                    )
+                    row = cur.fetchone()
+                    if row and row[0]:
+                        messages = row[0] if isinstance(row[0], list) else json.loads(row[0])
+                        last_bot_text = None
+                        for msg in reversed(messages):
+                            if msg.get('sender') == 'bot' and msg.get('text'):
+                                last_bot_text = msg['text']
+                                break
+                        if last_bot_text:
+                            result_summary = _summarize_action_result(action_name, last_bot_text, user_id)
+        except Exception as e:
+            logger.warning("[Dispatcher] Failed to fetch action result summary: %s", e)
+
     return {
         'action_name': action_name,
+        'result_summary': result_summary,
         'run_id': run_id,
         'status': status,
         'error': error_message,
@@ -177,6 +202,110 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
         'completed_at': datetime.now(timezone.utc) if status != 'running' else None,
         'session_id': session_id,
     }
+
+
+def _summarize_action_result(action_name: str, bot_response: str, user_id: str) -> Optional[str]:
+    """Summarize an action's output into key results using a lightweight LLM call."""
+    try:
+        from langchain_core.messages import HumanMessage
+        from chat.backend.agent.providers import create_chat_model
+        from chat.backend.agent.llm import ModelConfig
+        from chat.backend.agent.utils.llm_usage_tracker import tracked_invoke
+        from chat.background.summarization import _extract_text_from_response
+
+        # Truncate input to avoid blowing context window
+        truncated_response = bot_response[:4000]
+
+        prompt = f"""Action "{action_name}" completed. State the findings/outcomes only — NOT what the AI did.
+
+Example: Instead of "Scanned repo for vulnerabilities" → "3 critical: SQL injection in auth.py, exposed creds in config.yml"
+
+Bullets, each <15 words.
+
+Response:
+{truncated_response}
+
+Results:"""
+
+        llm = create_chat_model(
+            ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,
+            temperature=0.1,
+            streaming=False,
+        )
+
+        response = tracked_invoke(
+            llm,
+            [HumanMessage(content=prompt)],
+            user_id=user_id,
+            session_id=None,
+            model_name=ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,
+            request_type="action_result_summary",
+        )
+
+        if response and response.content:
+            summary = _extract_text_from_response(response.content)
+            if summary:
+                summary = _normalize_bullets(summary)
+                return summary[:1500]
+        return None
+
+    except Exception as e:
+        logger.warning("[Dispatcher] Failed to summarize action result: %s", e)
+        return None
+
+
+def _normalize_bullets(text: str) -> str:
+    """Normalize inconsistent bullet characters to a uniform format."""
+    import re
+    lines = text.split('\n')
+    normalized = []
+    for line in lines:
+        normalized.append(re.sub(r'^[\s]*[*\-•]\s*', '• ', line))
+    return '\n'.join(normalized)
+
+
+def _store_start_message_info(run_id: str, msg_info: Dict[str, str], user_id: str) -> None:
+    """Store the Slack started message ts/channel in action_runs.trigger_context."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:StoreStartMsg]")
+                cur.execute(
+                    """UPDATE action_runs
+                       SET trigger_context = COALESCE(trigger_context, '{}'::jsonb)
+                           || %s::jsonb
+                       WHERE id = %s""",
+                    (json.dumps({
+                        'slack_start_message_ts': msg_info['ts'],
+                        'slack_start_message_channel': msg_info['channel_id'],
+                    }), run_id),
+                )
+            conn.commit()
+    except Exception as e:
+        logger.warning("[Dispatcher] Failed to store start message info: %s", e)
+
+
+def _get_start_message_info(run_id: str, user_id: str) -> Optional[Dict[str, str]]:
+    """Retrieve the stored Slack started message ts/channel from action_runs."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:GetStartMsg]")
+                cur.execute(
+                    "SELECT trigger_context FROM action_runs WHERE id = %s",
+                    (run_id,),
+                )
+                row = cur.fetchone()
+                if row and row[0]:
+                    ctx = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+                    ts = ctx.get('slack_start_message_ts')
+                    channel = ctx.get('slack_start_message_channel')
+                    if ts:
+                        return {'ts': ts, 'channel_id': channel}
+        return None
+    except Exception as e:
+        logger.warning("[Dispatcher] Failed to get start message info: %s", e)
+        return None
 
 
 def _send_emails(org_id: str, user_id: str, send_fn_name: str, payload: Any) -> None:
@@ -337,7 +466,10 @@ def notify_action_started(user_id: str, trigger_metadata: Dict[str, Any], sessio
                 from utils.notifications.slack_notification_service import (
                     send_slack_action_started_notification,
                 )
-                send_slack_action_started_notification(user_id, action_data)
+                msg_info = send_slack_action_started_notification(user_id, action_data)
+                # Store the message ts so we can delete it when the action completes
+                if msg_info and trigger_metadata.get('run_id'):
+                    _store_start_message_info(trigger_metadata['run_id'], msg_info, user_id)
             except Exception:
                 logger.exception("[Dispatcher] Slack action started notification failed")
 
@@ -354,6 +486,14 @@ def notify_action_completed(user_id: str, trigger_metadata: Dict[str, Any], sess
             return
 
         action_data = _get_action_data(user_id, trigger_metadata, session_id, status=status, error_message=error_message)
+
+        # Retrieve the stored start message info for deletion
+        run_id = trigger_metadata.get('run_id')
+        if run_id:
+            start_msg_info = _get_start_message_info(run_id, user_id)
+            if start_msg_info:
+                action_data['start_message_ts'] = start_msg_info['ts']
+                action_data['start_message_channel'] = start_msg_info.get('channel_id')
 
         # --- Email ---
         email_enabled = bool(get_org_preference(org_id, 'action_email_notifications', default=False))

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -216,16 +216,14 @@ def _summarize_action_result(action_name: str, bot_response: str, user_id: str) 
         # Truncate input to avoid blowing context window
         truncated_response = bot_response[:4000]
 
-        prompt = f"""Action "{action_name}" completed. State the findings/outcomes only — NOT what the AI did.
+        prompt = f"""Summarize the outcome of action "{action_name}" in ONE short sentence. State counts and status, not specifics.
 
-Example: Instead of "Scanned repo for vulnerabilities" → "3 critical: SQL injection in auth.py, exposed creds in config.yml"
-
-Bullets, each <15 words.
+Example: "Found 5 critical vulnerabilities across 3 services" or "2 active EC2 instances in us-east-1, both healthy"
 
 Response:
 {truncated_response}
 
-Results:"""
+One-line summary:"""
 
         llm = create_chat_model(
             ModelConfig.INCIDENT_REPORT_SUMMARIZATION_MODEL,
@@ -245,23 +243,12 @@ Results:"""
         if response and response.content:
             summary = _extract_text_from_response(response.content)
             if summary:
-                summary = _normalize_bullets(summary)
-                return summary[:1500]
+                return summary[:300]
         return None
 
     except Exception as e:
         logger.warning("[Dispatcher] Failed to summarize action result: %s", e)
         return None
-
-
-def _normalize_bullets(text: str) -> str:
-    """Normalize inconsistent bullet characters to a uniform format."""
-    import re
-    lines = text.split('\n')
-    normalized = []
-    for line in lines:
-        normalized.append(re.sub(r'^[\s]*[*\-•]\s*', '• ', line))
-    return '\n'.join(normalized)
 
 
 def _store_start_message_info(run_id: str, msg_info: Dict[str, str], user_id: str) -> None:

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -139,6 +139,55 @@ def _enrich_incident_summary(incident_data: Dict[str, Any], session_id: str, use
         logger.warning(f"[Dispatcher] Failed to enrich summary: {e}")
 
 
+def _fetch_action_run_details(run_id: str, user_id: str) -> tuple:
+    """Fetch action name and started_at from action_runs. Returns (name, started_at)."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:ActionData]")
+                cur.execute(
+                    """SELECT a.name, ar.started_at
+                       FROM action_runs ar
+                       JOIN actions a ON a.id = ar.action_id
+                       WHERE ar.id = %s""",
+                    (run_id,),
+                )
+                row = cur.fetchone()
+                if not row:
+                    return "Unknown Action", None
+                started = row[1]
+                if started and not started.tzinfo:
+                    started = started.replace(tzinfo=timezone.utc)
+                elif started:
+                    started = started.astimezone(timezone.utc)
+                return row[0], started
+    except Exception as e:
+        logger.warning("[Dispatcher] Failed to fetch action run details: %s", e)
+    return "Unknown Action", None
+
+
+def _fetch_last_bot_message(session_id: str, user_id: str) -> Optional[str]:
+    """Fetch the last bot message text from a chat session."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:ActionResult]")
+                cur.execute(
+                    "SELECT messages FROM chat_sessions WHERE id = %s",
+                    (session_id,),
+                )
+                row = cur.fetchone()
+                if not row or not row[0]:
+                    return None
+                messages = row[0] if isinstance(row[0], list) else json.loads(row[0])
+                for msg in reversed(messages):
+                    if msg.get('sender') == 'bot' and msg.get('text'):
+                        return msg['text']
+    except Exception as e:
+        logger.warning("[Dispatcher] Failed to fetch action result summary: %s", e)
+    return None
+
+
 def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id: str,
                      status: str = 'running', error_message: Optional[str] = None) -> Dict[str, Any]:
     """Build action data dict from trigger metadata and optional DB lookup."""
@@ -148,49 +197,12 @@ def _get_action_data(user_id: str, trigger_metadata: Dict[str, Any], session_id:
     started_at = None
 
     if run_id:
-        try:
-            with db_pool.get_admin_connection() as conn:
-                with conn.cursor() as cur:
-                    set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:ActionData]")
-                    cur.execute(
-                        """SELECT a.name, ar.started_at
-                           FROM action_runs ar
-                           JOIN actions a ON a.id = ar.action_id
-                           WHERE ar.id = %s""",
-                        (run_id,),
-                    )
-                    row = cur.fetchone()
-                    if row:
-                        action_name = row[0]
-                        if row[1]:
-                            started_at = row[1].astimezone(timezone.utc) if row[1].tzinfo else row[1].replace(tzinfo=timezone.utc)
-                        else:
-                            started_at = None
-        except Exception as e:
-            logger.warning("[Dispatcher] Failed to fetch action run details: %s", e)
+        action_name, started_at = _fetch_action_run_details(run_id, user_id)
 
-    # Fetch the last assistant message and summarize into key results
     if session_id and status != 'running':
-        try:
-            with db_pool.get_admin_connection() as conn:
-                with conn.cursor() as cur:
-                    set_rls_context(cur, conn, user_id, log_prefix="[Dispatcher:ActionResult]")
-                    cur.execute(
-                        "SELECT messages FROM chat_sessions WHERE id = %s",
-                        (session_id,),
-                    )
-                    row = cur.fetchone()
-                    if row and row[0]:
-                        messages = row[0] if isinstance(row[0], list) else json.loads(row[0])
-                        last_bot_text = None
-                        for msg in reversed(messages):
-                            if msg.get('sender') == 'bot' and msg.get('text'):
-                                last_bot_text = msg['text']
-                                break
-                        if last_bot_text:
-                            result_summary = _summarize_action_result(action_name, last_bot_text, user_id)
-        except Exception as e:
-            logger.warning("[Dispatcher] Failed to fetch action result summary: %s", e)
+        last_bot_text = _fetch_last_bot_message(session_id, user_id)
+        if last_bot_text:
+            result_summary = _summarize_action_result(action_name, last_bot_text, user_id)
 
     return {
         'action_name': action_name,
@@ -241,12 +253,12 @@ One-line summary:"""
         if response and response.content:
             content = response.content
             if isinstance(content, list):
-                content = "".join(
-                    p.get("text", "") if isinstance(p, dict) else str(p)
+                content = " ".join(
+                    str(p.get("text") or "") if isinstance(p, dict) else str(p)
                     for p in content
                     if not (isinstance(p, dict) and p.get("type") in ("thinking", "reasoning"))
                 )
-            summary = str(content).strip()
+            summary = " ".join(str(content).split())
             if summary:
                 return summary[:300]
         return None

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -211,9 +211,7 @@ def _summarize_action_result(action_name: str, bot_response: str, user_id: str) 
         from chat.backend.agent.providers import create_chat_model
         from chat.backend.agent.llm import ModelConfig
         from chat.backend.agent.utils.llm_usage_tracker import tracked_invoke
-        from chat.background.summarization import _extract_text_from_response
 
-        # Truncate input to avoid blowing context window
         truncated_response = bot_response[:4000]
 
         prompt = f"""Summarize the outcome of action "{action_name}" in ONE short sentence. State counts and status, not specifics.
@@ -241,7 +239,14 @@ One-line summary:"""
         )
 
         if response and response.content:
-            summary = _extract_text_from_response(response.content)
+            content = response.content
+            if isinstance(content, list):
+                content = "".join(
+                    p.get("text", "") if isinstance(p, dict) else str(p)
+                    for p in content
+                    if not (isinstance(p, dict) and p.get("type") in ("thinking", "reasoning"))
+                )
+            summary = str(content).strip()
             if summary:
                 return summary[:300]
         return None

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -471,7 +471,7 @@ def send_slack_investigation_failed_notification(
         return False
 
 
-def send_slack_action_started_notification(user_id: str, action_data: Dict[str, Any]) -> bool:
+def send_slack_action_started_notification(user_id: str, action_data: Dict[str, Any]) -> Optional[Dict[str, str]]:
     """
     Send Slack notification when an action starts running.
 
@@ -480,20 +480,22 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
         action_data: Dictionary with action_name, run_id, session_id, started_at
 
     Returns:
-        True if message sent successfully, False otherwise
+        Dict with 'ts' and 'channel_id' if sent successfully, None otherwise
     """
     try:
         client = get_slack_client_for_user(user_id)
         if not client:
-            return False
+            return None
 
         channel_id = _get_incidents_channel_id(user_id, client)
         if not channel_id:
-            return False
+            return None
 
         action_name = action_data.get('action_name', 'Unknown Action')
         session_id = action_data.get('session_id', '')
         session_url = f"{FRONTEND_URL}/chat?sessionId={session_id}" if session_id else None
+
+        detail_text = f"*Action:* {action_name}\n*Status:* Running"
 
         blocks = [
             {
@@ -507,7 +509,7 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Action:* {action_name}\n*Status:* Running"
+                    "text": detail_text
                 }
             }
         ]
@@ -526,7 +528,9 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
         if not validate_slack_blocks(blocks):
             simple_text = f"*Action Started:* {action_name}"
             result = client.send_message(channel=channel_id, text=simple_text)
-            return result is not None
+            if result and result.get('ts'):
+                return {'ts': result['ts'], 'channel_id': channel_id}
+            return None
 
         result = client.send_message(
             channel=channel_id,
@@ -534,19 +538,20 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
             blocks=blocks
         )
 
-        if result:
+        if result and result.get('ts'):
             logger.info(f"[SlackNotification] Sent action started notification for '{action_name}'")
-            return True
-        return False
+            return {'ts': result['ts'], 'channel_id': channel_id}
+        return None
 
     except Exception:
         logger.exception("[SlackNotification] Error sending action started notification")
-        return False
+        return None
 
 
 def send_slack_action_completed_notification(user_id: str, action_data: Dict[str, Any]) -> bool:
     """
     Send Slack notification when an action completes (success or error).
+    Deletes the "Action Started" message if one was stored.
 
     Args:
         user_id: User ID
@@ -564,9 +569,20 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         if not channel_id:
             return False
 
+        # Delete the "Action Started" message if we have it stored
+        start_msg_ts = action_data.get('start_message_ts')
+        start_msg_channel = action_data.get('start_message_channel') or channel_id
+        if start_msg_ts:
+            try:
+                client.delete_message(channel=start_msg_channel, ts=start_msg_ts)
+                logger.info(f"[SlackNotification] Deleted action started message {start_msg_ts}")
+            except Exception as e:
+                logger.warning(f"[SlackNotification] Failed to delete started message: {e}")
+
         action_name = action_data.get('action_name', 'Unknown Action')
         status = action_data.get('status', 'unknown')
         error_message = action_data.get('error')
+        result_summary = action_data.get('result_summary')
         session_id = action_data.get('session_id', '')
         session_url = f"{FRONTEND_URL}/chat?sessionId={session_id}" if session_id else None
 
@@ -604,6 +620,20 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
                 },
                 "url": session_url,
             }
+
+        # Add result summary as a separate section if available
+        if result_summary:
+            truncated_summary = result_summary[:2500] + "..." if len(result_summary) > 2500 else result_summary
+            from routes.slack.slack_events_helpers import format_response_for_slack
+            formatted_summary = format_response_for_slack(truncated_summary)
+            blocks.append({"type": "divider"})
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": formatted_summary or truncated_summary
+                }
+            })
 
         from routes.slack.slack_events_helpers import validate_slack_blocks
         if not validate_slack_blocks(blocks):

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -570,8 +570,6 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         if not channel_id:
             return False
 
-        _delete_start_message(client, action_data, channel_id)
-
         action_name = action_data.get('action_name', 'Unknown Action')
         status = action_data.get('status', 'unknown')
         error_message = action_data.get('error')
@@ -620,7 +618,10 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         if not validate_slack_blocks(blocks):
             simple_text = f"*Action Complete:* {action_name} — {status_text}"
             result = client.send_message(channel=channel_id, text=simple_text)
-            return result is not None
+            if result is not None:
+                _delete_start_message(client, action_data, channel_id)
+                return True
+            return False
 
         result = client.send_message(
             channel=channel_id,
@@ -629,6 +630,7 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         )
 
         if result:
+            _delete_start_message(client, action_data, channel_id)
             logger.info(f"[SlackNotification] Sent action completed notification for '{action_name}' ({status})")
             return True
         return False

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -590,6 +590,8 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         status_text = "Completed Successfully" if status == 'success' else "Failed"
 
         detail_text = f"*Action:* {action_name}\n*Status:* {status_emoji} {status_text}"
+        if result_summary:
+            detail_text += f"\n*Result:* {result_summary}"
         if error_message:
             truncated_error = error_message[:200] + "..." if len(error_message) > 200 else error_message
             detail_text += f"\n*Error:* {truncated_error}"
@@ -620,20 +622,6 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
                 },
                 "url": session_url,
             }
-
-        # Add result summary as a separate section if available
-        if result_summary:
-            truncated_summary = result_summary[:2500] + "..." if len(result_summary) > 2500 else result_summary
-            from routes.slack.slack_events_helpers import format_response_for_slack
-            formatted_summary = format_response_for_slack(truncated_summary)
-            blocks.append({"type": "divider"})
-            blocks.append({
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": formatted_summary or truncated_summary
-                }
-            })
 
         from routes.slack.slack_events_helpers import validate_slack_blocks
         if not validate_slack_blocks(blocks):

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -548,6 +548,19 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
         return None
 
 
+def _delete_start_message(client: SlackClient, action_data: Dict[str, Any], fallback_channel: str) -> None:
+    """Delete the 'Action Started' message if its ts was stored."""
+    start_msg_ts = action_data.get('start_message_ts')
+    if not start_msg_ts:
+        return
+    channel = action_data.get('start_message_channel') or fallback_channel
+    try:
+        client.delete_message(channel=channel, ts=start_msg_ts)
+        logger.info(f"[SlackNotification] Deleted action started message {start_msg_ts}")
+    except Exception as e:
+        logger.warning(f"[SlackNotification] Failed to delete started message: {e}")
+
+
 def send_slack_action_completed_notification(user_id: str, action_data: Dict[str, Any]) -> bool:
     """
     Send Slack notification when an action completes (success or error).
@@ -569,15 +582,7 @@ def send_slack_action_completed_notification(user_id: str, action_data: Dict[str
         if not channel_id:
             return False
 
-        # Delete the "Action Started" message if we have it stored
-        start_msg_ts = action_data.get('start_message_ts')
-        start_msg_channel = action_data.get('start_message_channel') or channel_id
-        if start_msg_ts:
-            try:
-                client.delete_message(channel=start_msg_channel, ts=start_msg_ts)
-                logger.info(f"[SlackNotification] Deleted action started message {start_msg_ts}")
-            except Exception as e:
-                logger.warning(f"[SlackNotification] Failed to delete started message: {e}")
+        _delete_start_message(client, action_data, channel_id)
 
         action_name = action_data.get('action_name', 'Unknown Action')
         status = action_data.get('status', 'unknown')

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -492,8 +492,6 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
             return None
 
         action_name = action_data.get('action_name', 'Unknown Action')
-        session_id = action_data.get('session_id', '')
-        session_url = f"{FRONTEND_URL}/chat?sessionId={session_id}" if session_id else None
 
         detail_text = f"*Action:* {action_name}\n*Status:* Running"
 
@@ -513,16 +511,6 @@ def send_slack_action_started_notification(user_id: str, action_data: Dict[str, 
                 }
             }
         ]
-
-        if session_url:
-            blocks[1]["accessory"] = {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": "View Session"
-                },
-                "url": session_url,
-            }
 
         from routes.slack.slack_events_helpers import validate_slack_blocks
         if not validate_slack_blocks(blocks):


### PR DESCRIPTION
Add LLM-generated one-line result summary to action completion notifications
Delete "Action Started" message when action completes to halve channel noise
Add delete_message method to Slack client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action notifications can now generate and include an optional one-line result summary in Slack “action completed” updates.
  * “Action started” Slack notifications are now tracked (timestamp/channel) and automatically deleted when the action finishes.
* **Improvements**
  * The Slack notification flow now uses returned send metadata to reliably associate subsequent completion updates with the correct prior message.
  * Completion messages can append the result summary in addition to existing error details when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->