### PR TITLE
chore(release): 1.2.18

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.17
-appVersion: "1.2.17"
+version: 1.2.18
+appVersion: "1.2.18"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary

Bumps chart `version` and `appVersion` to `1.2.18` so Helm consumers pick up the three changes merged since `v1.2.17`. Chart.yaml only, matching the 1.2.17 release (e9577e31).

Ships:
- Gemini 3.6 Flash / 3.5 Flash-Lite Vertex support (#599)
- Bitbucket slashy branch resolution for repo file reads (#597)
- Bitbucket Incident Prevention pre-merge PR risk review (#598)

## Release steps after merge

Publishing is driven entirely by the tag push, not by this merge:

```bash
git checkout main && git pull
git tag -a v1.2.18 -m "chore(release): 1.2.18"
git push origin v1.2.18
```

That triggers `publish-helm.yml` (gh-pages + GHCR OCI at `ghcr.io/arvo-ai/charts/aurora-oss`) and `publish-images.yml` (multi-arch server/frontend tagged `:1.2.18`, `:1.2`, `:latest`). The tag must be annotated (`-a`) and must match Chart.yaml exactly, or the `validate-version` gate fails.

## Test plan

- [x] `helm lint deploy/helm/aurora` passes
- [x] `validate-version` gate simulated locally: tag `1.2.18` matches Chart.yaml `1.2.18`
- [ ] After tagging: confirm both publish workflows go green and `helm show chart oci://ghcr.io/arvo-ai/charts/aurora-oss --version 1.2.18` resolves

## Note

`appVersion` does not pin the deployed images — every template renders `.Values.image.tag`, which defaults to `latest` in `values.yaml`. Chart 1.2.18 will still pull `:latest`. It works because the same tag push re-points `latest`, but it floats. Pinning `image.tag` is a deliberate behavior change and is intentionally left out of this release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment chart and application release versions to 1.2.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->