### PR TITLE
Fix proactive AWS credential refresh silently skipping all credentials

### DIFF
--- a/server/chat/backend/agent/skills/integrations/github/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/github/SKILL.md
@@ -44,10 +44,12 @@ Connected account: {username}
    - Pass `incident_time` (ISO 8601) for automatic time window correlation
 3. `github_fix(file_path=..., edits=[{old_string, new_string, replace_all?}, ...], fix_description=..., root_cause_summary=...)` — Suggest a code fix via anchored search-and-replace edits (stored for user review, not auto-applied). First call `get_file_contents` to read the current file so you can copy the exact `old_string` (with enough surrounding context to be unique).
 4. `github_apply_fix(suggestion_id=...)` — Create a PR from an approved fix (only after user reviews)
-5. `github_commit(repo=..., commit_message=...)` — Push Terraform files to GitHub
+5. `github_commit(repo=..., commit_message=...)` — Push generated Terraform (.tf) files from the IaC workflow to GitHub. This is NOT a general-purpose commit tool — it only pushes .tf files from the terraform working directory.
 
 ### MCP Tools (for direct GitHub API operations beyond RCA)
 - Files: `get_file_contents`, `create_or_update_file`, `push_files`, `get_repository_tree`
+- **Size limit:** `create_or_update_file` and `push_files` enforce a 50 KB per-file cap. Files exceeding this limit will be rejected. Do NOT attempt to work around this via terminal commands or other tools — the limit is intentional.
+- **Updates:** When updating an existing file, the new content must be at least 50% of the original file size (for files over 10 KB). This prevents accidental truncation.
 - Branches: `create_branch`, `list_branches`, `list_commits`, `get_commit`
 - PRs: `create_pull_request`, `list_pull_requests`, `merge_pull_request`, `get_pull_request_files`
 - Issues: `create_issue`, `list_issues`, `search_issues`, `add_issue_comment`

--- a/server/tests/utils/test_credential_refresh.py
+++ b/server/tests/utils/test_credential_refresh.py
@@ -1,0 +1,83 @@
+"""Tests for utils.aws.credential_refresh -- proactive STS credential refresh."""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+
+class TestCredentialRefresh:
+    """Proactive refresh must target connections whose cached creds are expiring."""
+
+    @patch("utils.auth.stateless_auth.set_rls_context")
+    @patch("utils.db.connection_pool.db_pool")
+    @patch("utils.aws.aws_sts_client.assume_workspace_role")
+    def test_expiring_connection_is_refreshed(self, mock_assume, mock_db_pool, mock_set_rls):
+        """A cached credential inside the refresh window must trigger a re-assume."""
+        from utils.aws.aws_sts_client import _credential_cache
+        from utils.aws.credential_refresh import refresh_aws_credentials
+
+        role_arn = "arn:aws:iam::123456789012:role/AuroraRole"
+        cache_key = f"42:{role_arn}:ext-abc:full"
+
+        _credential_cache.clear()
+        _credential_cache[cache_key] = {"expiration": int(time.time()) + 300}
+
+        fake_cursor = MagicMock()
+        fake_cursor.fetchall.side_effect = [
+            [(42, 100)],  # users query
+            [(42, role_arn, "us-east-1", "workspace-1", "ext-abc")],  # connections query
+        ]
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value.__enter__.return_value = fake_cursor
+        mock_db_pool.get_admin_connection.return_value.__enter__.return_value = fake_conn
+
+        result = refresh_aws_credentials()
+
+        assert result["refreshed"] == 1
+        assert result["skipped"] == 0
+        mock_assume.assert_called_once_with(
+            role_arn=role_arn,
+            external_id="ext-abc",
+            workspace_id="workspace-1",
+            region="us-east-1",
+            user_id=42,
+        )
+
+    @patch("utils.auth.stateless_auth.set_rls_context")
+    @patch("utils.db.connection_pool.db_pool")
+    @patch("utils.aws.aws_sts_client.assume_workspace_role")
+    def test_prefix_does_not_match_longer_role(self, mock_assume, mock_db_pool, mock_set_rls):
+        """The prefix for `Admin` must not accidentally match `AdminReadOnly`."""
+        from utils.aws.aws_sts_client import _credential_cache
+        from utils.aws.credential_refresh import refresh_aws_credentials
+
+        admin = "arn:aws:iam::123456789012:role/Admin"
+        admin_ro = "arn:aws:iam::123456789012:role/AdminReadOnly"
+
+        _credential_cache.clear()
+        _credential_cache[f"42:{admin}:ext-abc:full"] = {"expiration": int(time.time()) + 300}
+        _credential_cache[f"42:{admin_ro}:ext-abc:full"] = {"expiration": int(time.time()) + 300}
+
+        fake_cursor = MagicMock()
+        fake_cursor.fetchall.side_effect = [
+            [(42, 100)],
+            [(42, admin, "us-east-1", "workspace-1", "ext-abc")],  # only Admin returned
+        ]
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value.__enter__.return_value = fake_cursor
+        mock_db_pool.get_admin_connection.return_value.__enter__.return_value = fake_conn
+
+        refresh_aws_credentials()
+
+        mock_assume.assert_called_once_with(
+            role_arn=admin,
+            external_id="ext-abc",
+            workspace_id="workspace-1",
+            region="us-east-1",
+            user_id=42,
+        )

--- a/server/utils/aws/credential_refresh.py
+++ b/server/utils/aws/credential_refresh.py
@@ -39,8 +39,6 @@ def refresh_aws_credentials():
         logger.debug("No AWS credentials need proactive refresh")
         return {"refreshed": 0, "skipped": 0}
 
-    expiring_role_arns = {k.split(":")[0] for k in expiring_cache_keys}
-
     from utils.db.connection_pool import db_pool
     from utils.auth.stateless_auth import set_rls_context
 
@@ -72,7 +70,11 @@ def refresh_aws_credentials():
         return {"refreshed": 0, "error": str(e)}
 
     for user_id, role_arn, region, workspace_id, external_id in rows:
-        if role_arn not in expiring_role_arns:
+        cache_key_prefix = f"{user_id}:{role_arn}:{external_id}:"
+        if not any(
+            cache_key.startswith(cache_key_prefix)
+            for cache_key in expiring_cache_keys
+        ):
             skipped += 1
             continue
         region = region or "us-east-1"


### PR DESCRIPTION
## Problem

The proactive STS credential refresh task in `server/utils/aws/credential_refresh.py`
never refreshes any credentials.

Cache keys are built in `aws_sts_client.py` as:

    f"{uid}:{role_arn}:{external_id}:{policy_hash}"

The refresh task tried to recover the role ARN from each key with
`k.split(":")[0]`. Because AWS ARNs themselves contain colons
(`arn:aws:iam::123456789012:role/MyRole`), `split(":")[0]` returns the
`uid`, not the ARN. The later check `if role_arn not in expiring_role_arns`
then compares a real ARN against a set of user IDs, which never matches —
so every credential is skipped and the task silently does nothing. No error
is raised, so the failure is invisible in normal operation.

## Fix

Instead of parsing the ARN back out of the key, reconstruct the deterministic
prefix from the DB row and match with `startswith()`:

    cache_key_prefix = f"{user_id}:{role_arn}:{external_id}:"
    if not any(k.startswith(cache_key_prefix) for k in expiring_cache_keys):
        skipped += 1
        continue

The trailing `:` anchors the match to the field boundary, so a role such as
`.../role/Admin` cannot accidentally match `.../role/AdminReadOnly`. Because
`policy_hash` is the final field, the prefix correctly matches all cached
policy variants for the same connection.

## Testing

Adds `server/tests/utils/test_credential_refresh.py` with two tests:
- `test_expiring_connection_is_refreshed` — a near-expiry cache entry triggers
  a re-assume. Fails on current `main`, passes with this fix.
- `test_prefix_does_not_match_longer_role` — proves the `Admin` prefix does not
  match `AdminReadOnly`.

Both pass locally.

## Scope

This fixes the matching only. The task re-assumes the full-policy variant, so
restricted (`session_policy`) cache entries are still not proactively refreshed
— that's pre-existing behavior and out of scope here, but could be a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS credential refresh behavior so only the intended connection is refreshed when credentials are nearing expiration.
  * Prevented overlapping role names from triggering the wrong refresh action.

* **Documentation**
  * Clarified GitHub MCP tool usage guidance, including file size limits and update requirements for uploaded files.

* **Tests**
  * Added coverage for credential refresh behavior, including expiration handling and role-matching accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->