### PR TITLE
fix: enforce RLS by downgrading DB connection role to non-superuser

### DIFF
--- a/server/services/actions/postmortem_action.py
+++ b/server/services/actions/postmortem_action.py
@@ -19,6 +19,7 @@ def _get_action_instructions(user_id: str) -> tuple:
     try:
         with db_pool.get_connection() as conn:
             with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[PostmortemAction:instructions]")
                 cur.execute(
                     """SELECT a.instructions, a.id, a.org_id FROM actions a
                        JOIN users u ON u.org_id = a.org_id

--- a/server/tests/db/test_connection_pool.py
+++ b/server/tests/db/test_connection_pool.py
@@ -41,7 +41,13 @@ from utils.db import connection_pool as cp_module  # noqa: E402
 from utils.db.connection_pool import DatabaseConnectionPool  # noqa: E402
 
 
-_RESET_SQL = "RESET myapp.current_user_id; RESET myapp.current_org_id;"
+_RESET_SQL = (
+    "RESET ROLE; "
+    "RESET myapp.current_user_id; "
+    "RESET myapp.current_org_id; "
+    "RESET myapp.mcp_token_resolve; "
+    "RESET myapp.kubectl_token_resolve;"
+)
 
 
 def _make_conn():
@@ -159,10 +165,13 @@ class TestSetRlsVarsFromRequest:
         assert not any(s.startswith("SET myapp.") for s in sql)
 
     def test_set_failure_does_not_abort_yield(self, fresh_pool, flask_app):
-        """If the SET cursor raises, get_connection still yields the conn."""
+        """If the SET RLS vars cursor raises, get_connection still yields the conn.
+        (SET ROLE succeeds, but SET myapp.* fails)
+        """
         pool, factory = fresh_pool
         connection, cursor = _make_conn()
-        cursor.execute.side_effect = [Exception("set failed"), None, None]
+        # SET ROLE succeeds, then SET myapp.current_user_id raises, then RESET succeeds
+        cursor.execute.side_effect = [None, Exception("set failed"), None, None]
         factory.return_value.getconn.return_value = connection
 
         with flask_app.test_request_context(
@@ -230,7 +239,8 @@ class TestGetConnectionCleanup:
         pool, factory = fresh_pool
         connection, cursor = _make_conn()
         factory.return_value.getconn.return_value = connection
-        cursor.execute.side_effect = [None, None, Exception("conn lost")]
+        # SET ROLE succeeds, SET user_id succeeds, SET org_id succeeds, RESET raises
+        cursor.execute.side_effect = [None, None, None, Exception("conn lost")]
 
         with flask_app.test_request_context(
             "/api/x", headers={"X-User-ID": "u-1", "X-Org-ID": "org-7"},
@@ -238,8 +248,8 @@ class TestGetConnectionCleanup:
             with pool.get_connection() as conn:
                 assert conn is connection
 
-        assert _RESET_SQL in _executed_sql(cursor)
-        factory.return_value.putconn.assert_called_once_with(connection)
+        # Connection should be discarded (closed) since reset failed
+        factory.return_value.putconn.assert_called_once_with(connection, close=True)
 
     def test_putconn_failure_swallowed(self, fresh_pool):
         """``pool.putconn`` raising must be logged, not propagated."""
@@ -361,8 +371,8 @@ class TestRLSContextAdversarial:
         """
         pool, factory = fresh_pool
         connection, cursor = _make_conn()
-        # First execute (SET user_id) raises; subsequent calls (RESET) succeed.
-        cursor.execute.side_effect = [Exception("db gone"), None, None]
+        # SET ROLE succeeds, then SET user_id raises; subsequent calls (RESET) succeed.
+        cursor.execute.side_effect = [None, Exception("db gone"), None, None]
         factory.return_value.getconn.return_value = connection
 
         with (

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -141,10 +141,10 @@ class DatabaseConnectionPool:
     def get_connection(self):
         """Get a connection from the pool with automatic cleanup.
 
-        Automatically sets RLS session variables (myapp.current_user_id,
-        myapp.current_org_id) from the Flask request context when available.
-        This ensures all queries on RLS-protected tables work correctly
-        without callers needing to SET them manually.
+        Downgrades to the aurora_app role (NOSUPERUSER NOBYPASSRLS) so that
+        PostgreSQL RLS policies are enforced. Also sets RLS session variables
+        (myapp.current_user_id, myapp.current_org_id) from the Flask request
+        context when available.
         """
         pool = self._get_pool()
         connection = None
@@ -152,6 +152,7 @@ class DatabaseConnectionPool:
             connection = self._getconn_with_retry(pool)
             if connection:
                 connection.autocommit = False
+                self._downgrade_role(connection)
                 self._set_rls_vars(connection)
                 logger.debug("Retrieved connection from pool")
                 yield connection
@@ -169,7 +170,49 @@ class DatabaseConnectionPool:
             if connection:
                 try:
                     connection.rollback()
-                    with connection.cursor() as cur:  # No RLS needed — pool cleanup (RESET vars)
+                    with connection.cursor() as cur:
+                        cur.execute(
+                            "RESET ROLE; RESET myapp.current_user_id; RESET myapp.current_org_id;"
+                        )
+                    connection.commit()
+                except Exception as e:
+                    logger.warning("Failed to reset session vars on pool return: %s", e)
+                try:
+                    self._putconn_notify(pool, connection)
+                except Exception as e:
+                    logger.error("Error returning connection to pool: %s", e)
+
+    @contextmanager
+    def get_admin_connection(self):
+        """Get a connection that retains superuser privileges (bypasses RLS).
+
+        Use ONLY for: DDL/migrations, cross-org background tasks that
+        explicitly call set_rls_context() per-org, and bootstrap queries
+        (e.g. auth registration before org context exists).
+        """
+        pool = self._get_pool()
+        connection = None
+        try:
+            connection = self._getconn_with_retry(pool)
+            if connection:
+                connection.autocommit = False
+                logger.debug("Retrieved admin connection from pool (no role downgrade)")
+                yield connection
+            else:
+                raise Exception("Failed to get connection from pool")
+        except Exception as e:
+            if connection:
+                try:
+                    connection.rollback()
+                except Exception:
+                    pass
+            logger.error(f"Error with admin connection: {e}")
+            raise
+        finally:
+            if connection:
+                try:
+                    connection.rollback()
+                    with connection.cursor() as cur:
                         cur.execute(
                             "RESET myapp.current_user_id; RESET myapp.current_org_id;"
                         )
@@ -182,6 +225,19 @@ class DatabaseConnectionPool:
                     logger.error("Error returning connection to pool: %s", e)
 
     @staticmethod
+    def _downgrade_role(connection):
+        """Downgrade session to aurora_app so RLS is enforced."""
+        try:
+            with connection.cursor() as cur:
+                cur.execute("SET ROLE aurora_app;")
+        except Exception as exc:
+            logger.debug("SET ROLE aurora_app failed (role may not exist yet): %s", exc)
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+
+    @staticmethod
     def _set_rls_vars(connection):
         """Set RLS session variables from Flask request context if available."""
         try:
@@ -191,7 +247,7 @@ class DatabaseConnectionPool:
             user_id = request.headers.get('X-User-ID')
             org_id = request.headers.get('X-Org-ID') or getattr(g, '_org_id_resolved', None) or None
             if user_id or org_id:
-                with connection.cursor() as cur:  # No RLS needed — auto-setting RLS vars for Flask request
+                with connection.cursor() as cur:
                     if user_id:
                         cur.execute("SET myapp.current_user_id = %s", (user_id,))
                     if org_id:
@@ -204,12 +260,8 @@ class DatabaseConnectionPool:
         except Exception as exc:
             logger.debug("_set_rls_vars failed, continuing without RLS context: %s", exc)
 
-    # Backward compatibility aliases
+    # Backward compatibility alias
     def get_user_connection(self):
-        """Alias for get_connection() - kept for backward compatibility."""
-        return self.get_connection()
-
-    def get_admin_connection(self):
         """Alias for get_connection() - kept for backward compatibility."""
         return self.get_connection()
 

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -168,6 +168,7 @@ class DatabaseConnectionPool:
             raise
         finally:
             if connection:
+                reset_failed = False
                 try:
                     connection.rollback()
                     with connection.cursor() as cur:
@@ -181,17 +182,18 @@ class DatabaseConnectionPool:
                     connection.commit()
                 except Exception as e:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
+                    reset_failed = True
                     try:
                         pool.putconn(connection, close=True)
                     except Exception as close_exc:
                         logger.debug("Failed to close broken connection during cleanup: %s", close_exc)
                     with self._pool_available:
                         self._pool_available.notify()
-                    return
-                try:
-                    self._putconn_notify(pool, connection)
-                except Exception as e:
-                    logger.error("Error returning connection to pool: %s", e)
+                if not reset_failed:
+                    try:
+                        self._putconn_notify(pool, connection)
+                    except Exception as e:
+                        logger.error("Error returning connection to pool: %s", e)
 
     @contextmanager
     def get_admin_connection(self):
@@ -221,6 +223,7 @@ class DatabaseConnectionPool:
             raise
         finally:
             if connection:
+                reset_failed = False
                 try:
                     connection.rollback()
                     with connection.cursor() as cur:
@@ -234,17 +237,18 @@ class DatabaseConnectionPool:
                     connection.commit()
                 except Exception as e:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
+                    reset_failed = True
                     try:
                         pool.putconn(connection, close=True)
-                    except Exception:
-                        pass
+                    except Exception as close_exc:
+                        logger.debug("Failed to close broken admin connection during cleanup: %s", close_exc)
                     with self._pool_available:
                         self._pool_available.notify()
-                    return
-                try:
-                    self._putconn_notify(pool, connection)
-                except Exception as e:
-                    logger.error("Error returning connection to pool: %s", e)
+                if not reset_failed:
+                    try:
+                        self._putconn_notify(pool, connection)
+                    except Exception as e:
+                        logger.error("Error returning connection to pool: %s", e)
 
     @staticmethod
     def _downgrade_role(connection):

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -183,8 +183,8 @@ class DatabaseConnectionPool:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
                     try:
                         pool.putconn(connection, close=True)
-                    except Exception:
-                        pass
+                    except Exception as close_exc:
+                        logger.debug("Failed to close broken connection during cleanup: %s", close_exc)
                     with self._pool_available:
                         self._pool_available.notify()
                     return

--- a/server/utils/db/connection_pool.py
+++ b/server/utils/db/connection_pool.py
@@ -162,8 +162,8 @@ class DatabaseConnectionPool:
             if connection:
                 try:
                     connection.rollback()
-                except Exception:
-                    pass  # rollback is best-effort during error handling
+                except Exception as rollback_exc:
+                    logger.debug("Rollback failed in connection error handler: %s", rollback_exc)
             logger.error(f"Error with connection: {e}")
             raise
         finally:
@@ -172,11 +172,22 @@ class DatabaseConnectionPool:
                     connection.rollback()
                     with connection.cursor() as cur:
                         cur.execute(
-                            "RESET ROLE; RESET myapp.current_user_id; RESET myapp.current_org_id;"
+                            "RESET ROLE; "
+                            "RESET myapp.current_user_id; "
+                            "RESET myapp.current_org_id; "
+                            "RESET myapp.mcp_token_resolve; "
+                            "RESET myapp.kubectl_token_resolve;"
                         )
                     connection.commit()
                 except Exception as e:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
+                    try:
+                        pool.putconn(connection, close=True)
+                    except Exception:
+                        pass
+                    with self._pool_available:
+                        self._pool_available.notify()
+                    return
                 try:
                     self._putconn_notify(pool, connection)
                 except Exception as e:
@@ -204,8 +215,8 @@ class DatabaseConnectionPool:
             if connection:
                 try:
                     connection.rollback()
-                except Exception:
-                    pass
+                except Exception as rollback_exc:
+                    logger.debug("Rollback failed in admin connection error handler: %s", rollback_exc)
             logger.error(f"Error with admin connection: {e}")
             raise
         finally:
@@ -214,11 +225,22 @@ class DatabaseConnectionPool:
                     connection.rollback()
                     with connection.cursor() as cur:
                         cur.execute(
-                            "RESET myapp.current_user_id; RESET myapp.current_org_id;"
+                            "RESET ROLE; "
+                            "RESET myapp.current_user_id; "
+                            "RESET myapp.current_org_id; "
+                            "RESET myapp.mcp_token_resolve; "
+                            "RESET myapp.kubectl_token_resolve;"
                         )
                     connection.commit()
                 except Exception as e:
                     logger.warning("Failed to reset session vars on pool return: %s", e)
+                    try:
+                        pool.putconn(connection, close=True)
+                    except Exception:
+                        pass
+                    with self._pool_available:
+                        self._pool_available.notify()
+                    return
                 try:
                     self._putconn_notify(pool, connection)
                 except Exception as e:
@@ -226,16 +248,21 @@ class DatabaseConnectionPool:
 
     @staticmethod
     def _downgrade_role(connection):
-        """Downgrade session to aurora_app so RLS is enforced."""
+        """Downgrade session to aurora_app so RLS is enforced.
+
+        Raises RuntimeError if the role switch fails — connections must not
+        be used without RLS enforcement (fail closed).
+        """
         try:
             with connection.cursor() as cur:
                 cur.execute("SET ROLE aurora_app;")
         except Exception as exc:
-            logger.debug("SET ROLE aurora_app failed (role may not exist yet): %s", exc)
+            logger.error("SET ROLE aurora_app failed; refusing to run without RLS enforcement: %s", exc)
             try:
                 connection.rollback()
-            except Exception:
-                pass
+            except Exception as rollback_exc:
+                logger.debug("Rollback after failed role downgrade also failed: %s", rollback_exc)
+            raise RuntimeError("Failed to downgrade database role for RLS enforcement") from exc
 
     @staticmethod
     def _set_rls_vars(connection):

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -3059,6 +3059,31 @@ def initialize_tables():
                 conn.rollback()
 
             conn.commit()
+
+            # Ensure a non-superuser application role exists for RLS enforcement.
+            # The aurora superuser owns the tables and runs DDL, but all
+            # request-handling connections downgrade to aurora_app via SET ROLE
+            # so that RLS policies are actually enforced.
+            try:
+                cursor.execute("""
+                    DO $$ BEGIN
+                        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aurora_app') THEN
+                            CREATE ROLE aurora_app NOSUPERUSER NOBYPASSRLS NOLOGIN;
+                        END IF;
+                    END $$;
+                """)
+                cursor.execute("GRANT ALL ON ALL TABLES IN SCHEMA public TO aurora_app;")
+                cursor.execute("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO aurora_app;")
+                cursor.execute("GRANT USAGE ON SCHEMA public TO aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO aurora_app;")
+                cursor.execute("GRANT aurora_app TO CURRENT_USER;")
+                conn.commit()
+                logging.info("Ensured aurora_app role exists with NOSUPERUSER NOBYPASSRLS.")
+            except Exception as e:
+                logging.warning(f"Error creating aurora_app role: {e}")
+                conn.rollback()
+
             logging.info("Database tables initialized successfully.")
             cursor.close()
 

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -3069,14 +3069,16 @@ def initialize_tables():
                     DO $$ BEGIN
                         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aurora_app') THEN
                             CREATE ROLE aurora_app NOSUPERUSER NOBYPASSRLS NOLOGIN;
+                        ELSE
+                            ALTER ROLE aurora_app NOSUPERUSER NOBYPASSRLS NOLOGIN;
                         END IF;
                     END $$;
                 """)
-                cursor.execute("GRANT ALL ON ALL TABLES IN SCHEMA public TO aurora_app;")
-                cursor.execute("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO aurora_app;")
+                cursor.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO aurora_app;")
+                cursor.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aurora_app;")
                 cursor.execute("GRANT USAGE ON SCHEMA public TO aurora_app;")
-                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO aurora_app;")
-                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO aurora_app;")
                 cursor.execute("GRANT aurora_app TO CURRENT_USER;")
                 conn.commit()
                 logging.info("Ensured aurora_app role exists with NOSUPERUSER NOBYPASSRLS.")

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -3083,8 +3083,9 @@ def initialize_tables():
                 conn.commit()
                 logging.info("Ensured aurora_app role exists with NOSUPERUSER NOBYPASSRLS.")
             except Exception as e:
-                logging.warning(f"Error creating aurora_app role: {e}")
+                logging.error(f"FATAL: Error creating aurora_app role: {e}")
                 conn.rollback()
+                raise
 
             logging.info("Database tables initialized successfully.")
             cursor.close()

--- a/server/utils/db/db_utils.py
+++ b/server/utils/db/db_utils.py
@@ -3074,16 +3074,20 @@ def initialize_tables():
                         END IF;
                     END $$;
                 """)
+                cursor.execute("REVOKE ALL ON ALL TABLES IN SCHEMA public FROM aurora_app;")
+                cursor.execute("REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM aurora_app;")
                 cursor.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO aurora_app;")
                 cursor.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO aurora_app;")
                 cursor.execute("GRANT USAGE ON SCHEMA public TO aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM aurora_app;")
+                cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM aurora_app;")
                 cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO aurora_app;")
                 cursor.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO aurora_app;")
                 cursor.execute("GRANT aurora_app TO CURRENT_USER;")
                 conn.commit()
                 logging.info("Ensured aurora_app role exists with NOSUPERUSER NOBYPASSRLS.")
-            except Exception as e:
-                logging.error(f"FATAL: Error creating aurora_app role: {e}")
+            except Exception:
+                logging.exception("FATAL: Error creating aurora_app role")
                 conn.rollback()
                 raise
 


### PR DESCRIPTION
## Summary
- The `aurora` PostgreSQL role is a superuser which **bypasses all RLS policies**, even with `FORCE ROW LEVEL SECURITY`. This caused cross-org data leakage on tables that relied solely on RLS without an explicit `WHERE org_id` filter (specifically the actions table, which auto-seeds system actions per-org — new accounts would see other orgs' actions and run history).
- Creates an `aurora_app` role (`NOSUPERUSER NOBYPASSRLS NOLOGIN`) during DB initialization and grants it full table/sequence access.
- `get_connection()` now issues `SET ROLE aurora_app` so RLS policies are actually enforced for all request-handling queries.
- `get_admin_connection()` is a real separate code path that retains superuser privileges — used only for DDL/migrations, auth registration, and cross-org background tasks that explicitly call `set_rls_context()` per-org.

## Test plan
- [x] Verified locally: new user sees only their own org's actions (2), not all orgs' actions (4)
- [x] Admin connection still bypasses RLS for migrations and scheduled tasks
- [x] Celery scheduled actions continue to succeed
- [x] Server starts cleanly, role is created idempotently on each boot
- [ ] Verify no regressions on routes that use `get_connection()` (incidents, connectors, chat, etc.)
- [ ] Verify production Helm deployment picks up role creation on first restart

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `aurora_app` PostgreSQL role and initialized consistent permissions for `public` tables, sequences, and future objects.

* **Bug Fixes**
  * Improved database session handling to enforce Row Level Security by switching to the correct role and clearing all RLS/session variables on connection release.
  * Ensures RLS context is set before retrieving postmortem action instructions.

* **Tests**
  * Updated connection-pool and RLS/reset behavior tests to reflect the new cleanup and failure semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->