### PR TITLE
security: require security-reviewer approval on all PRs to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,11 @@
 #   - Keep this file ordered general -> specific.
 #   - Add a comment above any new rule explaining why it is security-sensitive.
 
+# Baseline: every change to main requires a security-reviewer approval.
+# More-specific rules below still apply (last match wins); this catch-all
+# only governs paths no other rule covers (e.g. docs, website, configs).
+*                                                   @Arvo-AI/security-reviewers
+
 # Agent execution surface
 /server/chat/backend/agent/**                       @Arvo-AI/security-reviewers
 


### PR DESCRIPTION
## Summary
- Add a catch-all `* @Arvo-AI/security-reviewers` rule at the top of `.github/CODEOWNERS` so **every** PR to `main` requires a security-reviewer approval.
- Closes the gap where docs/website/config-only PRs (e.g. #552) had no code owner, so a single approval — including the change-gating bot's auto-approval — could satisfy the 1-review merge gate with no human security sign-off.

## Why
Branch protection already has `require_code_owner_reviews: true`, but CODEOWNERS only listed security-reviewers for specific sensitive paths. Files matching no rule had no owner, so the code-owner requirement had nothing to enforce. The catch-all makes security-reviewers the default owner of everything.

## Behavior
- **Last-match-wins** CODEOWNERS semantics mean all existing specific rules stay intact; the catch-all only governs otherwise-unmatched paths.
- The change-gating bot (`arvo-ai-staging[bot]`) is not a member of `@Arvo-AI/security-reviewers`, so its approval will no longer be sufficient to merge — a human security-reviewer is always required.

## Test plan
- [ ] Confirm Require review from Code Owners is on for `main` (already enabled).
- [ ] After merge, open a docs-only PR and verify it now requests/requires `@Arvo-AI/security-reviewers` and cannot merge on a bot approval alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened approval requirements for changes affecting the main branch, adding an extra security review step before those updates can be merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->