### PR TITLE
Add hover tooltip to Incident Prevention toggle

### DIFF
--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1175,7 +1175,7 @@ export default function GitHubProviderIntegration() {
                               </button>
                             </TooltipTrigger>
                             <TooltipContent side="right" className="max-w-xs">
-                              <p>When enabled, Aurora automatically reviews pull requests for potential incident risk using knowledge of your infrastructure and other connected services, helping prevent production issues before they are merged.</p>
+                              <p>Aurora reviews pull requests using knowledge of your infrastructure and connected services to flag changes that could cause production incidents.</p>
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1175,7 +1175,7 @@ export default function GitHubProviderIntegration() {
                               </button>
                             </TooltipTrigger>
                             <TooltipContent side="right" className="max-w-xs">
-                              <p>When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues.</p>
+                              <p>When enabled, Aurora automatically reviews pull requests for potential incident risk using knowledge of your infrastructure and other connected services, helping prevent production issues before they are merged.</p>
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1174,7 +1174,7 @@ export default function GitHubProviderIntegration() {
                                 <Info className="h-3 w-3" />
                               </button>
                             </TooltipTrigger>
-                            <TooltipContent side="left" className="max-w-xs">
+                            <TooltipContent side="right" className="max-w-xs">
                               <p>When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues.</p>
                             </TooltipContent>
                           </Tooltip>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1174,7 +1174,7 @@ export default function GitHubProviderIntegration() {
                                 <Info className="h-3 w-3" />
                               </button>
                             </TooltipTrigger>
-                            <TooltipContent side="top" className="max-w-xs">
+                            <TooltipContent side="left" className="max-w-xs">
                               <p>When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues.</p>
                             </TooltipContent>
                           </Tooltip>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -5,13 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from '@/hooks/use-toast';
 import { ToastAction } from '@/components/ui/toast';
-import { Loader2, Check, ExternalLink, LogOut, ChevronDown, ChevronRight, RefreshCw, Pencil, X, Search, RotateCw, Trash2, AlertCircle, ShieldAlert, FolderX } from 'lucide-react';
+import { Loader2, Check, ExternalLink, LogOut, ChevronDown, ChevronRight, RefreshCw, Pencil, X, Search, RotateCw, Trash2, AlertCircle, ShieldAlert, FolderX, Info } from 'lucide-react';
 import Image from 'next/image';
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -1164,11 +1165,20 @@ export default function GitHubProviderIntegration() {
                       <p className="text-xs text-muted-foreground">{repo.metadata_summary.replace(/\*\*/g, '')}</p>
                     )}
                     {repo.installation_id != null && authConfig.incident_prevention_enabled && (
-                      <div
-                        className="flex items-center justify-between gap-2 pt-1"
-                        title="Incident Prevention — Aurora reviews PRs for incident risk"
-                      >
-                        <span className="text-xs text-muted-foreground">Incident Prevention</span>
+                      <div className="flex items-center justify-between gap-2 pt-1">
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground cursor-help">
+                                Incident Prevention
+                                <Info className="h-3 w-3" />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-xs">
+                              <p>When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues.</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                         <Switch
                           checked={!!repo.change_gating_enabled}
                           disabled={gatingUpdating.has(repo.repo_full_name)}

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1169,7 +1169,7 @@ export default function GitHubProviderIntegration() {
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground cursor-help">
+                              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                                 Incident Prevention
                                 <Info className="h-3 w-3" />
                               </span>

--- a/client/src/components/github-provider-integration.tsx
+++ b/client/src/components/github-provider-integration.tsx
@@ -1166,13 +1166,13 @@ export default function GitHubProviderIntegration() {
                     )}
                     {repo.installation_id != null && authConfig.incident_prevention_enabled && (
                       <div className="flex items-center justify-between gap-2 pt-1">
-                        <TooltipProvider>
+                        <TooltipProvider delayDuration={0}>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                              <button type="button" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
                                 Incident Prevention
                                 <Info className="h-3 w-3" />
-                              </span>
+                              </button>
                             </TooltipTrigger>
                             <TooltipContent side="top" className="max-w-xs">
                               <p>When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues.</p>


### PR DESCRIPTION
## Summary
- Replaces the plain `title` attribute on the Incident Prevention toggle with a proper Tooltip component (shadcn/radix)
- Adds an info icon next to the label to signal hover-for-details
- Tooltip explains: "When enabled, Aurora automatically reviews pull requests for potential incident risk before they are merged, helping prevent production issues."

## Test plan
- [ ] Enable incident prevention on a GitHub App-linked repo
- [ ] Hover over the "Incident Prevention" label/info icon and verify the tooltip appears
- [ ] Confirm toggle still functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Info icon next to the “Incident Prevention” label that shows a helpful tooltip with more information on hover or click (when applicable to the connected repository and configuration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->