### PR TITLE
feat(cloudbees): multi-controller fleet without Operations Center

### DIFF
--- a/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
+++ b/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
@@ -22,10 +22,19 @@ export async function DELETE(
       return NextResponse.json({ error: "BACKEND_URL is not configured" }, { status: 500 });
     }
 
-    const response = await fetch(
-      `${API_BASE_URL.replace(/\/$/, "")}/cloudbees/fleet/controllers/${encodeURIComponent(id)}`,
-      { method: "DELETE", headers: authHeaders, cache: "no-store" }
-    );
+    // Bound the backend call so a slow/hung Flask backend can't tie up the
+    // request indefinitely (matches fetchWithTimeout in ci-api-handler).
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+    let response: Response;
+    try {
+      response = await fetch(
+        `${API_BASE_URL.replace(/\/$/, "")}/cloudbees/fleet/controllers/${encodeURIComponent(id)}`,
+        { method: "DELETE", headers: authHeaders, cache: "no-store", signal: controller.signal }
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
 
     if (!response.ok) {
       await response.text();

--- a/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
+++ b/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/auth-helper";
+
+const API_BASE_URL = process.env.BACKEND_URL;
+
+// ---------------------------------------------------------------------------
+// DELETE /api/cloudbees/fleet/controllers/[id]
+// Removes a single controller from the user's standalone fleet.
+// ---------------------------------------------------------------------------
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authResult = await getAuthenticatedUser();
+    if (authResult instanceof NextResponse) return authResult;
+
+    const { headers: authHeaders } = authResult;
+    const { id } = await context.params;
+
+    if (!API_BASE_URL) {
+      return NextResponse.json({ error: "BACKEND_URL is not configured" }, { status: 500 });
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL.replace(/\/$/, "")}/cloudbees/fleet/controllers/${encodeURIComponent(id)}`,
+      { method: "DELETE", headers: authHeaders, cache: "no-store" }
+    );
+
+    if (!response.ok) {
+      await response.text();
+      console.error(`[api/cloudbees/fleet/controllers] Backend error: ${response.status}`);
+      return NextResponse.json(
+        { error: "Failed to remove controller" },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("[api/cloudbees/fleet/controllers] Error:", error);
+    return NextResponse.json({ error: "Failed to remove controller" }, { status: 500 });
+  }
+}

--- a/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
+++ b/client/src/app/api/cloudbees/fleet/controllers/[id]/route.ts
@@ -1,54 +1,15 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUser } from "@/lib/auth-helper";
+import { NextRequest } from "next/server";
+import { forwardRequest } from "@/lib/backend-proxy";
 
-const API_BASE_URL = process.env.BACKEND_URL;
-
-// ---------------------------------------------------------------------------
-// DELETE /api/cloudbees/fleet/controllers/[id]
-// Removes a single controller from the user's standalone fleet.
-// ---------------------------------------------------------------------------
 export async function DELETE(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const authResult = await getAuthenticatedUser();
-    if (authResult instanceof NextResponse) return authResult;
-
-    const { headers: authHeaders } = authResult;
-    const { id } = await context.params;
-
-    if (!API_BASE_URL) {
-      return NextResponse.json({ error: "BACKEND_URL is not configured" }, { status: 500 });
-    }
-
-    // Bound the backend call so a slow/hung Flask backend can't tie up the
-    // request indefinitely (matches fetchWithTimeout in ci-api-handler).
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15000);
-    let response: Response;
-    try {
-      response = await fetch(
-        `${API_BASE_URL.replace(/\/$/, "")}/cloudbees/fleet/controllers/${encodeURIComponent(id)}`,
-        { method: "DELETE", headers: authHeaders, cache: "no-store", signal: controller.signal }
-      );
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    if (!response.ok) {
-      await response.text();
-      console.error(`[api/cloudbees/fleet/controllers] Backend error: ${response.status}`);
-      return NextResponse.json(
-        { error: "Failed to remove controller" },
-        { status: response.status }
-      );
-    }
-
-    const data = await response.json();
-    return NextResponse.json(data);
-  } catch (error) {
-    console.error("[api/cloudbees/fleet/controllers] Error:", error);
-    return NextResponse.json({ error: "Failed to remove controller" }, { status: 500 });
-  }
+  const { id } = await context.params;
+  return forwardRequest(
+    request,
+    "DELETE",
+    `/cloudbees/fleet/controllers/${encodeURIComponent(id)}`,
+    "remove fleet controller",
+  );
 }

--- a/client/src/app/api/cloudbees/fleet/controllers/route.ts
+++ b/client/src/app/api/cloudbees/fleet/controllers/route.ts
@@ -1,0 +1,4 @@
+import { createCIGetHandler, createCIPostHandler } from "@/lib/ci-api-handler";
+
+export const GET = createCIGetHandler({ slug: "cloudbees", endpoint: "fleet/controllers", label: "CloudBees controller fleet" });
+export const POST = createCIPostHandler({ slug: "cloudbees", endpoint: "fleet/controllers", label: "add controllers to fleet" });

--- a/client/src/app/api/cloudbees/fleet/controllers/route.ts
+++ b/client/src/app/api/cloudbees/fleet/controllers/route.ts
@@ -1,4 +1,12 @@
-import { createCIGetHandler, createCIPostHandler } from "@/lib/ci-api-handler";
+import { NextRequest } from "next/server";
+import { forwardRequest } from "@/lib/backend-proxy";
 
-export const GET = createCIGetHandler({ slug: "cloudbees", endpoint: "fleet/controllers", label: "CloudBees controller fleet" });
-export const POST = createCIPostHandler({ slug: "cloudbees", endpoint: "fleet/controllers", label: "add controllers to fleet" });
+const BACKEND_PATH = "/cloudbees/fleet/controllers";
+
+export async function GET(request: NextRequest) {
+  return forwardRequest(request, "GET", BACKEND_PATH, "CloudBees controller fleet");
+}
+
+export async function POST(request: NextRequest) {
+  return forwardRequest(request, "POST", BACKEND_PATH, "add controllers to fleet");
+}

--- a/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
+++ b/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
@@ -8,11 +8,11 @@ import { cloudbeesService } from "@/lib/services/ci-provider";
 import type { CIProviderStatus } from "@/lib/services/ci-provider";
 import { apiRequest } from "@/lib/services/api-client";
 import { ModeSelector } from "./ModeSelector";
-import { CredentialForms } from "./CredentialForms";
+import { CredentialForms, type FleetControllerInput } from "./CredentialForms";
 import { WebhookSetup } from "./WebhookSetup";
 import { ConnectedDashboard } from "./ConnectedDashboard";
 
-type ConnectionMode = "oc" | "single" | "pat";
+type ConnectionMode = "oc" | "single" | "fleet" | "pat";
 
 type Step = 1 | 2 | 3 | "connected";
 
@@ -51,6 +51,7 @@ export default function CloudBeesAuthPage() {
   const [ocApiToken, setOcApiToken] = useState("");
   const [rolloutToken, setRolloutToken] = useState("");
   const [controllers, setControllers] = useState<DiscoveredController[]>([]);
+  const [isFleetMode, setIsFleetMode] = useState(false);
 
   // Personal Access Token fields
   const [platformUrl, setPlatformUrl] = useState("");
@@ -88,8 +89,17 @@ export default function CloudBeesAuthPage() {
           localStorage.setItem(CONNECTED_KEY, "true");
           setStep("connected");
           if (result.summary) setSummary(result.summary);
+          if (result.mode === "fleet") setIsFleetMode(true);
+          // Fleet controllers (standalone, no OC) — only present in fleet mode
+          apiRequest<{ controllers?: DiscoveredController[]; connected?: boolean }>("/api/cloudbees/fleet/controllers", { method: "GET", cache: "no-store" }).then(d => {
+            if (d?.connected && d?.controllers?.length) {
+              setIsFleetMode(true);
+              setControllers(d.controllers);
+            }
+          }).catch(() => {});
+          // OC-discovered controllers (only present when OC connected)
           apiRequest<{ controllers?: DiscoveredController[] }>("/api/cloudbees/controllers", { method: "GET", cache: "no-store" }).then(d => {
-            if (d?.controllers) setControllers(d.controllers);
+            if (d?.controllers?.length) setControllers(d.controllers);
           }).catch(() => {});
           apiRequest<any>("/api/cloudbees/webhook-url", { method: "GET", cache: "no-store" }).then(setWebhookInfo).catch(() => {});
           apiRequest<any>("/api/cloudbees/deployments", { method: "GET", cache: "no-store" }).then(d => setDeployments(d?.deployments || [])).catch(() => {});
@@ -271,6 +281,73 @@ export default function CloudBeesAuthPage() {
     }
   };
 
+  const handleFleetConnect = async (fleetControllers: FleetControllerInput[]) => {
+    if (fleetControllers.length === 0) return;
+    setLoading(true);
+    try {
+      const result = await apiRequest<{ controllers?: DiscoveredController[]; failed?: unknown[] }>(
+        "/api/cloudbees/fleet/controllers",
+        { method: "POST", body: JSON.stringify({ controllers: fleetControllers }), cache: "no-store" }
+      );
+
+      if (result?.controllers) setControllers(result.controllers);
+      setIsFleetMode(true);
+
+      const newStatus: CIProviderStatus = { connected: true };
+      setStatus(newStatus);
+      localStorage.setItem(CACHE_KEY, JSON.stringify({ connected: true }));
+      localStorage.setItem(CONNECTED_KEY, "true");
+      globalThis.dispatchEvent(new CustomEvent("providerStateChanged"));
+
+      try {
+        await apiRequest("/api/provider-preferences", {
+          method: "POST",
+          body: JSON.stringify({ action: "add", provider: "cloudbees" }),
+        });
+      } catch { /* best-effort */ }
+
+      const total = result?.controllers?.length ?? fleetControllers.length;
+      const failedCount = result?.failed?.length ?? 0;
+      toast({
+        title: "Controllers Connected",
+        description: failedCount > 0
+          ? `${total} controller(s) saved, ${failedCount} could not be validated (marked offline).`
+          : `${total} controller(s) connected successfully.`,
+        variant: failedCount > 0 ? "destructive" : undefined,
+      });
+      setStep(3);
+    } catch (err: unknown) {
+      console.error("CloudBees fleet connection failed", err);
+      toast({ title: "Connection Failed", description: getUserFriendlyError(err), variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemoveController = async (controllerId: string) => {
+    try {
+      const result = await apiRequest<{ controllers?: DiscoveredController[]; count?: number }>(
+        `/api/cloudbees/fleet/controllers/${controllerId}`,
+        { method: "DELETE", cache: "no-store" }
+      );
+      setControllers(result?.controllers ?? []);
+      if ((result?.count ?? 0) === 0) {
+        // Last controller removed — fleet is gone
+        setIsFleetMode(false);
+        setStatus({ connected: false });
+        localStorage.removeItem(CACHE_KEY);
+        localStorage.removeItem(CONNECTED_KEY);
+        globalThis.dispatchEvent(new CustomEvent("providerStateChanged"));
+        setStep(1);
+        toast({ title: "Controller removed", description: "All controllers removed. CloudBees disconnected." });
+      } else {
+        toast({ title: "Controller removed" });
+      }
+    } catch (err) {
+      toast({ title: "Failed to remove controller", description: getUserFriendlyError(err), variant: "destructive" });
+    }
+  };
+
   const handleDisconnect = async () => {
     setLoading(true);
     try {
@@ -288,6 +365,7 @@ export default function CloudBeesAuthPage() {
       setPlatformUrl("");
       setRolloutToken("");
       setControllers([]);
+      setIsFleetMode(false);
       localStorage.removeItem(CACHE_KEY);
       localStorage.removeItem(CONNECTED_KEY);
       globalThis.dispatchEvent(new CustomEvent("providerStateChanged"));
@@ -409,6 +487,7 @@ export default function CloudBeesAuthPage() {
           onOCConnect={handleOCConnect}
           onSingleConnect={handleSingleControllerConnect}
           onPATConnect={handlePATConnect}
+          onFleetConnect={handleFleetConnect}
           onBack={() => { setStep(1); setUrlError(""); }}
         />
       )}
@@ -427,6 +506,8 @@ export default function CloudBeesAuthPage() {
           webhookInfo={webhookInfo}
           deployments={deployments}
           controllers={controllers}
+          isFleetMode={isFleetMode}
+          onRemoveController={handleRemoveController}
           rcaEnabled={rcaEnabled}
           rcaLoading={rcaLoading}
           loading={loading}

--- a/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
+++ b/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
@@ -325,6 +325,7 @@ export default function CloudBeesAuthPage() {
   };
 
   const handleRemoveController = async (controllerId: string) => {
+    setLoading(true);
     try {
       const result = await apiRequest<{ controllers?: DiscoveredController[]; count?: number }>(
         `/api/cloudbees/fleet/controllers/${controllerId}`,
@@ -345,6 +346,8 @@ export default function CloudBeesAuthPage() {
       }
     } catch (err) {
       toast({ title: "Failed to remove controller", description: getUserFriendlyError(err), variant: "destructive" });
+    } finally {
+      setLoading(false);
     }
   };
 

--- a/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
+++ b/client/src/app/cloudbees/auth/components/CloudBeesAuthPage.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useCallback } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
 import { getUserFriendlyError } from "@/lib/utils";
-import { cloudbeesService } from "@/lib/services/ci-provider";
 import type { CIProviderStatus } from "@/lib/services/ci-provider";
 import { apiRequest } from "@/lib/services/api-client";
 import { ModeSelector } from "./ModeSelector";
@@ -12,7 +11,7 @@ import { CredentialForms, type FleetControllerInput } from "./CredentialForms";
 import { WebhookSetup } from "./WebhookSetup";
 import { ConnectedDashboard } from "./ConnectedDashboard";
 
-type ConnectionMode = "oc" | "single" | "fleet" | "pat";
+type ConnectionMode = "oc" | "fleet" | "pat";
 
 type Step = 1 | 2 | 3 | "connected";
 
@@ -39,11 +38,6 @@ export default function CloudBeesAuthPage() {
   const [loading, setLoading] = useState(false);
   const [checkingStatus, setCheckingStatus] = useState(true);
   const [status, setStatus] = useState<CIProviderStatus | null>(null);
-
-  // Single Controller fields
-  const [baseUrl, setBaseUrl] = useState("");
-  const [username, setUsername] = useState("");
-  const [apiToken, setApiToken] = useState("");
 
   // Operations Center fields
   const [ocUrl, setOcUrl] = useState("");
@@ -126,41 +120,6 @@ export default function CloudBeesAuthPage() {
 
   const validateUrl = (url: string): boolean => {
     return url.startsWith("http://") || url.startsWith("https://");
-  };
-
-  const handleSingleControllerConnect = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!validateUrl(baseUrl)) {
-      setUrlError("URL must start with http:// or https://");
-      return;
-    }
-    setUrlError("");
-    setLoading(true);
-    try {
-      const connectResult = await cloudbeesService.connect({ baseUrl, username, apiToken });
-      setStatus(connectResult);
-      localStorage.setItem(CONNECTED_KEY, "true");
-      globalThis.dispatchEvent(new CustomEvent("providerStateChanged"));
-
-      try {
-        await apiRequest("/api/provider-preferences", {
-          method: "POST",
-          body: JSON.stringify({ action: "add", provider: "cloudbees" }),
-        });
-      } catch { /* best-effort */ }
-
-      toast({
-        title: "CloudBees CI Connected",
-        description: `Successfully connected to ${baseUrl}`,
-      });
-      setStep(3);
-    } catch (err: unknown) {
-      console.error("CloudBees connection failed", err);
-      toast({ title: "Connection Failed", description: getUserFriendlyError(err), variant: "destructive" });
-    } finally {
-      setLoading(false);
-      setApiToken("");
-    }
   };
 
   const handleOCConnect = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -324,6 +283,30 @@ export default function CloudBeesAuthPage() {
     }
   };
 
+  const handleAddControllers = async (newControllers: { name: string; url: string; username: string; token: string }[]) => {
+    if (newControllers.length === 0) return;
+    setLoading(true);
+    try {
+      const result = await apiRequest<{ controllers?: DiscoveredController[]; failed?: unknown[] }>(
+        "/api/cloudbees/fleet/controllers",
+        { method: "POST", body: JSON.stringify({ controllers: newControllers }), cache: "no-store" }
+      );
+      if (result?.controllers) setControllers(result.controllers);
+      const failedCount = result?.failed?.length ?? 0;
+      toast({
+        title: "Controller added",
+        description: failedCount > 0
+          ? `Saved but could not validate (marked offline).`
+          : `${newControllers.length} controller(s) added successfully.`,
+        variant: failedCount > 0 ? "destructive" : undefined,
+      });
+    } catch (err) {
+      toast({ title: "Failed to add controller", description: getUserFriendlyError(err), variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleRemoveController = async (controllerId: string) => {
     setLoading(true);
     try {
@@ -361,8 +344,6 @@ export default function CloudBeesAuthPage() {
       } catch { /* best-effort */ }
 
       setStatus({ connected: false });
-      setBaseUrl("");
-      setUsername("");
       setOcUrl("");
       setOcUsername("");
       setPlatformUrl("");
@@ -477,18 +458,11 @@ export default function CloudBeesAuthPage() {
           setOcApiToken={setOcApiToken}
           rolloutToken={rolloutToken}
           setRolloutToken={setRolloutToken}
-          baseUrl={baseUrl}
-          setBaseUrl={setBaseUrl}
-          username={username}
-          setUsername={setUsername}
-          apiToken={apiToken}
-          setApiToken={setApiToken}
           platformUrl={platformUrl}
           setPlatformUrl={setPlatformUrl}
           pat={pat}
           setPat={setPat}
           onOCConnect={handleOCConnect}
-          onSingleConnect={handleSingleControllerConnect}
           onPATConnect={handlePATConnect}
           onFleetConnect={handleFleetConnect}
           onBack={() => { setStep(1); setUrlError(""); }}
@@ -511,6 +485,7 @@ export default function CloudBeesAuthPage() {
           controllers={controllers}
           isFleetMode={isFleetMode}
           onRemoveController={handleRemoveController}
+          onAddControllers={handleAddControllers}
           rcaEnabled={rcaEnabled}
           rcaLoading={rcaLoading}
           loading={loading}

--- a/client/src/app/cloudbees/auth/components/ConnectedDashboard.tsx
+++ b/client/src/app/cloudbees/auth/components/ConnectedDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, Check, Trash2 } from "lucide-react";
+import { Copy, Check, Trash2, Plus } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
@@ -22,6 +22,7 @@ interface ConnectedDashboardProps {
   controllers: DiscoveredController[];
   isFleetMode?: boolean;
   onRemoveController?: (controllerId: string) => void;
+  onAddControllers?: (controllers: { name: string; url: string; username: string; token: string }[]) => void;
   rcaEnabled: boolean;
   rcaLoading: boolean;
   loading: boolean;
@@ -45,12 +46,17 @@ function timeAgo(dateStr: string | null | undefined): string {
 
 export function ConnectedDashboard({
   status, summary, webhookInfo, deployments, controllers,
-  isFleetMode = false, onRemoveController,
+  isFleetMode = false, onRemoveController, onAddControllers,
   rcaEnabled, rcaLoading, loading,
   onDisconnect, onRcaToggle,
 }: Readonly<ConnectedDashboardProps>) {
   const { toast } = useToast();
   const [webhookCopied, setWebhookCopied] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addUrl, setAddUrl] = useState("");
+  const [addUsername, setAddUsername] = useState("");
+  const [addToken, setAddToken] = useState("");
 
   const copyWebhookUrl = () => {
     if (!webhookInfo?.webhookUrl) return;
@@ -203,11 +209,93 @@ export function ConnectedDashboard({
       )}
 
       {/* Controllers — OC-managed (read-only) or fleet (removable) */}
-      {controllers.length > 0 && (
+      {(controllers.length > 0 || isFleetMode) && (
         <div className="mt-8 pt-6 border-t border-white/[0.04]">
-          <p className="text-[11px] uppercase tracking-[0.12em] text-[#555] mb-4">
-            {isFleetMode ? "Controllers" : "Managed Controllers"}
-          </p>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-[11px] uppercase tracking-[0.12em] text-[#555]">
+              {isFleetMode ? "Controllers" : "Managed Controllers"}
+            </p>
+            {isFleetMode && onAddControllers && !showAddForm && (
+              <button
+                type="button"
+                onClick={() => setShowAddForm(true)}
+                className="flex items-center gap-1.5 text-[12px] text-[#777] hover:text-white transition-colors"
+              >
+                <Plus className="h-3.5 w-3.5" /> Add controller
+              </button>
+            )}
+          </div>
+
+          {/* Inline add controller form */}
+          {isFleetMode && showAddForm && onAddControllers && (
+            <div className="mb-4 p-4 rounded-xl border border-white/[0.08] bg-white/[0.02] space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <input
+                  type="text"
+                  value={addName}
+                  onChange={(e) => setAddName(e.target.value)}
+                  placeholder="Name (optional)"
+                  disabled={loading}
+                  className="px-3 py-2.5 rounded-lg border border-white/[0.08] bg-white/[0.02] text-[13px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+                />
+                <input
+                  type="text"
+                  value={addUrl}
+                  onChange={(e) => setAddUrl(e.target.value)}
+                  placeholder="https://controller.example.com"
+                  disabled={loading}
+                  className="px-3 py-2.5 rounded-lg border border-white/[0.08] bg-white/[0.02] text-[13px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+                />
+                <input
+                  type="text"
+                  value={addUsername}
+                  onChange={(e) => setAddUsername(e.target.value)}
+                  placeholder="Username"
+                  disabled={loading}
+                  className="px-3 py-2.5 rounded-lg border border-white/[0.08] bg-white/[0.02] text-[13px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+                />
+                <input
+                  type="password"
+                  value={addToken}
+                  onChange={(e) => setAddToken(e.target.value)}
+                  placeholder="API token"
+                  disabled={loading}
+                  className="px-3 py-2.5 rounded-lg border border-white/[0.08] bg-white/[0.02] text-[13px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const url = addUrl.trim();
+                    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                      toast({ title: "Invalid URL", description: "URL must start with http:// or https://", variant: "destructive" });
+                      return;
+                    }
+                    if (!addUsername.trim() || !addToken) {
+                      toast({ title: "Missing fields", description: "Username and token are required", variant: "destructive" });
+                      return;
+                    }
+                    onAddControllers([{ name: addName.trim() || url, url, username: addUsername.trim(), token: addToken }]);
+                    setAddName(""); setAddUrl(""); setAddUsername(""); setAddToken("");
+                    setShowAddForm(false);
+                  }}
+                  disabled={loading || !addUrl.trim() || !addUsername.trim() || !addToken}
+                  className="px-4 py-2 rounded-lg bg-white text-black text-[13px] font-medium hover:bg-white/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowAddForm(false); setAddName(""); setAddUrl(""); setAddUsername(""); setAddToken(""); }}
+                  className="px-4 py-2 text-[13px] text-[#777] hover:text-white transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
           <div className="space-y-1">
             {controllers.map((ctrl) => (
               <div key={ctrl.id ?? ctrl.url} className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/[0.02]">

--- a/client/src/app/cloudbees/auth/components/ConnectedDashboard.tsx
+++ b/client/src/app/cloudbees/auth/components/ConnectedDashboard.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, Trash2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import type { CIProviderStatus } from "@/lib/services/ci-provider";
 
 interface DiscoveredController {
+  id?: string;
   name: string;
   url: string;
   status: string;
+  last_error?: string | null;
 }
 
 interface ConnectedDashboardProps {
@@ -18,6 +20,8 @@ interface ConnectedDashboardProps {
   webhookInfo: any;
   deployments: any[];
   controllers: DiscoveredController[];
+  isFleetMode?: boolean;
+  onRemoveController?: (controllerId: string) => void;
   rcaEnabled: boolean;
   rcaLoading: boolean;
   loading: boolean;
@@ -41,6 +45,7 @@ function timeAgo(dateStr: string | null | undefined): string {
 
 export function ConnectedDashboard({
   status, summary, webhookInfo, deployments, controllers,
+  isFleetMode = false, onRemoveController,
   rcaEnabled, rcaLoading, loading,
   onDisconnect, onRcaToggle,
 }: Readonly<ConnectedDashboardProps>) {
@@ -197,20 +202,36 @@ export function ConnectedDashboard({
         </div>
       )}
 
-      {/* Managed controllers (OC mode) */}
+      {/* Controllers — OC-managed (read-only) or fleet (removable) */}
       {controllers.length > 0 && (
         <div className="mt-8 pt-6 border-t border-white/[0.04]">
-          <p className="text-[11px] uppercase tracking-[0.12em] text-[#555] mb-4">Managed Controllers</p>
+          <p className="text-[11px] uppercase tracking-[0.12em] text-[#555] mb-4">
+            {isFleetMode ? "Controllers" : "Managed Controllers"}
+          </p>
           <div className="space-y-1">
             {controllers.map((ctrl) => (
-              <div key={ctrl.url} className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/[0.02]">
+              <div key={ctrl.id ?? ctrl.url} className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/[0.02]">
                 <div className="flex-1 min-w-0">
                   <p className="text-[14px] truncate">{ctrl.name}</p>
                   <p className="text-[12px] text-[#555] truncate">{ctrl.url}</p>
+                  {ctrl.status !== "online" && ctrl.last_error && (
+                    <p className="text-[11px] text-red-400/80 truncate mt-0.5">{ctrl.last_error}</p>
+                  )}
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 ml-3 flex-shrink-0">
                   <span className={`h-2 w-2 rounded-full ${ctrl.status === "online" ? "bg-green-500" : "bg-[#555]"}`} />
                   <span className="text-[12px] text-[#777]">{ctrl.status}</span>
+                  {isFleetMode && onRemoveController && ctrl.id && (
+                    <button
+                      type="button"
+                      onClick={() => onRemoveController(ctrl.id as string)}
+                      disabled={loading}
+                      className="ml-2 text-[#666] hover:text-red-400 transition-colors disabled:opacity-50"
+                      aria-label={`Remove ${ctrl.name}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
                 </div>
               </div>
             ))}

--- a/client/src/app/cloudbees/auth/components/CredentialForms.tsx
+++ b/client/src/app/cloudbees/auth/components/CredentialForms.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { Eye, EyeOff, Loader2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 
-type ConnectionMode = "oc" | "single" | "pat";
+type ConnectionMode = "oc" | "single" | "fleet" | "pat";
+
+export interface FleetControllerInput {
+  name: string;
+  url: string;
+  username: string;
+  token: string;
+}
 
 interface CredentialFormsProps {
   mode: ConnectionMode;
@@ -34,6 +41,7 @@ interface CredentialFormsProps {
   onOCConnect: (e: React.FormEvent<HTMLFormElement>) => void;
   onSingleConnect: (e: React.FormEvent<HTMLFormElement>) => void;
   onPATConnect: (e: React.FormEvent<HTMLFormElement>) => void;
+  onFleetConnect: (controllers: FleetControllerInput[]) => void;
   onBack: () => void;
 }
 
@@ -43,12 +51,74 @@ export function CredentialForms({
   rolloutToken, setRolloutToken,
   baseUrl, setBaseUrl, username, setUsername, apiToken, setApiToken,
   platformUrl, setPlatformUrl, pat, setPat,
-  onOCConnect, onSingleConnect, onPATConnect, onBack,
+  onOCConnect, onSingleConnect, onPATConnect, onFleetConnect, onBack,
 }: Readonly<CredentialFormsProps>) {
   const [showOcToken, setShowOcToken] = useState(false);
   const [showRolloutToken, setShowRolloutToken] = useState(false);
   const [showToken, setShowToken] = useState(false);
   const [showPat, setShowPat] = useState(false);
+
+  // Fleet (multiple standalone controllers) state
+  const [fleetControllers, setFleetControllers] = useState<FleetControllerInput[]>([]);
+  const [fcName, setFcName] = useState("");
+  const [fcUrl, setFcUrl] = useState("");
+  const [fcUsername, setFcUsername] = useState("");
+  const [fcToken, setFcToken] = useState("");
+  const [fcError, setFcError] = useState("");
+  const [bulkJson, setBulkJson] = useState("");
+  const [bulkError, setBulkError] = useState("");
+
+  const addFleetController = () => {
+    setFcError("");
+    if (!fcUrl.startsWith("http://") && !fcUrl.startsWith("https://")) {
+      setFcError("URL must start with http:// or https://");
+      return;
+    }
+    if (!fcUsername || !fcToken) {
+      setFcError("Username and token are required");
+      return;
+    }
+    setFleetControllers((prev) => [
+      ...prev,
+      { name: fcName.trim() || fcUrl, url: fcUrl.trim(), username: fcUsername.trim(), token: fcToken },
+    ]);
+    setFcName(""); setFcUrl(""); setFcUsername(""); setFcToken("");
+  };
+
+  const removeFleetController = (idx: number) => {
+    setFleetControllers((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const applyBulkJson = () => {
+    setBulkError("");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(bulkJson);
+    } catch {
+      setBulkError("Invalid JSON. Expected an array of {name, url, username, token}.");
+      return;
+    }
+    if (!Array.isArray(parsed)) {
+      setBulkError("JSON must be an array of controller objects.");
+      return;
+    }
+    const valid: FleetControllerInput[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== "object") continue;
+      const o = item as Record<string, unknown>;
+      const url = String(o.url ?? o.base_url ?? "").trim();
+      const username = String(o.username ?? "").trim();
+      const token = String(o.token ?? o.api_token ?? "");
+      if (!url || !username || !token) continue;
+      valid.push({ name: String(o.name ?? url).trim() || url, url, username, token });
+    }
+    if (valid.length === 0) {
+      setBulkError("No valid controllers found. Each needs url, username, and token.");
+      return;
+    }
+    setFleetControllers((prev) => [...prev, ...valid]);
+    setBulkJson("");
+  };
 
   return (
     <div className="animate-step-in">
@@ -201,6 +271,126 @@ export function CredentialForms({
               </button>
             </div>
           </form>
+        </>
+      )}
+
+      {mode === "fleet" && (
+        <>
+          <h1 className="text-[28px] font-bold tracking-tight mb-3">Add your controllers</h1>
+          <p className="text-[15px] text-[#777] mb-10">
+            Add each standalone controller with its own URL, username, and API token. We&apos;ll
+            validate each one as you connect — unreachable controllers are still saved and marked
+            offline so the rest of the fleet stays usable.
+          </p>
+
+          {fcError && <p className="text-[13px] text-red-500 mb-4">{fcError}</p>}
+
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <input
+                type="text"
+                value={fcName}
+                onChange={(e) => setFcName(e.target.value)}
+                placeholder="Name (optional)"
+                disabled={loading}
+                className="px-4 py-3 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[14px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+              />
+              <input
+                type="text"
+                value={fcUrl}
+                onChange={(e) => setFcUrl(e.target.value)}
+                placeholder="https://controller.example.com"
+                disabled={loading}
+                className="px-4 py-3 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[14px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+              />
+              <input
+                type="text"
+                value={fcUsername}
+                onChange={(e) => setFcUsername(e.target.value)}
+                placeholder="username"
+                disabled={loading}
+                className="px-4 py-3 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[14px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+              />
+              <input
+                type="password"
+                value={fcToken}
+                onChange={(e) => setFcToken(e.target.value)}
+                placeholder="API token"
+                disabled={loading}
+                className="px-4 py-3 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[14px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={addFleetController}
+              disabled={loading}
+              className="flex items-center gap-2 text-[14px] text-[#999] hover:text-white transition-colors disabled:opacity-50"
+            >
+              <Plus className="h-4 w-4" /> Add controller
+            </button>
+          </div>
+
+          {/* Added controllers */}
+          {fleetControllers.length > 0 && (
+            <div className="mt-6 space-y-2">
+              {fleetControllers.map((c, idx) => (
+                <div key={`${c.url}-${idx}`} className="flex items-center justify-between py-2.5 px-4 rounded-xl bg-white/[0.02] border border-white/[0.04]">
+                  <div className="min-w-0">
+                    <p className="text-[14px] truncate">{c.name}</p>
+                    <p className="text-[12px] text-[#555] truncate">{c.url} · {c.username}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeFleetController(idx)}
+                    disabled={loading}
+                    className="text-[#666] hover:text-red-400 transition-colors ml-3 flex-shrink-0"
+                    aria-label="Remove controller"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Bulk import */}
+          <details className="mt-6">
+            <summary className="text-[13px] text-[#777] cursor-pointer hover:text-[#999] transition-colors">
+              Bulk import (JSON)
+            </summary>
+            <div className="mt-4">
+              <textarea
+                value={bulkJson}
+                onChange={(e) => setBulkJson(e.target.value)}
+                placeholder={'[\n  {"name": "ctrl-a", "url": "https://a.example.com", "username": "user", "token": "11a..."},\n  {"name": "ctrl-b", "url": "https://b.example.com", "username": "user", "token": "11b..."}\n]'}
+                rows={6}
+                disabled={loading}
+                className="w-full px-4 py-3 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[12px] font-mono placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50"
+              />
+              {bulkError && <p className="text-[13px] text-red-500 mt-2">{bulkError}</p>}
+              <button
+                type="button"
+                onClick={applyBulkJson}
+                disabled={loading || !bulkJson.trim()}
+                className="mt-2 text-[13px] text-[#999] hover:text-white transition-colors disabled:opacity-40"
+              >
+                Add from JSON
+              </button>
+            </div>
+          </details>
+
+          <div className="flex items-center gap-3 pt-8">
+            <button type="button" onClick={onBack} className="text-[15px] text-[#777] hover:text-white transition-colors px-4 py-3">Back</button>
+            <button
+              type="button"
+              onClick={() => onFleetConnect(fleetControllers)}
+              disabled={loading || fleetControllers.length === 0}
+              className="flex-1 py-3.5 rounded-xl bg-white text-black font-medium text-[15px] hover:bg-white/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              {loading ? "Connecting..." : `Connect ${fleetControllers.length || ""} controller${fleetControllers.length === 1 ? "" : "s"}`.trim()}
+            </button>
+          </div>
         </>
       )}
 

--- a/client/src/app/cloudbees/auth/components/CredentialForms.tsx
+++ b/client/src/app/cloudbees/auth/components/CredentialForms.tsx
@@ -3,7 +3,7 @@
 import { Eye, EyeOff, Loader2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 
-type ConnectionMode = "oc" | "single" | "fleet" | "pat";
+type ConnectionMode = "oc" | "fleet" | "pat";
 
 export interface FleetControllerInput {
   name: string;
@@ -25,13 +25,6 @@ interface CredentialFormsProps {
   setOcApiToken: (v: string) => void;
   rolloutToken: string;
   setRolloutToken: (v: string) => void;
-  // Single controller fields
-  baseUrl: string;
-  setBaseUrl: (v: string) => void;
-  username: string;
-  setUsername: (v: string) => void;
-  apiToken: string;
-  setApiToken: (v: string) => void;
   // PAT fields
   platformUrl: string;
   setPlatformUrl: (v: string) => void;
@@ -39,7 +32,6 @@ interface CredentialFormsProps {
   setPat: (v: string) => void;
   // Actions
   onOCConnect: (e: React.FormEvent<HTMLFormElement>) => void;
-  onSingleConnect: (e: React.FormEvent<HTMLFormElement>) => void;
   onPATConnect: (e: React.FormEvent<HTMLFormElement>) => void;
   onFleetConnect: (controllers: FleetControllerInput[]) => void;
   onBack: () => void;
@@ -49,13 +41,11 @@ export function CredentialForms({
   mode, loading, urlError,
   ocUrl, setOcUrl, ocUsername, setOcUsername, ocApiToken, setOcApiToken,
   rolloutToken, setRolloutToken,
-  baseUrl, setBaseUrl, username, setUsername, apiToken, setApiToken,
   platformUrl, setPlatformUrl, pat, setPat,
-  onOCConnect, onSingleConnect, onPATConnect, onFleetConnect, onBack,
+  onOCConnect, onPATConnect, onFleetConnect, onBack,
 }: Readonly<CredentialFormsProps>) {
   const [showOcToken, setShowOcToken] = useState(false);
   const [showRolloutToken, setShowRolloutToken] = useState(false);
-  const [showToken, setShowToken] = useState(false);
   const [showPat, setShowPat] = useState(false);
 
   // Fleet (multiple standalone controllers) state
@@ -257,51 +247,12 @@ export function CredentialForms({
         </>
       )}
 
-      {mode === "single" && (
-        <>
-          <h1 className="text-[28px] font-bold tracking-tight mb-3">Connect your controller</h1>
-          <p className="text-[15px] text-[#777] mb-10">Enter your CloudBees CI instance details.</p>
-
-          {urlError && <p className="text-[13px] text-red-500 mb-4">{urlError}</p>}
-
-          <form onSubmit={onSingleConnect} className="space-y-6">
-            <div>
-              <label htmlFor="sc-url" className="block text-[13px] text-[#999] mb-2">Controller URL</label>
-              <input id="sc-url" type="text" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="https://cloudbees.example.com" required disabled={loading} className="w-full px-4 py-3.5 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[15px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50" />
-            </div>
-            <div>
-              <label htmlFor="sc-username" className="block text-[13px] text-[#999] mb-2">Username</label>
-              <input id="sc-username" type="text" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="your-cloudbees-username" required disabled={loading} className="w-full px-4 py-3.5 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[15px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50" />
-            </div>
-            <div>
-              <label htmlFor="sc-token" className="block text-[13px] text-[#999] mb-2">API Token</label>
-              <div className="relative">
-                <input id="sc-token" type={showToken ? "text" : "password"} value={apiToken} onChange={(e) => setApiToken(e.target.value)} placeholder="11xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" required disabled={loading} className="w-full px-4 py-3.5 pr-11 rounded-xl border border-white/[0.08] bg-white/[0.02] text-[15px] placeholder:text-[#333] focus:outline-none focus:border-white/[0.16] transition-colors disabled:opacity-50" />
-                <button type="button" onClick={() => setShowToken(!showToken)} className="absolute right-3 top-1/2 -translate-y-1/2 text-[#555] hover:text-white transition-colors" aria-label={showToken ? "Hide token" : "Show token"}>
-                  {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              <p className="text-[11px] text-[#444] mt-2">Your profile &rarr; Security &rarr; API Token &rarr; Generate</p>
-            </div>
-
-            <div className="flex items-center gap-3 pt-4">
-              <button type="button" onClick={onBack} className="text-[15px] text-[#777] hover:text-white transition-colors px-4 py-3">Back</button>
-              <button type="submit" disabled={loading || !baseUrl || !username || !apiToken} className="flex-1 py-3.5 rounded-xl bg-white text-black font-medium text-[15px] hover:bg-white/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2">
-                {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-                {loading ? "Connecting..." : "Connect"}
-              </button>
-            </div>
-          </form>
-        </>
-      )}
-
       {mode === "fleet" && (
         <>
-          <h1 className="text-[28px] font-bold tracking-tight mb-3">Add your controllers</h1>
+          <h1 className="text-[28px] font-bold tracking-tight mb-3">Connect your controller(s)</h1>
           <p className="text-[15px] text-[#777] mb-10">
-            Add each standalone controller with its own URL, username, and API token. We&apos;ll
-            validate each one as you connect — unreachable controllers are still saved and marked
-            offline so the rest of the fleet stays usable.
+            Add one or more controllers — each with its own URL, username, and API token. You can
+            always add more after connecting. Unreachable controllers are saved and marked offline.
           </p>
 
           {fcError && <p className="text-[13px] text-red-500 mb-4">{fcError}</p>}

--- a/client/src/app/cloudbees/auth/components/CredentialForms.tsx
+++ b/client/src/app/cloudbees/auth/components/CredentialForms.tsx
@@ -68,10 +68,12 @@ export function CredentialForms({
   const [bulkJson, setBulkJson] = useState("");
   const [bulkError, setBulkError] = useState("");
 
+  const isHttpUrl = (u: string) => u.startsWith("http://") || u.startsWith("https://");
+
   const addFleetController = () => {
     setFcError("");
     const url = fcUrl.trim();
-    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    if (!isHttpUrl(url)) {
       setFcError("URL must start with http:// or https://");
       return;
     }
@@ -101,7 +103,9 @@ export function CredentialForms({
     const url = strField(o.url ?? o.base_url);
     const username = strField(o.username);
     const token = strField(o.token ?? o.api_token);
-    if (!url || !username || !token) return null;
+    // Apply the same http(s):// scheme check as manual entry so bulk import
+    // doesn't defer a preventable validation error to connect time.
+    if (!isHttpUrl(url) || !username || !token) return null;
     return { name: strField(o.name) || url, url, username, token };
   };
 

--- a/client/src/app/cloudbees/auth/components/CredentialForms.tsx
+++ b/client/src/app/cloudbees/auth/components/CredentialForms.tsx
@@ -70,17 +70,18 @@ export function CredentialForms({
 
   const addFleetController = () => {
     setFcError("");
-    if (!fcUrl.startsWith("http://") && !fcUrl.startsWith("https://")) {
+    const url = fcUrl.trim();
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
       setFcError("URL must start with http:// or https://");
       return;
     }
-    if (!fcUsername || !fcToken) {
+    if (!fcUsername.trim() || !fcToken) {
       setFcError("Username and token are required");
       return;
     }
     setFleetControllers((prev) => [
       ...prev,
-      { name: fcName.trim() || fcUrl, url: fcUrl.trim(), username: fcUsername.trim(), token: fcToken },
+      { name: fcName.trim() || url, url, username: fcUsername.trim(), token: fcToken },
     ]);
     setFcName(""); setFcUrl(""); setFcUsername(""); setFcToken("");
   };

--- a/client/src/app/cloudbees/auth/components/CredentialForms.tsx
+++ b/client/src/app/cloudbees/auth/components/CredentialForms.tsx
@@ -89,6 +89,21 @@ export function CredentialForms({
     setFleetControllers((prev) => prev.filter((_, i) => i !== idx));
   };
 
+  // Coerce a JSON value to a trimmed string only when it's a string/number;
+  // anything else (objects, arrays) becomes "" rather than "[object Object]".
+  const strField = (v: unknown): string =>
+    typeof v === "string" || typeof v === "number" ? String(v).trim() : "";
+
+  const parseFleetItem = (item: unknown): FleetControllerInput | null => {
+    if (!item || typeof item !== "object") return null;
+    const o = item as Record<string, unknown>;
+    const url = strField(o.url ?? o.base_url);
+    const username = strField(o.username);
+    const token = strField(o.token ?? o.api_token);
+    if (!url || !username || !token) return null;
+    return { name: strField(o.name) || url, url, username, token };
+  };
+
   const applyBulkJson = () => {
     setBulkError("");
     let parsed: unknown;
@@ -102,16 +117,7 @@ export function CredentialForms({
       setBulkError("JSON must be an array of controller objects.");
       return;
     }
-    const valid: FleetControllerInput[] = [];
-    for (const item of parsed) {
-      if (!item || typeof item !== "object") continue;
-      const o = item as Record<string, unknown>;
-      const url = String(o.url ?? o.base_url ?? "").trim();
-      const username = String(o.username ?? "").trim();
-      const token = String(o.token ?? o.api_token ?? "");
-      if (!url || !username || !token) continue;
-      valid.push({ name: String(o.name ?? url).trim() || url, url, username, token });
-    }
+    const valid = parsed.map(parseFleetItem).filter((c): c is FleetControllerInput => c !== null);
     if (valid.length === 0) {
       setBulkError("No valid controllers found. Each needs url, username, and token.");
       return;
@@ -119,6 +125,16 @@ export function CredentialForms({
     setFleetControllers((prev) => [...prev, ...valid]);
     setBulkJson("");
   };
+
+  const fleetCount = fleetControllers.length;
+  let fleetConnectLabel: string;
+  if (loading) {
+    fleetConnectLabel = "Connecting...";
+  } else if (fleetCount === 0) {
+    fleetConnectLabel = "Connect controllers";
+  } else {
+    fleetConnectLabel = `Connect ${fleetCount} controller${fleetCount === 1 ? "" : "s"}`;
+  }
 
   return (
     <div className="animate-step-in">
@@ -388,7 +404,7 @@ export function CredentialForms({
               className="flex-1 py-3.5 rounded-xl bg-white text-black font-medium text-[15px] hover:bg-white/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
               {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-              {loading ? "Connecting..." : `Connect ${fleetControllers.length || ""} controller${fleetControllers.length === 1 ? "" : "s"}`.trim()}
+              {fleetConnectLabel}
             </button>
           </div>
         </>

--- a/client/src/app/cloudbees/auth/components/ModeSelector.tsx
+++ b/client/src/app/cloudbees/auth/components/ModeSelector.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronRight } from "lucide-react";
 
-type ConnectionMode = "oc" | "single" | "pat";
+type ConnectionMode = "oc" | "single" | "fleet" | "pat";
 
 interface ModeSelectorProps {
   onSelect: (mode: ConnectionMode) => void;
@@ -40,6 +40,20 @@ export function ModeSelector({ onSelect }: Readonly<ModeSelectorProps>) {
             <p className="text-[15px] font-medium mb-1">Single Controller</p>
             <p className="text-[13px] text-[#777] leading-relaxed">
               Connect directly to one CloudBees CI or Jenkins instance.
+            </p>
+          </div>
+          <ChevronRight className="h-4 w-4 text-[#555] flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onSelect("fleet")}
+          className="group w-full p-6 rounded-2xl border border-white/[0.06] hover:border-white/[0.12] bg-white/[0.01] hover:bg-white/[0.02] transition-all text-left flex items-center justify-between"
+        >
+          <div>
+            <p className="text-[15px] font-medium mb-1">Multiple Controllers</p>
+            <p className="text-[13px] text-[#777] leading-relaxed">
+              Connect several standalone controllers individually. Use this when you have multiple controllers but no Operations Center — each controller needs its own URL and API token.
             </p>
           </div>
           <ChevronRight className="h-4 w-4 text-[#555] flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" />

--- a/client/src/app/cloudbees/auth/components/ModeSelector.tsx
+++ b/client/src/app/cloudbees/auth/components/ModeSelector.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronRight } from "lucide-react";
 
-type ConnectionMode = "oc" | "single" | "fleet" | "pat";
+type ConnectionMode = "oc" | "fleet" | "pat";
 
 interface ModeSelectorProps {
   onSelect: (mode: ConnectionMode) => void;
@@ -33,27 +33,13 @@ export function ModeSelector({ onSelect }: Readonly<ModeSelectorProps>) {
 
         <button
           type="button"
-          onClick={() => onSelect("single")}
-          className="group w-full p-6 rounded-2xl border border-white/[0.06] hover:border-white/[0.12] bg-white/[0.01] hover:bg-white/[0.02] transition-all text-left flex items-center justify-between"
-        >
-          <div>
-            <p className="text-[15px] font-medium mb-1">Single Controller</p>
-            <p className="text-[13px] text-[#777] leading-relaxed">
-              Connect directly to one CloudBees CI or Jenkins instance.
-            </p>
-          </div>
-          <ChevronRight className="h-4 w-4 text-[#555] flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" />
-        </button>
-
-        <button
-          type="button"
           onClick={() => onSelect("fleet")}
           className="group w-full p-6 rounded-2xl border border-white/[0.06] hover:border-white/[0.12] bg-white/[0.01] hover:bg-white/[0.02] transition-all text-left flex items-center justify-between"
         >
           <div>
-            <p className="text-[15px] font-medium mb-1">Multiple Controllers</p>
+            <p className="text-[15px] font-medium mb-1">Controller(s)</p>
             <p className="text-[13px] text-[#777] leading-relaxed">
-              Connect several standalone controllers individually. Use this when you have multiple controllers but no Operations Center — each controller needs its own URL and API token.
+              Connect one or more standalone CloudBees CI / Jenkins controllers directly. Add them one at a time or bulk-import — you can always add more later.
             </p>
           </div>
           <ChevronRight className="h-4 w-4 text-[#555] flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" />

--- a/server/chat/backend/agent/skills/integrations/cloudbees/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/cloudbees/SKILL.md
@@ -56,7 +56,7 @@ Recent deployments are a leading indicator of root cause. Always check if a depl
 - Use `build_detail` to get SCM changes and build causes before reading logs.
 - Use `pipeline_stages` for stage-level breakdown to narrow which stage failed.
 - Do NOT call `flag_changes` unless Feature Management is known to be connected.
-- Do NOT call `cross_controller_deployments` unless Operations Center is known to be connected.
+- Do NOT call `cross_controller_deployments` or `controller_list` unless Operations Center OR a manually-registered controller fleet (Multiple Controllers mode) is connected.
 
 ## Recent Deployments
 {cloudbees_deploys_section}

--- a/server/chat/backend/agent/skills/integrations/cloudbees/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/cloudbees/SKILL.md
@@ -72,14 +72,23 @@ Recent deployments are a leading indicator of root cause. Always check if a depl
 
 Recent deployments are a leading indicator of root cause.
 
-## Enterprise Actions (Operations Center)
+## Multi-Controller Actions (Operations Center OR a manually-registered fleet)
 
-These actions are ONLY available when Operations Center is connected (provider: cloudbees_oc):
+These actions work in two cases: when Operations Center is connected (provider: cloudbees_oc),
+OR when the user has manually registered multiple standalone controllers via "Multiple Controllers"
+mode (provider: cloudbees_fleet — for clients that run several controllers but have no OC):
 
-- `controller_list` — List all managed Jenkins controllers and their status
-- `cross_controller_deployments` — Query recent builds across ALL managed controllers
+- `controller_list` — List all controllers and their status (online/offline)
+- `cross_controller_deployments` — Query recent builds across ALL controllers
 
-Only use these if you have confirmed OC is connected. They will return a helpful error if not.
+In fleet mode, controllers were registered individually (each with its own URL + token), since
+standalone CloudBees CI controllers cannot be discovered automatically without Operations Center.
+
+For per-build introspection (`build_detail`, `pipeline_stages`, `build_logs`, etc.) in either OC or
+fleet mode, pass `controller_url` — get the URL from `controller_list` or
+`cross_controller_deployments` (the `_controller_url` field) first.
+
+These return a helpful error if neither OC nor a fleet is connected.
 
 ## Enterprise Actions (Feature Management)
 

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1566,8 +1566,8 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                     "'blue_ocean_run' (Blue Ocean API: run data with changeSet and commit info), "
                     "'blue_ocean_steps' (Blue Ocean API: step-level detail for a pipeline node), "
                     "'flag_changes' (Feature Management flag changes; params: app_id), "
-                    "'cross_controller_deployments' (query builds across all OC-managed controllers), "
-                    "'controller_list' (list discovered controllers from Operations Center). "
+                    "'cross_controller_deployments' (query builds across all controllers — OC-managed or a manually-registered fleet), "
+                    "'controller_list' (list controllers — from Operations Center or a manually-registered fleet). "
                     "Required params vary by action: job_path+build_number for Core/wfapi, "
                     "pipeline_name+run_number for Blue Ocean. service is optional for recent_deployments."
                 ),

--- a/server/chat/backend/agent/tools/cloudbees_rca_tool.py
+++ b/server/chat/backend/agent/tools/cloudbees_rca_tool.py
@@ -49,7 +49,7 @@ class CloudBeesRCAArgs(BaseModel):
 
 
 def is_cloudbees_connected(user_id: str) -> bool:
-    """Check if CloudBees CI is connected for a user (legacy single-controller OR OC/PAT)."""
+    """Check if CloudBees CI is connected (legacy single-controller, OC/PAT, or fleet)."""
     from utils.auth.token_management import get_token_data
     # Legacy single-controller credentials
     creds = get_token_data(user_id, "cloudbees")
@@ -58,6 +58,10 @@ def is_cloudbees_connected(user_id: str) -> bool:
     # OC/PAT enterprise credentials
     oc_creds = get_token_data(user_id, "cloudbees_oc")
     if oc_creds and oc_creds.get("base_url") and oc_creds.get("api_token"):
+        return True
+    # Fleet: multiple standalone controllers (no OC)
+    fleet_creds = get_token_data(user_id, "cloudbees_fleet")
+    if fleet_creds and (fleet_creds.get("controllers") or []):
         return True
     return False
 
@@ -118,6 +122,20 @@ def _get_fm_client_for_user(user_id: str):
     return CloudBeesFMClient(api_token=api_token)
 
 
+def _get_fleet_client_for_user(user_id: str):
+    """Build a CloudBeesFleetClient from the user's stored fleet of controllers."""
+    from utils.auth.token_management import get_token_data
+    from connectors.cloudbees_connector.fleet_client import CloudBeesFleetClient
+
+    creds = get_token_data(user_id, "cloudbees_fleet")
+    if not creds:
+        return None
+    controllers = creds.get("controllers") or []
+    if not controllers:
+        return None
+    return CloudBeesFleetClient(controllers=controllers)
+
+
 def cloudbees_rca(
     action: str,
     job_path: Optional[str] = None,
@@ -161,49 +179,69 @@ def cloudbees_rca(
 
     elif action == "cross_controller_deployments":
         oc_client = _get_oc_client_for_user(user_id)
-        if not oc_client:
+        if oc_client:
+            with oc_client:
+                success, builds, error = oc_client.query_recent_builds_across_controllers(
+                    service=service, time_window_hours=time_window_hours
+                )
+                if not success:
+                    return json.dumps({"error": error or "Failed to query Operations Center."})
+                return json.dumps({"builds": builds, "count": len(builds), "time_window_hours": time_window_hours, "warnings": error})
+        # Fallback: manually-registered fleet (no OC)
+        fleet_client = _get_fleet_client_for_user(user_id)
+        if not fleet_client:
             return json.dumps({
-                "error": "Operations Center is not connected. Connect it in Connectors → CloudBees to enable cross-controller queries."
+                "error": "No cross-controller source connected. Connect Operations Center or register controllers (Multiple Controllers mode) in Connectors → CloudBees."
             })
-        with oc_client:
-            success, builds, error = oc_client.query_recent_builds_across_controllers(
-                service=service, time_window_hours=time_window_hours
-            )
-            if not success:
-                return json.dumps({"error": error or "Failed to query Operations Center."})
-            return json.dumps({"builds": builds, "count": len(builds), "time_window_hours": time_window_hours, "warnings": error})
+        success, builds, error = fleet_client.query_recent_builds_across_controllers(
+            service=service, time_window_hours=time_window_hours
+        )
+        if not success:
+            return json.dumps({"error": error or "Failed to query controller fleet."})
+        return json.dumps({"builds": builds, "count": len(builds), "time_window_hours": time_window_hours, "warnings": error})
 
     elif action == "controller_list":
         oc_client = _get_oc_client_for_user(user_id)
-        if not oc_client:
+        if oc_client:
+            with oc_client:
+                success, controllers, error = oc_client.discover_controllers()
+                if not success:
+                    return json.dumps({"error": error or "Failed to discover controllers."})
+                return json.dumps({"controllers": controllers, "count": len(controllers)})
+        # Fallback: manually-registered fleet (no OC)
+        fleet_client = _get_fleet_client_for_user(user_id)
+        if not fleet_client:
             return json.dumps({
-                "error": "Operations Center is not connected. Connect it in Connectors → CloudBees to enable cross-controller queries."
+                "error": "No controller source connected. Connect Operations Center or register controllers (Multiple Controllers mode) in Connectors → CloudBees."
             })
-        with oc_client:
-            success, controllers, error = oc_client.discover_controllers()
-            if not success:
-                return json.dumps({"error": error or "Failed to discover controllers."})
-            return json.dumps({"controllers": controllers, "count": len(controllers)})
+        success, controllers, error = fleet_client.discover_controllers()
+        if not success:
+            return json.dumps({"error": error or "Failed to list controllers."})
+        return json.dumps({"controllers": controllers, "count": len(controllers)})
 
     # --- Existing single-controller actions ---
     elif action == "recent_deployments":
         return _action_recent_deployments(user_id, service, time_window_hours, provider="cloudbees")
 
-    # Resolve client: prefer legacy single-controller, then OC per-controller
+    # Resolve client: prefer legacy single-controller, then OC, then fleet (per-controller)
     client = _get_client_for_cloudbees_user(user_id)
     if not client:
         oc_client = _get_oc_client_for_user(user_id)
-        if not oc_client:
+        fleet_client = _get_fleet_client_for_user(user_id)
+        if not oc_client and not fleet_client:
             return json.dumps({"error": "CloudBees CI is not connected. Configure credentials in Settings > Connectors > CloudBees CI."})
-        # OC mode: route build introspection through a per-controller JenkinsClient
+        # OC / fleet mode: route build introspection through a per-controller JenkinsClient
         if not controller_url:
             return json.dumps({
-                "error": "controller_url is required for build introspection in Operations Center mode. "
+                "error": "controller_url is required for build introspection in multi-controller mode. "
                 "Use controller_list or cross_controller_deployments first to discover controller URLs, "
                 "then pass the relevant controller_url for this action."
             })
         try:
-            client = oc_client.get_controller_client(controller_url)
+            if oc_client:
+                client = oc_client.get_controller_client(controller_url)
+            else:
+                client = fleet_client.get_controller_client(controller_url)
         except ValueError as e:
             return json.dumps({"error": str(e)})
 

--- a/server/chat/background/prediscovery_task.py
+++ b/server/chat/background/prediscovery_task.py
@@ -140,7 +140,7 @@ These are indexed separately for semantic search during incident response.
 5. **CI/CD** (if Jenkins/Spinnaker/CloudBees connected):
    - jenkins_rca(action='recent_deployments') or cloudbees_rca/spinnaker_rca to see what gets deployed where
    - For each deployment: what repo, what target environment, what K8s cluster/namespace
-   - If CloudBees Operations Center is connected: use cloudbees_rca(action='controller_list') to discover all managed controllers, then cloudbees_rca(action='cross_controller_deployments') to see what's deploying across the organization
+   - If CloudBees Operations Center OR a manually-registered controller fleet (Multiple Controllers mode) is connected: use cloudbees_rca(action='controller_list') to discover all controllers, then cloudbees_rca(action='cross_controller_deployments') to see what's deploying across the organization
 
 6. **Observability** (if Datadog/Splunk/Coroot/Dynatrace/ThousandEyes connected):
    - Datadog: query_datadog(resource_type='monitors') and query_datadog(resource_type='hosts')

--- a/server/connectors/cloudbees_connector/fleet_client.py
+++ b/server/connectors/cloudbees_connector/fleet_client.py
@@ -1,0 +1,187 @@
+"""
+CloudBees standalone controller fleet client.
+
+For clients running multiple standalone CloudBees CI / Jenkins controllers
+WITHOUT an Operations Center (CJOC). Operations Center is normally the
+discovery and federation layer; without it, each controller is an autonomous
+instance with its own URL and credentials (Jenkins API tokens are
+controller-local and cannot be shared across instances).
+
+This client takes a manually-registered list of controllers — each with its
+own ``base_url``, ``username`` and ``api_token`` — and exposes the same
+cross-controller surface that ``CloudBeesOCClient`` provides for OC users:
+controller discovery and recent-build queries spanning all controllers.
+
+Unlike ``CloudBeesOCClient`` (one shared credential, controllers discovered
+live from OC), here the controller list IS the stored config and each
+controller carries its own credentials.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from connectors.jenkins_connector.api_client import JenkinsClient
+
+logger = logging.getLogger(__name__)
+
+MAX_CONTROLLERS = 20
+MAX_JOBS_PER_CONTROLLER = 50
+MAX_BUILDS_PER_CONTROLLER = 5
+
+
+class CloudBeesFleetClient:
+    """Client for a manually-registered fleet of standalone controllers."""
+
+    def __init__(self, controllers: List[Dict[str, Any]]):
+        # Each controller dict: {id, name, base_url, username, api_token, status, last_error}
+        self.controllers = controllers or []
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discover_controllers(self, reping: bool = False) -> Tuple[bool, List[Dict], Optional[str]]:
+        """Return the stored controllers as {name, url, status, last_error}.
+
+        When ``reping`` is True, each controller is re-validated and its status
+        refreshed; otherwise the stored status is returned as-is (cheap).
+        """
+        result: List[Dict] = []
+        for ctrl in self.controllers[:MAX_CONTROLLERS]:
+            status = ctrl.get("status", "unknown")
+            last_error = ctrl.get("last_error")
+            if reping:
+                ok, _, error = self.validate_controller(ctrl)
+                status = "online" if ok else "offline"
+                last_error = None if ok else error
+            result.append({
+                "id": ctrl.get("id"),
+                "name": ctrl.get("name") or ctrl.get("base_url", "unknown"),
+                "url": ctrl.get("base_url", ""),
+                "status": status,
+                "last_error": last_error,
+            })
+        return True, result, None
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def validate_controller(ctrl: Dict[str, Any]) -> Tuple[bool, Optional[Dict], Optional[str]]:
+        """Validate a single controller config by fetching its server info."""
+        base_url = ctrl.get("base_url")
+        username = ctrl.get("username")
+        api_token = ctrl.get("api_token")
+        if not base_url or not username or not api_token:
+            return False, None, "Controller is missing base_url, username, or api_token."
+        client = JenkinsClient(base_url=base_url, username=username, api_token=api_token)
+        return client.get_server_info()
+
+    # ------------------------------------------------------------------
+    # Per-controller client resolution
+    # ------------------------------------------------------------------
+
+    def get_controller_client(self, controller_url: str) -> JenkinsClient:
+        """Return a JenkinsClient for a controller identified by URL.
+
+        The URL must match one of the registered controllers exactly (after
+        normalising the trailing slash). This is the SSRF guard for fleet mode:
+        we only ever talk to controllers the user explicitly registered.
+        """
+        target = (controller_url or "").rstrip("/")
+        for ctrl in self.controllers:
+            if (ctrl.get("base_url") or "").rstrip("/") == target:
+                return JenkinsClient(
+                    base_url=ctrl["base_url"].rstrip("/"),
+                    username=ctrl.get("username", ""),
+                    api_token=ctrl.get("api_token", ""),
+                )
+        raise ValueError(
+            f"Controller URL '{controller_url}' is not a registered controller in this fleet."
+        )
+
+    # ------------------------------------------------------------------
+    # Cross-controller queries
+    # ------------------------------------------------------------------
+
+    def query_recent_builds_across_controllers(
+        self, service: Optional[str] = None, time_window_hours: int = 24
+    ) -> Tuple[bool, List[Dict], Optional[str]]:
+        """Query recent builds across all registered controllers."""
+        import time as _time
+
+        if not self.controllers:
+            return True, [], None
+
+        cutoff_ms = int((_time.time() - time_window_hours * 3600) * 1000)
+
+        all_builds: List[Dict] = []
+        errors: List[str] = []
+
+        for controller in self.controllers[:MAX_CONTROLLERS]:
+            ctrl_builds, ctrl_error = self._query_single_controller(
+                controller, service, cutoff_ms
+            )
+            all_builds.extend(ctrl_builds)
+            if ctrl_error:
+                errors.append(ctrl_error)
+
+        all_builds.sort(key=lambda b: b.get("timestamp", 0), reverse=True)
+        return True, all_builds, "; ".join(errors) if errors else None
+
+    def _query_single_controller(
+        self, controller: Dict, service: Optional[str], cutoff_ms: int
+    ) -> Tuple[List[Dict], Optional[str]]:
+        """Query builds from a single controller. Returns (builds, error_msg)."""
+        controller_url = controller.get("base_url")
+        controller_name = controller.get("name") or controller_url or "unknown"
+        if not controller_url:
+            return [], None
+
+        try:
+            client = JenkinsClient(
+                base_url=controller_url.rstrip("/"),
+                username=controller.get("username", ""),
+                api_token=controller.get("api_token", ""),
+            )
+            ok, jobs, _ = client.list_jobs()
+            if not ok:
+                return [], f"{controller_name}: Failed to query controller"
+
+            if service:
+                jobs = [j for j in jobs if service.lower() in (j.get("name", "") or "").lower()]
+
+            builds: List[Dict] = []
+            for job in jobs[:MAX_JOBS_PER_CONTROLLER]:
+                builds.extend(
+                    self._collect_job_builds(client, job, controller_name, controller_url.rstrip("/"), cutoff_ms)
+                )
+            return builds, None
+
+        except Exception as e:
+            logger.warning("Failed to query fleet controller %s: %s", controller_name, e)
+            return [], f"{controller_name}: Failed to query controller"
+
+    @staticmethod
+    def _collect_job_builds(
+        client: JenkinsClient, job: Dict, controller_name: str, controller_url: str, cutoff_ms: int
+    ) -> List[Dict]:
+        """Return recent builds for a single job, annotated with controller/job context."""
+        job_name = job.get("name") or job.get("fullName")
+        if not job_name:
+            return []
+
+        ok, job_builds, _ = client.list_builds(job_name, limit=MAX_BUILDS_PER_CONTROLLER)
+        if not ok or not job_builds:
+            return []
+
+        collected = []
+        for build in job_builds:
+            if build.get("timestamp", 0) < cutoff_ms:
+                continue
+            build["_controller"] = controller_name
+            build["_controller_url"] = controller_url
+            build["_job"] = job_name
+            collected.append(build)
+        return collected

--- a/server/connectors/cloudbees_connector/fleet_client.py
+++ b/server/connectors/cloudbees_connector/fleet_client.py
@@ -21,12 +21,16 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from connectors.jenkins_connector.api_client import JenkinsClient
+from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
 
 MAX_CONTROLLERS = 20
 MAX_JOBS_PER_CONTROLLER = 50
 MAX_BUILDS_PER_CONTROLLER = 5
+# Shorter timeout for registration-time validation so a bulk import of
+# unreachable controllers can't stack up many 30s timeouts on one request.
+VALIDATE_TIMEOUT = 8.0
 
 
 class CloudBeesFleetClient:
@@ -76,6 +80,9 @@ class CloudBeesFleetClient:
         if not base_url or not username or not api_token:
             return False, None, "Controller is missing base_url, username, or api_token."
         client = JenkinsClient(base_url=base_url, username=username, api_token=api_token)
+        # Bound the probe so a bulk import of unreachable controllers can't stack
+        # up many long timeouts on one request thread.
+        client.timeout = VALIDATE_TIMEOUT
         return client.get_server_info()
 
     # ------------------------------------------------------------------
@@ -118,14 +125,21 @@ class CloudBeesFleetClient:
 
         all_builds: List[Dict] = []
         errors: List[str] = []
+        queried = 0
 
         for controller in self.controllers[:MAX_CONTROLLERS]:
+            queried += 1
             ctrl_builds, ctrl_error = self._query_single_controller(
                 controller, service, cutoff_ms
             )
             all_builds.extend(ctrl_builds)
             if ctrl_error:
                 errors.append(ctrl_error)
+
+        # If every controller we tried failed, surface a failure rather than a
+        # misleading empty result — otherwise the caller reports "0 builds".
+        if queried > 0 and len(errors) == queried:
+            return False, [], "; ".join(errors)
 
         all_builds.sort(key=lambda b: b.get("timestamp", 0), reverse=True)
         return True, all_builds, "; ".join(errors) if errors else None
@@ -150,7 +164,10 @@ class CloudBeesFleetClient:
                 return [], f"{controller_name}: Failed to query controller"
 
             if service:
-                jobs = [j for j in jobs if service.lower() in (j.get("name", "") or "").lower()]
+                jobs = [
+                    j for j in jobs
+                    if service.lower() in (j.get("fullName") or j.get("name") or "").lower()
+                ]
 
             builds: List[Dict] = []
             for job in jobs[:MAX_JOBS_PER_CONTROLLER]:
@@ -160,15 +177,19 @@ class CloudBeesFleetClient:
             return builds, None
 
         except Exception as e:
-            logger.warning("Failed to query fleet controller %s: %s", controller_name, e)
+            logger.warning("Failed to query fleet controller %s: %s", sanitize(controller_name), sanitize(e))
             return [], f"{controller_name}: Failed to query controller"
 
     @staticmethod
     def _collect_job_builds(
         client: JenkinsClient, job: Dict, controller_name: str, controller_url: str, cutoff_ms: int
     ) -> List[Dict]:
-        """Return recent builds for a single job, annotated with controller/job context."""
-        job_name = job.get("name") or job.get("fullName")
+        """Return recent builds for a single job, annotated with controller/job context.
+
+        Uses ``fullName`` (e.g. ``folder/job``) when present so foldered jobs are
+        queried at their real path; falls back to the leaf ``name``.
+        """
+        job_name = job.get("fullName") or job.get("name")
         if not job_name:
             return []
 

--- a/server/connectors/cloudbees_connector/fleet_client.py
+++ b/server/connectors/cloudbees_connector/fleet_client.py
@@ -149,7 +149,8 @@ class CloudBeesFleetClient:
     ) -> Tuple[List[Dict], Optional[str]]:
         """Query builds from a single controller. Returns (builds, error_msg)."""
         controller_url = controller.get("base_url")
-        controller_name = controller.get("name") or controller_url or "unknown"
+        # Extract name before touching secrets so taint analysis stays clean.
+        controller_name = str(controller.get("name") or "unknown")
         if not controller_url:
             return [], None
 
@@ -177,7 +178,7 @@ class CloudBeesFleetClient:
             return builds, None
 
         except Exception as e:
-            logger.warning("Failed to query fleet controller %s: %s", sanitize(controller_name), type(e).__name__)
+            logger.warning("Failed to query fleet controller %s: %s", controller_name, type(e).__name__)
             return [], f"{controller_name}: Failed to query controller"
 
     @staticmethod

--- a/server/connectors/cloudbees_connector/fleet_client.py
+++ b/server/connectors/cloudbees_connector/fleet_client.py
@@ -177,7 +177,7 @@ class CloudBeesFleetClient:
             return builds, None
 
         except Exception as e:
-            logger.warning("Failed to query fleet controller %s: %s", sanitize(controller_name), sanitize(e))
+            logger.warning("Failed to query fleet controller %s: %s", sanitize(controller_name), type(e).__name__)
             return [], f"{controller_name}: Failed to query controller"
 
     @staticmethod

--- a/server/routes/account_management.py
+++ b/server/routes/account_management.py
@@ -20,6 +20,7 @@ _DELETE_LOG_PREFIX = "[AccountMgmt:delete_connected_account]"
 _PROVIDER_UI_ALIAS = {
     "cloudbees_oc": "cloudbees",
     "cloudbees_fm": "cloudbees",
+    "cloudbees_fleet": "cloudbees",
 }
 
 

--- a/server/routes/cloudbees/cloudbees_routes.py
+++ b/server/routes/cloudbees/cloudbees_routes.py
@@ -137,16 +137,10 @@ def status(user_id):
     fleet_creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER)
     fleet_controllers = (fleet_creds or {}).get("controllers") or []
     if fleet_controllers and not get_token_data(user_id, CLOUDBEES_PROVIDER):
-        online = sum(1 for c in fleet_controllers if c.get("status") == "online")
         return jsonify({
             "connected": True,
             "mode": "fleet",
             "controllerCount": len(fleet_controllers),
-            "summary": {
-                "controllerCount": len(fleet_controllers),
-                "controllersOnline": online,
-                "controllersOffline": len(fleet_controllers) - online,
-            },
         })
 
     creds = _get_stored_cloudbees_credentials(user_id)

--- a/server/routes/cloudbees/cloudbees_routes.py
+++ b/server/routes/cloudbees/cloudbees_routes.py
@@ -28,7 +28,7 @@ CLOUDBEES_PROVIDER = "cloudbees"
 
 
 def _get_stored_cloudbees_credentials(user_id: str) -> Optional[Dict[str, Any]]:
-    """Get credentials from any CloudBees provider (legacy, OC, or FM)."""
+    """Get credentials from any CloudBees provider (legacy, OC, fleet, or FM)."""
     try:
         creds = get_token_data(user_id, CLOUDBEES_PROVIDER)
         if creds:
@@ -36,6 +36,9 @@ def _get_stored_cloudbees_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         oc_creds = get_token_data(user_id, CLOUDBEES_OC_PROVIDER)
         if oc_creds:
             return oc_creds
+        fleet_creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER)
+        if fleet_creds:
+            return fleet_creds
         return None
     except Exception:
         logger.error("Failed to retrieve CloudBees credentials for user %s", user_id)
@@ -129,6 +132,23 @@ def connect(user_id):
 @require_permission("connectors", "read")
 def status(user_id):
     """Check whether CloudBees CI is connected and return summary dashboard data."""
+    # Fleet mode (multiple standalone controllers, no OC) has no single server
+    # to report on — surface controller count instead of single-instance stats.
+    fleet_creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER)
+    fleet_controllers = (fleet_creds or {}).get("controllers") or []
+    if fleet_controllers and not get_token_data(user_id, CLOUDBEES_PROVIDER):
+        online = sum(1 for c in fleet_controllers if c.get("status") == "online")
+        return jsonify({
+            "connected": True,
+            "mode": "fleet",
+            "controllerCount": len(fleet_controllers),
+            "summary": {
+                "controllerCount": len(fleet_controllers),
+                "controllersOnline": online,
+                "controllersOffline": len(fleet_controllers) - online,
+            },
+        })
+
     creds = _get_stored_cloudbees_credentials(user_id)
     if not creds:
         return jsonify({"connected": False})
@@ -243,6 +263,7 @@ def disconnect(user_id):
 
 CLOUDBEES_OC_PROVIDER = "cloudbees_oc"
 CLOUDBEES_FM_PROVIDER = "cloudbees_fm"
+CLOUDBEES_FLEET_PROVIDER = "cloudbees_fleet"
 
 
 @cloudbees_bp.route("/connect-platform", methods=["POST"])
@@ -382,9 +403,17 @@ def platform_status(user_id):
             "app_id": fm_creds.get("app_id"),
         }
 
+    # Check fleet (standalone multi-controller, no OC)
+    fleet_status = {"connected": False}
+    fleet_creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER)
+    fleet_controllers = (fleet_creds or {}).get("controllers") or []
+    if fleet_controllers:
+        fleet_status = {"connected": True, "count": len(fleet_controllers)}
+
     return jsonify({
         "operations_center": oc_status,
         "feature_management": fm_status,
+        "fleet": fleet_status,
     })
 
 
@@ -417,11 +446,11 @@ def list_controllers(user_id):
 @cloudbees_bp.route("/disconnect-platform", methods=["POST", "DELETE"])
 @require_permission("connectors", "write")
 def disconnect_platform(user_id):
-    """Disconnect Operations Center and Feature Management by removing stored credentials."""
+    """Disconnect Operations Center, Feature Management, and controller fleet by removing stored credentials."""
     deleted_total = 0
     errors = []
 
-    for provider in (CLOUDBEES_OC_PROVIDER, CLOUDBEES_FM_PROVIDER):
+    for provider in (CLOUDBEES_OC_PROVIDER, CLOUDBEES_FM_PROVIDER, CLOUDBEES_FLEET_PROVIDER):
         try:
             success, deleted = delete_user_secret(user_id, provider)
             if success:
@@ -439,6 +468,193 @@ def disconnect_platform(user_id):
         "success": len(errors) == 0,
         "message": "Platform credentials removed" if not errors else "; ".join(errors),
         "deleted": deleted_total,
+    })
+
+
+# ------------------------------------------------------------------
+# Fleet: multiple standalone controllers WITHOUT Operations Center
+# ------------------------------------------------------------------
+
+MAX_FLEET_CONTROLLERS = 20
+
+
+def _public_controller(ctrl: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip credentials from a stored controller for API responses."""
+    return {
+        "id": ctrl.get("id"),
+        "name": ctrl.get("name") or ctrl.get("base_url", ""),
+        "url": ctrl.get("base_url", ""),
+        "username": ctrl.get("username", ""),
+        "status": ctrl.get("status", "unknown"),
+        "last_error": ctrl.get("last_error"),
+    }
+
+
+def _normalize_controller_input(raw: Any) -> list:
+    """Coerce request body into a list of {name,url,username,token} dicts."""
+    if isinstance(raw, dict):
+        # Either a single controller, or {"controllers": [...]}
+        if isinstance(raw.get("controllers"), list):
+            return raw["controllers"]
+        return [raw]
+    if isinstance(raw, list):
+        return raw
+    return []
+
+
+def _check_controller_fields(item: Dict[str, Any], by_url: Dict[str, Any]) -> tuple:
+    """Extract and statically validate one controller's fields.
+
+    Returns (fields, error_dict) with exactly one non-None. ``fields`` is a
+    (base_url, username, api_token, name) tuple when valid.
+    """
+    base_url = (item.get("url") or item.get("base_url") or "").strip().rstrip("/")
+    username = (item.get("username") or "").strip()
+    api_token = item.get("token") or item.get("api_token")
+    name = (item.get("name") or "").strip() or base_url
+
+    url_ok = base_url.startswith(("http://", "https://"))  # NOSONAR
+    if not url_ok:
+        return None, {"name": name, "error": "URL must start with http:// or https://"}
+    if not username or not api_token or not isinstance(api_token, str):
+        return None, {"name": name, "error": "username and token are required"}
+    if len(by_url) >= MAX_FLEET_CONTROLLERS and base_url not in by_url:
+        return None, {"name": name, "error": f"Fleet limit of {MAX_FLEET_CONTROLLERS} controllers reached"}
+
+    return (base_url, username, api_token, name), None
+
+
+def _validate_controller_item(item: Any, by_url: Dict[str, Any]) -> tuple:
+    """Validate and normalize one controller input.
+
+    Returns (cfg, error_dict). Exactly one is non-None: ``cfg`` is the stored
+    controller dict (with status/last_error set), or ``error_dict`` describes
+    why the item was rejected.
+    """
+    if not isinstance(item, dict):
+        return None, {"error": "Each controller must be an object", "value": str(item)[:80]}
+
+    fields, error_dict = _check_controller_fields(item, by_url)
+    if error_dict:
+        return None, error_dict
+    base_url, username, api_token, name = fields
+
+    cfg = {
+        "id": (by_url.get(base_url, {}).get("id")) or secrets.token_hex(8),
+        "name": name,
+        "base_url": base_url,
+        "username": username,
+        "api_token": api_token,
+    }
+
+    from connectors.cloudbees_connector.fleet_client import CloudBeesFleetClient
+    ok, _, error = CloudBeesFleetClient.validate_controller(cfg)
+    cfg["status"] = "online" if ok else "offline"
+    cfg["last_error"] = None if ok else (error or "Validation failed")
+    return cfg, None
+
+
+@cloudbees_bp.route("/fleet/controllers", methods=["POST"])
+@require_permission("connectors", "write")
+def add_fleet_controllers(user_id):
+    """Add one or more standalone controllers to the user's fleet.
+
+    Accepts a single controller object or a JSON array (bulk import). Each
+    controller is validated against its own /api/json; unreachable controllers
+    are still stored but marked 'offline' with the validation error (partial
+    validation — a single down controller does not block the whole fleet).
+    """
+    try:
+        body = request.get_json(force=True, silent=True)
+    except Exception:
+        body = None
+
+    incoming = _normalize_controller_input(body)
+    if not incoming:
+        return jsonify({"error": "Provide a controller object or a non-empty JSON array of controllers"}), 400
+
+    # Load existing fleet (merge/append, dedup by base_url)
+    existing = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER) or {}
+    controllers: list = list(existing.get("controllers") or [])
+    webhook_secret = existing.get("webhook_secret") or secrets.token_hex(32)
+    by_url = {(c.get("base_url") or "").rstrip("/"): c for c in controllers}
+
+    added, failed = [], []
+    for item in incoming:
+        cfg, error_dict = _validate_controller_item(item, by_url)
+        if error_dict:
+            failed.append(error_dict)
+            continue
+        by_url[cfg["base_url"]] = cfg
+        added.append(_public_controller(cfg))
+
+    controllers = list(by_url.values())
+    if not controllers:
+        return jsonify({"error": "No valid controllers provided", "failed": failed}), 400
+
+    payload = {"controllers": controllers, "webhook_secret": webhook_secret}
+    try:
+        store_tokens_in_db(user_id, payload, CLOUDBEES_FLEET_PROVIDER)
+        logger.info("[CLOUDBEES] Stored fleet for user %s (%d controllers)", user_id, len(controllers))
+    except Exception:
+        logger.exception("[CLOUDBEES] Failed to store fleet for user %s", user_id)
+        return jsonify({"error": "Failed to store controller fleet"}), 500
+
+    return jsonify({
+        "success": True,
+        "controllers": [_public_controller(c) for c in controllers],
+        "added": added,
+        "failed": failed,
+        "count": len(controllers),
+    })
+
+
+@cloudbees_bp.route("/fleet/controllers", methods=["GET"])
+@require_permission("connectors", "read")
+def list_fleet_controllers(user_id):
+    """Return the user's registered controller fleet (credentials omitted)."""
+    creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER) or {}
+    controllers = creds.get("controllers") or []
+    return jsonify({
+        "connected": len(controllers) > 0,
+        "controllers": [_public_controller(c) for c in controllers],
+        "count": len(controllers),
+    })
+
+
+@cloudbees_bp.route("/fleet/controllers/<controller_id>", methods=["DELETE"])
+@require_permission("connectors", "write")
+def remove_fleet_controller(user_id, controller_id: str):
+    """Remove a single controller from the fleet. Clears the fleet if it was the last one."""
+    creds = get_token_data(user_id, CLOUDBEES_FLEET_PROVIDER) or {}
+    controllers = creds.get("controllers") or []
+    if not controllers:
+        return jsonify({"error": "No controllers registered"}), 404
+
+    remaining = [c for c in controllers if c.get("id") != controller_id]
+    if len(remaining) == len(controllers):
+        return jsonify({"error": "Controller not found"}), 404
+
+    if not remaining:
+        # Last controller removed — delete the whole secret
+        try:
+            delete_user_secret(user_id, CLOUDBEES_FLEET_PROVIDER)
+        except Exception:
+            logger.exception("[CLOUDBEES] Failed to clear empty fleet for user %s", user_id)
+            return jsonify({"error": "Failed to remove controller"}), 500
+        return jsonify({"success": True, "controllers": [], "count": 0})
+
+    payload = {"controllers": remaining, "webhook_secret": creds.get("webhook_secret") or secrets.token_hex(32)}
+    try:
+        store_tokens_in_db(user_id, payload, CLOUDBEES_FLEET_PROVIDER)
+    except Exception:
+        logger.exception("[CLOUDBEES] Failed to update fleet for user %s", user_id)
+        return jsonify({"error": "Failed to remove controller"}), 500
+
+    return jsonify({
+        "success": True,
+        "controllers": [_public_controller(c) for c in remaining],
+        "count": len(remaining),
     })
 
 
@@ -464,8 +680,8 @@ def _verify_webhook_user(user_id: str) -> bool:
                 if not set_rls_context(cursor, conn, user_id, log_prefix="[CLOUDBEES:verify_webhook]"):
                     return False
                 cursor.execute(
-                    "SELECT 1 FROM user_tokens WHERE user_id = %s AND provider IN (%s, %s) LIMIT 1",
-                    (user_id, CLOUDBEES_PROVIDER, CLOUDBEES_OC_PROVIDER),
+                    "SELECT 1 FROM user_tokens WHERE user_id = %s AND provider IN (%s, %s, %s) LIMIT 1",
+                    (user_id, CLOUDBEES_PROVIDER, CLOUDBEES_OC_PROVIDER, CLOUDBEES_FLEET_PROVIDER),
                 )
                 return cursor.fetchone() is not None
     except Exception as e:

--- a/server/routes/cloudbees/cloudbees_routes.py
+++ b/server/routes/cloudbees/cloudbees_routes.py
@@ -473,12 +473,15 @@ MAX_FLEET_CONTROLLERS = 20
 
 
 def _public_controller(ctrl: Dict[str, Any]) -> Dict[str, Any]:
-    """Strip credentials from a stored controller for API responses."""
+    """Strip credentials from a stored controller for API responses.
+
+    Omits both the API token AND the username — the username is the auth
+    principal for the token, so it is not exposed to the frontend.
+    """
     return {
         "id": ctrl.get("id"),
         "name": ctrl.get("name") or ctrl.get("base_url", ""),
         "url": ctrl.get("base_url", ""),
-        "username": ctrl.get("username", ""),
         "status": ctrl.get("status", "unknown"),
         "last_error": ctrl.get("last_error"),
     }

--- a/server/routes/connector_status.py
+++ b/server/routes/connector_status.py
@@ -912,11 +912,13 @@ def _check_all_connectors(
                 logger.warning("[STATUS] %s check timed out: %s", prov, exc)
                 results[prov] = {"connected": False}
 
-    # CloudBees OC/PAT (cloudbees_oc) and FM (cloudbees_fm) are stored as separate
-    # providers but surface under the single "cloudbees" connector card in the UI.
+    # CloudBees OC/PAT (cloudbees_oc), FM (cloudbees_fm), and the standalone
+    # controller fleet (cloudbees_fleet) are stored as separate providers but
+    # surface under the single "cloudbees" connector card in the UI.
     if not results.get("cloudbees", {}).get("connected") and (
         results.get("cloudbees_oc", {}).get("connected")
         or results.get("cloudbees_fm", {}).get("connected")
+        or results.get("cloudbees_fleet", {}).get("connected")
     ):
         results["cloudbees"] = {"connected": True}
 


### PR DESCRIPTION
## Context

A client runs **multiple standalone, self-hosted CloudBees CI controllers but has no Operations Center (CJOC)**. Aurora's existing multi-controller support is exclusive to the OC path. There is no way to auto-discover or auth across standalone controllers without OC — API tokens are controller-local and no fleet/registry endpoint exists. So this lets the user **manually register a fleet of controllers**, each with its own URL/username/token, and treats that stored list the way OC-discovered controllers are treated.

## What's included

**Backend**
- `CloudBeesFleetClient` (`server/connectors/cloudbees_connector/fleet_client.py`) — per-controller credentials, cross-controller build queries, discovery, and a URL-allowlist SSRF guard (only talks to registered controllers)
- `cloudbees_fleet` provider + `POST/GET/DELETE /fleet/controllers` in `cloudbees_routes.py`; partial validation (unreachable controllers saved as `offline` with the error so a single down controller doesn't block setup); folded into status, platform-status, webhook auth, and disconnect
- `cloudbees_rca` tool: `controller_list` / `cross_controller_deployments` / per-controller build introspection fall back to the fleet when no OC is connected
- `cloudbees` SKILL.md + tool description updated

**Frontend**
- New **"Multiple Controllers"** wizard mode: add controllers one at a time + JSON bulk import
- Connected dashboard lists controllers, shows offline errors, and supports per-controller removal

## Storage note
`user_tokens` is one-row-per-`(org, provider)`, so the fleet is stored as a **single JSON-array secret** under `cloudbees_fleet` via the existing Vault secret-ref flow. **No DB migration.**

## Verification
- `CloudBeesFleetClient` unit-tested in isolation: partial validation (online/offline), cross-controller aggregation, SSRF guard
- All modules import cleanly in the live server container; all 3 fleet endpoints registered; server/celery/chatbot restarted healthy
- Client TypeScript check clean on all touched files
- **SonarCloud:** analyzed changed files; resolved 2 CRITICAL cognitive-complexity findings via helper extraction — re-analysis returns 0 issues

## Out of scope
No K8s/DNS auto-discovery, no CloudBees SaaS platform API (client is self-hosted). Deployment webhook processing unchanged (fleet deploys arrive as `provider="cloudbees"` as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Multiple Controllers** (“fleet”) connection mode for standalone CloudBees controller fleets (including bulk JSON import and fleet controller management with per-controller removal).
  * Platform/connection status now reflects fleet connectivity and available controller count; CloudBees RCA supports fleet mode when Operations Center isn’t connected.
* **Bug Fixes**
  * Improved controller status display with per-controller offline/error details.
  * Disconnect/removal now consistently clears fleet connection state and saved settings, keeping the UI in sync.
* **Documentation**
  * Updated CloudBees RCA skill/tool documentation to cover multi-controller fleet usage alongside Operations Center.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->