### PR TITLE
chore(release): 1.2.17

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.16
-appVersion: "1.2.16"
+version: 1.2.17
+appVersion: "1.2.17"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- Bumps Helm `version` and `appVersion` from 1.2.16 → 1.2.17 so a `v1.2.17` tag can publish the chart (gh-pages + OCI) and refresh container tags (`1.2.17`, `1.2`, `latest`).
- Unblocks Vertex-only self-hosted deploys that correctly pinned `1.2.16` / `latest` and therefore missed post-June-8 fixes already on `main` (#501, #527).

## After merge
1. Tag `main`: `git tag v1.2.17 && git push origin v1.2.17`
2. Confirm workflows: **Publish Helm Chart** + **Publish Docker Images**
3. Verify:
   ```bash
   curl -sL https://raw.githubusercontent.com/Arvo-AI/aurora/gh-pages/index.yaml | rg -A2 'version: 1.2.17'
   helm show chart oci://ghcr.io/arvo-ai/charts/aurora-oss --version 1.2.17
   docker buildx imagetools inspect ghcr.io/arvo-ai/aurora-server:1.2.17
   ```
4. Tell Bombora to set chart `version = "1.2.17"` and `image.tag: "1.2.17"`, then apply.

## Test plan
- [ ] PR CI green
- [ ] After merge + tag: both publish workflows succeed
- [ ] Chart 1.2.17 visible on gh-pages index and OCI
- [ ] Images `aurora-server:1.2.17` and `aurora-frontend:1.2.17` exist
- [ ] Juan upgrades and can chat with `GUARDRAILS_ENABLED=true` + Vertex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and deployment chart versions to 1.2.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->