### PR TITLE
feat: Memory Injector — async prefetch injects relevant memories into prompt

### DIFF
--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -13,6 +13,7 @@ from .tools.cloud_tools import set_websocket_context
 from chat.backend.agent.utils.prefix_cache import PrefixCacheManager
 from chat.backend.agent.prompt.prompt_builder import build_prompt_segments, assemble_system_prompt, register_prompt_cache_breakpoints
 from chat.backend.agent.utils.llm_usage_tracker import LLMUsageTracker, LLMUsage
+from services.memory.injector import MemoryPrefetch
 import time
 import asyncio
 from datetime import datetime, timezone
@@ -348,17 +349,17 @@ class Agent:
             _memory_prefetch = None
             if state.user_id and state.session_id:
                 try:
-                    from services.memory.injector import start_memory_prefetch
                     _last_msg_content = ""
                     if state.messages:
                         _lm = state.messages[-1]
                         _last_msg_content = _lm.content if isinstance(getattr(_lm, 'content', ''), str) else str(getattr(_lm, 'content', ''))
                     if _last_msg_content:
-                        _memory_prefetch = start_memory_prefetch(
+                        _memory_prefetch = MemoryPrefetch(
                             user_id=state.user_id,
                             session_id=state.session_id,
                             user_message=_last_msg_content,
                         )
+                        _memory_prefetch.start()
                 except Exception as _mpe:
                     logging.debug("Failed to start memory prefetch: %s", _mpe)
 

--- a/server/chat/backend/agent/agent.py
+++ b/server/chat/backend/agent/agent.py
@@ -344,6 +344,24 @@ class Agent:
                 getattr(state, 'attachments', []),
             )
 
+            # Fire async memory prefetch — runs in parallel with prompt building and tool setup.
+            _memory_prefetch = None
+            if state.user_id and state.session_id:
+                try:
+                    from services.memory.injector import start_memory_prefetch
+                    _last_msg_content = ""
+                    if state.messages:
+                        _lm = state.messages[-1]
+                        _last_msg_content = _lm.content if isinstance(getattr(_lm, 'content', ''), str) else str(getattr(_lm, 'content', ''))
+                    if _last_msg_content:
+                        _memory_prefetch = start_memory_prefetch(
+                            user_id=state.user_id,
+                            session_id=state.session_id,
+                            user_message=_last_msg_content,
+                        )
+                except Exception as _mpe:
+                    logging.debug("Failed to start memory prefetch: %s", _mpe)
+
             # Build prompt segments in background while getting tools on main thread
             # (get_cloud_tools needs thread-local context for tool_capture/user resolution)
             from concurrent.futures import ThreadPoolExecutor as _TPE
@@ -357,6 +375,16 @@ class Agent:
                 )
                 tools = get_cloud_tools()
                 segments = _prompt_future.result()
+
+            # Collect prefetch result and append injected memories to the prompt
+            if _memory_prefetch:
+                try:
+                    injected = _memory_prefetch.get_result(timeout=6.0)
+                    if injected:
+                        memory_index = segments.knowledge_base_memory or ""
+                        segments.knowledge_base_memory = (memory_index + "\n\n" + injected) if memory_index else injected
+                except Exception:
+                    logging.debug("Memory prefetch result unavailable")
 
             system_prompt_text = assemble_system_prompt(segments)
             if system_prompt_override is not None:

--- a/server/chat/backend/agent/prompt/composer.py
+++ b/server/chat/backend/agent/prompt/composer.py
@@ -124,7 +124,8 @@ def build_prompt_segments(
         except Exception as e:
             logging.warning(f"Failed to build skills index: {e}")
 
-    # Build memory index for authenticated users
+    # Build memory index for authenticated users (static TOC of title + description).
+    # The injector's full-content memories are appended in agent.py after this returns.
     memory_context = ""
     user_id = getattr(state, "user_id", None) if state else None
     if user_id:

--- a/server/services/memory/index_builder.py
+++ b/server/services/memory/index_builder.py
@@ -5,15 +5,11 @@ Generates the memory index for injection into the agent's system prompt.
 Lists all memory entries with title + description so the agent knows what
 org knowledge exists and can call read_memory() to load specific topics.
 
-Future: A relevance-ranking agent will decide which memories to load fully
-into the prompt based on the current conversation context.
-
-SCALING: Truncation is a non-critical safeguard. The relevance-ranking agent
-reads all entries and selects the top N, and the consolidation mechanism keeps
-memory lean. Long-term, we can move to a directory-style index.
+Also provides shared data-access functions used by the injector.
 """
 
 import logging
+from typing import Dict, List, Optional
 
 from utils.db.connection_pool import db_pool
 from utils.auth.stateless_auth import set_rls_context
@@ -26,6 +22,82 @@ MAX_INDEX_LINES = 200
 MAX_INDEX_BYTES = 25000
 
 
+# ---------------------------------------------------------------------------
+# Shared data access — used by both the index builder and the injector
+# ---------------------------------------------------------------------------
+
+
+def get_memory_entries(user_id: str, limit: int = 200) -> List[Dict]:
+    """Fetch memory entry metadata (no content) for the user's org.
+
+    Returns a list of dicts with: category, title, description, updated_at.
+    Ordered by most recently updated first.
+    """
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryIndex]")
+                if not org_id:
+                    return []
+
+                cursor.execute(
+                    """SELECT category, title, description, updated_at
+                       FROM artifacts
+                       WHERE org_id = %s AND category = ANY(%s)
+                       ORDER BY updated_at DESC
+                       LIMIT %s""",
+                    (org_id, list(MEMORY_CATEGORIES), limit),
+                )
+                return [
+                    {"category": r[0], "title": r[1], "description": r[2] or "", "updated_at": r[3]}
+                    for r in cursor.fetchall()
+                ]
+    except Exception as e:
+        logger.warning("[MemoryIndex] Failed to fetch entries for user %s: %s", user_id, e)
+        return []
+
+
+def fetch_memory_content(user_id: str, entries: List[Dict]) -> List[Dict]:
+    """Fetch full content for a list of memory entries.
+
+    Takes entries (with category + title) and returns them enriched with content.
+    """
+    if not entries:
+        return []
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryIndex:fetch]")
+                if not org_id:
+                    return []
+
+                results = []
+                for entry in entries:
+                    cursor.execute(
+                        """SELECT content, updated_at FROM artifacts
+                           WHERE org_id = %s AND category = %s AND title = %s""",
+                        (org_id, entry["category"], entry["title"]),
+                    )
+                    row = cursor.fetchone()
+                    if row:
+                        results.append({
+                            "category": entry["category"],
+                            "title": entry["title"],
+                            "content": row[0] or "",
+                            "updated_at": row[1],
+                        })
+                return results
+    except Exception:
+        logger.exception("[MemoryIndex] Failed to fetch memory content")
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Index formatting (used by composer.py for the static TOC)
+# ---------------------------------------------------------------------------
+
+
 def build_memory_index(user_id: str) -> str:
     """Build a table-of-contents index of all org memory entries.
 
@@ -33,76 +105,50 @@ def build_memory_index(user_id: str) -> str:
     description. The agent uses this to discover what knowledge exists and
     calls read_memory() to load full content on demand.
     """
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                resolved_org_id = set_rls_context(
-                    cursor, conn, user_id, log_prefix="[MemoryIndex]"
-                )
-                if not resolved_org_id:
-                    return ""
+    entries = get_memory_entries(user_id)
+    if not entries:
+        return ""
 
-                # Fetch all memory entries for this org (title + description only, no content)
-                cursor.execute(
-                    """SELECT category, title, description, updated_at
-                       FROM artifacts
-                       WHERE org_id = %s AND category = ANY(%s)
-                       ORDER BY category, updated_at DESC""",
-                    (resolved_org_id, list(MEMORY_CATEGORIES)),
-                )
-                rows = cursor.fetchall()
+    # Regroup by category (entries come sorted by updated_at, need category grouping)
+    from itertools import groupby
+    sorted_entries = sorted(entries, key=lambda e: e["category"])
 
-        if not rows:
-            return ""
+    lines = ["ORG MEMORY INDEX — use read_memory(category, title) for full content:\n"]
 
-        # Format as a grouped list: entries under category headers
-        lines = ["ORG MEMORY INDEX — use read_memory(category, title) for full content:\n"]
+    def _prompt_label(value: object, max_chars: int = 500) -> str:
+        return " ".join(str(value or "").split())[:max_chars]
 
-        def _prompt_label(value: object, max_chars: int = 500) -> str:
-            return " ".join(str(value or "").split())[:max_chars]
+    for category, group in groupby(sorted_entries, key=lambda e: e["category"]):
+        group_list = list(group)
+        lines.append(f"## {category} ({len(group_list)})")
 
-        current_category = None
-        for category, title, description, updated_at in rows:
-            # Print a category header when we enter a new group
-            if category != current_category:
-                count = sum(1 for r in rows if r[0] == category)
-                lines.append(f"## {category} ({count})")
-                current_category = category
-
-            # Each entry: path-style identifier + description as inline comment
-            safe_title = _prompt_label(title)
-            safe_desc = _prompt_label(description)
+        for entry in group_list:
+            safe_title = _prompt_label(entry["title"])
+            safe_desc = _prompt_label(entry["description"])
             desc_suffix = f"  # {safe_desc}" if safe_desc else ""
             lines.append(f"- {category}/{safe_title}{desc_suffix}")
 
-        result = "\n".join(lines)
+    result = "\n".join(lines)
 
-        # Enforce line budget — prevent the index from consuming too much prompt space
-        truncated = False
-        result_lines = result.split("\n")
-        if len(result_lines) > MAX_INDEX_LINES:
-            result = "\n".join(result_lines[:MAX_INDEX_LINES])
-            result += "\n... (index truncated — use list_memories() to see all)"
-            truncated = True
+    # Enforce line budget
+    truncated = False
+    result_lines = result.split("\n")
+    if len(result_lines) > MAX_INDEX_LINES:
+        result = "\n".join(result_lines[:MAX_INDEX_LINES])
+        result += "\n... (index truncated — use list_memories() to see all)"
+        truncated = True
 
-        # Enforce byte budget — safety net for orgs with many long titles/descriptions
-        if len(result.encode("utf-8")) > MAX_INDEX_BYTES:
-            while len(result.encode("utf-8")) > MAX_INDEX_BYTES and "\n" in result:
-                result = result.rsplit("\n", 1)[0]
-            result += "\n... (index truncated)"
-            truncated = True
+    # Enforce byte budget
+    if len(result.encode("utf-8")) > MAX_INDEX_BYTES:
+        while len(result.encode("utf-8")) > MAX_INDEX_BYTES and "\n" in result:
+            result = result.rsplit("\n", 1)[0]
+        result += "\n... (index truncated)"
+        truncated = True
 
-        if truncated:
-            logger.warning(
-                "[MemoryIndex] Index truncated for org %s: %d entries",
-                resolved_org_id, len(rows),
-            )
+    if truncated:
+        logger.warning("[MemoryIndex] Index truncated: %d entries", len(entries))
 
-        # LangChain interprets {text} as template variables — escape them
-        result = result.replace("{", "{{").replace("}", "}}")
+    # LangChain interprets {text} as template variables — escape them
+    result = result.replace("{", "{{").replace("}", "}}")
 
-        return result
-
-    except Exception as e:
-        logger.warning(f"[MemoryIndex] Error building index for user {user_id}: {e}")
-        return ""
+    return result

--- a/server/services/memory/index_builder.py
+++ b/server/services/memory/index_builder.py
@@ -4,93 +4,16 @@ Memory Index Builder
 Generates the memory index for injection into the agent's system prompt.
 Lists all memory entries with title + description so the agent knows what
 org knowledge exists and can call read_memory() to load specific topics.
-
-Also provides shared data-access functions used by the injector.
 """
 
 import logging
-from typing import Dict, List, Optional
 
-from utils.db.connection_pool import db_pool
-from utils.auth.stateless_auth import set_rls_context
-
-from services.memory import MEMORY_CATEGORIES
+from services.memory.queries import get_memory_entries
 
 logger = logging.getLogger(__name__)
 
 MAX_INDEX_LINES = 200
 MAX_INDEX_BYTES = 25000
-
-
-# ---------------------------------------------------------------------------
-# Shared data access — used by both the index builder and the injector
-# ---------------------------------------------------------------------------
-
-
-def get_memory_entries(user_id: str, limit: int = 200) -> List[Dict]:
-    """Fetch memory entry metadata (no content) for the user's org.
-
-    Returns a list of dicts with: category, title, description, updated_at.
-    Ordered by most recently updated first.
-    """
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryIndex]")
-                if not org_id:
-                    return []
-
-                cursor.execute(
-                    """SELECT category, title, description, updated_at
-                       FROM artifacts
-                       WHERE org_id = %s AND category = ANY(%s)
-                       ORDER BY updated_at DESC
-                       LIMIT %s""",
-                    (org_id, list(MEMORY_CATEGORIES), limit),
-                )
-                return [
-                    {"category": r[0], "title": r[1], "description": r[2] or "", "updated_at": r[3]}
-                    for r in cursor.fetchall()
-                ]
-    except Exception as e:
-        logger.warning("[MemoryIndex] Failed to fetch entries for user %s: %s", user_id, e)
-        return []
-
-
-def fetch_memory_content(user_id: str, entries: List[Dict]) -> List[Dict]:
-    """Fetch full content for a list of memory entries.
-
-    Takes entries (with category + title) and returns them enriched with content.
-    """
-    if not entries:
-        return []
-
-    try:
-        with db_pool.get_admin_connection() as conn:
-            with conn.cursor() as cursor:
-                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryIndex:fetch]")
-                if not org_id:
-                    return []
-
-                results = []
-                for entry in entries:
-                    cursor.execute(
-                        """SELECT content, updated_at FROM artifacts
-                           WHERE org_id = %s AND category = %s AND title = %s""",
-                        (org_id, entry["category"], entry["title"]),
-                    )
-                    row = cursor.fetchone()
-                    if row:
-                        results.append({
-                            "category": entry["category"],
-                            "title": entry["title"],
-                            "content": row[0] or "",
-                            "updated_at": row[1],
-                        })
-                return results
-    except Exception:
-        logger.exception("[MemoryIndex] Failed to fetch memory content")
-        return []
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -4,7 +4,7 @@ Memory Injector — Async Prefetch + Single-Pass LLM Selection
 Runs as a non-blocking prefetch in parallel with prompt building.
 One fast LLM call selects up to 5 relevant memories from the index
 (title + description). Whatever it selects gets injected into the system prompt. 
-- Hard caps: 5 entries max, 4KB per entry, 60KB per session.
+- Hard caps: 5 entries max, 4KB per entry.
 - Dedup: never re-surface a memory already shown this session.
 """
 
@@ -17,6 +17,10 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from utils.cache.redis_client import get_redis_client
 from services.memory.queries import get_memory_entries, fetch_memory_content
+from chat.backend.agent.providers import create_chat_model
+from langchain_core.messages import SystemMessage, HumanMessage
+from chat.backend.agent.llm import ModelConfig
+
 
 logger = logging.getLogger(__name__)
 
@@ -26,17 +30,12 @@ logger = logging.getLogger(__name__)
 
 MAX_SELECTED = 5
 MAX_MEMORY_BYTES_PER_ENTRY = 4096
-MAX_SESSION_BYTES = 60_000
-MAX_INDEX_ENTRIES = 200
-MIN_QUERY_LENGTH = 8  # Single words don't provide enough selection context
 STALENESS_DAYS = 2
-
-from chat.backend.agent.llm import ModelConfig
 
 SELECTOR_MODEL = ModelConfig.RCA_MODEL
 SELECTOR_TIMEOUT = 5.0
 
-_SESSION_BUDGET_TTL = 86400
+_SURFACED_SET_TTL = 86400
 _prefetch_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="mem-inject")
 
 # ---------------------------------------------------------------------------
@@ -104,19 +103,10 @@ class MemoryPrefetch:
 
     def _execute(self) -> str:
         try:
-            # Not enough context to select meaningfully
-            if len(self.user_message.strip()) < MIN_QUERY_LENGTH:
-                return ""
-
-            # Session budget exhausted — memories already saturate context
-            budget_used = _get_session_budget(self.session_id)
-            if budget_used >= MAX_SESSION_BYTES:
-                return ""
-
             already_surfaced = _get_surfaced_set(self.session_id)
 
             # Scan index (titles + descriptions, no content)
-            entries = get_memory_entries(self.user_id, limit=MAX_INDEX_ENTRIES)
+            entries = get_memory_entries(self.user_id)
             if not entries:
                 return ""
 
@@ -135,35 +125,22 @@ class MemoryPrefetch:
             if not memories:
                 return ""
 
-            # Format and inject (with staleness headers + budget enforcement)
-            remaining_budget = MAX_SESSION_BYTES - budget_used
-            injection_text, bytes_used, surfaced_keys = _format_for_injection(memories, remaining_budget)
+            # Format and inject (with staleness headers + per-entry cap)
+            injection_text, surfaced_keys = _format_for_injection(memories)
             if not injection_text:
                 return ""
 
-            _update_session_budget(self.session_id, budget_used + bytes_used)
             _mark_surfaced(self.session_id, surfaced_keys)
 
             logger.info(
-                "[MemoryInjector] Injected %d memories (%d bytes) for session %s",
-                len(surfaced_keys), bytes_used, self.session_id,
+                "[MemoryInjector] Injected %d memories for session %s",
+                len(surfaced_keys), self.session_id,
             )
             return injection_text
 
         except Exception:
             logger.exception("[MemoryInjector] Unhandled error in prefetch")
             return ""
-
-
-def start_memory_prefetch(
-    user_id: str,
-    session_id: str,
-    user_message: str,
-) -> MemoryPrefetch:
-    """Fire a non-blocking memory prefetch. Returns a handle to collect results."""
-    prefetch = MemoryPrefetch(user_id, session_id, user_message)
-    prefetch.start()
-    return prefetch
 
 
 # ---------------------------------------------------------------------------
@@ -173,8 +150,6 @@ def start_memory_prefetch(
 
 def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Dict]:
     """One strict LLM call: select up to 5 from the index."""
-    from chat.backend.agent.providers import create_chat_model
-    from langchain_core.messages import SystemMessage, HumanMessage
 
     manifest_lines = []
     for entry in entries:
@@ -229,21 +204,13 @@ def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Di
 # ---------------------------------------------------------------------------
 
 
-def _format_for_injection(
-    memories: List[Dict], remaining_budget: int
-) -> Tuple[str, int, Set[str]]:
-    """Format memories with staleness headers, respecting per-entry and budget caps."""
+def _format_for_injection(memories: List[Dict]) -> Tuple[str, Set[str]]:
+    """Format memories with staleness headers and per-entry cap."""
     now = datetime.now(timezone.utc)
     parts = []
-    total_bytes = 0
     surfaced: Set[str] = set()
 
-    header = "RELEVANT MEMORIES (auto-loaded — verify stale data before acting):\n"
-    header_bytes = len(header.encode("utf-8"))
-    if header_bytes > remaining_budget:
-        return "", 0, set()
-    total_bytes += header_bytes
-    parts.append(header)
+    parts.append("RELEVANT MEMORIES (auto-loaded — verify stale data before acting):\n")
 
     for mem in memories:
         key = _entry_key(mem)
@@ -261,49 +228,24 @@ def _format_for_injection(
             if age > timedelta(days=STALENESS_DAYS):
                 staleness = f" ⚠️ Last updated {age.days}d ago — verify before acting"
 
-        entry_text = f"\n--- {mem['category']}/{mem['title']}{staleness} ---\n{content}\n"
-        entry_bytes = len(entry_text.encode("utf-8"))
-
-        # Budget check
-        if total_bytes + entry_bytes > remaining_budget:
-            break
-
-        parts.append(entry_text)
-        total_bytes += entry_bytes
+        parts.append(f"\n--- {mem['category']}/{mem['title']}{staleness} ---\n{content}\n")
         surfaced.add(key)
 
     if not surfaced:
-        return "", 0, set()
+        return "", set()
 
     result = "".join(parts)
     result = result.replace("{", "{{").replace("}", "}}")
-    return result, total_bytes, surfaced
+    return result, surfaced
 
 
 # ---------------------------------------------------------------------------
-# Session tracking (Redis)
+# Session dedup (Redis)
 # ---------------------------------------------------------------------------
 
 
 def _entry_key(entry: Dict) -> str:
     return f"{entry.get('category', '')}/{entry.get('title', '')}"
-
-
-def _get_session_budget(session_id: str) -> int:
-    try:
-        r = get_redis_client()
-        val = r.get(f"mem:inject:budget:{session_id}")
-        return int(val) if val else 0
-    except Exception:
-        return 0
-
-
-def _update_session_budget(session_id: str, new_total: int):
-    try:
-        r = get_redis_client()
-        r.setex(f"mem:inject:budget:{session_id}", _SESSION_BUDGET_TTL, str(new_total))
-    except Exception:
-        pass
 
 
 def _get_surfaced_set(session_id: str) -> Set[str]:
@@ -322,7 +264,7 @@ def _mark_surfaced(session_id: str, keys: Set[str]):
         r = get_redis_client()
         pipe = r.pipeline()
         pipe.sadd(f"mem:inject:surfaced:{session_id}", *keys)
-        pipe.expire(f"mem:inject:surfaced:{session_id}", _SESSION_BUDGET_TTL)
+        pipe.expire(f"mem:inject:surfaced:{session_id}", _SURFACED_SET_TTL)
         pipe.execute()
     except Exception:
         pass

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Set, Tuple
 
 from utils.cache.redis_client import get_redis_client
-from services.memory.index_builder import get_memory_entries, fetch_memory_content
+from services.memory.queries import get_memory_entries, fetch_memory_content
 
 logger = logging.getLogger(__name__)
 

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -10,7 +10,6 @@ One fast LLM call selects up to 5 relevant memories from the index
 
 import json
 import logging
-import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone, timedelta
@@ -32,8 +31,10 @@ MAX_INDEX_ENTRIES = 200
 MIN_QUERY_LENGTH = 8  # Single words don't provide enough selection context
 STALENESS_DAYS = 2
 
-SELECTOR_MODEL = os.getenv("MEMORY_SELECTOR_MODEL", "anthropic/claude-haiku-4.5")
-SELECTOR_TIMEOUT = float(os.getenv("MEMORY_SELECTOR_TIMEOUT", "5.0"))
+from chat.backend.agent.llm import ModelConfig
+
+SELECTOR_MODEL = ModelConfig.RCA_MODEL
+SELECTOR_TIMEOUT = 5.0
 
 _SESSION_BUDGET_TTL = 86400
 _prefetch_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="mem-inject")
@@ -67,17 +68,6 @@ Select 0-5 memories. Only include those you are certain will help. JSON only."""
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-
-
-def start_memory_prefetch(
-    user_id: str,
-    session_id: str,
-    user_message: str,
-) -> "MemoryPrefetch":
-    """Fire a non-blocking memory prefetch. Returns a handle to collect results."""
-    prefetch = MemoryPrefetch(user_id, session_id, user_message)
-    prefetch.start()
-    return prefetch
 
 
 class MemoryPrefetch:
@@ -118,6 +108,17 @@ class MemoryPrefetch:
         except Exception:
             logger.exception("[MemoryInjector] Unhandled error in prefetch")
             return ""
+
+
+def start_memory_prefetch(
+    user_id: str,
+    session_id: str,
+    user_message: str,
+) -> MemoryPrefetch:
+    """Fire a non-blocking memory prefetch. Returns a handle to collect results."""
+    prefetch = MemoryPrefetch(user_id, session_id, user_message)
+    prefetch.start()
+    return prefetch
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -104,7 +104,52 @@ class MemoryPrefetch:
 
     def _execute(self) -> str:
         try:
-            return _run_prefetch(self.user_id, self.session_id, self.user_message)
+            # Not enough context to select meaningfully
+            if len(self.user_message.strip()) < MIN_QUERY_LENGTH:
+                return ""
+
+            # Session budget exhausted — memories already saturate context
+            budget_used = _get_session_budget(self.session_id)
+            if budget_used >= MAX_SESSION_BYTES:
+                return ""
+
+            already_surfaced = _get_surfaced_set(self.session_id)
+
+            # Scan index (titles + descriptions, no content)
+            entries = get_memory_entries(self.user_id, limit=MAX_INDEX_ENTRIES)
+            if not entries:
+                return ""
+
+            # Remove already-surfaced entries (don't waste selection slots)
+            available = [e for e in entries if _entry_key(e) not in already_surfaced]
+            if not available:
+                return ""
+
+            # Single LLM pass: select up to 5
+            selected = _select_relevant_memories(self.user_message, available)
+            if not selected:
+                return ""
+
+            # Fetch content of the selected entries
+            memories = fetch_memory_content(self.user_id, selected)
+            if not memories:
+                return ""
+
+            # Format and inject (with staleness headers + budget enforcement)
+            remaining_budget = MAX_SESSION_BYTES - budget_used
+            injection_text, bytes_used, surfaced_keys = _format_for_injection(memories, remaining_budget)
+            if not injection_text:
+                return ""
+
+            _update_session_budget(self.session_id, budget_used + bytes_used)
+            _mark_surfaced(self.session_id, surfaced_keys)
+
+            logger.info(
+                "[MemoryInjector] Injected %d memories (%d bytes) for session %s",
+                len(surfaced_keys), bytes_used, self.session_id,
+            )
+            return injection_text
+
         except Exception:
             logger.exception("[MemoryInjector] Unhandled error in prefetch")
             return ""
@@ -119,60 +164,6 @@ def start_memory_prefetch(
     prefetch = MemoryPrefetch(user_id, session_id, user_message)
     prefetch.start()
     return prefetch
-
-
-# ---------------------------------------------------------------------------
-# Pipeline: scan → select (1 LLM call) → fetch content → format → inject
-# ---------------------------------------------------------------------------
-
-
-def _run_prefetch(user_id: str, session_id: str, user_message: str) -> str:
-    # Not enough context to select meaningfully
-    if len(user_message.strip()) < MIN_QUERY_LENGTH:
-        return ""
-
-    # Session budget exhausted — memories already saturate context
-    budget_used = _get_session_budget(session_id)
-    if budget_used >= MAX_SESSION_BYTES:
-        return ""
-
-    already_surfaced = _get_surfaced_set(session_id)
-
-    # Scan index (titles + descriptions, no content)
-    entries = get_memory_entries(user_id, limit=MAX_INDEX_ENTRIES)
-    if not entries:
-        return ""
-
-    # Remove already-surfaced entries (don't waste selection slots)
-    available = [e for e in entries if _entry_key(e) not in already_surfaced]
-    if not available:
-        return ""
-
-    # Single LLM pass: select up to 5
-    selected = _select_relevant_memories(user_message, available)
-    if not selected:
-        return ""
-
-    # Fetch content of the selected entries
-    memories = fetch_memory_content(user_id, selected)
-    if not memories:
-        return ""
-
-    # Format and inject (with staleness headers + budget enforcement)
-    remaining_budget = MAX_SESSION_BYTES - budget_used
-    injection_text, bytes_used, surfaced_keys = _format_for_injection(memories, remaining_budget)
-    if not injection_text:
-        return ""
-
-    _update_session_budget(session_id, budget_used + bytes_used)
-    _mark_surfaced(session_id, surfaced_keys)
-
-    elapsed = (time.perf_counter() - time.perf_counter())  # logged by caller
-    logger.info(
-        "[MemoryInjector] Injected %d memories (%d bytes) for session %s",
-        len(surfaced_keys), bytes_used, session_id,
-    )
-    return injection_text
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -1,0 +1,336 @@
+"""
+Memory Injector — Async Prefetch + Single-Pass LLM Selection
+
+Runs as a non-blocking prefetch in parallel with prompt building.
+One fast LLM call selects up to 5 relevant memories from the index
+(title + description). Whatever it selects gets injected into the system prompt. 
+- Hard caps: 5 entries max, 4KB per entry, 60KB per session.
+- Dedup: never re-surface a memory already shown this session.
+"""
+
+import json
+import logging
+import os
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime, timezone, timedelta
+from typing import Dict, List, Optional, Set, Tuple
+
+from utils.cache.redis_client import get_redis_client
+from services.memory.index_builder import get_memory_entries, fetch_memory_content
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_SELECTED = 5
+MAX_MEMORY_BYTES_PER_ENTRY = 4096
+MAX_SESSION_BYTES = 60_000
+MAX_INDEX_ENTRIES = 200
+MIN_QUERY_LENGTH = 8  # Single words don't provide enough selection context
+STALENESS_DAYS = 2
+
+SELECTOR_MODEL = os.getenv("MEMORY_SELECTOR_MODEL", "anthropic/claude-haiku-4.5")
+SELECTOR_TIMEOUT = float(os.getenv("MEMORY_SELECTOR_TIMEOUT", "5.0"))
+
+_SESSION_BUDGET_TTL = 86400
+_prefetch_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="mem-inject")
+
+# ---------------------------------------------------------------------------
+# Selector prompt — strict, single-pass
+# ---------------------------------------------------------------------------
+
+_SELECTOR_SYSTEM = """You are selecting memories that will be useful to Aurora (a cloud operations AI) as it processes a user's query. Aurora investigates incidents, runs root cause analysis, manages infrastructure, and assists with DevOps/SRE tasks. You will be given the user's message and a list of available memory entries with their category, title, and description.
+
+Return a list of entries that will clearly be useful to Aurora as it processes this query (up to 5). Only include memories that you are certain will be helpful based on their title and description.
+- If you are unsure if a memory will be useful, do not include it. Be selective and discerning.
+- If there are no memories that would clearly be useful, return an empty list.
+- Do not select memories that merely repeat generic knowledge Aurora already has. DO still select memories containing org-specific context, warnings, known issues, past incident patterns, or team preferences — those always matter.
+- Prioritize: runbooks when troubleshooting, infrastructure context for system questions, learned patterns from past incidents for debugging, org preferences for behavioral questions.
+
+Return JSON:
+{"selected": [{"category": "...", "title": "..."}, ...]}
+
+If nothing is relevant: {"selected": []}"""
+
+_SELECTOR_USER = """USER MESSAGE:
+{user_message}
+
+MEMORY INDEX:
+{manifest}
+
+Select 0-5 memories. Only include those you are certain will help. JSON only."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def start_memory_prefetch(
+    user_id: str,
+    session_id: str,
+    user_message: str,
+) -> "MemoryPrefetch":
+    """Fire a non-blocking memory prefetch. Returns a handle to collect results."""
+    prefetch = MemoryPrefetch(user_id, session_id, user_message)
+    prefetch.start()
+    return prefetch
+
+
+class MemoryPrefetch:
+    """Handle for an in-flight memory prefetch operation."""
+
+    def __init__(self, user_id: str, session_id: str, user_message: str):
+        self.user_id = user_id
+        self.session_id = session_id
+        self.user_message = user_message
+        self._future: Optional[Future] = None
+        self._result: Optional[str] = None
+        self._started_at: float = 0
+
+    def start(self):
+        self._started_at = time.perf_counter()
+        self._future = _prefetch_pool.submit(self._execute)
+
+    def get_result(self, timeout: float = SELECTOR_TIMEOUT + 2.0) -> str:
+        """Block until prefetch settles. Returns injection text or empty string."""
+        if self._result is not None:
+            return self._result
+
+        if self._future is None:
+            return ""
+
+        try:
+            self._result = self._future.result(timeout=timeout)
+        except Exception as e:
+            elapsed = (time.perf_counter() - self._started_at) * 1000
+            logger.warning("[MemoryInjector] Prefetch failed after %.0fms: %s", elapsed, e)
+            self._result = ""
+
+        return self._result
+
+    def _execute(self) -> str:
+        try:
+            return _run_prefetch(self.user_id, self.session_id, self.user_message)
+        except Exception:
+            logger.exception("[MemoryInjector] Unhandled error in prefetch")
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: scan → select (1 LLM call) → fetch content → format → inject
+# ---------------------------------------------------------------------------
+
+
+def _run_prefetch(user_id: str, session_id: str, user_message: str) -> str:
+    # Not enough context to select meaningfully
+    if len(user_message.strip()) < MIN_QUERY_LENGTH:
+        return ""
+
+    # Session budget exhausted — memories already saturate context
+    budget_used = _get_session_budget(session_id)
+    if budget_used >= MAX_SESSION_BYTES:
+        return ""
+
+    already_surfaced = _get_surfaced_set(session_id)
+
+    # Scan index (titles + descriptions, no content)
+    entries = get_memory_entries(user_id, limit=MAX_INDEX_ENTRIES)
+    if not entries:
+        return ""
+
+    # Remove already-surfaced entries (don't waste selection slots)
+    available = [e for e in entries if _entry_key(e) not in already_surfaced]
+    if not available:
+        return ""
+
+    # Single LLM pass: select up to 5
+    selected = _select_relevant_memories(user_message, available)
+    if not selected:
+        return ""
+
+    # Fetch content of the selected entries
+    memories = fetch_memory_content(user_id, selected)
+    if not memories:
+        return ""
+
+    # Format and inject (with staleness headers + budget enforcement)
+    remaining_budget = MAX_SESSION_BYTES - budget_used
+    injection_text, bytes_used, surfaced_keys = _format_for_injection(memories, remaining_budget)
+    if not injection_text:
+        return ""
+
+    _update_session_budget(session_id, budget_used + bytes_used)
+    _mark_surfaced(session_id, surfaced_keys)
+
+    elapsed = (time.perf_counter() - time.perf_counter())  # logged by caller
+    logger.info(
+        "[MemoryInjector] Injected %d memories (%d bytes) for session %s",
+        len(surfaced_keys), bytes_used, session_id,
+    )
+    return injection_text
+
+
+# ---------------------------------------------------------------------------
+# Select (single LLM call)
+# ---------------------------------------------------------------------------
+
+
+def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Dict]:
+    """One strict LLM call: select up to 5 from the index."""
+    from chat.backend.agent.providers import create_chat_model
+    from langchain_core.messages import SystemMessage, HumanMessage
+
+    manifest_lines = []
+    for entry in entries:
+        ts = entry["updated_at"].isoformat() if entry["updated_at"] else "unknown"
+        desc = entry["description"][:150] if entry["description"] else "(no description)"
+        manifest_lines.append(f"- [{entry['category']}] {entry['title']} ({ts}): {desc}")
+
+    prompt = _SELECTOR_USER.format(
+        user_message=user_message[:2000],
+        manifest="\n".join(manifest_lines),
+    )
+
+    try:
+        llm = create_chat_model(SELECTOR_MODEL, temperature=0.0, streaming=False, max_tokens=256)
+        response = llm.invoke([
+            SystemMessage(content=_SELECTOR_SYSTEM),
+            HumanMessage(content=prompt),
+        ])
+
+        content = response.content if hasattr(response, "content") else str(response)
+        json_str = content.strip()
+        if json_str.startswith("```"):
+            json_str = json_str.split("\n", 1)[1] if "\n" in json_str else json_str
+            json_str = json_str.rsplit("```", 1)[0]
+
+        parsed = json.loads(json_str)
+        selected_raw = parsed.get("selected", [])
+        if not isinstance(selected_raw, list):
+            return []
+
+        # Validate against actual entries
+        entry_lookup = {_entry_key(e): e for e in entries}
+        validated = []
+        for sel in selected_raw[:MAX_SELECTED]:
+            key = f"{sel.get('category', '')}/{sel.get('title', '')}"
+            if key in entry_lookup:
+                validated.append(entry_lookup[key])
+
+        logger.info("[MemoryInjector] Selected %d/%d entries", len(validated), len(entries))
+        return validated
+
+    except json.JSONDecodeError as e:
+        logger.warning("[MemoryInjector] Selector returned invalid JSON: %s", e)
+        return []
+    except Exception as e:
+        logger.warning("[MemoryInjector] Selector failed: %s", e)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Format for injection
+# ---------------------------------------------------------------------------
+
+
+def _format_for_injection(
+    memories: List[Dict], remaining_budget: int
+) -> Tuple[str, int, Set[str]]:
+    """Format memories with staleness headers, respecting per-entry and budget caps."""
+    now = datetime.now(timezone.utc)
+    parts = []
+    total_bytes = 0
+    surfaced: Set[str] = set()
+
+    header = "RELEVANT MEMORIES (auto-loaded — verify stale data before acting):\n"
+    header_bytes = len(header.encode("utf-8"))
+    if header_bytes > remaining_budget:
+        return "", 0, set()
+    total_bytes += header_bytes
+    parts.append(header)
+
+    for mem in memories:
+        key = _entry_key(mem)
+        content = mem["content"]
+
+        # Per-entry cap: 4KB
+        if len(content.encode("utf-8")) > MAX_MEMORY_BYTES_PER_ENTRY:
+            content = content[:MAX_MEMORY_BYTES_PER_ENTRY]
+            content += "\n... (truncated — use read_memory() for full content)"
+
+        # Staleness header
+        staleness = ""
+        if mem["updated_at"]:
+            age = now - mem["updated_at"]
+            if age > timedelta(days=STALENESS_DAYS):
+                staleness = f" ⚠️ Last updated {age.days}d ago — verify before acting"
+
+        entry_text = f"\n--- {mem['category']}/{mem['title']}{staleness} ---\n{content}\n"
+        entry_bytes = len(entry_text.encode("utf-8"))
+
+        # Budget check
+        if total_bytes + entry_bytes > remaining_budget:
+            break
+
+        parts.append(entry_text)
+        total_bytes += entry_bytes
+        surfaced.add(key)
+
+    if not surfaced:
+        return "", 0, set()
+
+    result = "".join(parts)
+    result = result.replace("{", "{{").replace("}", "}}")
+    return result, total_bytes, surfaced
+
+
+# ---------------------------------------------------------------------------
+# Session tracking (Redis)
+# ---------------------------------------------------------------------------
+
+
+def _entry_key(entry: Dict) -> str:
+    return f"{entry.get('category', '')}/{entry.get('title', '')}"
+
+
+def _get_session_budget(session_id: str) -> int:
+    try:
+        r = get_redis_client()
+        val = r.get(f"mem:inject:budget:{session_id}")
+        return int(val) if val else 0
+    except Exception:
+        return 0
+
+
+def _update_session_budget(session_id: str, new_total: int):
+    try:
+        r = get_redis_client()
+        r.setex(f"mem:inject:budget:{session_id}", _SESSION_BUDGET_TTL, str(new_total))
+    except Exception:
+        pass
+
+
+def _get_surfaced_set(session_id: str) -> Set[str]:
+    try:
+        r = get_redis_client()
+        members = r.smembers(f"mem:inject:surfaced:{session_id}")
+        return {m.decode("utf-8") if isinstance(m, bytes) else m for m in members} if members else set()
+    except Exception:
+        return set()
+
+
+def _mark_surfaced(session_id: str, keys: Set[str]):
+    if not keys:
+        return
+    try:
+        r = get_redis_client()
+        pipe = r.pipeline()
+        pipe.sadd(f"mem:inject:surfaced:{session_id}", *keys)
+        pipe.expire(f"mem:inject:surfaced:{session_id}", _SESSION_BUDGET_TTL)
+        pipe.execute()
+    except Exception:
+        pass

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -155,7 +155,7 @@ def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Di
     for entry in entries:
         ts = entry["updated_at"].isoformat() if entry["updated_at"] else "unknown"
         desc = entry["description"][:150] if entry["description"] else "(no description)"
-        manifest_lines.append(f"- [{entry['category']}] {entry['title']} ({ts}): {desc}")
+        manifest_lines.append(f"- [{entry['category']}] \"{entry['title']}\" | updated: {ts} | {desc}")
 
     prompt = _SELECTOR_USER.format(
         user_message=user_message[:2000],
@@ -184,7 +184,8 @@ def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Di
         entry_lookup = {_entry_key(e): e for e in entries}
         validated = []
         for sel in selected_raw[:MAX_SELECTED]:
-            key = f"{sel.get('category', '')}/{sel.get('title', '')}"
+            title = sel.get("title", "").strip().strip('"')
+            key = f"{sel.get('category', '')}/{title}"
             if key in entry_lookup:
                 validated.append(entry_lookup[key])
 
@@ -206,11 +207,11 @@ def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Di
 
 def _format_for_injection(memories: List[Dict]) -> Tuple[str, Set[str]]:
     """Format memories with staleness headers and per-entry cap."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     parts = []
     surfaced: Set[str] = set()
 
-    parts.append("RELEVANT MEMORIES (auto-loaded — verify stale data before acting):\n")
+    parts.append("RELEVANT MEMORIES (pre-loaded — only call read_memory() if content below is marked truncated):\n")
 
     for mem in memories:
         key = _entry_key(mem)

--- a/server/services/memory/injector.py
+++ b/server/services/memory/injector.py
@@ -163,7 +163,7 @@ def _select_relevant_memories(user_message: str, entries: List[Dict]) -> List[Di
     )
 
     try:
-        llm = create_chat_model(SELECTOR_MODEL, temperature=0.0, streaming=False, max_tokens=256)
+        llm = create_chat_model(SELECTOR_MODEL, temperature=0.0, streaming=False, max_tokens=256, timeout=SELECTOR_TIMEOUT)
         response = llm.invoke([
             SystemMessage(content=_SELECTOR_SYSTEM),
             HumanMessage(content=prompt),

--- a/server/services/memory/queries.py
+++ b/server/services/memory/queries.py
@@ -61,22 +61,18 @@ def fetch_memory_content(user_id: str, entries: List[Dict]) -> List[Dict]:
                 if not org_id:
                     return []
 
-                results = []
-                for entry in entries:
-                    cursor.execute(
-                        """SELECT content, updated_at FROM artifacts
-                           WHERE org_id = %s AND category = %s AND title = %s""",
-                        (org_id, entry["category"], entry["title"]),
-                    )
-                    row = cursor.fetchone()
-                    if row:
-                        results.append({
-                            "category": entry["category"],
-                            "title": entry["title"],
-                            "content": row[0] or "",
-                            "updated_at": row[1],
-                        })
-                return results
+                # Batch fetch all entries in a single query
+                pairs = [(entry["category"], entry["title"]) for entry in entries]
+                cursor.execute(
+                    """SELECT category, title, content, updated_at FROM artifacts
+                       WHERE org_id = %s AND (category, title) IN %s""",
+                    (org_id, tuple(pairs)),
+                )
+                rows = cursor.fetchall()
+                return [
+                    {"category": row[0], "title": row[1], "content": row[2] or "", "updated_at": row[3]}
+                    for row in rows
+                ]
     except Exception:
         logger.exception("[MemoryQueries] Failed to fetch memory content")
         return []

--- a/server/services/memory/queries.py
+++ b/server/services/memory/queries.py
@@ -1,0 +1,82 @@
+"""
+Memory data-access helpers.
+
+Shared DB queries for fetching memory entries (artifacts table).
+Used by both the index builder and the injector.
+"""
+
+import logging
+from typing import Dict, List
+
+from utils.db.connection_pool import db_pool
+from utils.auth.stateless_auth import set_rls_context
+
+from services.memory import MEMORY_CATEGORIES
+
+logger = logging.getLogger(__name__)
+
+
+def get_memory_entries(user_id: str, limit: int = 200) -> List[Dict]:
+    """Fetch memory entry metadata (no content) for the user's org.
+
+    Returns a list of dicts with: category, title, description, updated_at.
+    Ordered by most recently updated first.
+    """
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryIndex]")
+                if not org_id:
+                    return []
+
+                cursor.execute(
+                    """SELECT category, title, description, updated_at
+                       FROM artifacts
+                       WHERE org_id = %s AND category = ANY(%s)
+                       ORDER BY updated_at DESC
+                       LIMIT %s""",
+                    (org_id, list(MEMORY_CATEGORIES), limit),
+                )
+                return [
+                    {"category": r[0], "title": r[1], "description": r[2] or "", "updated_at": r[3]}
+                    for r in cursor.fetchall()
+                ]
+    except Exception as e:
+        logger.warning("[MemoryQueries] Failed to fetch entries for user %s: %s", user_id, e)
+        return []
+
+
+def fetch_memory_content(user_id: str, entries: List[Dict]) -> List[Dict]:
+    """Fetch full content for a list of memory entries.
+
+    Takes entries (with category + title) and returns them enriched with content.
+    """
+    if not entries:
+        return []
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[MemoryQueries:fetch]")
+                if not org_id:
+                    return []
+
+                results = []
+                for entry in entries:
+                    cursor.execute(
+                        """SELECT content, updated_at FROM artifacts
+                           WHERE org_id = %s AND category = %s AND title = %s""",
+                        (org_id, entry["category"], entry["title"]),
+                    )
+                    row = cursor.fetchone()
+                    if row:
+                        results.append({
+                            "category": entry["category"],
+                            "title": entry["title"],
+                            "content": row[0] or "",
+                            "updated_at": row[1],
+                        })
+                return results
+    except Exception:
+        logger.exception("[MemoryQueries] Failed to fetch memory content")
+        return []


### PR DESCRIPTION
## Summary
- Adds a single-pass LLM selector that picks up to 5 relevant memories from the org memory index (title + description) and injects their full content into the system prompt
- Runs as a non-blocking async prefetch in parallel with prompt building — fires early in `agentic_tool_flow`, result consumed in `composer.py`
- Session-level dedup (Redis set) and 60KB cumulative budget prevent re-surfacing and context bloat

## Key Design Decisions
- **Single LLM call** (not two-pass): speed > precision for an async prefetch that must settle before the turn ends
- **Quality pushed left**: selection quality depends on good `description` fields in memory metadata, not a second filter pass
- **4KB per-file cap**: truncated memories include a note to use `read_memory()` for full content
- **Staleness headers**: memories older than 2 days get a verification warning

## Files
- `server/services/memory/injector.py` (new)
- `server/chat/backend/agent/agent.py` (prefetch start)
- `server/chat/backend/agent/prompt/composer.py` (prefetch consumption)

## Test plan
- [ ] Verify prefetch fires and settles within timeout for interactive chats
- [ ] Verify background RCA sessions skip prefetch (`is_background` guard)
- [ ] Verify empty selection returns empty string (no injection)
- [ ] Verify session budget exhaustion stops further prefetches
- [ ] Verify dedup: same memory not re-surfaced in subsequent turns

Made with [Cursor](https://cursor.com)