### PR TITLE
docs: document Bitbucket API-token auth and correct OAuth gating

### DIFF
--- a/website/docs/integrations/connectors.md
+++ b/website/docs/integrations/connectors.md
@@ -1277,22 +1277,69 @@ See [kubectl-agent README](https://github.com/arvo-ai/aurora/blob/main/kubectl-a
 
 ### Bitbucket
 
-OAuth App authentication for Bitbucket Cloud.
+Bitbucket Cloud supports two authentication methods: **API Token** (recommended — no `.env` setup) or **OAuth** (optional — requires registering a consumer and enabling a feature flag).
 
-#### 1. Create OAuth Consumer
+:::tip Scopes need read **and** write
+Aurora's remediation features open pull requests, push branches/commits, comment on issues, and trigger pipelines. Both auth methods therefore need **write** access to repositories, pull requests, issues, and pipelines — read-only credentials will connect but block those actions.
+:::
+
+#### Option A: API Token (recommended)
+
+No environment variables are required — credentials are entered in the Aurora UI and stored in Vault.
+
+##### 1. Create a Scoped API Token
+
+Create a **scoped** API token at [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens). Classic (unscoped) API tokens are **not** supported.
+
+Grant these scopes:
+
+- `read:user:bitbucket`
+- `read:workspace:bitbucket`
+- `read:project:bitbucket`
+- `read:repository:bitbucket`, `write:repository:bitbucket`
+- `read:pullrequest:bitbucket`, `write:pullrequest:bitbucket`
+- `read:issue:bitbucket`, `write:issue:bitbucket`
+- `read:pipeline:bitbucket`, `write:pipeline:bitbucket`
+
+##### 2. Connect via Aurora UI
+
+1. Navigate to **Connectors** > **Bitbucket**
+2. Enter your Atlassian account **email** and the **API token**
+3. Click **Connect**
+
+#### Option B: OAuth (optional)
+
+Use OAuth if you prefer a per-user consent flow. This path requires both a feature flag (to show the OAuth option in the UI) and a registered OAuth consumer.
+
+##### 1. Create OAuth Consumer
 
 1. Go to **Bitbucket workspace settings** > **OAuth consumers** > **Add consumer**
    - Name: `Aurora`
    - Callback URL: `{NEXT_PUBLIC_BACKEND_URL}/bitbucket/callback` (e.g. `https://your-aurora-domain/bitbucket/callback`)
-   - Permissions: **Repositories** (Read), **Pull requests** (Read)
+   - Permissions: **Account** (Read), **Projects** (Read), **Repositories** (Read & Write), **Pull requests** (Read & Write), **Issues** (Read & Write), **Pipelines** (Read & Write)
 2. Copy the **Key** and **Secret**
 
-#### 2. Configure Environment
+##### 2. Configure Environment
 
 ```bash
+# Show the OAuth option in the Connectors UI (frontend flag, default false).
+# Without this, only the API Token form is shown.
+NEXT_PUBLIC_ENABLE_BITBUCKET_OAUTH=true
+
 BB_OAUTH_CLIENT_ID=your-bitbucket-key
 BB_OAUTH_CLIENT_SECRET=your-bitbucket-secret
 ```
+
+Restart Aurora after setting these, then connect via **Connectors** > **Bitbucket** > **OAuth**.
+
+#### Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| "Authentication failed... you are using a classic API token (not supported)" | Create a **scoped** token at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens), not a classic one |
+| "Missing required scopes: ..." | Recreate the API token with all the read+write scopes listed above |
+| "Bitbucket OAuth is not available. Use an API token instead." | `BB_OAUTH_CLIENT_ID`/`BB_OAUTH_CLIENT_SECRET` are not set. Use the API token method, or configure the OAuth consumer |
+| OAuth tab not visible in the UI | `NEXT_PUBLIC_ENABLE_BITBUCKET_OAUTH` is not `true`. Set it and restart |
 
 ---
 


### PR DESCRIPTION
## Summary
The Bitbucket connector docs were inaccurate in two ways, which came up while onboarding a customer:

- **Auth method**: the section presented OAuth as the *only* method and listed `BB_OAUTH_CLIENT_ID`/`BB_OAUTH_CLIENT_SECRET` as required `.env` vars. In reality the connector supports an **API-token path that needs no `.env` setup** (`/bitbucket/login` accepts `email` + `api_token`), and OAuth is **optional** — gated behind the `NEXT_PUBLIC_ENABLE_BITBUCKET_OAUTH` frontend flag (default `false`, only controls whether the OAuth tab shows) plus the client creds.
- **Scopes**: the doc said "Repositories (Read), Pull requests (Read)", but the connector requires **read + write** on repositories, pull requests, issues, and pipelines for its remediation features (open PRs, push commits, comment on issues, trigger pipelines). Source of truth: `_REQUIRED_SCOPES` in `server/routes/bitbucket/bitbucket.py` and `BITBUCKET_SCOPES` in `server/connectors/bitbucket_connector/oauth_utils.py`.

This rewrite documents the API-token path as the recommended default, keeps OAuth as an optional path with the correct flag + creds, fixes the scope list, and adds a troubleshooting table matching the actual error strings the connector returns (classic-token rejection, `OAUTH_NOT_CONFIGURED`, missing scopes, hidden OAuth tab).

Docs-only change.

## Test plan
- [ ] `cd website && npm run build` (docs site builds)
- [ ] Verify the rendered Bitbucket section reads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Bitbucket connector docs to cover both scoped API token and OAuth connection options.
  * Clarified required repository permissions for remediation actions.
  * Added step-by-step setup guidance for token-based and OAuth-based connections, including necessary environment settings and restart steps.
  * Reworked troubleshooting with clearer error-to-fix guidance for common connection and permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->