### PR TITLE
fix(bitbucket): resolve slashy branch names for repo file reads

### DIFF
--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -4,6 +4,7 @@ Wraps the Bitbucket 2.0 REST API with authentication and pagination support.
 """
 import base64
 import logging
+import re
 from urllib.parse import quote, unquote, urlsplit
 
 import requests
@@ -12,6 +13,9 @@ logger = logging.getLogger(__name__)
 
 BITBUCKET_API_BASE = "https://api.bitbucket.org/2.0"
 _BITBUCKET_ALLOWED_HOSTS = frozenset({"api.bitbucket.org", "bitbucket.org"})
+# Bitbucket Cloud /src/{ref}/ rejects branch names containing "/" (even %2F-encoded).
+# Always put a commit hash in that path segment. See BCLOUD-14674 / Atlassian forums.
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 
 
 def _validate_bitbucket_url(url: str) -> None:
@@ -264,31 +268,35 @@ class BitbucketAPIClient:
     # ------------------------------------------------------------------
 
     def _resolve_commit(self, workspace, repo_slug, ref):
-        """Resolve a branch/tag name to a commit hash. Returns the ref unchanged if resolution fails."""
-        # "HEAD" isn't a valid ref in Bitbucket's API — resolve to the repo's default branch
+        """Resolve HEAD / branch / tag to a commit hash for /src/{commit}/ paths.
+
+        Returns *ref* unchanged if resolution fails (caller gets a normal API error).
+        """
         if ref == "HEAD":
             repo_info = self._get(
                 f"{BITBUCKET_API_BASE}/repositories/"
                 f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}"
             )
-            if isinstance(repo_info, dict) and not repo_info.get("error"):
-                main_branch = repo_info.get("mainbranch", {}).get("name")
-                if main_branch:
-                    return main_branch
+            if not isinstance(repo_info, dict) or repo_info.get("error"):
+                return ref
+            ref = (repo_info.get("mainbranch") or {}).get("name") or ref
+            if ref == "HEAD":
+                return ref
+
+        if _COMMIT_SHA_RE.fullmatch(ref):
             return ref
-        # Already a commit SHA — no resolution needed
-        if len(ref) >= 12 and ref.isalnum():
-            return ref
-        # Branch/tag name — resolve to its commit hash
-        result = self._get(
-            f"{BITBUCKET_API_BASE}/repositories/"
-            f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}"
-            f"/refs/branches/{quote(ref, safe='')}"
-        )
-        if isinstance(result, dict) and not result.get("error"):
-            target_hash = result.get("target", {}).get("hash")
-            if target_hash:
-                return target_hash
+
+        # Prefer branch, then tag. /refs/... accepts URL-encoded "/" in the name.
+        for kind in ("branches", "tags"):
+            result = self._get(
+                f"{BITBUCKET_API_BASE}/repositories/"
+                f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}"
+                f"/refs/{kind}/{quote(ref, safe='')}"
+            )
+            if isinstance(result, dict) and not result.get("error"):
+                target_hash = (result.get("target") or {}).get("hash")
+                if target_hash:
+                    return target_hash
         return ref
 
     def get_file_contents(self, workspace, repo_slug, path, commit="HEAD"):
@@ -297,7 +305,7 @@ class BitbucketAPIClient:
         url = (
             f"{BITBUCKET_API_BASE}/repositories/"
             f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}"
-            f"/src/{commit}/{quote(path, safe='/')}"
+            f"/src/{quote(commit, safe='')}/{quote(path, safe='/')}"
         )
         _validate_bitbucket_url(url)
         headers = self._get_headers()
@@ -344,7 +352,7 @@ class BitbucketAPIClient:
         url = (
             f"{BITBUCKET_API_BASE}/repositories/"
             f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}"
-            f"/src/{commit}/{quote(path, safe='/')}"
+            f"/src/{quote(commit, safe='')}/{quote(path, safe='/')}"
         )
         # format=meta returns directory metadata; omitting it returns the file listing
         params = None if list_files else {"format": "meta"}

--- a/server/tests/connectors/test_bitbucket_resolve_commit.py
+++ b/server/tests/connectors/test_bitbucket_resolve_commit.py
@@ -1,0 +1,50 @@
+"""Bitbucket /src/ cannot take slashy branch names — _resolve_commit must hash them."""
+from unittest.mock import MagicMock
+
+from connectors.bitbucket_connector.api_client import BitbucketAPIClient
+
+
+def _client_with_gets(responses):
+    client = BitbucketAPIClient("token")
+    client._get = MagicMock(side_effect=responses)
+    return client
+
+
+def test_head_with_slashy_default_branch_resolves_to_hash():
+    client = _client_with_gets([
+        {"mainbranch": {"name": "fix/aurora-abc", "type": "branch"}},
+        {"target": {"hash": "deadbeefcafef00d1234567890abcdef12345678"}},
+    ])
+    assert client._resolve_commit("ws", "repo", "HEAD") == "deadbeefcafef00d1234567890abcdef12345678"
+    # Second call must hit /refs/branches/ with the slash encoded, not /src/
+    assert "refs/branches/fix%2Faurora-abc" in client._get.call_args_list[1].args[0]
+
+
+def test_slashy_branch_resolves_to_hash():
+    client = _client_with_gets([
+        {"target": {"hash": "abc1234567890"}},
+    ])
+    assert client._resolve_commit("ws", "repo", "feature/x") == "abc1234567890"
+
+
+def test_tag_used_when_branch_missing():
+    client = _client_with_gets([
+        {"error": True, "status": 404},
+        {"target": {"hash": "taghash000001"}},
+    ])
+    assert client._resolve_commit("ws", "repo", "v1.2.3") == "taghash000001"
+
+
+def test_sha_passthrough():
+    client = _client_with_gets([])
+    sha = "2e94a766f8f2f12b4664d6befd4737a60143808f"
+    assert client._resolve_commit("ws", "repo", sha) == sha
+    client._get.assert_not_called()
+
+
+def test_alphanumeric_branch_is_not_treated_as_sha():
+    """Regression: old isalnum() check would skip resolving release20240101."""
+    client = _client_with_gets([
+        {"target": {"hash": "realhash000001"}},
+    ])
+    assert client._resolve_commit("ws", "repo", "release20240101") == "realhash000001"

--- a/server/tests/connectors/test_bitbucket_resolve_commit.py
+++ b/server/tests/connectors/test_bitbucket_resolve_commit.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from connectors.bitbucket_connector.api_client import BitbucketAPIClient
 
 
-def _client_with_gets(responses):
+def _client_with_gets(responses) -> BitbucketAPIClient:
     client = BitbucketAPIClient("token")
     client._get = MagicMock(side_effect=responses)
     return client
@@ -37,8 +37,9 @@ def test_tag_used_when_branch_missing():
 
 def test_sha_passthrough():
     client = _client_with_gets([])
-    sha = "2e94a766f8f2f12b4664d6befd4737a60143808f"
-    assert client._resolve_commit("ws", "repo", sha) == sha
+    # 7 chars is the shortest form _COMMIT_SHA_RE accepts, 40 the longest.
+    for sha in ("2e94a76", "2e94a766f8f2f12b4664d6befd4737a60143808f"):
+        assert client._resolve_commit("ws", "repo", sha) == sha
     client._get.assert_not_called()
 
 

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -96,8 +96,12 @@ def _fetch_bitbucket_readme(access_token: str, auth_type: str, workspace: str, r
     client = BitbucketAPIClient(access_token, auth_type=auth_type, email=email)
     for filename in ("README.md", "README.rst", "README.txt", "README"):
         result = client.get_file_contents(workspace, repo_slug, filename)
-        if isinstance(result, dict) and result.get("error"):
-            continue
+        if isinstance(result, dict):
+            if result.get("error"):
+                continue
+            content = result.get("content")
+            if isinstance(content, str) and content:
+                return content[:4000]
         if isinstance(result, str):
             return result[:4000]
     return ""


### PR DESCRIPTION
## Summary
- Bitbucket Cloud cannot read files from branches whose names contain `/` (e.g. `fix/...`) via `/src/{branch}/` — even URL-encoded — so repo description generation failed with a red error in the UI.
- We now resolve HEAD / branch / tag to a commit hash before calling `/src/`, and correctly read README content from the API response dict.
- Covers `get_file_contents` and `get_directory_tree` (the only paths that hit this Bitbucket limitation).

## Test plan
- [x] Unit tests for `_resolve_commit` (slashy branch, HEAD, tag fallback, SHA passthrough)
- [x] Live: connected Bitbucket repo with default branch `fix/...` fetches README + listing
- [ ] Hit Retry on a previously failed connected repo and confirm description generates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitbucket link handling for commits, branches, tags, and default branches, including branch names containing slashes.
  * Preserved unresolved references instead of incorrectly modifying them.
  * Improved Bitbucket README retrieval when content is returned in structured responses.
  * README content is now limited to the first 4,000 characters for valid responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->