### PR TITLE
fix: org-scope GitHub App connector so all org members share the connection (DEV-1299)

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -170,10 +170,17 @@ class Agent:
         return False
 
     def _get_github_username_for_user(self, user_id: str) -> str:
-        """Get GitHub username for ``user_id`` — primary App installation's account_login."""
+        """Get GitHub username for ``user_id`` — primary App installation's account_login.
+
+        Org-scoped so org members share the connection: an installation
+        linked by any org member resolves, with the user's own link
+        preferred for the returned account name.
+        """
         try:
             from utils.db.connection_pool import db_pool
+            from utils.auth.stateless_auth import get_org_id_for_user
 
+            org_id = get_org_id_for_user(user_id)
             with db_pool.get_admin_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
@@ -181,12 +188,13 @@ class Agent:
                              FROM user_github_installations ugi
                              JOIN github_installations gi
                                   ON gi.installation_id = ugi.installation_id
-                            WHERE ugi.user_id = %s
+                            WHERE (ugi.user_id = %s OR ugi.org_id = %s)
                               AND ugi.disconnected_at IS NULL
                               AND gi.suspended_at IS NULL
-                            ORDER BY ugi.is_primary DESC, ugi.linked_at DESC
+                            ORDER BY (ugi.user_id = %s) DESC,
+                                     ugi.is_primary DESC, ugi.linked_at DESC
                             LIMIT 1""",
-                        (user_id,),
+                        (user_id, org_id, user_id),
                     )
                     row = cur.fetchone()
             if row:

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -197,7 +197,8 @@ def get_connected_accounts(user_id, target_user_id):
                     WHERE (ugi.user_id = %s OR ugi.org_id = %s)
                       AND ugi.disconnected_at IS NULL
                       AND gi.suspended_at IS NULL
-                    ORDER BY (ugi.user_id = %s) DESC, gi.account_login
+                    ORDER BY (ugi.user_id = %s) DESC,
+                             ugi.is_primary DESC, ugi.linked_at DESC
                     LIMIT 1""",
                 (user_id, org_id, user_id),
             )

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -194,12 +194,12 @@ def get_connected_accounts(user_id, target_user_id):
                      FROM user_github_installations ugi
                      JOIN github_installations gi
                           ON gi.installation_id = ugi.installation_id
-                    WHERE ugi.user_id = %s
+                    WHERE (ugi.user_id = %s OR ugi.org_id = %s)
                       AND ugi.disconnected_at IS NULL
                       AND gi.suspended_at IS NULL
-                    ORDER BY gi.account_login
+                    ORDER BY (ugi.user_id = %s) DESC, gi.account_login
                     LIMIT 1""",
-                (user_id,),
+                (user_id, org_id, user_id),
             )
             row = cursor.fetchone()
             if row:

--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -19,7 +19,11 @@ import requests
 from flask import Blueprint, jsonify
 
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import (
+    get_org_id_for_user,
+    get_org_id_from_request,
+    set_rls_context,
+)
 from utils.auth.token_management import get_token_data, store_tokens_in_db
 from utils.db.connection_pool import db_pool
 
@@ -270,11 +274,17 @@ def _check_google_chat(creds: Dict[str, Any]) -> Dict[str, Any]:
         return {"connected": False}
 
 
-def _check_github(creds_or_user_id, app_runtime_ready: bool = True) -> Dict[str, Any]:
+def _check_github(
+    creds_or_user_id, app_runtime_ready: bool = True, org_id: str | None = None
+) -> Dict[str, Any]:
     """Mirrors /github/status — App-aware AND OAuth-aware (hybrid mode).
 
     Accepts either a credentials dict (with ``_user_id``) for generic
     PROVIDER_CHECKERS dispatch, or a plain user_id string for direct callers.
+
+    The App check is org-scoped: an installation linked by any member of the
+    user's org marks the connector connected, so every org member sees the
+    same state (consistent with OAuth tokens and all other connectors).
     """
     from utils.auth.github_auth_mode import is_app_enabled, is_oauth_token_honored
 
@@ -284,6 +294,8 @@ def _check_github(creds_or_user_id, app_runtime_ready: bool = True) -> Dict[str,
         user_id = creds_or_user_id
 
     if is_app_enabled() and app_runtime_ready:
+        if org_id is None:
+            org_id = get_org_id_for_user(user_id)
         try:
             with db_pool.get_admin_connection() as conn:
                 with conn.cursor() as cur:
@@ -292,11 +304,11 @@ def _check_github(creds_or_user_id, app_runtime_ready: bool = True) -> Dict[str,
                              FROM user_github_installations ugi
                              JOIN github_installations gi
                                   ON gi.installation_id = ugi.installation_id
-                            WHERE ugi.user_id = %s
+                            WHERE (ugi.user_id = %s OR ugi.org_id = %s)
                               AND ugi.disconnected_at IS NULL
                               AND gi.suspended_at IS NULL
                             LIMIT 1""",
-                        (user_id,),
+                        (user_id, org_id),
                     )
                     row = cur.fetchone()
             if row:
@@ -858,7 +870,7 @@ def _check_all_connectors(
         if provider == "grafana":
             return provider, _check_grafana(user_id, org_id)
         if provider == "github":
-            return provider, _check_github(user_id, app_runtime_ready)
+            return provider, _check_github(user_id, app_runtime_ready, org_id)
         creds = get_token_data(token_owner_id, provider)
         if not creds:
             with db_pool.get_admin_connection() as fallback_conn:

--- a/server/routes/github/github_app.py
+++ b/server/routes/github/github_app.py
@@ -964,6 +964,11 @@ def github_status(user_id):
 
     app_username: str | None = None
     if app_branch_active:
+        # Org-scoped: an installation linked by any org member marks the
+        # connector connected, so every member sees identical state
+        # (consistent with OAuth tokens and all other connectors). The
+        # user's own link is preferred for the displayed account name.
+        org_id = get_org_id_for_user(user_id)
         try:
             with db_pool.get_admin_connection() as conn:
                 with conn.cursor() as cur:
@@ -972,12 +977,13 @@ def github_status(user_id):
                              FROM user_github_installations ugi
                              JOIN github_installations gi
                                   ON gi.installation_id = ugi.installation_id
-                            WHERE ugi.user_id = %s
+                            WHERE (ugi.user_id = %s OR ugi.org_id = %s)
                               AND ugi.disconnected_at IS NULL
                               AND gi.suspended_at IS NULL
-                            ORDER BY ugi.is_primary DESC, ugi.linked_at DESC
+                            ORDER BY (ugi.user_id = %s) DESC,
+                                     ugi.is_primary DESC, ugi.linked_at DESC
                             LIMIT 1""",
-                        (user_id,),
+                        (user_id, org_id, user_id),
                     )
                     row = cur.fetchone()
                     if row:

--- a/server/routes/github/github_user_repos.py
+++ b/server/routes/github/github_user_repos.py
@@ -52,7 +52,7 @@ from utils.auth.github_auth_router import (
     make_auth_header,
 )
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_credentials_from_db
+from utils.auth.stateless_auth import get_credentials_from_db, get_org_id_for_user
 from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 
@@ -87,21 +87,26 @@ def create_cors_response(data=None, status=200):
 
 
 def _list_user_installation_ids(user_id: str) -> list[int]:
-    """Return ALL installation_ids linked to ``user_id`` in one DB round-trip.
+    """Return ALL installation_ids linked to the user's org in one DB round-trip.
 
     Batched so that ``/github/user-repos`` makes exactly ONE query
     against ``user_github_installations`` regardless of how many App
     installations the user has — no N+1.
+
+    Resolution is org-scoped: installations linked by any member of the
+    user's org are included, so every org member can list the org's repos
+    (consistent with how all other connectors are shared org-wide).
     """
+    org_id = get_org_id_for_user(user_id)
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """SELECT installation_id
+                """SELECT DISTINCT installation_id
                      FROM user_github_installations
-                    WHERE user_id = %s
+                    WHERE (user_id = %s OR org_id = %s)
                       AND disconnected_at IS NULL
                     ORDER BY installation_id""",
-                (user_id,),
+                (user_id, org_id),
             )
             return [row[0] for row in cur.fetchall()]
 

--- a/server/utils/auth/github_auth_router.py
+++ b/server/utils/auth/github_auth_router.py
@@ -54,7 +54,11 @@ from utils.auth.github_app_token import (
     get_installation_token,
 )
 from utils.auth.github_auth_mode import is_oauth_token_honored
-from utils.auth.stateless_auth import get_credentials_from_db, set_rls_context
+from utils.auth.stateless_auth import (
+    get_credentials_from_db,
+    get_org_id_for_user,
+    set_rls_context,
+)
 from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 
@@ -294,57 +298,78 @@ def make_auth_header(auth: AuthResult) -> dict[str, str]:
     return {"Authorization": f"token {auth.token}"}
 
 
-def _lookup_install_by_account(user_id: str, account_login: str) -> int | None:
-    """Return the user's active install whose ``account_login`` matches (case-insensitive)."""
+def _lookup_install_by_account(
+    user_id: str, account_login: str, org_id: str | None = None
+) -> int | None:
+    """Return an active install whose ``account_login`` matches (case-insensitive).
+
+    Resolution is org-scoped: an installation linked by any member of the
+    user's org counts, mirroring how every other Aurora connector is
+    shared org-wide. The user's own link is preferred when both exist.
+    ``org_id`` is resolved from the user when not supplied so org-scoping
+    is the default and call sites cannot accidentally drop it.
+    """
+    if org_id is None:
+        org_id = get_org_id_for_user(user_id)
 
     sql = """
         SELECT u.installation_id
         FROM user_github_installations u
         JOIN github_installations i
             ON i.installation_id = u.installation_id
-        WHERE u.user_id = %s
+        WHERE (u.user_id = %s OR u.org_id = %s)
           AND u.disconnected_at IS NULL
           AND i.suspended_at IS NULL
           AND LOWER(i.account_login) = LOWER(%s)
-        ORDER BY u.is_primary DESC, u.linked_at DESC
+        ORDER BY (u.user_id = %s) DESC, u.is_primary DESC, u.linked_at DESC
         LIMIT 1
     """
 
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cursor:
-            cursor.execute(sql, (user_id, account_login))
+            cursor.execute(sql, (user_id, org_id, account_login, user_id))
             row = cursor.fetchone()
     return row[0] if row else None
 
 
-def _lookup_any_active_installation(user_id: str) -> int | None:
-    """Return the first non-suspended installation_id linked to ``user_id``.
+def _lookup_any_active_installation(
+    user_id: str, org_id: str | None = None
+) -> int | None:
+    """Return the first non-suspended installation_id linked to the user's org.
 
     Joins ``user_github_installations`` to ``github_installations`` and
     filters out rows whose installation is suspended or whose
-    installation row was deleted (LEFT-JOIN miss). Ordering is
-    deterministic — primary installations win, then most recent links —
-    so concurrent calls for the same user receive the same installation
-    id even when there are multiple candidates.
+    installation row was deleted (LEFT-JOIN miss). Resolution is
+    org-scoped — an installation linked by any member of ``org_id``
+    counts — so every org member shares the connection (consistent with
+    OAuth tokens and all other connectors). The user's own link is
+    preferred; ordering is otherwise deterministic (primary installs
+    first, then most recent links) so concurrent calls receive the same
+    installation id even when there are multiple candidates.
 
-    Returns ``None`` when the user has no usable installation.
+    Returns ``None`` when neither the user nor their org has a usable
+    installation. ``org_id`` is resolved from the user when not supplied
+    so org-scoping is the default and call sites cannot accidentally drop
+    it.
     """
+    if org_id is None:
+        org_id = get_org_id_for_user(user_id)
 
     sql = """
         SELECT u.installation_id
         FROM user_github_installations u
         JOIN github_installations i
             ON i.installation_id = u.installation_id
-        WHERE u.user_id = %s
+        WHERE (u.user_id = %s OR u.org_id = %s)
           AND u.disconnected_at IS NULL
           AND i.suspended_at IS NULL
-        ORDER BY u.is_primary DESC, u.linked_at DESC
+        ORDER BY (u.user_id = %s) DESC, u.is_primary DESC, u.linked_at DESC
         LIMIT 1
     """
 
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cursor:
-            cursor.execute(sql, (user_id,))
+            cursor.execute(sql, (user_id, org_id, user_id))
             row = cursor.fetchone()
 
     if row is None:


### PR DESCRIPTION
## Problem
After an org switched GitHub auth from OAuth to the GitHub App, only the member who ran the install saw the connector as connected. Every other member of the same org saw "not connected" until they manually re-migrated — even though a connector should look identical to every member of an org.

## Root cause
The GitHub App connector resolved state **per-user**: every read of `user_github_installations` filtered by `user_id` only, ignoring the `org_id` column that's already on the table. Every other Aurora connector resolves **org-wide** (`user_id = %s OR org_id = %s`).

## Fix
Make every read of `user_github_installations` org-scoped (`user_id = %s OR org_id = %s`, the user's own link preferred), so any member of an org whose install row carries the matching `org_id` sees the connector connected and can use it — no per-user migration needed.

- **Status/display:** `/github/status`, `/api/connectors/status`, connected-accounts
- **Operations:** auth/token resolution, `is_github_connected`, repo listing, agent GitHub username lookup

`org_id` already exists on the table (since App-only auth landed) and is populated best-effort at install time; this PR only changes the reads to honor it.

## Out of scope (intentional)
- Disconnect stays per-user — a non-owner can't tear down the org's connection.

## Verification
- 56 tests pass (GitHub + architectural + change-gating).
- Reproduced the two-user case locally: a non-migrating org member flips from "not connected" → connected via the org install, and the auth router / repo listing resolve the org installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization-level GitHub App installations are now recognized and available for use alongside personal installations.
  * GitHub connector status and authentication now support organization-wide app connections, with personal links prioritized when multiple options exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->