### PR TITLE
fix(auth): resolve org context safely in Celery — fixes two recurring prod ERRORs

### DIFF
--- a/server/routes/datadog/datadog_routes.py
+++ b/server/routes/datadog/datadog_routes.py
@@ -11,7 +11,7 @@ from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize, hash_for_log
 from utils.auth.token_management import get_token_data, store_tokens_in_db
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import get_org_id_from_request, resolve_org_id, set_rls_context
 from utils.secrets.secret_ref_utils import delete_user_secret
 logger = logging.getLogger(__name__)
 
@@ -245,7 +245,10 @@ def _get_stored_datadog_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         if data:
             return data
 
-        org_id = get_org_id_from_request()
+        # resolve_org_id() works in and out of request context (DB fallback);
+        # get_org_id_from_request() raises "working outside of application
+        # context" when called from Celery tasks.
+        org_id = resolve_org_id(user_id)
         if not org_id:
             return None
 

--- a/server/routes/newrelic/newrelic_routes.py
+++ b/server/routes/newrelic/newrelic_routes.py
@@ -18,7 +18,7 @@ from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 from utils.auth.token_management import get_token_data, store_tokens_in_db
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import get_org_id_from_request, resolve_org_id, set_rls_context
 from utils.secrets.secret_ref_utils import delete_user_secret
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,10 @@ def _get_stored_newrelic_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         if data:
             return data
 
-        org_id = get_org_id_from_request()
+        # resolve_org_id() works in and out of request context (DB fallback);
+        # get_org_id_from_request() raises "working outside of application
+        # context" when called from Celery tasks.
+        org_id = resolve_org_id(user_id)
         if not org_id:
             return None
 

--- a/server/routes/opsgenie/opsgenie_routes.py
+++ b/server/routes/opsgenie/opsgenie_routes.py
@@ -13,7 +13,7 @@ from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 from utils.auth.token_management import get_token_data, store_tokens_in_db
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import get_org_id_from_request, resolve_org_id, set_rls_context
 from utils.secrets.secret_ref_utils import delete_user_secret
 
 logger = logging.getLogger(__name__)
@@ -408,7 +408,10 @@ def _get_stored_opsgenie_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         if data:
             return data
 
-        org_id = get_org_id_from_request()
+        # resolve_org_id() works in and out of request context (DB fallback);
+        # get_org_id_from_request() raises "working outside of application
+        # context" when called from Celery tasks.
+        org_id = resolve_org_id(user_id)
         if not org_id:
             return None
 

--- a/server/routes/sentry/sentry_routes.py
+++ b/server/routes/sentry/sentry_routes.py
@@ -23,7 +23,7 @@ from utils.db.connection_pool import db_pool
 from utils.log_sanitizer import sanitize
 from utils.auth.token_management import get_token_data, store_tokens_in_db
 from utils.auth.rbac_decorators import require_permission
-from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
+from utils.auth.stateless_auth import get_org_id_from_request, resolve_org_id, set_rls_context
 from utils.secrets.secret_ref_utils import delete_user_secret
 from routes.sentry.tasks import extract_sentry_title, process_sentry_event
 
@@ -43,7 +43,10 @@ def _get_stored_sentry_credentials(user_id: str) -> Optional[Dict[str, Any]]:
         if data:
             return data
 
-        org_id = get_org_id_from_request()
+        # resolve_org_id() works in and out of request context (DB fallback);
+        # get_org_id_from_request() raises "working outside of application
+        # context" when called from Celery tasks.
+        org_id = resolve_org_id(user_id)
         if not org_id:
             return None
 

--- a/server/tests/auth/test_command_policy.py
+++ b/server/tests/auth/test_command_policy.py
@@ -318,7 +318,7 @@ class TestFailOpenOnDbError:
     def test_partial_db_failure_after_rule_fetch_still_returns_disabled(
         self, monkeypatch,
     ):
-        """Rule SELECT succeeds, ``get_user_preference`` raises -> still fail-open."""
+        """Rule SELECT succeeds, ``get_org_preference`` raises -> still fail-open."""
         import utils.auth.stateless_auth as sa_module
         import utils.db.connection_pool as cp_module
 
@@ -331,7 +331,7 @@ class TestFailOpenOnDbError:
         monkeypatch.setattr(cp_module, "db_pool", pool)
         monkeypatch.setattr(
             sa_module,
-            "get_user_preference",
+            "get_org_preference",
             MagicMock(side_effect=RuntimeError("preference table gone")),
         )
 
@@ -350,7 +350,7 @@ class TestFailOpenOnDbError:
         broken_pool.get_admin_connection.side_effect = RuntimeError("db down")
         monkeypatch.setattr(cp_module, "db_pool", broken_pool)
         monkeypatch.setattr(
-            sa_module, "get_user_preference", MagicMock(return_value="off"),
+            sa_module, "get_org_preference", MagicMock(return_value="off"),
         )
 
         now_ts = time.monotonic()
@@ -373,7 +373,7 @@ class TestFailOpenOnDbError:
         recovered_pool.get_admin_connection.return_value.__enter__.return_value = deny_conn
         monkeypatch.setattr(cp_module, "db_pool", recovered_pool)
         monkeypatch.setattr(
-            sa_module, "get_user_preference", MagicMock(side_effect=lambda *a, **kw: "on"),
+            sa_module, "get_org_preference", MagicMock(side_effect=lambda *a, **kw: "on"),
         )
 
         _, deny2, states2 = command_policy._get_cached("org-7")
@@ -381,6 +381,74 @@ class TestFailOpenOnDbError:
         assert states2.denylist_enabled is True
         assert len(deny2) == 1
         assert deny2[0].id == 10
+
+
+# ---------------------------------------------------------------------------
+# Org-scoped list-state read path (regression for "Missing org_id ... cannot
+# set RLS context" — see stateless_auth.set_rls_context)
+# ---------------------------------------------------------------------------
+
+
+class TestListStatesReadViaOrgPreference:
+    """``_fetch`` must read the allowlist/denylist enabled flags with
+    ``get_org_preference(org_id, ...)``.
+
+    These flags are written by ``store_org_preference`` against a synthetic
+    ``__org__<uuid>`` user id. The old code read them back with
+    ``get_user_preference("__org__<uuid>", ...)``, which routed through
+    ``set_rls_context`` -> ``get_org_id_for_user`` and tried to resolve the
+    pseudo-id against the users table. That always failed, logging
+    "Missing org_id for user __org__...; cannot set RLS context" on every
+    command evaluation and silently defaulting BOTH lists to "off" — i.e.
+    disabling the org command policy. This pins the org-scoped read so the
+    regression cannot return.
+    """
+
+    def _stub_rule_select(self, monkeypatch):
+        """Make the rule SELECT succeed with no rows so _fetch reaches the
+        preference read."""
+        import utils.db.connection_pool as cp_module
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cursor
+        pool = MagicMock()
+        pool.get_admin_connection.return_value.__enter__.return_value = conn
+        monkeypatch.setattr(cp_module, "db_pool", pool)
+
+    def test_fetch_reads_states_with_get_org_preference_by_org_id(
+        self, monkeypatch,
+    ):
+        import utils.auth.stateless_auth as sa_module
+
+        self._stub_rule_select(monkeypatch)
+
+        calls = []
+
+        def fake_get_org_preference(org_id, key, default=None):
+            calls.append((org_id, key))
+            return "on"
+
+        get_user_pref = MagicMock(
+            side_effect=AssertionError(
+                "command policy must not read org list-states via "
+                "get_user_preference (pseudo-user RLS lookup fails)"
+            )
+        )
+        monkeypatch.setattr(sa_module, "get_org_preference", fake_get_org_preference)
+        monkeypatch.setattr(sa_module, "get_user_preference", get_user_pref)
+
+        _, _, states = command_policy._fetch("org-42")
+
+        # Read with the real org_id, never an "__org__"-prefixed pseudo-user.
+        assert ("org-42", "command_policy_allowlist") in calls
+        assert ("org-42", "command_policy_denylist") in calls
+        assert all(not str(org).startswith("__org__") for org, _ in calls)
+        get_user_pref.assert_not_called()
+
+        assert states.allowlist_enabled is True
+        assert states.denylist_enabled is True
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/auth/test_integration_credentials_context_safe.py
+++ b/server/tests/auth/test_integration_credentials_context_safe.py
@@ -1,0 +1,73 @@
+"""Regression guard: integration credential helpers must resolve org context
+in a request-context-safe way.
+
+The ``_get_stored_*_credentials`` helpers for Opsgenie / Sentry / New Relic /
+Datadog are invoked from Celery tasks (event processing, RCA correlation) as
+well as from HTTP routes. They used to call ``get_org_id_from_request()``,
+which touches ``flask.request`` / ``flask.g`` and raises
+
+    RuntimeError: Working outside of application context.
+
+when there is no Flask request context — i.e. on every Celery invocation. The
+helper caught it and logged
+``[<PROVIDER>] Failed to retrieve credentials for user <id>: Working outside
+of application context``, so org-shared integration credentials could not be
+loaded in background work.
+
+The fix is to resolve org context with ``resolve_org_id(user_id)``, which is
+documented as safe to call inside OR outside a request context (it falls back
+to a direct DB lookup). This test parses the helper source with ``ast`` so it
+needs none of the heavy runtime deps (Redis, casbin, ...) the route modules
+import at module load.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+import pytest
+
+_SERVER_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+
+# (module path relative to server/, credential-helper function name)
+_CREDENTIAL_HELPERS = [
+    ("routes/opsgenie/opsgenie_routes.py", "_get_stored_opsgenie_credentials"),
+    ("routes/sentry/sentry_routes.py", "_get_stored_sentry_credentials"),
+    ("routes/newrelic/newrelic_routes.py", "_get_stored_newrelic_credentials"),
+    ("routes/datadog/datadog_routes.py", "_get_stored_datadog_credentials"),
+]
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found")
+
+
+def _called_names(func: ast.FunctionDef) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+    return names
+
+
+@pytest.mark.parametrize("rel_path,func_name", _CREDENTIAL_HELPERS)
+def test_credential_helper_is_request_context_safe(rel_path, func_name):
+    source = open(os.path.join(_SERVER_DIR, rel_path)).read()
+    func = _find_function(ast.parse(source), func_name)
+    called = _called_names(func)
+
+    assert "get_org_id_from_request" not in called, (
+        f"{rel_path}:{func_name} calls get_org_id_from_request(), which raises "
+        "'Working outside of application context' from Celery tasks. Use "
+        "resolve_org_id(user_id) instead."
+    )
+    assert "resolve_org_id" in called, (
+        f"{rel_path}:{func_name} must resolve org context via "
+        "resolve_org_id(user_id) so it works outside a Flask request context."
+    )

--- a/server/utils/auth/command_policy.py
+++ b/server/utils/auth/command_policy.py
@@ -84,7 +84,7 @@ def _fetch(org_id: str) -> Tuple[List[PolicyRule], List[PolicyRule], ListStates]
 
     try:
         from utils.db.connection_pool import db_pool
-        from utils.auth.stateless_auth import get_user_preference
+        from utils.auth.stateless_auth import get_org_preference
 
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
@@ -112,9 +112,15 @@ def _fetch(org_id: str) -> Tuple[List[PolicyRule], List[PolicyRule], ListStates]
                     else:
                         deny_rules.append(rule)
 
-        org_pref_key = f"__org__{org_id}"
-        al_raw = get_user_preference(org_pref_key, "command_policy_allowlist") or "off"
-        dl_raw = get_user_preference(org_pref_key, "command_policy_denylist") or "off"
+        # Read org-scoped list states written via store_org_preference().
+        # These rows use a synthetic "__org__<uuid>" user id, so they must be
+        # read with get_org_preference() (RLS configured from org_id directly).
+        # The old get_user_preference("__org__<uuid>", ...) path tried to
+        # resolve that pseudo-id against the users table, which always failed
+        # ("Missing org_id ... cannot set RLS context") and silently defaulted
+        # both lists to "off" — disabling policy enforcement.
+        al_raw = get_org_preference(org_id, "command_policy_allowlist") or "off"
+        dl_raw = get_org_preference(org_id, "command_policy_denylist") or "off"
         states = ListStates(
             allowlist_enabled=(str(al_raw).lower() == "on"),
             denylist_enabled=(str(dl_raw).lower() == "on"),


### PR DESCRIPTION
## Summary

Two distinct ERROR-level log lines fire continuously in production from the `celery-worker` pods. Both are caused by resolving org context in a way that only works inside a Flask **request** context, so they fail on every Celery (background-task) invocation. Verified against production logs (7-day window):

| Error | Volume / 7d | Where |
|-------|-------------|-------|
| `[Prefs:get] Missing org_id for user __org__…; cannot set RLS context` | ~1,887 (~250/day, ~20 orgs) | `utils.auth.stateless_auth` via `command_policy._fetch` |
| `[OPSGENIE/SENTRY/NEWRELIC/DATADOG] Failed to retrieve credentials for user …: Working outside of application context` | ~1,896 (~250/day, ~20 users) | the four `_get_stored_*_credentials` helpers |

Both were still firing as of investigation time.

## Root cause & fix

**1. Command policy disabled silently (`command_policy.py`)**
`_fetch` read the org-scoped allowlist/denylist enabled flags with `get_user_preference("__org__<uuid>", ...)`. Those flags are written by `store_org_preference` against a synthetic `__org__<uuid>` user id that does not exist in the `users` table. `get_user_preference` → `set_rls_context` → `get_org_id_for_user` therefore failed to resolve an org, logged `Missing org_id … cannot set RLS context`, and (because the read returned nothing) **defaulted both lists to `"off"` — silently disabling the org command policy** on every evaluation.

Fix: read via `get_org_preference(org_id, ...)`, the symmetric reader that pairs with `store_org_preference` and configures RLS from `org_id` directly. (`get_org_id_from_request` is unaffected; this is the org-pref read path.)

**2. Integration credentials fail in Celery (`opsgenie`/`sentry`/`newrelic`/`datadog` routes)**
The `_get_stored_*_credentials` helpers resolved org via `get_org_id_from_request()`, which touches `flask.request`/`flask.g` and raises `RuntimeError: Working outside of application context` when called from Celery tasks (event processing, RCA correlation). The helper caught it and returned `None`, so org-shared integration credentials couldn't load in background work.

Fix: resolve org via `resolve_org_id(user_id)` — already documented in the codebase as *"working both inside and outside Flask request context … Safe to call from Celery tasks"* (DB fallback).

Both replacement functions already existed; this PR just routes the callers to them. Minimal, low-risk.

## Tests

- **New** `test_command_policy.py::TestListStatesReadViaOrgPreference` — pins the org-scoped read path; **fails on the old `get_user_preference` code**, passes on the fix.
- **New** `test_integration_credentials_context_safe.py` — ast-based guard pinning all four credential helpers to `resolve_org_id` and forbidding `get_org_id_from_request`; **fails on the old code**, passes on the fix. (ast-based so it needs none of the route modules' heavy runtime deps.)
- Updated existing `_fetch` fail-open tests to patch `get_org_preference`.
- `pytest tests/auth tests/security` → **475 passed**.

## Not included
Two other findings from the same investigation are intentionally out of scope (lower severity / different class): a `TTLCache.ttl` setter `WARNING` (high-volume but harmless cache-disable) and a transient `t2v-transformers` DNS burst on Jun 28 that has self-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
