### PR TITLE
chore(helm): add SUMMARIZATION_MODEL chart default

### DIFF
--- a/deploy/helm/aurora/values.yaml
+++ b/deploy/helm/aurora/values.yaml
@@ -262,6 +262,8 @@ config:
   RCA_ORCHESTRATOR_MODEL: ""
   # * Only when ORCHESTRATOR_ENABLED=true — sub-agent investigator model.
   RCA_SUBAGENT_MODEL: ""
+  # Lightweight model for mechanical summarization (tool-output capping, alert/repo summaries). Empty = falls back to MAIN_MODEL.
+  SUMMARIZATION_MODEL: ""
 
   # --- AWS Bedrock (non-secret config; credentials live in secrets.llm) ---
   # Gateway mode: set BEDROCK_BASE_URL to an OpenAI-compatible endpoint in front of


### PR DESCRIPTION
## Summary
- Adds the missing `SUMMARIZATION_MODEL` default to the Helm chart `values.yaml` (empty string = falls back to `MAIN_MODEL`).
- The `SUMMARIZATION_MODEL` env var is already consumed by the server (`server/chat/backend/agent/llm.py`) and present in `docker-compose.yaml` / `.env.example` on `main`; only the Helm default was missing, so Helm-based deployments couldn't set a cheaper summarization model without an ad-hoc override.

## Why separate
Split out of the prompt-caching PR (#568), where it was batched in by mistake during a Helm-defaults cleanup. It's unrelated to caching.

## Test plan
- [ ] `helm template deploy/helm/aurora` renders with `SUMMARIZATION_MODEL` present and defaulting to empty.
- [ ] Setting `config.SUMMARIZATION_MODEL=google/gemini-2.5-flash` propagates to the pod env.