### PR TITLE
docs: clarify Vertex AI uses LLM_PROVIDER_MODE=vertex

### DIFF
--- a/website/docs/configuration/environment.md
+++ b/website/docs/configuration/environment.md
@@ -265,6 +265,7 @@ AGENT_RECURSION_LIMIT=240
 VERTEX_AI_PROJECT=my-gcp-project
 VERTEX_AI_LOCATION=global
 VERTEX_AI_SERVICE_ACCOUNT_JSON={"type":"service_account",...}
+LLM_PROVIDER_MODE=vertex   # route every model pick through Vertex
 ```
 
 ### Ollama (Local Models)

--- a/website/docs/integrations/llm-providers.md
+++ b/website/docs/integrations/llm-providers.md
@@ -144,16 +144,23 @@ VERTEX_AI_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"...","pri
 # Optional: Location (default: global)
 VERTEX_AI_LOCATION=global
 
-LLM_PROVIDER_MODE=direct
+# Route every model pick through Vertex (recommended — works with clean
+# model names like "Gemini 2.5 Pro" in the picker, no vertex/ prefix needed).
+LLM_PROVIDER_MODE=vertex
 ```
+
+:::tip Two ways to route to Vertex
+- **`LLM_PROVIDER_MODE=vertex`** (recommended) — forces every supported model pick through Vertex; models Vertex can't serve fall back to their own provider.
+- **`LLM_PROVIDER_MODE=direct`** — only routes to Vertex when the model id carries a `vertex/` prefix (e.g. `MAIN_MODEL=vertex/gemini-2.5-pro`). A clean `google/...` id goes to the Google AI provider instead, not Vertex.
+:::
 
 **Authentication options:**
 1. **Service account JSON** (recommended): Set `VERTEX_AI_SERVICE_ACCOUNT_JSON` to the full JSON contents of your service account key file.
 2. **Application Default Credentials (ADC)**: If running on GCP (Cloud Run, GKE), ADC is automatic — just set `VERTEX_AI_PROJECT`.
 3. **Credentials file path**: Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of your service account key file.
 
-:::tip
-The project ID is automatically extracted from the service account JSON if `VERTEX_AI_PROJECT` is not set.
+:::note
+`VERTEX_AI_PROJECT` is required — the provider is considered unavailable without it. The service account JSON only supplies credentials, not the project id.
 :::
 
 **Optional configuration:**

--- a/website/docs/integrations/llm-providers.md
+++ b/website/docs/integrations/llm-providers.md
@@ -10,13 +10,13 @@ Aurora requires an LLM provider for its AI-powered investigation and Root Cause 
 
 | Provider | Mode | Environment Variable | Get API Key |
 |----------|------|---------------------|-------------|
-| **OpenRouter** | Gateway | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| **OpenRouter** | `openrouter` | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | **OpenAI** | Direct | `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com/api-keys) |
 | **Anthropic** | Direct | `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google AI** | Direct | `GOOGLE_AI_API_KEY` | [ai.google.dev](https://ai.google.dev/) |
-| **Vertex AI** | Direct | `VERTEX_AI_PROJECT` + credentials | [console.cloud.google.com](https://console.cloud.google.com/) |
+| **Vertex AI** | `vertex` | `VERTEX_AI_PROJECT` + credentials | [console.cloud.google.com](https://console.cloud.google.com/) |
 | **Ollama** | Direct | `OLLAMA_BASE_URL` | [ollama.com](https://ollama.com/) (free, local) |
-| **AWS Bedrock** | Direct | `BEDROCK_BASE_URL` (gateway) or `BEDROCK_REGION` (native) | [aws.amazon.com/bedrock](https://aws.amazon.com/bedrock/) |
+| **AWS Bedrock** | `bedrock` | `BEDROCK_BASE_URL` (gateway) or `BEDROCK_REGION` (native) | [aws.amazon.com/bedrock](https://aws.amazon.com/bedrock/) |
 
 Only **one** provider is required.
 


### PR DESCRIPTION
## Summary
- Document `LLM_PROVIDER_MODE=vertex` as the recommended way to run Aurora on Vertex AI, instead of the previously-recommended `direct` mode.
- The provider registry treats any non-`openrouter`/`direct`/`auto` value as a forced provider name. Under `direct` mode, routing is by model prefix, so only `vertex/...` ids reach Vertex — a clean `google/...` id silently goes to the Google AI (API-key) provider instead. `LLM_PROVIDER_MODE=vertex` removes that ambiguity by forcing all supported picks through Vertex.
- Fix an inaccurate tip in the Vertex setup section claiming the project id is auto-extracted from the service account JSON. The provider reads `VERTEX_AI_PROJECT` directly (`is_available()` returns `bool(self.project)`) and is unavailable without it.

Docs-only change; no code behavior changes.

## Test plan
- [ ] `cd website && npm run build` (or docs build) renders the updated Vertex section without MDX errors
- [ ] Verify the `:::tip` / `:::note` admonitions render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vertex AI setup guidance to include `LLM_PROVIDER_MODE=vertex` for clearer model routing.
  * Added a tip explaining two routing options for Vertex: using the Vertex mode or direct `vertex/`-prefixed model IDs.
  * Expanded authentication instructions with supported credential options and clarified that a project ID must be provided separately.
  * Added the same Vertex routing example to the environment configuration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->