### PR TITLE
fix: action thoughts leaking into RCA thoughts panel

### DIFF
--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1467,7 +1467,7 @@ async def _execute_background_chat(
             wf._ui_state["triggerMetadata"] = trigger_metadata
         
         # Run the workflow - this is the same function used by regular chats
-        await process_workflow_async(wf, state, background_ws, user_id, incident_id=incident_id)
+        await process_workflow_async(wf, state, background_ws, user_id, incident_id=None if is_action_source else incident_id)
         
         # CRITICAL: Wait for any ongoing tool calls to complete before marking as done
         # The workflow stream might complete, but tool calls could still be running

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -1465,7 +1465,10 @@ async def _execute_background_chat(
         if trigger_metadata:
             wf._trigger_metadata = trigger_metadata
             wf._ui_state["triggerMetadata"] = trigger_metadata
-        
+
+        # Determine early so it can gate the incident_id passed to process_workflow_async.
+        is_action_source = (trigger_metadata or {}).get('source') == 'action'
+
         # Run the workflow - this is the same function used by regular chats
         await process_workflow_async(wf, state, background_ws, user_id, incident_id=None if is_action_source else incident_id)
         
@@ -1518,7 +1521,6 @@ async def _execute_background_chat(
 
         # Also finalize the incident and enqueue post-RCA tasks here (inside the
         # async function) because asyncio.run() may never return to the caller.
-        is_action_source = (trigger_metadata or {}).get('source') == 'action'
         if incident_id and not is_action_source:
             try:
                 with db_pool.get_admin_connection() as conn:

--- a/server/main_chatbot.py
+++ b/server/main_chatbot.py
@@ -331,7 +331,6 @@ def create_websocket_sender(websocket, user_id, session_id):
 
 
 async def process_workflow_async(wf, state, websocket, user_id, incident_id=None):
-    incident_id = incident_id or getattr(state, "incident_id", None)
     curr_node = "START"
     sent_message_count = 0
     websocket_connected = True


### PR DESCRIPTION
Actions with on_incident trigger were writing their reasoning to incident_thoughts, polluting the RCA Thoughts panel
Root cause: process_workflow_async received incident_id for actions, and a fallback on line 334 re-populated it from state even if passed as None
Fix: remove dead fallback in main_chatbot.py, pass incident_id=None for action-sourced chats in task.py
Action agent context (state.incident_id) is unaffected — actions still know which incident they're operating on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action-triggered chats now execute without inheriting an incident context, ensuring workflow behavior matches the trigger source.
  * Workflow processing now uses only the incident ID explicitly provided to it, preventing unintended incident-related saving or analysis when no incident ID is supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->