### PR TITLE
Add Bitbucket repo select-all and bulk Incident Prevention enable

### DIFF
--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -80,16 +80,12 @@ export default function BitbucketWorkspaceBrowser() {
     setGatingUpdating(prev => new Set(prev).add(repoFullName));
     try {
       const result = await BitbucketIntegrationService.updateChangeGating(repoFullName, enabled);
-      // webhook_configured is never set optimistically: creating a hook is not
-      // evidence that deliveries reach Aurora. It stays false until Verify or a
-      // real delivery confirms it, so the badge can't claim a working setup.
       setSavedRepos(prev => prev.map(r =>
         r.full_name === repoFullName
-          ? { ...r, change_gating_enabled: enabled, webhook_configured: false, webhook_stale: false }
+          ? { ...r, change_gating_enabled: enabled, webhook_configured: !!(enabled && result.webhook_auto_created), webhook_stale: false }
           : r
       ));
-      if (enabled && result.webhook_url) {
-        // Always walk the user through webhook setup/verification on enable.
+      if (enabled && result.webhook_url && result.webhook_auto_created === false) {
         setWebhookSetup(result);
       } else if (!enabled && webhookSetup?.repo_full_name === repoFullName) {
         setWebhookSetup(null);
@@ -119,19 +115,30 @@ export default function BitbucketWorkspaceBrowser() {
   };
 
   const handleBulkEnable = async () => {
-    const names = savedRepos.filter(r => !r.change_gating_enabled).map(r => r.full_name);
-    if (names.length === 0) return;
+    const names = savedRepos
+      .filter(r => r.workspace === selectedWorkspace && checkedRepos.has(r.slug) && !r.change_gating_enabled)
+      .map(r => r.full_name);
+    if (names.length === 0) {
+      const checkedConnected = [...checkedRepos].some(s => savedReposByWorkspace.get(selectedWorkspace)?.has(s));
+      toast({
+        title: checkedConnected ? "Incident Prevention is already on for the selected connected repos" : "Save selected repos first",
+      });
+      return;
+    }
     setBulkEnabling(true);
     try {
-      const result = await BitbucketIntegrationService.updateChangeGatingBulk(names);
-      const byName = new Map(result.results.map(r => [r.repo_full_name, r]));
-      setSavedRepos(prev => prev.map(r => {
-        const row = byName.get(r.full_name);
-        if (!row || row.error) return r;
-        return { ...r, change_gating_enabled: true, webhook_configured: false, webhook_stale: false };
-      }));
-      const manual = result.results.filter(r => r.webhook_auto_created === false);
-      if (manual.length && result.webhook_url) {
+      const job = await BitbucketIntegrationService.updateChangeGatingBulk(names);
+      let status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
+      while (!status.complete) {
+        await new Promise(r => setTimeout(r, 2000));
+        status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
+      }
+      if (status.error) throw new Error(status.status || "Failed to enable Incident Prevention");
+      const result = status.result;
+      const data = await BitbucketIntegrationService.loadWorkspaceSelection();
+      if (data?.repositories) setSavedRepos(parseConnectedRepos(data.repositories));
+      const manual = result?.results.filter(r => r.webhook_auto_created === false) ?? [];
+      if (manual.length && result?.webhook_url) {
         setWebhookSetup({
           repo_full_name: manual[0].repo_full_name,
           change_gating_enabled: true,
@@ -142,24 +149,59 @@ export default function BitbucketWorkspaceBrowser() {
           manual_count: manual.length,
         });
       } else {
-        const enabled = result.results.filter(r => !r.error).length;
+        const enabled = result?.results.filter(r => !r.error).length ?? 0;
         if (enabled) {
           toast({ title: `Incident Prevention enabled on ${enabled} repo${enabled === 1 ? '' : 's'}` });
         }
       }
-      const skipped = result.results.filter(r => r.error === 'no_default_branch').length;
+      const skipped = result?.results.filter(r => r.error === 'no_default_branch').length ?? 0;
       if (skipped) {
         toast({
           title: `${skipped} repo${skipped === 1 ? '' : 's'} skipped`,
-          description: 'No default branch recorded. Re-save the repository selection, then try again.',
-          variant: 'destructive',
+          description: "No default branch recorded. Re-save the repository selection, then try again.",
+          variant: "destructive",
         });
       }
     } catch (error: unknown) {
       const err = error as Error;
-      toast({ title: 'Error', description: err.message || 'Failed to enable Incident Prevention', variant: 'destructive' });
+      toast({ title: "Error", description: err.message || "Failed to enable Incident Prevention", variant: "destructive" });
     } finally {
       setBulkEnabling(false);
+    }
+  };
+
+  const handleDisconnectSelected = async () => {
+    if (!selectedWorkspace) return;
+    const saved = savedReposByWorkspace.get(selectedWorkspace);
+    if (!saved?.size) return;
+    const remainingSlugs = [...saved].filter(s => !checkedRepos.has(s));
+    const removed = saved.size - remainingSlugs.length;
+    setIsSaving(true);
+    try {
+      await BitbucketIntegrationService.saveWorkspaceSelection({
+        workspace: selectedWorkspace,
+        repositories: remainingSlugs.map(slug => {
+          const repo = repos.find(r => r.slug === slug);
+          return repo ?? { slug, name: slug, full_name: `${selectedWorkspace}/${slug}`, is_private: false };
+        }),
+      });
+      setCheckedRepos(new Set(remainingSlugs));
+      setSavedReposByWorkspace(prev => {
+        const next = new Map(prev);
+        if (remainingSlugs.length) next.set(selectedWorkspace, new Set(remainingSlugs));
+        else next.delete(selectedWorkspace);
+        savedReposByWorkspaceRef.current = next;
+        return next;
+      });
+      const data = await BitbucketIntegrationService.loadWorkspaceSelection();
+      setSavedRepos(data?.repositories ? parseConnectedRepos(data.repositories) : []);
+      window.dispatchEvent(new CustomEvent('providerStateChanged'));
+      toast({ title: "Disconnected", description: `${removed} repo${removed === 1 ? '' : 's'} disconnected` });
+    } catch (error: unknown) {
+      const err = error as Error;
+      toast({ title: "Error", description: err.message || "Failed to disconnect", variant: "destructive" });
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -554,17 +596,15 @@ export default function BitbucketWorkspaceBrowser() {
             </div>
           ) : repos.length > 0 ? (
             <div className="space-y-1">
-              {repos.length > 10 && (
-                <div className="relative">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
-                  <Input
-                    placeholder="Filter repositories..."
-                    value={searchFilter}
-                    onChange={(e) => setSearchFilter(e.target.value)}
-                    className="h-8 text-xs pl-7"
-                  />
-                </div>
-              )}
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                <Input
+                  placeholder="Filter repositories..."
+                  value={searchFilter}
+                  onChange={(e) => setSearchFilter(e.target.value)}
+                  className="h-8 text-xs pl-7"
+                />
+              </div>
               {visibleRepos.length > 0 && (
                 <label className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground cursor-pointer hover:text-foreground">
                   <Checkbox
@@ -626,17 +666,34 @@ export default function BitbucketWorkspaceBrowser() {
       )}
 
       {selectedWorkspace && repos.length > 0 && (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={isSaving || checkedRepos.size === 0 || !selectionChanged}
+            disabled={isSaving || bulkEnabling || checkedRepos.size === 0 || !selectionChanged}
           >
             {isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
             Save
           </Button>
+          {!!currentWorkspaceSaved?.size && [...checkedRepos].some(s => currentWorkspaceSaved.has(s)) && (
+            <Button size="sm" variant="outline" onClick={handleDisconnectSelected} disabled={isSaving || bulkEnabling}>
+              Disconnect selected
+            </Button>
+          )}
+          {incidentPreventionEnabled && checkedRepos.size > 0 && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isSaving || bulkEnabling}
+              onClick={handleBulkEnable}
+              data-testid="bb-enable-gating-selected"
+            >
+              {bulkEnabling ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
+              Enable Incident Prevention
+            </Button>
+          )}
           {totalSavedRepos > 0 && (
-            <Button size="sm" variant="outline" onClick={handleClear}>
+            <Button size="sm" variant="outline" onClick={handleClear} disabled={isSaving || bulkEnabling}>
               Clear All
             </Button>
           )}
@@ -645,22 +702,7 @@ export default function BitbucketWorkspaceBrowser() {
 
       {savedRepos.length > 0 && (
         <div className="space-y-2 pt-2 border-t border-border">
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-sm font-medium text-muted-foreground">Connected Repositories</p>
-            {incidentPreventionEnabled && savedRepos.some(r => !r.change_gating_enabled) && (
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                disabled={bulkEnabling}
-                onClick={handleBulkEnable}
-                data-testid="bb-enable-all-gating"
-              >
-                {bulkEnabling ? <Loader2 className="h-3 w-3 animate-spin mr-1.5" /> : null}
-                Enable Incident Prevention on all
-              </Button>
-            )}
-          </div>
+          <p className="text-sm font-medium text-muted-foreground">Connected Repositories</p>
           {savedRepos.map(repo => {
             const isEditing = editingMetadata[repo.full_name] !== undefined;
             const isReady = repo.metadata_status === 'ready';

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -134,33 +134,43 @@ export default function BitbucketWorkspaceBrowser() {
       const job = await BitbucketIntegrationService.updateChangeGatingBulk(names, enabled);
       let status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       const deadline = Date.now() + 10 * 60 * 1000;
+      let consecutiveErrors = 0;
       while (!status.complete) {
         if (Date.now() > deadline) {
           throw new Error('Incident Prevention is taking longer than expected. Reload this page to see the current state.');
         }
-        const data = await BitbucketIntegrationService.loadWorkspaceSelection();
-        if (data?.repositories) {
-          const updated = parseConnectedRepos(data.repositories);
-          setSavedRepos(updated);
-          setGatingUpdating(prev => {
-            const next = new Set(prev);
-            for (const r of updated) {
-              if (!next.has(r.full_name)) continue;
-              const settled = enabled
-                ? r.webhook_configured || !r.change_gating_enabled
-                : !r.change_gating_enabled;
-              if (settled) next.delete(r.full_name);
+        // A failed poll is not evidence the job failed — the worker runs
+        // regardless. Only give up once several in a row fail; a real task
+        // failure arrives as status.error and is handled after the loop.
+        try {
+          const data = await BitbucketIntegrationService.loadWorkspaceSelection();
+          if (data?.repositories) {
+            const updated = parseConnectedRepos(data.repositories);
+            setSavedRepos(updated);
+            setGatingUpdating(prev => {
+              const next = new Set(prev);
+              for (const r of updated) {
+                if (!next.has(r.full_name)) continue;
+                const settled = enabled
+                  ? r.webhook_configured || !r.change_gating_enabled
+                  : !r.change_gating_enabled;
+                if (settled) next.delete(r.full_name);
+              }
+              return next;
+            });
+            // Disable is done once the DB flag is off. Hook deletes keep
+            // running in the worker; the UI does not wait on them.
+            if (!enabled && names.every(n => !updated.find(r => r.full_name === n)?.change_gating_enabled)) {
+              break;
             }
-            return next;
-          });
-          // Disable is done once the DB flag is off. Hook deletes keep
-          // running in the worker; the UI does not wait on them.
-          if (!enabled && names.every(n => !updated.find(r => r.full_name === n)?.change_gating_enabled)) {
-            break;
           }
+          await new Promise(r => setTimeout(r, 2000));
+          status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
+          consecutiveErrors = 0;
+        } catch (pollError) {
+          if (++consecutiveErrors >= 3) throw pollError;
+          await new Promise(r => setTimeout(r, 2000));
         }
-        await new Promise(r => setTimeout(r, 2000));
-        status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       }
       if (status.complete && status.error) throw new Error(status.status || 'Failed to update Incident Prevention');
       const result = status.result;
@@ -179,7 +189,8 @@ export default function BitbucketWorkspaceBrowser() {
             manual_count: manual.length,
           });
         } else {
-          toast({ title: `Incident Prevention enabled on ${names.length} repo${names.length === 1 ? '' : 's'}` });
+          const succeeded = result?.results.filter(r => !r.error).length ?? names.length;
+          toast({ title: `Incident Prevention enabled on ${succeeded} repo${succeeded === 1 ? '' : 's'}` });
         }
         const skipped = result?.results.filter(r => r.error === 'no_default_branch').length ?? 0;
         if (skipped) {
@@ -620,8 +631,9 @@ export default function BitbucketWorkspaceBrowser() {
           ) : repos.length > 0 ? (
             <div className="space-y-1">
               <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                <Search aria-hidden="true" className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
                 <Input
+                  aria-label="Filter repositories"
                   placeholder="Filter repositories..."
                   value={searchFilter}
                   onChange={(e) => setSearchFilter(e.target.value)}

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Check, Pencil, RotateCw, X, RefreshCw, Info, Copy, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { Loader2, Check, Pencil, RotateCw, X, RefreshCw, Info, Copy, AlertTriangle, CheckCircle2, Search } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -52,6 +53,7 @@ export default function BitbucketWorkspaceBrowser() {
 
   const [repos, setRepos] = useState<Repo[]>([]);
   const [checkedRepos, setCheckedRepos] = useState<Set<string>>(new Set());
+  const [searchFilter, setSearchFilter] = useState('');
   const [isLoadingRepos, setIsLoadingRepos] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -70,6 +72,7 @@ export default function BitbucketWorkspaceBrowser() {
   // live Bitbucket API round-trip and left the toggle invisible for seconds.
   const incidentPreventionEnabled = isIncidentPreventionEnabled();
   const [gatingUpdating, setGatingUpdating] = useState<Set<string>>(new Set());
+  const [bulkEnabling, setBulkEnabling] = useState(false);
   const [webhookSetup, setWebhookSetup] = useState<ChangeGatingResponse | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
 
@@ -112,6 +115,51 @@ export default function BitbucketWorkspaceBrowser() {
         next.delete(repoFullName);
         return next;
       });
+    }
+  };
+
+  const handleBulkEnable = async () => {
+    const names = savedRepos.filter(r => !r.change_gating_enabled).map(r => r.full_name);
+    if (names.length === 0) return;
+    setBulkEnabling(true);
+    try {
+      const result = await BitbucketIntegrationService.updateChangeGatingBulk(names);
+      const byName = new Map(result.results.map(r => [r.repo_full_name, r]));
+      setSavedRepos(prev => prev.map(r => {
+        const row = byName.get(r.full_name);
+        if (!row || row.error) return r;
+        return { ...r, change_gating_enabled: true, webhook_configured: false, webhook_stale: false };
+      }));
+      const manual = result.results.filter(r => r.webhook_auto_created === false);
+      if (manual.length && result.webhook_url) {
+        setWebhookSetup({
+          repo_full_name: manual[0].repo_full_name,
+          change_gating_enabled: true,
+          webhook_url: result.webhook_url,
+          webhook_secret: result.webhook_secret,
+          webhook_events: result.webhook_events,
+          webhook_auto_created: false,
+          manual_count: manual.length,
+        });
+      } else {
+        const enabled = result.results.filter(r => !r.error).length;
+        if (enabled) {
+          toast({ title: `Incident Prevention enabled on ${enabled} repo${enabled === 1 ? '' : 's'}` });
+        }
+      }
+      const skipped = result.results.filter(r => r.error === 'no_default_branch').length;
+      if (skipped) {
+        toast({
+          title: `${skipped} repo${skipped === 1 ? '' : 's'} skipped`,
+          description: 'No default branch recorded. Re-save the repository selection, then try again.',
+          variant: 'destructive',
+        });
+      }
+    } catch (error: unknown) {
+      const err = error as Error;
+      toast({ title: 'Error', description: err.message || 'Failed to enable Incident Prevention', variant: 'destructive' });
+    } finally {
+      setBulkEnabling(false);
     }
   };
 
@@ -232,6 +280,7 @@ export default function BitbucketWorkspaceBrowser() {
   useEffect(() => {
     if (isRestoringSelectionRef.current) return;
     if (selectedWorkspace) {
+      setSearchFilter('');
       fetchRepos(selectedWorkspace);
     }
   }, [selectedWorkspace]);
@@ -441,6 +490,10 @@ export default function BitbucketWorkspaceBrowser() {
     checkedRepos.size !== (currentWorkspaceSaved?.size ?? 0) ||
     [...checkedRepos].some(s => !currentWorkspaceSaved?.has(s))
   );
+  const visibleRepos = searchFilter
+    ? repos.filter(r => `${r.full_name} ${r.name}`.toLowerCase().includes(searchFilter.toLowerCase()))
+    : repos;
+  const allVisibleChecked = visibleRepos.length > 0 && visibleRepos.every(r => checkedRepos.has(r.slug));
 
   return (
     <div className="space-y-3">
@@ -500,34 +553,71 @@ export default function BitbucketWorkspaceBrowser() {
               Loading repositories...
             </div>
           ) : repos.length > 0 ? (
-            <div className="space-y-1 max-h-48 overflow-y-auto border border-border rounded-lg p-2">
-              {repos.map((repo) => (
-                <label
-                  key={repo.slug}
-                  className="w-full flex items-center gap-3 p-2 rounded-md cursor-pointer hover:bg-muted/30 transition-colors"
-                >
-                  <Checkbox
-                    checked={checkedRepos.has(repo.slug)}
-                    onCheckedChange={() => toggleRepo(repo.slug)}
+            <div className="space-y-1">
+              {repos.length > 10 && (
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                  <Input
+                    placeholder="Filter repositories..."
+                    value={searchFilter}
+                    onChange={(e) => setSearchFilter(e.target.value)}
+                    className="h-8 text-xs pl-7"
                   />
-                  <div className="flex flex-col min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium truncate">{repo.name}</span>
-                      <Badge variant={repo.is_private ? "secondary" : "outline"} className="text-xs">
-                        {repo.is_private ? 'Private' : 'Public'}
-                      </Badge>
-                    </div>
-                    {repo.mainbranch?.name && (
-                      <span className="text-xs text-muted-foreground mt-0.5">
-                        {repo.mainbranch.name}
-                      </span>
-                    )}
-                  </div>
-                  {currentWorkspaceSaved?.has(repo.slug) && (
-                    <Check className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
-                  )}
+                </div>
+              )}
+              {visibleRepos.length > 0 && (
+                <label className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+                  <Checkbox
+                    data-testid="bb-select-all"
+                    checked={allVisibleChecked}
+                    onCheckedChange={(checked) => {
+                      setCheckedRepos(prev => {
+                        const next = new Set(prev);
+                        if (checked) visibleRepos.forEach(r => next.add(r.slug));
+                        else visibleRepos.forEach(r => next.delete(r.slug));
+                        return next;
+                      });
+                    }}
+                  />
+                  <span>
+                    Select all
+                    {searchFilter ? ' (filtered)' : ''}
+                    {' · '}
+                    {visibleRepos.length} repos
+                  </span>
                 </label>
-              ))}
+              )}
+              <div className="space-y-1 max-h-48 overflow-y-auto border border-border rounded-lg p-2">
+                {visibleRepos.length > 0 ? visibleRepos.map((repo) => (
+                  <label
+                    key={repo.slug}
+                    className="w-full flex items-center gap-3 p-2 rounded-md cursor-pointer hover:bg-muted/30 transition-colors"
+                  >
+                    <Checkbox
+                      checked={checkedRepos.has(repo.slug)}
+                      onCheckedChange={() => toggleRepo(repo.slug)}
+                    />
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium truncate">{repo.name}</span>
+                        <Badge variant={repo.is_private ? "secondary" : "outline"} className="text-xs">
+                          {repo.is_private ? 'Private' : 'Public'}
+                        </Badge>
+                      </div>
+                      {repo.mainbranch?.name && (
+                        <span className="text-xs text-muted-foreground mt-0.5">
+                          {repo.mainbranch.name}
+                        </span>
+                      )}
+                    </div>
+                    {currentWorkspaceSaved?.has(repo.slug) && (
+                      <Check className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+                    )}
+                  </label>
+                )) : (
+                  <p className="text-xs text-muted-foreground text-center py-4">No repositories match your filter.</p>
+                )}
+              </div>
             </div>
           ) : (
             <p className="text-xs text-muted-foreground">No repositories found in this workspace.</p>
@@ -555,7 +645,22 @@ export default function BitbucketWorkspaceBrowser() {
 
       {savedRepos.length > 0 && (
         <div className="space-y-2 pt-2 border-t border-border">
-          <p className="text-sm font-medium text-muted-foreground">Connected Repositories</p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium text-muted-foreground">Connected Repositories</p>
+            {incidentPreventionEnabled && savedRepos.some(r => !r.change_gating_enabled) && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                disabled={bulkEnabling}
+                onClick={handleBulkEnable}
+                data-testid="bb-enable-all-gating"
+              >
+                {bulkEnabling ? <Loader2 className="h-3 w-3 animate-spin mr-1.5" /> : null}
+                Enable Incident Prevention on all
+              </Button>
+            )}
+          </div>
           {savedRepos.map(repo => {
             const isEditing = editingMetadata[repo.full_name] !== undefined;
             const isReady = repo.metadata_status === 'ready';
@@ -667,7 +772,7 @@ export default function BitbucketWorkspaceBrowser() {
                         <button
                           type="button"
                           className="inline-flex disabled:opacity-50"
-                          disabled={isGatingUpdating}
+                          disabled={isGatingUpdating || bulkEnabling}
                           onClick={() => handleReopenSetup(repo.full_name)}
                           title={repo.webhook_stale
                             ? "This repo's webhook points at a different Aurora URL and can no longer reach us — click to get the current URL and secret"
@@ -690,6 +795,7 @@ export default function BitbucketWorkspaceBrowser() {
                     ) : (
                       <Switch
                         checked={repo.change_gating_enabled}
+                        disabled={bulkEnabling}
                         onCheckedChange={(checked) => handleChangeGatingToggle(repo.full_name, checked)}
                         className="scale-75 origin-right"
                         aria-label={`Incident Prevention for ${repo.full_name}`}
@@ -707,12 +813,18 @@ export default function BitbucketWorkspaceBrowser() {
       <Dialog open={!!webhookSetup?.webhook_url} onOpenChange={(open) => { if (!open) setWebhookSetup(null); }}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Webhook setup — {webhookSetup?.repo_full_name}</DialogTitle>
+            <DialogTitle>
+              Webhook setup — {(webhookSetup?.manual_count ?? 0) > 1
+                ? `${webhookSetup!.manual_count} repos`
+                : webhookSetup?.repo_full_name}
+            </DialogTitle>
             <DialogDescription>
               {webhookSetup?.webhook_auto_created === undefined
                 ? 'Incident Prevention is already on for this repository. Below are the webhook details for it.'
                 : webhookSetup.webhook_auto_created
                 ? 'Aurora created the webhook on this repository, so there is nothing to paste. Click Verify to confirm it.'
+                : (webhookSetup?.manual_count ?? 0) > 1
+                ? `Aurora could not create the webhook automatically on ${webhookSetup!.manual_count} repos (that needs the write:webhook:bitbucket scope). Add it in Bitbucket using the URL and secret below.`
                 : 'Aurora could not create the webhook automatically (that needs the write:webhook:bitbucket scope). Add it in Bitbucket using the URL and secret below.'}
             </DialogDescription>
           </DialogHeader>
@@ -721,7 +833,8 @@ export default function BitbucketWorkspaceBrowser() {
               In Bitbucket, go to <span className="font-medium">Repository settings → Webhooks → Add webhook</span> and
               paste the URL and secret below, with triggers <span className="font-mono">Pull request: Created</span> and{' '}
               <span className="font-mono">Pull request: Updated</span>. Bitbucket sends no test event, so Aurora confirms
-              the hook on the first pull request — open or update a PR to activate it, or click Verify to check now.
+              the hook on the first pull request — open or update a PR to activate it
+              {(webhookSetup?.manual_count ?? 0) > 1 ? '.' : ', or click Verify to check now.'}
             </p>
           )}
           <p className="text-xs text-muted-foreground font-medium">
@@ -751,11 +864,13 @@ export default function BitbucketWorkspaceBrowser() {
             <Button variant="outline" size="sm" onClick={() => setWebhookSetup(null)}>
               Later
             </Button>
-            <Button size="sm" disabled={isVerifying}
-              onClick={() => webhookSetup && handleVerifyWebhook(webhookSetup.repo_full_name)}>
-              {isVerifying ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
-              Verify webhook
-            </Button>
+            {(webhookSetup?.manual_count ?? 0) <= 1 && (
+              <Button size="sm" disabled={isVerifying}
+                onClick={() => webhookSetup && handleVerifyWebhook(webhookSetup.repo_full_name)}>
+                {isVerifying ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
+                Verify webhook
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -133,7 +133,11 @@ export default function BitbucketWorkspaceBrowser() {
     try {
       const job = await BitbucketIntegrationService.updateChangeGatingBulk(names, enabled);
       let status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
+      const deadline = Date.now() + 10 * 60 * 1000;
       while (!status.complete) {
+        if (Date.now() > deadline) {
+          throw new Error('Incident Prevention is taking longer than expected. Reload this page to see the current state.');
+        }
         const data = await BitbucketIntegrationService.loadWorkspaceSelection();
         if (data?.repositories) {
           const updated = parseConnectedRepos(data.repositories);
@@ -209,9 +213,9 @@ export default function BitbucketWorkspaceBrowser() {
     try {
       await BitbucketIntegrationService.saveWorkspaceSelection({
         workspace: selectedWorkspace,
-        repositories: remainingSlugs.map(slug => {
+        repositories: remainingSlugs.map((slug): Repo => {
           const repo = repos.find(r => r.slug === slug);
-          return repo ?? { slug, name: slug, full_name: `${selectedWorkspace}/${slug}`, is_private: false };
+          return repo ?? { slug, name: slug, full_name: `${selectedWorkspace}/${slug}` };
         }),
       });
       setCheckedRepos(new Set(remainingSlugs));

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -161,6 +161,28 @@ export default function BitbucketWorkspaceBrowser() {
             // Disable is done once the DB flag is off. Hook deletes keep
             // running in the worker; the UI does not wait on them.
             if (!enabled && names.every(n => !updated.find(r => r.full_name === n)?.change_gating_enabled)) {
+              void (async () => {
+                const cleanupDeadline = Date.now() + 10 * 60 * 1000;
+                while (Date.now() < cleanupDeadline) {
+                  try {
+                    const cleanupStatus = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
+                    if (!cleanupStatus.complete) {
+                      await new Promise(r => setTimeout(r, 2000));
+                      continue;
+                    }
+                    if (cleanupStatus.result?.webhook_cleanup_failed) {
+                      toast({
+                        title: "Some webhooks couldn't be removed",
+                        description: "No PRs will be reviewed, but remove them in Repository settings to stop Bitbucket sending events.",
+                        variant: "destructive",
+                      });
+                    }
+                    return;
+                  } catch {
+                    return;
+                  }
+                }
+              })();
               break;
             }
           }

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -114,57 +114,65 @@ export default function BitbucketWorkspaceBrowser() {
     }
   };
 
-  const handleBulkEnable = async () => {
+  const handleBulkGating = async (enabled: boolean) => {
     const names = savedRepos
-      .filter(r => r.workspace === selectedWorkspace && checkedRepos.has(r.slug) && !r.change_gating_enabled)
+      .filter(r => r.workspace === selectedWorkspace && checkedRepos.has(r.slug) && r.change_gating_enabled !== enabled)
       .map(r => r.full_name);
     if (names.length === 0) {
       const checkedConnected = [...checkedRepos].some(s => savedReposByWorkspace.get(selectedWorkspace)?.has(s));
       toast({
-        title: checkedConnected ? "Incident Prevention is already on for the selected connected repos" : "Save selected repos first",
+        title: checkedConnected
+          ? `Incident Prevention is already ${enabled ? 'on' : 'off'} for the selected connected repos`
+          : 'Save selected repos first',
       });
       return;
     }
     setBulkEnabling(true);
     try {
-      const job = await BitbucketIntegrationService.updateChangeGatingBulk(names);
+      const job = await BitbucketIntegrationService.updateChangeGatingBulk(names, enabled);
       let status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       while (!status.complete) {
         await new Promise(r => setTimeout(r, 2000));
         status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       }
-      if (status.error) throw new Error(status.status || "Failed to enable Incident Prevention");
+      if (status.error) throw new Error(status.status || 'Failed to update Incident Prevention');
       const result = status.result;
       const data = await BitbucketIntegrationService.loadWorkspaceSelection();
       if (data?.repositories) setSavedRepos(parseConnectedRepos(data.repositories));
-      const manual = result?.results.filter(r => r.webhook_auto_created === false) ?? [];
-      if (manual.length && result?.webhook_url) {
-        setWebhookSetup({
-          repo_full_name: manual[0].repo_full_name,
-          change_gating_enabled: true,
-          webhook_url: result.webhook_url,
-          webhook_secret: result.webhook_secret,
-          webhook_events: result.webhook_events,
-          webhook_auto_created: false,
-          manual_count: manual.length,
-        });
-      } else {
-        const enabled = result?.results.filter(r => !r.error).length ?? 0;
-        if (enabled) {
-          toast({ title: `Incident Prevention enabled on ${enabled} repo${enabled === 1 ? '' : 's'}` });
+      if (enabled) {
+        const manual = result?.results.filter(r => r.webhook_auto_created === false) ?? [];
+        if (manual.length && result?.webhook_url) {
+          setWebhookSetup({
+            repo_full_name: manual[0].repo_full_name,
+            change_gating_enabled: true,
+            webhook_url: result.webhook_url,
+            webhook_secret: result.webhook_secret,
+            webhook_events: result.webhook_events,
+            webhook_auto_created: false,
+            manual_count: manual.length,
+          });
+        } else {
+          toast({ title: `Incident Prevention enabled on ${names.length} repo${names.length === 1 ? '' : 's'}` });
         }
-      }
-      const skipped = result?.results.filter(r => r.error === 'no_default_branch').length ?? 0;
-      if (skipped) {
+        const skipped = result?.results.filter(r => r.error === 'no_default_branch').length ?? 0;
+        if (skipped) {
+          toast({
+            title: `${skipped} repo${skipped === 1 ? '' : 's'} skipped`,
+            description: 'No default branch recorded. Re-save the repository selection, then try again.',
+            variant: 'destructive',
+          });
+        }
+      } else {
         toast({
-          title: `${skipped} repo${skipped === 1 ? '' : 's'} skipped`,
-          description: "No default branch recorded. Re-save the repository selection, then try again.",
-          variant: "destructive",
+          title: `Incident Prevention disabled on ${names.length} repo${names.length === 1 ? '' : 's'}`,
+          description: result?.webhook_cleanup_failed
+            ? "Aurora can't delete some webhooks (Bitbucket only allows that for hooks it created). Remove those in Repository settings to stop Bitbucket sending events."
+            : undefined,
         });
       }
     } catch (error: unknown) {
       const err = error as Error;
-      toast({ title: "Error", description: err.message || "Failed to enable Incident Prevention", variant: "destructive" });
+      toast({ title: 'Error', description: err.message || 'Failed to update Incident Prevention', variant: 'destructive' });
     } finally {
       setBulkEnabling(false);
     }
@@ -477,24 +485,6 @@ export default function BitbucketWorkspaceBrowser() {
     }
   };
 
-  const handleClear = async () => {
-    try {
-      await BitbucketIntegrationService.clearWorkspaceSelection();
-      setSelectedWorkspace('');
-      setCheckedRepos(new Set());
-      setRepos([]);
-      setSavedReposByWorkspace(new Map());
-      savedReposByWorkspaceRef.current = new Map();
-      setSavedRepos([]);
-      window.dispatchEvent(new CustomEvent('providerStateChanged'));
-      toast({ title: "Cleared", description: "Bitbucket repos disconnected" });
-    } catch (error: unknown) {
-      const err = error as Error;
-      console.error('Error clearing selection:', err);
-      toast({ title: "Error", description: err.message || "Failed to clear", variant: "destructive" });
-    }
-  };
-
   const handleRegenerate = async (repoFullName: string) => {
     try {
       await BitbucketIntegrationService.generateRepoMetadata(repoFullName);
@@ -526,7 +516,6 @@ export default function BitbucketWorkspaceBrowser() {
     }
   };
 
-  const totalSavedRepos = Array.from(savedReposByWorkspace.values()).reduce((sum, set) => sum + set.size, 0);
   const currentWorkspaceSaved = savedReposByWorkspace.get(selectedWorkspace);
   const selectionChanged = selectedWorkspace && (
     checkedRepos.size !== (currentWorkspaceSaved?.size ?? 0) ||
@@ -677,25 +666,31 @@ export default function BitbucketWorkspaceBrowser() {
           </Button>
           {!!currentWorkspaceSaved?.size && [...checkedRepos].some(s => currentWorkspaceSaved.has(s)) && (
             <Button size="sm" variant="outline" onClick={handleDisconnectSelected} disabled={isSaving || bulkEnabling}>
-              Disconnect selected
+              Disconnect
             </Button>
           )}
           {incidentPreventionEnabled && checkedRepos.size > 0 && (
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={isSaving || bulkEnabling}
-              onClick={handleBulkEnable}
-              data-testid="bb-enable-gating-selected"
-            >
-              {bulkEnabling ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
-              Enable Incident Prevention
-            </Button>
-          )}
-          {totalSavedRepos > 0 && (
-            <Button size="sm" variant="outline" onClick={handleClear} disabled={isSaving || bulkEnabling}>
-              Clear All
-            </Button>
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isSaving || bulkEnabling}
+                onClick={() => handleBulkGating(true)}
+                data-testid="bb-enable-gating-selected"
+              >
+                {bulkEnabling ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
+                Enable Incident Prevention
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isSaving || bulkEnabling}
+                onClick={() => handleBulkGating(false)}
+                data-testid="bb-disable-gating-selected"
+              >
+                Disable Incident Prevention
+              </Button>
+            </>
           )}
         </div>
       )}

--- a/client/src/components/bitbucket-workspace-browser.tsx
+++ b/client/src/components/bitbucket-workspace-browser.tsx
@@ -58,6 +58,7 @@ export default function BitbucketWorkspaceBrowser() {
   const [isSaving, setIsSaving] = useState(false);
 
   const isRestoringSelectionRef = useRef(false);
+  const reposFetchGen = useRef(0);
   // Map of workspace → set of saved slugs (supports multi-workspace)
   const [savedReposByWorkspace, setSavedReposByWorkspace] = useState<Map<string, Set<string>>>(new Map());
   const savedReposByWorkspaceRef = useRef<Map<string, Set<string>>>(new Map());
@@ -72,7 +73,7 @@ export default function BitbucketWorkspaceBrowser() {
   // live Bitbucket API round-trip and left the toggle invisible for seconds.
   const incidentPreventionEnabled = isIncidentPreventionEnabled();
   const [gatingUpdating, setGatingUpdating] = useState<Set<string>>(new Set());
-  const [bulkEnabling, setBulkEnabling] = useState(false);
+  const [bulkEnabling, setBulkEnabling] = useState<false | 'enable' | 'disable'>(false);
   const [webhookSetup, setWebhookSetup] = useState<ChangeGatingResponse | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
 
@@ -127,15 +128,37 @@ export default function BitbucketWorkspaceBrowser() {
       });
       return;
     }
-    setBulkEnabling(true);
+    setBulkEnabling(enabled ? 'enable' : 'disable');
+    setGatingUpdating(new Set(names));
     try {
       const job = await BitbucketIntegrationService.updateChangeGatingBulk(names, enabled);
       let status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       while (!status.complete) {
+        const data = await BitbucketIntegrationService.loadWorkspaceSelection();
+        if (data?.repositories) {
+          const updated = parseConnectedRepos(data.repositories);
+          setSavedRepos(updated);
+          setGatingUpdating(prev => {
+            const next = new Set(prev);
+            for (const r of updated) {
+              if (!next.has(r.full_name)) continue;
+              const settled = enabled
+                ? r.webhook_configured || !r.change_gating_enabled
+                : !r.change_gating_enabled;
+              if (settled) next.delete(r.full_name);
+            }
+            return next;
+          });
+          // Disable is done once the DB flag is off. Hook deletes keep
+          // running in the worker; the UI does not wait on them.
+          if (!enabled && names.every(n => !updated.find(r => r.full_name === n)?.change_gating_enabled)) {
+            break;
+          }
+        }
         await new Promise(r => setTimeout(r, 2000));
         status = await BitbucketIntegrationService.getChangeGatingBulkJob(job.task_id);
       }
-      if (status.error) throw new Error(status.status || 'Failed to update Incident Prevention');
+      if (status.complete && status.error) throw new Error(status.status || 'Failed to update Incident Prevention');
       const result = status.result;
       const data = await BitbucketIntegrationService.loadWorkspaceSelection();
       if (data?.repositories) setSavedRepos(parseConnectedRepos(data.repositories));
@@ -165,9 +188,6 @@ export default function BitbucketWorkspaceBrowser() {
       } else {
         toast({
           title: `Incident Prevention disabled on ${names.length} repo${names.length === 1 ? '' : 's'}`,
-          description: result?.webhook_cleanup_failed
-            ? "Aurora can't delete some webhooks (Bitbucket only allows that for hooks it created). Remove those in Repository settings to stop Bitbucket sending events."
-            : undefined,
         });
       }
     } catch (error: unknown) {
@@ -175,6 +195,7 @@ export default function BitbucketWorkspaceBrowser() {
       toast({ title: 'Error', description: err.message || 'Failed to update Incident Prevention', variant: 'destructive' });
     } finally {
       setBulkEnabling(false);
+      setGatingUpdating(new Set());
     }
   };
 
@@ -350,20 +371,24 @@ export default function BitbucketWorkspaceBrowser() {
   };
 
   const fetchRepos = async (workspace: string) => {
+    const gen = ++reposFetchGen.current;
     setIsLoadingRepos(true);
     try {
       const data = await BitbucketIntegrationService.getRepos(workspace);
-      const repoList = Array.isArray(data) ? data : data?.repositories || [];
+      if (gen !== reposFetchGen.current) return;
+      const repoList = Array.isArray(data) ? data : data?.repositories;
+      if (!Array.isArray(repoList)) throw new Error('Failed to fetch repositories');
       setRepos(repoList);
       // Use ref to always read the latest saved state (avoids stale closure)
       const saved = savedReposByWorkspaceRef.current.get(workspace);
       setCheckedRepos(saved ? new Set(saved) : new Set());
     } catch (error) {
+      if (gen !== reposFetchGen.current) return;
       console.error('Error fetching repos:', error);
       setRepos([]);
       setCheckedRepos(new Set());
     } finally {
-      setIsLoadingRepos(false);
+      if (gen === reposFetchGen.current) setIsLoadingRepos(false);
     }
   };
 
@@ -387,24 +412,27 @@ export default function BitbucketWorkspaceBrowser() {
   const revalidateWebhooks = (connected: ConnectedRepo[]) => {
     const enabled = connected.filter(r => r.change_gating_enabled).map(r => r.full_name);
     if (!incidentPreventionEnabled || enabled.length === 0) return;
-    void Promise.all(enabled.map(async name => {
-      try {
-        const res = await BitbucketIntegrationService.verifyChangeGatingWebhook(name);
-        return { name, verified: !!res.verified };
-      } catch {
-        return null;
-      }
-    })).then(results => {
-      const byName = new Map(results.filter(r => r !== null).map(r => [r!.name, r!.verified]));
+    // ponytail: browser ~6 connections/host. 50 parallel verifies starved GET /repos.
+    void (async () => {
+      const byName = new Map<string, boolean>();
+      let i = 0;
+      const worker = async () => {
+        while (i < enabled.length) {
+          const name = enabled[i++];
+          try {
+            const res = await BitbucketIntegrationService.verifyChangeGatingWebhook(name);
+            byName.set(name, !!res.verified);
+          } catch { /* background refresh; badge stays as last known */ }
+        }
+      };
+      await Promise.all([worker(), worker()]);
       if (byName.size === 0) return;
       setSavedRepos(prev => prev.map(r =>
         byName.has(r.full_name)
-          // A fresh positive also clears `stale`: verify only succeeds against
-          // the URL Aurora serves now.
           ? { ...r, webhook_configured: byName.get(r.full_name)!, webhook_stale: byName.get(r.full_name)! ? false : r.webhook_stale }
           : r
       ));
-    });
+    })();
   };
 
   const loadStoredSelection = async () => {
@@ -426,22 +454,18 @@ export default function BitbucketWorkspaceBrowser() {
       savedReposByWorkspaceRef.current = byWorkspace;
       setSavedRepos(connected);
       startMetadataPolling(connected);
-      revalidateWebhooks(connected);
 
-      // Set the active workspace to the first one with saved repos
       const firstWorkspace = data.workspace || byWorkspace.keys().next().value;
       if (firstWorkspace) {
         isRestoringSelectionRef.current = true;
         setSelectedWorkspace(firstWorkspace);
-
-        const repoData = await BitbucketIntegrationService.getRepos(firstWorkspace);
-        const repoList = Array.isArray(repoData) ? repoData : repoData?.repositories || [];
-        setRepos(repoList);
-
-        const saved = byWorkspace.get(firstWorkspace);
-        setCheckedRepos(saved ? new Set(saved) : new Set());
-        isRestoringSelectionRef.current = false;
+        try {
+          await fetchRepos(firstWorkspace);
+        } finally {
+          isRestoringSelectionRef.current = false;
+        }
       }
+      revalidateWebhooks(connected);
     } catch (error) {
       console.error('Error loading stored selection:', error);
       isRestoringSelectionRef.current = false;
@@ -525,6 +549,12 @@ export default function BitbucketWorkspaceBrowser() {
     ? repos.filter(r => `${r.full_name} ${r.name}`.toLowerCase().includes(searchFilter.toLowerCase()))
     : repos;
   const allVisibleChecked = visibleRepos.length > 0 && visibleRepos.every(r => checkedRepos.has(r.slug));
+  const bulkBusy = !!bulkEnabling;
+  const checkedConnected = savedRepos.filter(
+    r => r.workspace === selectedWorkspace && checkedRepos.has(r.slug)
+  );
+  const canEnableGating = checkedConnected.some(r => !r.change_gating_enabled);
+  const canDisableGating = checkedConnected.some(r => r.change_gating_enabled);
 
   return (
     <div className="space-y-3">
@@ -659,37 +689,42 @@ export default function BitbucketWorkspaceBrowser() {
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={isSaving || bulkEnabling || checkedRepos.size === 0 || !selectionChanged}
+            disabled={isSaving || bulkBusy || checkedRepos.size === 0 || !selectionChanged}
           >
             {isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
             Save
           </Button>
           {!!currentWorkspaceSaved?.size && [...checkedRepos].some(s => currentWorkspaceSaved.has(s)) && (
-            <Button size="sm" variant="outline" onClick={handleDisconnectSelected} disabled={isSaving || bulkEnabling}>
+            <Button size="sm" variant="outline" onClick={handleDisconnectSelected} disabled={isSaving || bulkBusy}>
               Disconnect
             </Button>
           )}
           {incidentPreventionEnabled && checkedRepos.size > 0 && (
             <>
+              {(canEnableGating || bulkEnabling === 'enable') && (
               <Button
                 size="sm"
                 variant="outline"
-                disabled={isSaving || bulkEnabling}
+                disabled={isSaving || bulkBusy}
                 onClick={() => handleBulkGating(true)}
                 data-testid="bb-enable-gating-selected"
               >
-                {bulkEnabling ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
+                {bulkEnabling === 'enable' ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
                 Enable Incident Prevention
               </Button>
+              )}
+              {(canDisableGating || bulkEnabling === 'disable') && (
               <Button
                 size="sm"
                 variant="outline"
-                disabled={isSaving || bulkEnabling}
+                disabled={isSaving || bulkBusy}
                 onClick={() => handleBulkGating(false)}
                 data-testid="bb-disable-gating-selected"
               >
+                {bulkEnabling === 'disable' ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
                 Disable Incident Prevention
               </Button>
+              )}
             </>
           )}
         </div>
@@ -809,7 +844,7 @@ export default function BitbucketWorkspaceBrowser() {
                         <button
                           type="button"
                           className="inline-flex disabled:opacity-50"
-                          disabled={isGatingUpdating || bulkEnabling}
+                          disabled={isGatingUpdating || bulkBusy}
                           onClick={() => handleReopenSetup(repo.full_name)}
                           title={repo.webhook_stale
                             ? "This repo's webhook points at a different Aurora URL and can no longer reach us — click to get the current URL and secret"
@@ -832,7 +867,7 @@ export default function BitbucketWorkspaceBrowser() {
                     ) : (
                       <Switch
                         checked={repo.change_gating_enabled}
-                        disabled={bulkEnabling}
+                        disabled={bulkBusy}
                         onCheckedChange={(checked) => handleChangeGatingToggle(repo.full_name, checked)}
                         className="scale-75 origin-right"
                         aria-label={`Incident Prevention for ${repo.full_name}`}

--- a/client/src/services/bitbucket-integration-service.ts
+++ b/client/src/services/bitbucket-integration-service.ts
@@ -37,6 +37,21 @@ export interface ChangeGatingResponse {
   webhook_note?: string;
   webhook_auto_created?: boolean;
   webhook_cleanup_failed?: boolean;
+  manual_count?: number;
+}
+
+export interface ChangeGatingBulkResult {
+  repo_full_name: string;
+  webhook_auto_created?: boolean;
+  error?: string;
+}
+
+export interface ChangeGatingBulkResponse {
+  change_gating_enabled: boolean;
+  webhook_url?: string;
+  webhook_secret?: string;
+  webhook_events?: string[];
+  results: ChangeGatingBulkResult[];
 }
 
 export interface WebhookVerifyResponse {
@@ -228,6 +243,17 @@ export class BitbucketIntegrationService {
     return this.request<ChangeGatingResponse>(
       `/repo-selections/${encodeURIComponent(repoFullName)}/change-gating`,
       { method: 'PUT', body: { enabled }, errorMessage: 'Failed to update Incident Prevention setting' }
+    );
+  }
+
+  static async updateChangeGatingBulk(repoFullNames?: string[]): Promise<ChangeGatingBulkResponse> {
+    return this.request<ChangeGatingBulkResponse>(
+      '/repo-selections/change-gating',
+      {
+        method: 'PUT',
+        body: { enabled: true, ...(repoFullNames ? { repo_full_names: repoFullNames } : {}) },
+        errorMessage: 'Failed to enable Incident Prevention',
+      }
     );
   }
 

--- a/client/src/services/bitbucket-integration-service.ts
+++ b/client/src/services/bitbucket-integration-service.ts
@@ -10,7 +10,7 @@ export interface Repo {
   slug: string;
   name: string;
   full_name: string;
-  is_private: boolean;
+  is_private?: boolean;
   description?: string;
   mainbranch?: { name: string };
 }

--- a/client/src/services/bitbucket-integration-service.ts
+++ b/client/src/services/bitbucket-integration-service.ts
@@ -51,6 +51,7 @@ export interface ChangeGatingBulkResponse {
   webhook_url?: string;
   webhook_secret?: string;
   webhook_events?: string[];
+  webhook_cleanup_failed?: boolean;
   results: ChangeGatingBulkResult[];
 }
 
@@ -231,13 +232,6 @@ export class BitbucketIntegrationService {
     );
   }
 
-  static async clearWorkspaceSelection(): Promise<void> {
-    await this.request(
-      '/workspace-selection',
-      { method: 'DELETE', errorMessage: 'Failed to clear workspace selection' }
-    );
-  }
-
   static async generateRepoMetadata(repoFullName: string): Promise<void> {
     await this.request(
       '/repo-metadata/generate',
@@ -259,13 +253,13 @@ export class BitbucketIntegrationService {
     );
   }
 
-  static async updateChangeGatingBulk(repoFullNames: string[]): Promise<ChangeGatingBulkJob> {
+  static async updateChangeGatingBulk(repoFullNames: string[], enabled: boolean): Promise<ChangeGatingBulkJob> {
     return this.request<ChangeGatingBulkJob>(
       '/repo-selections/change-gating',
       {
         method: 'PUT',
-        body: { enabled: true, repo_full_names: repoFullNames },
-        errorMessage: 'Failed to enable Incident Prevention',
+        body: { enabled, repo_full_names: repoFullNames },
+        errorMessage: 'Failed to update Incident Prevention',
       }
     );
   }

--- a/client/src/services/bitbucket-integration-service.ts
+++ b/client/src/services/bitbucket-integration-service.ts
@@ -54,6 +54,19 @@ export interface ChangeGatingBulkResponse {
   results: ChangeGatingBulkResult[];
 }
 
+export interface ChangeGatingBulkJob {
+  task_id: string;
+  count: number;
+}
+
+export interface ChangeGatingBulkJobStatus {
+  state: string;
+  complete: boolean;
+  error?: boolean;
+  status?: string;
+  result?: ChangeGatingBulkResponse;
+}
+
 export interface WebhookVerifyResponse {
   verified: boolean;
   reason?: string;
@@ -246,14 +259,21 @@ export class BitbucketIntegrationService {
     );
   }
 
-  static async updateChangeGatingBulk(repoFullNames?: string[]): Promise<ChangeGatingBulkResponse> {
-    return this.request<ChangeGatingBulkResponse>(
+  static async updateChangeGatingBulk(repoFullNames: string[]): Promise<ChangeGatingBulkJob> {
+    return this.request<ChangeGatingBulkJob>(
       '/repo-selections/change-gating',
       {
         method: 'PUT',
-        body: { enabled: true, ...(repoFullNames ? { repo_full_names: repoFullNames } : {}) },
+        body: { enabled: true, repo_full_names: repoFullNames },
         errorMessage: 'Failed to enable Incident Prevention',
       }
+    );
+  }
+
+  static async getChangeGatingBulkJob(taskId: string): Promise<ChangeGatingBulkJobStatus> {
+    return this.request<ChangeGatingBulkJobStatus>(
+      `/repo-selections/change-gating/jobs/${encodeURIComponent(taskId)}`,
+      { errorMessage: 'Failed to check Incident Prevention job' }
     );
   }
 

--- a/deploy/helm/aurora/templates/celery-worker-deployment.yaml
+++ b/deploy/helm/aurora/templates/celery-worker-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: celery-worker
           image: "{{ .Values.image.registry }}/aurora-server:{{ .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "exec celery -A celery_config worker --loglevel=info --concurrency=${CELERY_CONCURRENCY:-4} --pidfile=/tmp/celery-worker.pid"]
+          command: ["sh", "-c", "exec celery -A celery_config worker --loglevel=info --concurrency=${CELERY_CONCURRENCY:-4} --queues=high,celery --pidfile=/tmp/celery-worker.pid"]
           securityContext:
             {{- include "aurora.containerSecurityContext" (dict "service" "celeryWorker" "global" $ "defaults" (dict)) | nindent 12 }}
           envFrom:

--- a/docker-compose.airtight.yml
+++ b/docker-compose.airtight.yml
@@ -268,6 +268,7 @@ services:
       celery -A celery_config worker
         --loglevel=info
         --concurrency=${CELERY_CONCURRENCY:-4}
+        -Q high,celery
     environment:
       <<: *common-env
       OTEL_SERVICE_NAME: celery-worker
@@ -276,6 +277,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL}
       BACKEND_URL: ${BACKEND_URL}
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}
+      NGROK_URL: ${NGROK_URL}
       AURORA_SETUP_CACHE_ENABLED: ${AURORA_SETUP_CACHE_ENABLED}
       AURORA_SETUP_CACHE_TTL: ${AURORA_SETUP_CACHE_TTL}
       AURORA_VERIFY_CLI_IDENTITY: ${AURORA_VERIFY_CLI_IDENTITY}

--- a/docker-compose.prod-local.yml
+++ b/docker-compose.prod-local.yml
@@ -304,6 +304,7 @@ services:
       celery -A celery_config worker
         --loglevel=info
         --concurrency=${CELERY_CONCURRENCY:-4}
+        -Q high,celery
     environment:
       <<: *common-env
       OTEL_SERVICE_NAME: celery-worker
@@ -314,6 +315,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL}
       BACKEND_URL: ${BACKEND_URL}
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}
+      NGROK_URL: ${NGROK_URL}
 
       # Cloud Provider Cache Settings (applies to all providers)
       AURORA_SETUP_CACHE_ENABLED: ${AURORA_SETUP_CACHE_ENABLED}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -300,6 +300,7 @@ services:
       celery -A celery_config worker
         --loglevel=info
         --concurrency=${CELERY_CONCURRENCY:-4}
+        -Q high,celery
     environment:
       <<: *common-env
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET}
@@ -309,6 +310,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL}
       BACKEND_URL: ${BACKEND_URL}
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}
+      NGROK_URL: ${NGROK_URL}
 
       # AWS
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/server/celery_config.py
+++ b/server/celery_config.py
@@ -105,6 +105,7 @@ celery_app.conf.update(
         'tasks.github_webhook_tasks',
         'tasks.bitbucket_webhook_tasks',
         'tasks.change_gating',
+        'routes.bitbucket.bitbucket_selection',
         'routes.github.github_repo_metadata',
         'utils.repo_metadata',
         'services.actions.scheduler',

--- a/server/celery_config.py
+++ b/server/celery_config.py
@@ -75,6 +75,11 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,  # Process one task at a time
     broker_connection_retry_on_startup=True,  # Explicitly enable for Celery 6.0+
     result_expires=3600,  # Expire task results after 1 hour (backend= is set above)
+    # ponytail: workers listen `-Q high,celery` (high first). Interactive
+    # Bitbucket Incident Prevention must not sit behind a Save of N metadata jobs.
+    task_routes={
+        "bitbucket.enable_change_gating_bulk": {"queue": "high"},
+    },
     # Explicitly include task modules from their new locations
     include=[
         'connectors.gcp_connector.gcp_post_auth_tasks',

--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -196,8 +196,6 @@ class BitbucketAPIClient:
                 _validate_bitbucket_url(url)
             except ValueError:
                 logger.warning("Pagination rejected untrusted next URL: %s", _sanitize_url(url))
-                if all_values:
-                    return all_values
                 return {
                     "error": True,
                     "status": None,

--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -5,6 +5,7 @@ Wraps the Bitbucket 2.0 REST API with authentication and pagination support.
 import base64
 import logging
 import re
+import time
 from urllib.parse import quote, unquote, urlsplit
 
 import requests
@@ -112,9 +113,19 @@ class BitbucketAPIClient:
     def _get(self, url, params=None):
         """Single-resource GET. Returns response JSON or error dict."""
         _validate_bitbucket_url(url)
-        response = requests.get(url, headers=self._get_headers(), params=params, timeout=self.REQUEST_TIMEOUT)
+        delay = 1
+        response = None
+        for _ in range(6):
+            response = requests.get(
+                url, headers=self._get_headers(), params=params, timeout=self.REQUEST_TIMEOUT
+            )
+            if response.status_code != 429:
+                break
+            time.sleep(delay)
+            delay = min(delay * 2, 16)
         if response.status_code != 200:
-            logger.error(f"Bitbucket GET {_sanitize_url(url)} failed: {response.status_code}")
+            if response.status_code != 404:
+                logger.error(f"Bitbucket GET {_sanitize_url(url)} failed: {response.status_code}")
             return self._handle_error(response)
         return response.json()
 
@@ -185,14 +196,26 @@ class BitbucketAPIClient:
                 _validate_bitbucket_url(url)
             except ValueError:
                 logger.warning("Pagination rejected untrusted next URL: %s", _sanitize_url(url))
+                if all_values:
+                    return all_values
                 return {
                     "error": True,
                     "status": None,
                     "message": "Pagination halted: next URL failed validation",
                 }
-            response = requests.get(url, headers=headers, params=params, timeout=self.REQUEST_TIMEOUT)
+            delay = 1
+            response = None
+            for _ in range(6):
+                response = requests.get(
+                    url, headers=headers, params=params, timeout=self.REQUEST_TIMEOUT
+                )
+                if response.status_code != 429:
+                    break
+                time.sleep(delay)
+                delay = min(delay * 2, 16)
             if response.status_code != 200:
-                logger.error(f"Bitbucket API error {response.status_code} at {_sanitize_url(url)}")
+                if response.status_code != 404:
+                    logger.error(f"Bitbucket API error {response.status_code} at {_sanitize_url(url)}")
                 if not all_values:
                     return self._handle_error(response)
                 logger.warning("Returning partial results due to mid-pagination error")
@@ -253,7 +276,8 @@ class BitbucketAPIClient:
     def get_repositories(self, workspace):
         """List repositories in a workspace."""
         return self._paginated_get(
-            f"{BITBUCKET_API_BASE}/repositories/{quote(workspace, safe='')}"
+            f"{BITBUCKET_API_BASE}/repositories/{quote(workspace, safe='')}",
+            params={"pagelen": 100},
         )
 
     def get_repository(self, workspace, repo_slug):
@@ -309,9 +333,17 @@ class BitbucketAPIClient:
         )
         _validate_bitbucket_url(url)
         headers = self._get_headers()
-        response = requests.get(url, headers=headers, timeout=self.REQUEST_TIMEOUT)
+        delay = 1
+        response = None
+        for _ in range(6):
+            response = requests.get(url, headers=headers, timeout=self.REQUEST_TIMEOUT)
+            if response.status_code != 429:
+                break
+            time.sleep(delay)
+            delay = min(delay * 2, 16)
         if response.status_code != 200:
-            logger.error(f"Failed to get file {path}: {response.status_code}")
+            if response.status_code != 404:
+                logger.error(f"Failed to get file {path}: {response.status_code}")
             return self._handle_error(response)
         content_type = response.headers.get("Content-Type", "")
         if "application/json" in content_type:

--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -115,11 +115,11 @@ class BitbucketAPIClient:
         _validate_bitbucket_url(url)
         delay = 1
         response = None
-        for _ in range(6):
+        for attempt in range(6):
             response = requests.get(
                 url, headers=self._get_headers(), params=params, timeout=self.REQUEST_TIMEOUT
             )
-            if response.status_code != 429:
+            if response.status_code != 429 or attempt == 5:
                 break
             time.sleep(delay)
             delay = min(delay * 2, 16)
@@ -205,11 +205,11 @@ class BitbucketAPIClient:
                 }
             delay = 1
             response = None
-            for _ in range(6):
+            for attempt in range(6):
                 response = requests.get(
                     url, headers=headers, params=params, timeout=self.REQUEST_TIMEOUT
                 )
-                if response.status_code != 429:
+                if response.status_code != 429 or attempt == 5:
                     break
                 time.sleep(delay)
                 delay = min(delay * 2, 16)
@@ -335,9 +335,9 @@ class BitbucketAPIClient:
         headers = self._get_headers()
         delay = 1
         response = None
-        for _ in range(6):
+        for attempt in range(6):
             response = requests.get(url, headers=headers, timeout=self.REQUEST_TIMEOUT)
-            if response.status_code != 429:
+            if response.status_code != 429 or attempt == 5:
                 break
             time.sleep(delay)
             delay = min(delay * 2, 16)
@@ -387,7 +387,7 @@ class BitbucketAPIClient:
             f"/src/{quote(commit, safe='')}/{quote(path, safe='/')}"
         )
         # format=meta returns directory metadata; omitting it returns the file listing
-        params = None if list_files else {"format": "meta"}
+        params = {"pagelen": 100} if list_files else {"format": "meta"}
         return self._get(url, params=params)
 
     def search_code(self, workspace, query):

--- a/server/routes/bitbucket/bitbucket_browsing.py
+++ b/server/routes/bitbucket/bitbucket_browsing.py
@@ -100,6 +100,8 @@ def list_repos(user_id, workspace):
             return jsonify({"error": "Bitbucket not connected"}), 401
 
         repos = client.get_repositories(workspace)
+        if isinstance(repos, dict) and repos.get("error"):
+            return jsonify({"error": "Failed to list repositories"}), 502
 
         # Optional project filter
         project_key = request.args.get("project")

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -438,8 +438,27 @@ def _try_auto_create_hook(
 
 
 @celery_app.task(name="bitbucket.enable_change_gating_bulk", time_limit=3600)
-def enable_change_gating_bulk(user_id, org_id, names):
+def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
     # ponytail: Bitbucket has no bulk webhook API. 3-wide pool; raise workers if 429s stay rare at 500 repos.
+    if not enabled:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
+                cur.execute(
+                    """UPDATE connected_repos
+                          SET change_gating_enabled = FALSE, updated_at = NOW()
+                        WHERE org_id = %s AND provider = 'bitbucket'
+                          AND repo_full_name = ANY(%s)""",
+                    (org_id, names),
+                )
+                conn.commit()
+        failed = cleanup_org_hooks(user_id, org_id, names)
+        return {
+            "change_gating_enabled": False,
+            "webhook_cleanup_failed": bool(failed),
+            "results": [{"repo_full_name": n} for n in names],
+        }
+
     webhook_events = ["pullrequest:created", "pullrequest:updated"]
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
@@ -504,8 +523,9 @@ def update_change_gating_bulk(user_id):
             return jsonify({"error": "Incident Prevention is disabled on this deployment."}), 409
 
         data = request.get_json(silent=True)
-        if not isinstance(data, dict) or data.get("enabled") is not True:
-            return jsonify({"error": "enabled must be true"}), 400
+        enabled = data.get("enabled") if isinstance(data, dict) else None
+        if not isinstance(enabled, bool):
+            return jsonify({"error": "enabled must be a boolean"}), 400
         names = data.get("repo_full_names")
         if not isinstance(names, list) or not names or not all(
             isinstance(n, str) and n.strip() for n in names
@@ -528,9 +548,10 @@ def update_change_gating_bulk(user_id):
         if missing:
             return jsonify({"error": "Repository not found", "missing": missing}), 404
 
-        task = enable_change_gating_bulk.delay(user_id, org_id, names)
+        task = enable_change_gating_bulk.delay(user_id, org_id, names, enabled)
         logger.info(
-            "Bitbucket Incident Prevention bulk-enable queued %s repos (org %s, by user %s, task %s)",
+            "Bitbucket Incident Prevention bulk-%s queued %s repos (org %s, by user %s, task %s)",
+            "enable" if enabled else "disable",
             len(names), _sanitize_log(org_id), _sanitize_log(user_id), task.id,
         )
         return jsonify({"task_id": task.id, "count": len(names)}), 202

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -420,6 +420,113 @@ def _try_auto_create_hook(
         return False
 
 
+@bitbucket_selection_bp.route("/repo-selections/change-gating", methods=["PUT"])
+@require_permission("connectors", "write")
+def update_change_gating_bulk(user_id):
+    """Enable Incident Prevention on many connected Bitbucket repos.
+
+    Body: ``{enabled: true, repo_full_names?: [str]}``. Omit names to enable
+    every connected Bitbucket repo for the org. Already-on repos are left
+    untouched in Bitbucket (no extra hook create). Repos with no recorded
+    default branch are skipped. Sequential hook creates — Bitbucket rate limits.
+    """
+    try:
+        from utils.flags.feature_flags import is_incident_prevention_enabled
+
+        if not is_incident_prevention_enabled():
+            return jsonify({"error": "Incident Prevention is disabled on this deployment."}), 409
+
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict) or data.get("enabled") is not True:
+            return jsonify({"error": "enabled must be true"}), 400
+
+        names = data.get("repo_full_names")
+        if names is not None:
+            if not isinstance(names, list) or not names or not all(
+                isinstance(n, str) and n.strip() for n in names
+            ):
+                return jsonify({"error": "repo_full_names must be a non-empty list of strings"}), 400
+
+        org_id = resolve_org(user_id)
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cur:
+                set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
+                if names is None:
+                    cur.execute(
+                        """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
+                             FROM connected_repos
+                            WHERE org_id = %s AND provider = 'bitbucket'
+                            GROUP BY repo_full_name""",
+                        (org_id,),
+                    )
+                else:
+                    cur.execute(
+                        """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
+                             FROM connected_repos
+                            WHERE org_id = %s AND provider = 'bitbucket'
+                              AND repo_full_name = ANY(%s)
+                            GROUP BY repo_full_name""",
+                        (org_id, names),
+                    )
+                rows = cur.fetchall()
+                found = {r[0] for r in rows}
+                if names is not None:
+                    missing = [n for n in names if n not in found]
+                    if missing:
+                        return jsonify({"error": "Repository not found", "missing": missing}), 404
+                if not rows:
+                    return jsonify({"error": "No connected repositories"}), 400
+
+                to_enable = [r[0] for r in rows if r[1] is not None]
+                skipped_no_branch = [r[0] for r in rows if r[1] is None]
+                already_on = {r[0] for r in rows if r[1] is not None and r[2]}
+                if to_enable:
+                    cur.execute(
+                        """UPDATE connected_repos
+                              SET change_gating_enabled = TRUE, updated_at = NOW()
+                            WHERE org_id = %s AND provider = 'bitbucket'
+                              AND repo_full_name = ANY(%s)""",
+                        (org_id, to_enable),
+                    )
+                conn.commit()
+
+        results = [{"repo_full_name": n, "error": "no_default_branch"} for n in skipped_no_branch]
+        webhook_events = ["pullrequest:created", "pullrequest:updated"]
+        response = {"change_gating_enabled": True, "results": results}
+
+        if to_enable:
+            from connectors.bitbucket_connector.webhook_secret import (
+                get_or_create_webhook_secret,
+            )
+
+            secret = get_or_create_webhook_secret(org_id)
+            webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
+            response.update({
+                "webhook_url": webhook_url,
+                "webhook_secret": secret,
+                "webhook_events": webhook_events,
+            })
+            for name in to_enable:
+                if name in already_on:
+                    results.append({"repo_full_name": name})
+                    continue
+                results.append({
+                    "repo_full_name": name,
+                    "webhook_auto_created": _try_auto_create_hook(
+                        user_id, org_id, name, webhook_url, webhook_events, secret
+                    ),
+                })
+
+        logger.info(
+            "Bitbucket Incident Prevention bulk-enabled %s repos (org %s, by user %s)",
+            len(to_enable), _sanitize_log(org_id), _sanitize_log(user_id),
+        )
+        return jsonify(response)
+    except Exception:
+        logger.exception("Error bulk-updating Bitbucket change gating")
+        return jsonify({"error": "Failed to update Incident Prevention"}), 500
+
+
 @bitbucket_selection_bp.route("/repo-selections/<path:repo_full_name>/change-gating", methods=["PUT"])
 @require_permission("connectors", "write")
 def update_change_gating(user_id, repo_full_name):

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -353,10 +353,17 @@ def cleanup_org_hooks(user_id: str, org_id: str, repo_full_names=None) -> list[s
     return failed
 
 
-def _until_not_429(fn):
+def _until_not_429(fn, attempts=7):
+    """Retry ``fn`` while it reports 429, with exponential backoff.
+
+    ``attempts`` exists because two very different callers share this: the
+    Celery bulk task can afford the full ~95s budget, but the single-repo
+    route runs inside a Flask request and must not hold a worker thread
+    that long — it passes a much smaller budget.
+    """
     delay = 1
     result = fn()
-    for _ in range(7):
+    for _ in range(attempts):
         if not (isinstance(result, dict) and result.get("status") == 429):
             return result
         time.sleep(delay)
@@ -368,20 +375,25 @@ def _until_not_429(fn):
 def _try_auto_create_hook(
     user_id: str, org_id: str, repo_full_name: str,
     webhook_url: str, webhook_events, secret: str,
+    retry_attempts: int = 7,
 ) -> bool:
     """Best-effort API creation of the repo webhook; returns True on success.
 
     Needs the write:webhook:bitbucket scope, which the connector token often
     lacks — manual setup is the primary path, so failure here is informational
-    only. An existing hook with the same URL counts as success (its uuid is
-    recorded too, so disable/disconnect can still delete it). A success also
-    records verification: creating/finding the hook is the same bar as Verify.
+    only. An existing hook with the same URL only counts as success when it is
+    active and carries both pullrequest triggers (its uuid is recorded too, so
+    disable/disconnect can still delete it). Success also records verification.
+
+    ``retry_attempts`` bounds the 429 backoff: callers on a Flask request
+    thread pass a small budget, the Celery bulk task keeps the default.
     """
     def _mark_verified(hook_uuid=None) -> None:
         # Isolated: by this point the hook EXISTS on Bitbucket, so a DB blip
         # here must not flip the return to False (which would tell the admin
-        # to create a second hook manually). The cost of a lost uuid is only
-        # that disable/disconnect can't auto-delete this hook later.
+        # to create a second hook manually). The cost is that this repo keeps
+        # no record of the hook: disable/disconnect can't auto-delete it, and
+        # it reports unverified until a delivery or Verify says otherwise.
         try:
             with db_pool.get_admin_connection() as conn:
                 with conn.cursor() as cur:
@@ -399,8 +411,9 @@ def _try_auto_create_hook(
                     conn.commit()
         except Exception:
             logger.warning(
-                "Bitbucket hook created for %s but uuid persistence failed — "
-                "automatic hook deletion on disable will not work for this repo",
+                "Bitbucket hook exists for %s but persisting its state failed — "
+                "this repo will report unverified and automatic hook deletion "
+                "on disable will not work for it",
                 _sanitize_log(repo_full_name),
             )
 
@@ -411,14 +424,16 @@ def _try_auto_create_hook(
         if client is None or "/" not in repo_full_name:
             return False
         ws, slug = repo_full_name.split("/", 1)
-        existing = _until_not_429(lambda: client.list_webhooks(ws, slug))
+        existing = _until_not_429(lambda: client.list_webhooks(ws, slug), retry_attempts)
         for hook in existing if isinstance(existing, list) else []:
             if not (isinstance(hook, dict) and hook.get("url") == webhook_url):
                 continue
-            # Same bar as verify_change_gating_webhook: an existing hook only
-            # counts as configured when it is active AND carries both
-            # pullrequest triggers — a disabled or partial hook would report
-            # success while deliveries silently never arrive.
+            # An existing hook was configured by someone else, so it has to
+            # clear verify_change_gating_webhook's bar: active AND both
+            # pullrequest triggers. A disabled or partial hook would report
+            # success while deliveries silently never arrive. The create path
+            # below needs no such check — we set active and both events in
+            # our own request.
             if not hook.get("active"):
                 continue
             if {"pullrequest:created", "pullrequest:updated"} - set(hook.get("events") or []):
@@ -429,7 +444,7 @@ def _try_auto_create_hook(
             ws, slug, webhook_url, webhook_events,
             description="Aurora Incident Prevention",
             secret=secret,
-        ))
+        ), retry_attempts)
         if not isinstance(created, dict) or created.get("error"):
             return False
         _mark_verified(created.get("uuid"))
@@ -576,30 +591,36 @@ def update_change_gating_bulk(user_id):
 @require_permission("connectors", "write")
 def get_change_gating_bulk_job(user_id, task_id):
     """Poll the Celery bulk-enable job."""
-    task = enable_change_gating_bulk.AsyncResult(task_id)
-    if task.state in ("PENDING", "STARTED"):
-        return jsonify({"state": task.state, "complete": False})
-    if task.state == "SUCCESS":
-        result = dict(task.result or {})
-        owner = result.pop("org_id", None)
-        if owner is not None and owner != resolve_org(user_id):
-            return jsonify({"error": "Not found"}), 404
-        results = result.get("results") or []
-        if result.get("change_gating_enabled") and any(
-            r.get("webhook_auto_created") is False for r in results
-        ):
-            result["webhook_secret"] = get_or_create_webhook_secret(resolve_org(user_id))
-        return jsonify({"state": task.state, "complete": True, "result": result})
-    logger.error(
-        "Bitbucket bulk-enable task %s ended in state %s: %s",
-        _sanitize_log(task_id), task.state, task.info,
-    )
-    return jsonify({
-        "state": task.state,
-        "complete": True,
-        "error": True,
-        "status": "Failed to update Incident Prevention",
-    }), 200
+    try:
+        task = enable_change_gating_bulk.AsyncResult(task_id)
+        if task.state in ("PENDING", "STARTED"):
+            return jsonify({"state": task.state, "complete": False})
+        if task.state == "SUCCESS":
+            result = dict(task.result or {})
+            owner = result.pop("org_id", None)
+            if owner is not None and owner != resolve_org(user_id):
+                return jsonify({"error": "Not found"}), 404
+            results = result.get("results") or []
+            if result.get("change_gating_enabled") and any(
+                r.get("webhook_auto_created") is False for r in results
+            ):
+                result["webhook_secret"] = get_or_create_webhook_secret(resolve_org(user_id))
+            return jsonify({"state": task.state, "complete": True, "result": result})
+        logger.error(
+            "Bitbucket bulk-enable task %s ended in state %s: %s",
+            _sanitize_log(task_id), task.state, task.info,
+        )
+        return jsonify({
+            "state": task.state,
+            "complete": True,
+            "error": True,
+            "status": "Failed to update Incident Prevention",
+        }), 200
+    except Exception:
+        # resolve_org and get_or_create_webhook_secret both hit the secrets
+        # backend; a blip there must not surface as a raw 500.
+        logger.exception("Failed to poll Bitbucket bulk-enable task %s", _sanitize_log(task_id))
+        return jsonify({"error": "Failed to check Incident Prevention"}), 500
 
 
 @bitbucket_selection_bp.route("/repo-selections/<path:repo_full_name>/change-gating", methods=["PUT"])
@@ -699,8 +720,11 @@ def update_change_gating(user_id, repo_full_name):
             # the flag entirely — absent means "not attempted", which is
             # neither the success nor the failure message.
             if not was_enabled:
+                # Small 429 budget: this runs on a Flask request thread, so it
+                # must not sleep out the full backoff the bulk task can afford.
                 response["webhook_auto_created"] = _try_auto_create_hook(
-                    user_id, org_id, repo_full_name, webhook_url, webhook_events, secret
+                    user_id, org_id, repo_full_name, webhook_url, webhook_events, secret,
+                    retry_attempts=2,
                 )
         else:
             # Disable: try to delete the hook, always clear verification state.

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -158,9 +158,9 @@ def save_workspace_selection(user_id):
                            VALUES (%s, %s, 'bitbucket', %s, %s, %s, 'pending')
                            ON CONFLICT (user_id, provider, repo_full_name) DO UPDATE SET
                                default_branch = COALESCE(EXCLUDED.default_branch, connected_repos.default_branch),
-                               is_private = EXCLUDED.is_private,
+                               is_private = COALESCE(EXCLUDED.is_private, connected_repos.is_private),
                                updated_at = NOW()""",
-                        (user_id, org_id, full_name, default_branch, repo.get("is_private", False)),
+                        (user_id, org_id, full_name, default_branch, repo.get("is_private")),
                     )
                     if full_name not in existing:
                         newly_added.append(full_name)
@@ -458,6 +458,7 @@ def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
                 conn.commit()
         failed = cleanup_org_hooks(user_id, org_id, names)
         return {
+            "org_id": org_id,
             "change_gating_enabled": False,
             "webhook_cleanup_failed": bool(failed),
             "results": [{"repo_full_name": n} for n in names],
@@ -469,7 +470,7 @@ def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
             cur.execute(
-                """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled),
+                """SELECT repo_full_name, MAX(default_branch),
                           bool_or(webhook_verified_url = %s)
                      FROM connected_repos
                     WHERE org_id = %s AND provider = 'bitbucket'
@@ -480,7 +481,7 @@ def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
             rows = cur.fetchall()
             to_enable = [r[0] for r in rows if r[1] is not None]
             skipped_no_branch = [r[0] for r in rows if r[1] is None]
-            hook_ok = {r[0] for r in rows if r[3]}
+            hook_ok = {r[0] for r in rows if r[2]}
             if to_enable:
                 cur.execute(
                     """UPDATE connected_repos
@@ -493,7 +494,7 @@ def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
 
     results = [{"repo_full_name": n, "error": "no_default_branch"} for n in skipped_no_branch]
     results.extend({"repo_full_name": n} for n in to_enable if n in hook_ok)
-    out = {"change_gating_enabled": True, "results": results}
+    out = {"org_id": org_id, "change_gating_enabled": True, "results": results}
     need_hooks = [n for n in to_enable if n not in hook_ok]
     if not need_hooks and not to_enable:
         return out
@@ -519,7 +520,7 @@ def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
 
 
 @celery_app.task(name="bitbucket.enable_change_gating_bulk", time_limit=3600, queue="high")
-def enable_change_gating_bulk(user_id, org_id, names, enabled=True, *_args, **_kwargs):
+def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
     return _apply_change_gating_bulk(user_id, org_id, names, enabled)
 
 
@@ -580,13 +581,25 @@ def get_change_gating_bulk_job(user_id, task_id):
         return jsonify({"state": task.state, "complete": False})
     if task.state == "SUCCESS":
         result = dict(task.result or {})
+        owner = result.pop("org_id", None)
+        if owner is not None and owner != resolve_org(user_id):
+            return jsonify({"error": "Not found"}), 404
         results = result.get("results") or []
         if result.get("change_gating_enabled") and any(
             r.get("webhook_auto_created") is False for r in results
         ):
             result["webhook_secret"] = get_or_create_webhook_secret(resolve_org(user_id))
         return jsonify({"state": task.state, "complete": True, "result": result})
-    return jsonify({"state": task.state, "complete": True, "error": True, "status": str(task.info)}), 200
+    logger.error(
+        "Bitbucket bulk-enable task %s ended in state %s: %s",
+        _sanitize_log(task_id), task.state, task.info,
+    )
+    return jsonify({
+        "state": task.state,
+        "complete": True,
+        "error": True,
+        "status": "Failed to update Incident Prevention",
+    }), 200
 
 
 @bitbucket_selection_bp.route("/repo-selections/<path:repo_full_name>/change-gating", methods=["PUT"])

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -13,9 +13,13 @@ duplicate rows on read and written to ALL org rows on update, so per-user
 duplicates can never disagree.
 """
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
 
+from celery_config import celery_app
 from flask import Blueprint, jsonify, request
 
+from connectors.bitbucket_connector.webhook_secret import get_or_create_webhook_secret
 from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import set_rls_context
 from utils.db.connection_pool import db_pool
@@ -118,10 +122,9 @@ def save_workspace_selection(user_id):
 
         if not workspace:
             return jsonify({"error": "Workspace is required"}), 400
-        if not repositories and not repository:
-            return jsonify({"error": "At least one repository is required"}), 400
-
-        if not repositories:
+        if repositories is None:
+            if not repository:
+                return jsonify({"error": "At least one repository is required"}), 400
             repositories = [repository]
 
         newly_added = []
@@ -345,6 +348,18 @@ def cleanup_org_hooks(user_id: str, org_id: str, repo_full_names=None) -> list[s
     return failed
 
 
+def _until_not_429(fn):
+    delay = 1
+    result = fn()
+    for _ in range(7):
+        if not (isinstance(result, dict) and result.get("status") == 429):
+            return result
+        time.sleep(delay)
+        delay = min(delay * 2, 32)
+        result = fn()
+    return result
+
+
 def _try_auto_create_hook(
     user_id: str, org_id: str, repo_full_name: str,
     webhook_url: str, webhook_events, secret: str,
@@ -354,9 +369,10 @@ def _try_auto_create_hook(
     Needs the write:webhook:bitbucket scope, which the connector token often
     lacks — manual setup is the primary path, so failure here is informational
     only. An existing hook with the same URL counts as success (its uuid is
-    recorded too, so disable/disconnect can still delete it).
+    recorded too, so disable/disconnect can still delete it). A success also
+    records verification: creating/finding the hook is the same bar as Verify.
     """
-    def _store_hook_uuid(hook_uuid: str) -> None:
+    def _mark_verified(hook_uuid=None) -> None:
         # Isolated: by this point the hook EXISTS on Bitbucket, so a DB blip
         # here must not flip the return to False (which would tell the admin
         # to create a second hook manually). The cost of a lost uuid is only
@@ -367,10 +383,13 @@ def _try_auto_create_hook(
                     set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:hook]")
                     cur.execute(
                         """UPDATE connected_repos
-                              SET webhook_hook_uuid = %s, updated_at = NOW()
+                              SET webhook_hook_uuid = COALESCE(%s, webhook_hook_uuid),
+                                  webhook_verified_at = COALESCE(webhook_verified_at, NOW()),
+                                  webhook_verified_url = %s,
+                                  updated_at = NOW()
                             WHERE org_id = %s AND provider = 'bitbucket'
                               AND repo_full_name = %s""",
-                        (hook_uuid, org_id, repo_full_name),
+                        (hook_uuid, webhook_url, org_id, repo_full_name),
                     )
                     conn.commit()
         except Exception:
@@ -387,7 +406,7 @@ def _try_auto_create_hook(
         if client is None or "/" not in repo_full_name:
             return False
         ws, slug = repo_full_name.split("/", 1)
-        existing = client.list_webhooks(ws, slug)
+        existing = _until_not_429(lambda: client.list_webhooks(ws, slug))
         for hook in existing if isinstance(existing, list) else []:
             if not (isinstance(hook, dict) and hook.get("url") == webhook_url):
                 continue
@@ -399,18 +418,16 @@ def _try_auto_create_hook(
                 continue
             if {"pullrequest:created", "pullrequest:updated"} - set(hook.get("events") or []):
                 continue
-            if hook.get("uuid"):
-                _store_hook_uuid(hook["uuid"])
+            _mark_verified(hook.get("uuid"))
             return True
-        created = client.create_webhook(
+        created = _until_not_429(lambda: client.create_webhook(
             ws, slug, webhook_url, webhook_events,
             description="Aurora Incident Prevention",
             secret=secret,
-        )
+        ))
         if not isinstance(created, dict) or created.get("error"):
             return False
-        if created.get("uuid"):
-            _store_hook_uuid(created["uuid"])
+        _mark_verified(created.get("uuid"))
         return True
     except Exception:
         logger.info(
@@ -420,16 +437,66 @@ def _try_auto_create_hook(
         return False
 
 
+@celery_app.task(name="bitbucket.enable_change_gating_bulk", time_limit=3600)
+def enable_change_gating_bulk(user_id, org_id, names):
+    # ponytail: Bitbucket has no bulk webhook API. 3-wide pool; raise workers if 429s stay rare at 500 repos.
+    webhook_events = ["pullrequest:created", "pullrequest:updated"]
+    with db_pool.get_admin_connection() as conn:
+        with conn.cursor() as cur:
+            set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
+            cur.execute(
+                """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
+                     FROM connected_repos
+                    WHERE org_id = %s AND provider = 'bitbucket'
+                      AND repo_full_name = ANY(%s)
+                    GROUP BY repo_full_name""",
+                (org_id, names),
+            )
+            rows = cur.fetchall()
+            to_enable = [r[0] for r in rows if r[1] is not None]
+            skipped_no_branch = [r[0] for r in rows if r[1] is None]
+            already_on = {r[0] for r in rows if r[1] is not None and r[2]}
+            if to_enable:
+                cur.execute(
+                    """UPDATE connected_repos
+                          SET change_gating_enabled = TRUE, updated_at = NOW()
+                        WHERE org_id = %s AND provider = 'bitbucket'
+                          AND repo_full_name = ANY(%s)""",
+                    (org_id, to_enable),
+                )
+            conn.commit()
+
+    results = [{"repo_full_name": n, "error": "no_default_branch"} for n in skipped_no_branch]
+    results.extend({"repo_full_name": n} for n in to_enable if n in already_on)
+    out = {"change_gating_enabled": True, "results": results}
+    need_hooks = [n for n in to_enable if n not in already_on]
+    if not need_hooks and not to_enable:
+        return out
+
+    secret = get_or_create_webhook_secret(org_id)
+    webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
+    out.update({
+        "webhook_url": webhook_url,
+        "webhook_secret": secret,
+        "webhook_events": webhook_events,
+    })
+    if need_hooks:
+        def _one(name):
+            return {
+                "repo_full_name": name,
+                "webhook_auto_created": _try_auto_create_hook(
+                    user_id, org_id, name, webhook_url, webhook_events, secret
+                ),
+            }
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            results.extend(pool.map(_one, need_hooks))
+    return out
+
+
 @bitbucket_selection_bp.route("/repo-selections/change-gating", methods=["PUT"])
 @require_permission("connectors", "write")
 def update_change_gating_bulk(user_id):
-    """Enable Incident Prevention on many connected Bitbucket repos.
-
-    Body: ``{enabled: true, repo_full_names?: [str]}``. Omit names to enable
-    every connected Bitbucket repo for the org. Already-on repos are left
-    untouched in Bitbucket (no extra hook create). Repos with no recorded
-    default branch are skipped. Sequential hook creates — Bitbucket rate limits.
-    """
+    """Enqueue Incident Prevention enable for selected connected Bitbucket repos."""
     try:
         from utils.flags.feature_flags import is_incident_prevention_enabled
 
@@ -439,92 +506,49 @@ def update_change_gating_bulk(user_id):
         data = request.get_json(silent=True)
         if not isinstance(data, dict) or data.get("enabled") is not True:
             return jsonify({"error": "enabled must be true"}), 400
-
         names = data.get("repo_full_names")
-        if names is not None:
-            if not isinstance(names, list) or not names or not all(
-                isinstance(n, str) and n.strip() for n in names
-            ):
-                return jsonify({"error": "repo_full_names must be a non-empty list of strings"}), 400
+        if not isinstance(names, list) or not names or not all(
+            isinstance(n, str) and n.strip() for n in names
+        ):
+            return jsonify({"error": "repo_full_names must be a non-empty list of strings"}), 400
 
         org_id = resolve_org(user_id)
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cur:
                 set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
-                if names is None:
-                    cur.execute(
-                        """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
-                             FROM connected_repos
-                            WHERE org_id = %s AND provider = 'bitbucket'
-                            GROUP BY repo_full_name""",
-                        (org_id,),
-                    )
-                else:
-                    cur.execute(
-                        """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
-                             FROM connected_repos
-                            WHERE org_id = %s AND provider = 'bitbucket'
-                              AND repo_full_name = ANY(%s)
-                            GROUP BY repo_full_name""",
-                        (org_id, names),
-                    )
-                rows = cur.fetchall()
-                found = {r[0] for r in rows}
-                if names is not None:
-                    missing = [n for n in names if n not in found]
-                    if missing:
-                        return jsonify({"error": "Repository not found", "missing": missing}), 404
-                if not rows:
-                    return jsonify({"error": "No connected repositories"}), 400
+                cur.execute(
+                    """SELECT repo_full_name FROM connected_repos
+                       WHERE org_id = %s AND provider = 'bitbucket'
+                         AND repo_full_name = ANY(%s)
+                       GROUP BY repo_full_name""",
+                    (org_id, names),
+                )
+                found = {r[0] for r in cur.fetchall()}
+        missing = [n for n in names if n not in found]
+        if missing:
+            return jsonify({"error": "Repository not found", "missing": missing}), 404
 
-                to_enable = [r[0] for r in rows if r[1] is not None]
-                skipped_no_branch = [r[0] for r in rows if r[1] is None]
-                already_on = {r[0] for r in rows if r[1] is not None and r[2]}
-                if to_enable:
-                    cur.execute(
-                        """UPDATE connected_repos
-                              SET change_gating_enabled = TRUE, updated_at = NOW()
-                            WHERE org_id = %s AND provider = 'bitbucket'
-                              AND repo_full_name = ANY(%s)""",
-                        (org_id, to_enable),
-                    )
-                conn.commit()
-
-        results = [{"repo_full_name": n, "error": "no_default_branch"} for n in skipped_no_branch]
-        webhook_events = ["pullrequest:created", "pullrequest:updated"]
-        response = {"change_gating_enabled": True, "results": results}
-
-        if to_enable:
-            from connectors.bitbucket_connector.webhook_secret import (
-                get_or_create_webhook_secret,
-            )
-
-            secret = get_or_create_webhook_secret(org_id)
-            webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
-            response.update({
-                "webhook_url": webhook_url,
-                "webhook_secret": secret,
-                "webhook_events": webhook_events,
-            })
-            for name in to_enable:
-                if name in already_on:
-                    results.append({"repo_full_name": name})
-                    continue
-                results.append({
-                    "repo_full_name": name,
-                    "webhook_auto_created": _try_auto_create_hook(
-                        user_id, org_id, name, webhook_url, webhook_events, secret
-                    ),
-                })
-
+        task = enable_change_gating_bulk.delay(user_id, org_id, names)
         logger.info(
-            "Bitbucket Incident Prevention bulk-enabled %s repos (org %s, by user %s)",
-            len(to_enable), _sanitize_log(org_id), _sanitize_log(user_id),
+            "Bitbucket Incident Prevention bulk-enable queued %s repos (org %s, by user %s, task %s)",
+            len(names), _sanitize_log(org_id), _sanitize_log(user_id), task.id,
         )
-        return jsonify(response)
+        return jsonify({"task_id": task.id, "count": len(names)}), 202
     except Exception:
-        logger.exception("Error bulk-updating Bitbucket change gating")
+        logger.exception("Error queueing Bitbucket change gating bulk enable")
         return jsonify({"error": "Failed to update Incident Prevention"}), 500
+
+
+@bitbucket_selection_bp.route("/repo-selections/change-gating/jobs/<task_id>", methods=["GET"])
+@require_permission("connectors", "write")
+def get_change_gating_bulk_job(user_id, task_id):
+    """Poll the Celery bulk-enable job."""
+    task = enable_change_gating_bulk.AsyncResult(task_id)
+    if task.state in ("PENDING", "STARTED"):
+        return jsonify({"state": task.state, "complete": False})
+    if task.state == "SUCCESS":
+        return jsonify({"state": task.state, "complete": True, "result": task.result or {}})
+    return jsonify({"state": task.state, "complete": True, "error": True, "status": str(task.info)}), 200
 
 
 @bitbucket_selection_bp.route("/repo-selections/<path:repo_full_name>/change-gating", methods=["PUT"])
@@ -603,10 +627,6 @@ def update_change_gating(user_id, repo_full_name):
 
         webhook_events = ["pullrequest:created", "pullrequest:updated"]
         if enabled:
-            from connectors.bitbucket_connector.webhook_secret import (
-                get_or_create_webhook_secret,
-            )
-
             secret = get_or_create_webhook_secret(org_id)
             webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
             response.update({

--- a/server/routes/bitbucket/bitbucket_selection.py
+++ b/server/routes/bitbucket/bitbucket_selection.py
@@ -312,10 +312,15 @@ def cleanup_org_hooks(user_id: str, org_id: str, repo_full_names=None) -> list[s
             hooks = cur.fetchall()
 
     # Phase 2: Bitbucket API calls, no DB connection held.
+    # Same 3-wide pool as bulk enable — Bitbucket has no bulk webhook API.
+    def _one(item):
+        repo_full_name, hook_uuid = item
+        return repo_full_name, _delete_repo_hook(user_id, repo_full_name, hook_uuid)
+
     deleted, failed = [], []
-    for repo_full_name, hook_uuid in hooks:
-        target = deleted if _delete_repo_hook(user_id, repo_full_name, hook_uuid) else failed
-        target.append(repo_full_name)
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        for repo_full_name, ok in pool.map(_one, hooks):
+            (deleted if ok else failed).append(repo_full_name)
 
     # Phase 3: clear verification state for EVERY targeted repo, whether or
     # not Bitbucket let us delete the hook. Aurora's own view of "is this
@@ -437,8 +442,7 @@ def _try_auto_create_hook(
         return False
 
 
-@celery_app.task(name="bitbucket.enable_change_gating_bulk", time_limit=3600)
-def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
+def _apply_change_gating_bulk(user_id, org_id, names, enabled=True):
     # ponytail: Bitbucket has no bulk webhook API. 3-wide pool; raise workers if 429s stay rare at 500 repos.
     if not enabled:
         with db_pool.get_admin_connection() as conn:
@@ -460,21 +464,23 @@ def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
         }
 
     webhook_events = ["pullrequest:created", "pullrequest:updated"]
+    webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
             set_rls_context(cur, conn, user_id, log_prefix="[BitbucketChangeGating:bulk]")
             cur.execute(
-                """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled)
+                """SELECT repo_full_name, MAX(default_branch), bool_or(change_gating_enabled),
+                          bool_or(webhook_verified_url = %s)
                      FROM connected_repos
                     WHERE org_id = %s AND provider = 'bitbucket'
                       AND repo_full_name = ANY(%s)
                     GROUP BY repo_full_name""",
-                (org_id, names),
+                (webhook_url, org_id, names),
             )
             rows = cur.fetchall()
             to_enable = [r[0] for r in rows if r[1] is not None]
             skipped_no_branch = [r[0] for r in rows if r[1] is None]
-            already_on = {r[0] for r in rows if r[1] is not None and r[2]}
+            hook_ok = {r[0] for r in rows if r[3]}
             if to_enable:
                 cur.execute(
                     """UPDATE connected_repos
@@ -486,17 +492,17 @@ def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
             conn.commit()
 
     results = [{"repo_full_name": n, "error": "no_default_branch"} for n in skipped_no_branch]
-    results.extend({"repo_full_name": n} for n in to_enable if n in already_on)
+    results.extend({"repo_full_name": n} for n in to_enable if n in hook_ok)
     out = {"change_gating_enabled": True, "results": results}
-    need_hooks = [n for n in to_enable if n not in already_on]
+    need_hooks = [n for n in to_enable if n not in hook_ok]
     if not need_hooks and not to_enable:
         return out
 
     secret = get_or_create_webhook_secret(org_id)
-    webhook_url = f"{_webhook_base_url()}/bitbucket/webhook/{org_id}"
+    # Secret is attached on job poll only if a repo needs the manual dialog.
+    # Celery INFO-logs the return value; never put the secret in the task result.
     out.update({
         "webhook_url": webhook_url,
-        "webhook_secret": secret,
         "webhook_events": webhook_events,
     })
     if need_hooks:
@@ -510,6 +516,11 @@ def enable_change_gating_bulk(user_id, org_id, names, enabled=True):
         with ThreadPoolExecutor(max_workers=3) as pool:
             results.extend(pool.map(_one, need_hooks))
     return out
+
+
+@celery_app.task(name="bitbucket.enable_change_gating_bulk", time_limit=3600, queue="high")
+def enable_change_gating_bulk(user_id, org_id, names, enabled=True, *_args, **_kwargs):
+    return _apply_change_gating_bulk(user_id, org_id, names, enabled)
 
 
 @bitbucket_selection_bp.route("/repo-selections/change-gating", methods=["PUT"])
@@ -548,7 +559,7 @@ def update_change_gating_bulk(user_id):
         if missing:
             return jsonify({"error": "Repository not found", "missing": missing}), 404
 
-        task = enable_change_gating_bulk.delay(user_id, org_id, names, enabled)
+        task = enable_change_gating_bulk.delay(user_id, org_id, names, enabled=enabled)
         logger.info(
             "Bitbucket Incident Prevention bulk-%s queued %s repos (org %s, by user %s, task %s)",
             "enable" if enabled else "disable",
@@ -568,7 +579,13 @@ def get_change_gating_bulk_job(user_id, task_id):
     if task.state in ("PENDING", "STARTED"):
         return jsonify({"state": task.state, "complete": False})
     if task.state == "SUCCESS":
-        return jsonify({"state": task.state, "complete": True, "result": task.result or {}})
+        result = dict(task.result or {})
+        results = result.get("results") or []
+        if result.get("change_gating_enabled") and any(
+            r.get("webhook_auto_created") is False for r in results
+        ):
+            result["webhook_secret"] = get_or_create_webhook_secret(resolve_org(user_id))
+        return jsonify({"state": task.state, "complete": True, "result": result})
     return jsonify({"state": task.state, "complete": True, "error": True, "status": str(task.info)}), 200
 
 

--- a/server/tests/tasks/test_bitbucket_change_gating_bulk.py
+++ b/server/tests/tasks/test_bitbucket_change_gating_bulk.py
@@ -61,17 +61,19 @@ def test_disable_updates_and_cleans_hooks(monkeypatch):
     _patch_db(monkeypatch, [])
     monkeypatch.setattr(sel, "cleanup_org_hooks", lambda *a: ["ws/r"])
     out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"], False)
+    assert out["org_id"] == "org-1"
     assert out["change_gating_enabled"] is False
     assert out["webhook_cleanup_failed"] is True
     assert out["results"] == [{"repo_full_name": "ws/r"}]
 
 
 def test_enable_creates_and_reports_hooks(monkeypatch):
-    _patch_db(monkeypatch, [("ws/r", "main", False, False)])
+    _patch_db(monkeypatch, [("ws/r", "main", False)])
     monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
     monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
     monkeypatch.setattr(sel, "_try_auto_create_hook", lambda *a: True)
     out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"], True)
+    assert out["org_id"] == "org-1"
     assert out["change_gating_enabled"] is True
     assert out["webhook_url"] == "https://api.example.com/bitbucket/webhook/org-1"
     assert "webhook_secret" not in out
@@ -80,7 +82,7 @@ def test_enable_creates_and_reports_hooks(monkeypatch):
 
 
 def test_enable_retries_hook_when_already_on_but_unverified(monkeypatch):
-    _patch_db(monkeypatch, [("ws/r", "main", True, False)])
+    _patch_db(monkeypatch, [("ws/r", "main", False)])
     monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
     monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
     called = []
@@ -91,7 +93,7 @@ def test_enable_retries_hook_when_already_on_but_unverified(monkeypatch):
 
 
 def test_enable_skips_hook_when_already_verified(monkeypatch):
-    _patch_db(monkeypatch, [("ws/r", "main", True, True)])
+    _patch_db(monkeypatch, [("ws/r", "main", True)])
     monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
     monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
     monkeypatch.setattr(

--- a/server/tests/tasks/test_bitbucket_change_gating_bulk.py
+++ b/server/tests/tasks/test_bitbucket_change_gating_bulk.py
@@ -1,0 +1,102 @@
+"""Bulk Incident Prevention enable/disable — arity and apply contract.
+
+The Flask route queues 4 arguments (user_id, org_id, names, enabled). A
+worker still running the 3-arg task raises TypeError; this file pins that
+the apply function accepts both 3-arg (enable default) and 4-arg calls.
+"""
+from __future__ import annotations
+
+import contextlib
+import inspect
+
+from routes.bitbucket import bitbucket_selection as sel
+
+
+class _Cur:
+    def __init__(self, rows):
+        self.rows = rows
+        self.sql = []
+
+    def execute(self, sql, params=None):
+        self.sql.append((sql, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _Conn:
+    def __init__(self, rows):
+        self.cur = _Cur(rows)
+
+    def cursor(self):
+        return self.cur
+
+    def commit(self):
+        pass
+
+
+def _patch_db(monkeypatch, rows):
+    @contextlib.contextmanager
+    def _conn():
+        yield _Conn(rows)
+
+    monkeypatch.setattr(sel.db_pool, "get_admin_connection", _conn)
+    monkeypatch.setattr(sel, "set_rls_context", lambda *a, **k: "org-1")
+
+
+def test_apply_accepts_enabled_as_fourth_arg():
+    sig = inspect.signature(sel._apply_change_gating_bulk)
+    params = list(sig.parameters)
+    assert params == ["user_id", "org_id", "names", "enabled"]
+    assert sig.parameters["enabled"].default is True
+
+
+def test_disable_updates_and_cleans_hooks(monkeypatch):
+    _patch_db(monkeypatch, [])
+    monkeypatch.setattr(sel, "cleanup_org_hooks", lambda *a: ["ws/r"])
+    out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"], False)
+    assert out["change_gating_enabled"] is False
+    assert out["webhook_cleanup_failed"] is True
+    assert out["results"] == [{"repo_full_name": "ws/r"}]
+
+
+def test_enable_creates_and_reports_hooks(monkeypatch):
+    _patch_db(monkeypatch, [("ws/r", "main", False, False)])
+    monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
+    monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
+    monkeypatch.setattr(sel, "_try_auto_create_hook", lambda *a: True)
+    out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"], True)
+    assert out["change_gating_enabled"] is True
+    assert out["webhook_url"] == "https://api.example.com/bitbucket/webhook/org-1"
+    assert "webhook_secret" not in out
+    created = [r for r in out["results"] if r.get("webhook_auto_created") is True]
+    assert created == [{"repo_full_name": "ws/r", "webhook_auto_created": True}]
+
+
+def test_enable_retries_hook_when_already_on_but_unverified(monkeypatch):
+    _patch_db(monkeypatch, [("ws/r", "main", True, False)])
+    monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
+    monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
+    called = []
+    monkeypatch.setattr(sel, "_try_auto_create_hook", lambda *a: called.append(a[2]) or True)
+    out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"], True)
+    assert called == ["ws/r"]
+    assert any(r.get("webhook_auto_created") is True for r in out["results"])
+
+
+def test_enable_skips_hook_when_already_verified(monkeypatch):
+    _patch_db(monkeypatch, [("ws/r", "main", True, True)])
+    monkeypatch.setattr(sel, "get_or_create_webhook_secret", lambda org: "secret")
+    monkeypatch.setattr(sel, "_webhook_base_url", lambda: "https://api.example.com")
+    monkeypatch.setattr(
+        sel, "_try_auto_create_hook", lambda *a: (_ for _ in ()).throw(AssertionError("should not create"))
+    )
+    out = sel._apply_change_gating_bulk("u", "org-1", ["ws/r"])
+    assert out["change_gating_enabled"] is True
+    assert {"repo_full_name": "ws/r"} in out["results"]

--- a/server/tests/tasks/test_repo_metadata_bitbucket.py
+++ b/server/tests/tasks/test_repo_metadata_bitbucket.py
@@ -1,0 +1,63 @@
+"""Bitbucket metadata: empty repos are not failures; fetch errors still are."""
+from unittest.mock import MagicMock, patch
+
+from utils.repo_metadata import (
+    _EMPTY_SUMMARY,
+    _fetch_bitbucket_context,
+    generate_repo_metadata,
+)
+
+
+def _client(listing, repo=None):
+    client = MagicMock()
+    client.get_repository.return_value = repo or {"mainbranch": {"name": "main"}}
+    client._resolve_commit.return_value = "abc1234"
+    client.get_directory_tree.return_value = listing
+    return client
+
+
+@patch("connectors.bitbucket_connector.api_client.BitbucketAPIClient")
+def test_empty_tree_is_not_a_fetch_failure(mock_cls):
+    mock_cls.return_value = _client({"error": True, "status": 404})
+    assert _fetch_bitbucket_context("tok", "api_token", "ws", "empty") == ("", "")
+    mock_cls.return_value.get_file_contents.assert_not_called()
+
+
+@patch("connectors.bitbucket_connector.api_client.BitbucketAPIClient")
+def test_size_zero_skips_src_hunt(mock_cls):
+    mock_cls.return_value = _client(
+        {"error": True, "status": 404},
+        repo={"size": 0, "mainbranch": {"name": "master"}},
+    )
+    assert _fetch_bitbucket_context("tok", "api_token", "ws", "empty") == ("", "")
+    mock_cls.return_value.get_directory_tree.assert_not_called()
+    mock_cls.return_value.get_file_contents.assert_not_called()
+
+
+@patch("connectors.bitbucket_connector.api_client.BitbucketAPIClient")
+def test_forbidden_listing_is_a_fetch_failure(mock_cls):
+    mock_cls.return_value = _client({"error": True, "status": 403})
+    assert _fetch_bitbucket_context("tok", "api_token", "ws", "priv") == (
+        "",
+        "(could not list files)",
+    )
+
+
+@patch("utils.repo_metadata._generate_summary")
+@patch("utils.repo_metadata._update_metadata")
+@patch("utils.repo_metadata._fetch_repo_context", return_value=("", ""))
+@patch("utils.repo_metadata._get_credentials", return_value={"access_token": "x"})
+def test_empty_repo_marked_ready(get_creds, fetch, update, summarize):
+    generate_repo_metadata.run("user-1", "bitbucket", "ws/empty")
+    summarize.assert_not_called()
+    update.assert_called_with("user-1", "bitbucket", "ws/empty", _EMPTY_SUMMARY, "ready")
+
+
+@patch("utils.repo_metadata._generate_summary")
+@patch("utils.repo_metadata._update_metadata")
+@patch("utils.repo_metadata._fetch_repo_context", return_value=("", "(could not list files)"))
+@patch("utils.repo_metadata._get_credentials", return_value={"access_token": "x"})
+def test_fetch_failure_marked_error(get_creds, fetch, update, summarize):
+    generate_repo_metadata.run("user-1", "bitbucket", "ws/oops")
+    summarize.assert_not_called()
+    update.assert_called_with("user-1", "bitbucket", "ws/oops", None, "error")

--- a/server/tests/tasks/test_repo_metadata_bitbucket.py
+++ b/server/tests/tasks/test_repo_metadata_bitbucket.py
@@ -1,11 +1,7 @@
 """Bitbucket metadata: empty repos are not failures; fetch errors still are."""
 from unittest.mock import MagicMock, patch
 
-from utils.repo_metadata import (
-    _EMPTY_SUMMARY,
-    _fetch_bitbucket_context,
-    generate_repo_metadata,
-)
+from utils.repo_metadata import _fetch_bitbucket_context
 
 
 def _client(listing, repo=None):
@@ -41,23 +37,3 @@ def test_forbidden_listing_is_a_fetch_failure(mock_cls):
         "",
         "(could not list files)",
     )
-
-
-@patch("utils.repo_metadata._generate_summary")
-@patch("utils.repo_metadata._update_metadata")
-@patch("utils.repo_metadata._fetch_repo_context", return_value=("", ""))
-@patch("utils.repo_metadata._get_credentials", return_value={"access_token": "x"})
-def test_empty_repo_marked_ready(get_creds, fetch, update, summarize):
-    generate_repo_metadata.run("user-1", "bitbucket", "ws/empty")
-    summarize.assert_not_called()
-    update.assert_called_with("user-1", "bitbucket", "ws/empty", _EMPTY_SUMMARY, "ready")
-
-
-@patch("utils.repo_metadata._generate_summary")
-@patch("utils.repo_metadata._update_metadata")
-@patch("utils.repo_metadata._fetch_repo_context", return_value=("", "(could not list files)"))
-@patch("utils.repo_metadata._get_credentials", return_value={"access_token": "x"})
-def test_fetch_failure_marked_error(get_creds, fetch, update, summarize):
-    generate_repo_metadata.run("user-1", "bitbucket", "ws/oops")
-    summarize.assert_not_called()
-    update.assert_called_with("user-1", "bitbucket", "ws/oops", None, "error")

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -91,37 +91,71 @@ def _fetch_gitlab_listing(base_url: str, token: str, project_path: str) -> str:
     return "\n".join(f"{'dir' if i.get('type') == 'tree' else 'file'}: {i.get('name')}" for i in items)
 
 
-def _fetch_bitbucket_readme(access_token: str, auth_type: str, workspace: str, repo_slug: str, email: Optional[str] = None) -> str:
+_README_NAMES = ("README.md", "README.rst", "README.txt", "README")
+_EMPTY_SUMMARY = "No files in this repository yet."
+
+
+def _parse_bitbucket_listing(result) -> str:
+    if isinstance(result, dict) and "values" in result:
+        items = result["values"]
+        return "\n".join(
+            f"{'dir' if i.get('type') == 'commit_directory' else 'file'}: {i.get('path', i.get('name', ''))}"
+            for i in items[:100]
+        )
+    if isinstance(result, list):
+        return "\n".join(
+            f"{'dir' if i.get('type') == 'commit_directory' else 'file'}: {i.get('path', i.get('name', ''))}"
+            for i in result[:100]
+        )
+    return "(could not list files)"
+
+
+def _fetch_bitbucket_context(
+    access_token: str, auth_type: str, workspace: str, repo_slug: str, email: Optional[str] = None
+) -> tuple[str, str]:
+    """README + listing in one pass. Empty repo → ("", ""). Fetch failure → ("", "(could not list files)")."""
     from connectors.bitbucket_connector.api_client import BitbucketAPIClient
+
     client = BitbucketAPIClient(access_token, auth_type=auth_type, email=email)
-    for filename in ("README.md", "README.rst", "README.txt", "README"):
-        result = client.get_file_contents(workspace, repo_slug, filename)
+    repo = client.get_repository(workspace, repo_slug)
+    if not isinstance(repo, dict) or repo.get("error"):
+        return "", "(could not list files)"
+    if repo.get("size") == 0:
+        return "", ""
+    ref = (repo.get("mainbranch") or {}).get("name") or "HEAD"
+    commit = client._resolve_commit(workspace, repo_slug, ref)
+    listing_raw = client.get_directory_tree(workspace, repo_slug, "", commit=commit, list_files=True)
+    if isinstance(listing_raw, dict) and listing_raw.get("status") == 404:
+        return "", ""
+    if isinstance(listing_raw, dict) and listing_raw.get("error"):
+        logger.warning(
+            f"Bitbucket directory listing error for {workspace}/{repo_slug}: {listing_raw.get('status')}"
+        )
+        return "", "(could not list files)"
+    listing = _parse_bitbucket_listing(listing_raw)
+    if listing == "(could not list files)":
+        return "", "(could not list files)"
+    listed_names = {
+        line.split(": ", 1)[1].rsplit("/", 1)[-1].lower()
+        for line in listing.splitlines()
+        if ": " in line
+    }
+    readme = ""
+    for filename in _README_NAMES:
+        if filename.lower() not in listed_names:
+            continue
+        result = client.get_file_contents(workspace, repo_slug, filename, commit=commit)
         if isinstance(result, dict):
             if result.get("error"):
                 continue
             content = result.get("content")
             if isinstance(content, str) and content:
-                return content[:4000]
-        if isinstance(result, str):
-            return result[:4000]
-    return ""
-
-
-def _fetch_bitbucket_listing(access_token: str, auth_type: str, workspace: str, repo_slug: str, email: Optional[str] = None) -> str:
-    from connectors.bitbucket_connector.api_client import BitbucketAPIClient
-    client = BitbucketAPIClient(access_token, auth_type=auth_type, email=email)
-    # Call without format=meta to get the actual file listing (paginated with "values")
-    result = client.get_directory_tree(workspace, repo_slug, "", list_files=True)
-    if isinstance(result, dict) and result.get("error"):
-        logger.warning(f"Bitbucket directory listing error for {workspace}/{repo_slug}: {result.get('error')}")
-        return "(could not list files)"
-    if isinstance(result, dict) and "values" in result:
-        items = result["values"]
-        return "\n".join(f"{'dir' if i.get('type') == 'commit_directory' else 'file'}: {i.get('path', i.get('name', ''))}" for i in items[:100])
-    if isinstance(result, list):
-        return "\n".join(f"{'dir' if i.get('type') == 'commit_directory' else 'file'}: {i.get('path', i.get('name', ''))}" for i in result[:100])
-    logger.warning(f"Bitbucket directory listing unexpected response for {workspace}/{repo_slug}: keys={list(result.keys()) if isinstance(result, dict) else type(result)}")
-    return "(could not list files)"
+                readme = content[:4000]
+                break
+        elif isinstance(result, str) and result:
+            readme = result[:4000]
+            break
+    return readme, listing
 
 
 # ---------------------------------------------------------------------------
@@ -140,13 +174,14 @@ def _update_metadata(user_id: str, provider: str, repo_full_name: str, summary: 
 
     with db_pool.get_admin_connection() as conn:
         with conn.cursor() as cur:
-            if not set_rls_context(cur, conn, user_id, log_prefix=f"[{provider.title()}Metadata]"):
+            org_id = set_rls_context(cur, conn, user_id, log_prefix=f"[{provider.title()}Metadata]")
+            if not org_id:
                 return
             cur.execute(
                 """UPDATE connected_repos
                    SET metadata_summary = %s, metadata_status = %s, updated_at = NOW()
-                   WHERE user_id = %s AND provider = %s AND repo_full_name = %s""",
-                (summary, status, user_id, provider, repo_full_name),
+                   WHERE provider = %s AND repo_full_name = %s""",
+                (summary, status, provider, repo_full_name),
             )
             conn.commit()
 
@@ -174,10 +209,7 @@ def _fetch_repo_context(provider: str, creds: dict, repo_full_name: str) -> tupl
         if len(parts) != 2:
             return "", "(invalid repo format)"
         workspace, repo_slug = parts
-        return (
-            _fetch_bitbucket_readme(token, auth_type, workspace, repo_slug, email),
-            _fetch_bitbucket_listing(token, auth_type, workspace, repo_slug, email),
-        )
+        return _fetch_bitbucket_context(token, auth_type, workspace, repo_slug, email)
 
     return "", "(unsupported provider)"
 
@@ -230,6 +262,10 @@ def generate_repo_metadata(self, user_id: str, provider: str, repo_full_name: st
             return
 
         readme, file_list = _fetch_repo_context(provider, creds, repo_full_name)
+
+        if not readme and not file_list:
+            _update_metadata(user_id, provider, repo_full_name, _EMPTY_SUMMARY, "ready")
+            return
 
         # Both README and file listing failed — nothing to summarize
         if not readme and (not file_list or file_list == "(could not list files)"):


### PR DESCRIPTION
## Summary
- Add GitHub-style select-all (and a filter when there are more than 10 repos) to the Bitbucket repo picker so a workspace can be connected without checking repos one by one.
- Add `PUT /bitbucket/repo-selections/change-gating` plus an **Enable Incident Prevention on all** control on Connected Repositories. Connecting a repo still does not turn gating on.
- If webhook auto-create fails, show one shared URL/secret dialog instead of a modal per repo.

Came out of the Bombora POC kickoff (Aug 20): Juan has 49 Bitbucket repos connected and one-by-one Incident Prevention toggles are not usable.

## Test plan
- [ ] Bitbucket connector → pick a workspace with many repos: Select all checks every listed repo; Save connects them. Filter + Select all only affects the filtered set.
- [ ] Saving a selection does **not** enable Incident Prevention.
- [ ] Connected Repositories → Enable Incident Prevention on all: all remaining repos turn on; per-repo switches stay usable.
- [ ] If `write:webhook:bitbucket` works: toast only, no 49 dialogs. If it does not: one dialog with the shared URL/secret.
- [ ] Repos with no default branch are skipped with an error toast; already-enabled repos are left alone in Bitbucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repository search, filtering, and filtered “select all” support for larger workspaces.
  * Added bulk Incident Prevention enablement and disablement for selected repositories.
  * Added multi-repository webhook setup with progress tracking and notifications.
  * Added selected-repository disconnect handling.

* **Improvements**
  * Automatically configured webhooks are recognized without unnecessary setup.
  * Repositories without default branches are clearly skipped.
  * Changing workspaces clears the repository search filter.
  * Improved handling of empty repositories, temporary Bitbucket rate limits, and connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->