### PR TITLE
fix(change-gating): pre-merge reviewer is advisory only — never approves PRs (DEV-1465)

### DIFF
--- a/server/services/change_gating/bitbucket_adapter.py
+++ b/server/services/change_gating/bitbucket_adapter.py
@@ -16,17 +16,16 @@ review flow it uses for GitHub. Provider quirks handled here (design doc
   so the core always falls back to a full-PR review (incremental reviews
   are a follow-up).
 - **No first-class reviews**: prior Aurora reviews are synthesized from
-  top-level marker comments + the PR's approval participants.
+  top-level marker comments.
 - **Post review** = marker comment only (no inline comments in the POC).
   Aurora never approves PRs — there is no approve call in the posting
   path.
-- **Dismiss / supersede** = unapprove (retracts legacy approvals posted
-  before Aurora stopped approving) + prepend a note on the prior
-  marker comment. Caveats: Bitbucket approval is account-level and
-  unapprove removes only the CALLING account's approval, so with no
-  bot configured this can retract a manual approval the connected
-  user made themselves, and a legacy approval left by a different
-  account (e.g. pre-bot) survives (the 404 is tolerated).
+- **Dismiss / supersede** = prepend a note on the prior marker comment
+  ONLY. The adapter never touches approvals in either direction:
+  Bitbucket approval is account-level, so an unapprove could strip a
+  manual approval the connected user made themselves. Legacy Aurora
+  approvals (posted before Aurora stopped approving) must be removed
+  by hand.
 - **"Is this Aurora?"** = marker AND author UUID in
   ``{bot_uuid, token_owner_uuid}`` — a marker alone (which a human can
   paste) never qualifies.
@@ -347,9 +346,6 @@ class BitbucketPRAdapter:
         self._default_branch = default_branch
         # Author UUIDs allowed to count as "Aurora" — resolved lazily, once.
         self._aurora_uuids: Optional[set] = None
-        # Participants captured from the latest get_pull_request call, used
-        # to derive the synthetic APPROVED state for the last marker comment.
-        self._last_participants: List[Dict[str, Any]] = []
         # post_issue_comment(pr) → delete_issue_comment(comment_id) mapping
         # (Bitbucket's comment-delete endpoint is PR-scoped, GitHub's isn't).
         self._comment_pr: Dict[Any, int] = {}
@@ -362,7 +358,7 @@ class BitbucketPRAdapter:
     # ------------------------------------------------------------------
 
     def _allowed_uuids(self) -> set:
-        """UUIDs whose comments/approvals count as Aurora's own.
+        """UUIDs whose comments count as Aurora's own.
 
         The posting identity (bot or connected user) plus the read identity
         (connected user) — reviews posted before a bot was configured must
@@ -390,17 +386,6 @@ class BitbucketPRAdapter:
             self._aurora_uuids = uuids
         return uuids
 
-    def _aurora_has_approved(self) -> bool:
-        """True when an allowlisted identity currently approves the PR."""
-        allowed = self._allowed_uuids()
-        for participant in self._last_participants:
-            if not isinstance(participant, dict) or not participant.get("approved"):
-                continue
-            user = participant.get("user") or {}
-            if isinstance(user, dict) and user.get("uuid") in allowed:
-                return True
-        return False
-
     # ------------------------------------------------------------------
     # Reads
     # ------------------------------------------------------------------
@@ -411,7 +396,6 @@ class BitbucketPRAdapter:
             self._read.get_pull_request(self.workspace, self.repo_slug, pr_number),
             "get_pull_request",
         )
-        self._last_participants = raw.get("participants") or []
         source = raw.get("source") or {}
         destination = raw.get("destination") or {}
         author = raw.get("author") or {}
@@ -484,7 +468,7 @@ class BitbucketPRAdapter:
             reviews.append(
                 {
                     "id": comment.get("id"),
-                    "state": "COMMENTED",  # refined in find_aurora_reviews
+                    "state": "COMMENTED",  # Bitbucket has no review states; never APPROVED
                     # Read-back translation: hidden Bitbucket markers become
                     # HTML-comment markers so decode_marker/has_aurora_marker
                     # (provider-neutral) recognize them.
@@ -500,10 +484,7 @@ class BitbucketPRAdapter:
 
         The marker alone is not enough — any workspace member could paste
         one into a comment to hijack the prior-review context or redirect
-        the supersede step. The synthetic ``state`` of the LAST Aurora
-        review becomes ``APPROVED`` when an allowlisted identity currently
-        approves the PR (approval is account-level on Bitbucket, so it
-        can only describe the most recent verdict).
+        the supersede step.
         """
         allowed = self._allowed_uuids()
         out: List[Dict[str, Any]] = []
@@ -516,8 +497,6 @@ class BitbucketPRAdapter:
             if not (isinstance(user, dict) and user.get("uuid") in allowed):
                 continue
             out.append(review)
-        if out and self._aurora_has_approved():
-            out[-1] = {**out[-1], "state": "APPROVED"}
         return out
 
     def list_review_comments(self, pr_number: int) -> List[Dict[str, Any]]:
@@ -573,39 +552,32 @@ class BitbucketPRAdapter:
         return {"id": comment.get("id")}
 
     def dismiss_review(self, pr_number: int, review_id: Any, message: str) -> Any:
-        """Retract a stale APPROVE: unapprove + best-effort note on the comment."""
-        result = self._post.unapprove_pull_request(
-            self.workspace, self.repo_slug, pr_number
-        )
-        if isinstance(result, dict) and result.get("error") and result.get("status") != 404:
-            # 404 = no approval to remove — already the desired end state.
-            raise BitbucketAPIError(
-                f"Bitbucket unapprove failed (status={result.get('status')})",
-                status_code=result.get("status") if isinstance(result.get("status"), int) else None,
-            )
+        """Mark a stale review: best-effort note on the comment.
+
+        Approvals are never touched — Bitbucket approval is account-level,
+        so an unapprove could strip a manual approval the connected user
+        made themselves.
+
+        Currently unreachable in production (kept for ``PRAdapter``
+        conformance): the core's only call site is the incremental dismiss
+        loop, gated on ``state == "APPROVED"`` — this adapter has no
+        incremental path and never surfaces APPROVED.
+        """
         self._prepend_note(pr_number, review_id, message, body=None)
         return {"id": review_id}
 
     def supersede_review(
         self, pr_number: int, prior_review: Dict[str, Any], message: str
     ) -> None:
-        """Mark a prior Aurora review superseded: prepend note (+ unapprove).
+        """Mark a prior Aurora review superseded: prepend a note.
 
+        Approvals are never touched (see :meth:`dismiss_review`).
         Idempotent: if the note is already there (a previous supersede whose
         follow-up failed), the body is left untouched.
         """
         self._prepend_note(
             pr_number, prior_review.get("id"), message, body=prior_review.get("body")
         )
-        if prior_review.get("state") == "APPROVED":
-            result = self._post.unapprove_pull_request(
-                self.workspace, self.repo_slug, pr_number
-            )
-            if isinstance(result, dict) and result.get("error") and result.get("status") != 404:
-                raise BitbucketAPIError(
-                    f"Bitbucket unapprove failed (status={result.get('status')})",
-                    status_code=result.get("status") if isinstance(result.get("status"), int) else None,
-                )
 
     def _prepend_note(
         self, pr_number: int, comment_id: Any, message: str, body: Optional[str]
@@ -638,7 +610,7 @@ class BitbucketPRAdapter:
                 "prepend_note",
             )
         except Exception as exc:
-            # The note is cosmetic; the unapprove/new review carry the signal.
+            # The note is cosmetic; the new review carries the signal.
             logger.warning(
                 "[ChangeGating:BB] supersede note failed for comment %s: %s",
                 comment_id, type(exc).__name__,

--- a/server/services/change_gating/bitbucket_adapter.py
+++ b/server/services/change_gating/bitbucket_adapter.py
@@ -17,11 +17,16 @@ review flow it uses for GitHub. Provider quirks handled here (design doc
   are a follow-up).
 - **No first-class reviews**: prior Aurora reviews are synthesized from
   top-level marker comments + the PR's approval participants.
-- **Post SAFE** = marker comment + approve; if approve fails (e.g. the
-  token owner's own PR) the comment is still kept.
-- **Post RISKY** = marker comment only (no inline comments in the POC).
-- **Dismiss / supersede** = unapprove + prepend a note on the prior
-  marker comment.
+- **Post review** = marker comment only (no inline comments in the POC).
+  Aurora never approves PRs — there is no approve call in the posting
+  path.
+- **Dismiss / supersede** = unapprove (retracts legacy approvals posted
+  before Aurora stopped approving) + prepend a note on the prior
+  marker comment. Caveats: Bitbucket approval is account-level and
+  unapprove removes only the CALLING account's approval, so with no
+  bot configured this can retract a manual approval the connected
+  user made themselves, and a legacy approval left by a different
+  account (e.g. pre-bot) survives (the 404 is tolerated).
 - **"Is this Aurora?"** = marker AND author UUID in
   ``{bot_uuid, token_owner_uuid}`` — a marker alone (which a human can
   paste) never qualifies.
@@ -548,17 +553,14 @@ class BitbucketPRAdapter:
         pr_number: int,
         *,
         commit_id: str,
-        event: str,
         body: str,
         comments: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """Post the review: marker comment (+ approve on SAFE).
+        """Post the review as a marker comment — never an approval.
 
         ``commit_id`` and inline ``comments`` are required by the
         ``PRAdapter`` Protocol but ignored in the POC — Bitbucket comments
-        are not commit-pinned and all findings live in the body table. The
-        approve step is best-effort: Bitbucket rejects approving your own
-        PR, and the finding comment must survive that.
+        are not commit-pinned and all findings live in the body table.
         """
         del commit_id, comments
         comment = _checked(
@@ -568,18 +570,6 @@ class BitbucketPRAdapter:
             ),
             "post_review",
         )
-        if event == "APPROVE":
-            result = self._post.approve_pull_request(
-                self.workspace, self.repo_slug, pr_number
-            )
-            if isinstance(result, dict) and result.get("error"):
-                logger.warning(
-                    "[ChangeGating:BB] approve failed (status=%s) for %s#%s — "
-                    "keeping the SAFE review comment. Common cause: the posting "
-                    "account authored this PR (Bitbucket forbids self-approval); "
-                    "configure a dedicated bot account to avoid this.",
-                    result.get("status"), self.repo_full_name, pr_number,
-                )
         return {"id": comment.get("id")}
 
     def dismiss_review(self, pr_number: int, review_id: Any, message: str) -> Any:

--- a/server/services/change_gating/github_adapter.py
+++ b/server/services/change_gating/github_adapter.py
@@ -256,11 +256,13 @@ class GitHubPRAdapter:
         pr_number: int,
         *,
         commit_id: str,
-        event: str,
         body: str,
         comments: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """POST a PR review (APPROVE or COMMENT) with optional inline comments.
+        """POST a COMMENT PR review with optional inline comments.
+
+        The event is hardcoded to COMMENT — Aurora never approves a PR,
+        so no caller can turn the verdict into an approval.
 
         Each comment is ``{"path", "line", "side": "RIGHT", "body"}``.
         GitHub 422s when any inline comment falls outside the diff hunks;
@@ -270,7 +272,7 @@ class GitHubPRAdapter:
         path = f"/pulls/{pr_number}/reviews"
         payload = {
             "commit_id": commit_id,
-            "event": event,
+            "event": "COMMENT",
             "body": body,
             "comments": comments,
         }

--- a/server/services/change_gating/protocol.py
+++ b/server/services/change_gating/protocol.py
@@ -86,16 +86,17 @@ class PRAdapter(Protocol):
         pr_number: int,
         *,
         commit_id: str,
-        event: str,
         body: str,
         comments: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """Post the review. ``event`` is ``APPROVE`` or ``COMMENT``;
-        ``comments`` are inline findings (may be ignored by providers
-        without inline support)."""
+        """Post the verdict as a COMMENT review — adapters must never
+        approve a PR (an approval would count toward required-approval
+        merge checks). ``comments`` are inline findings (may be ignored
+        by providers without inline support)."""
 
     def dismiss_review(self, pr_number: int, review_id: Any, message: str) -> Any:
-        """Retract a prior APPROVE (GitHub: dismissal; Bitbucket: unapprove)."""
+        """Retract a legacy APPROVE posted before Aurora stopped approving
+        (GitHub: dismissal; Bitbucket: unapprove)."""
 
     def supersede_review(
         self, pr_number: int, prior_review: Dict[str, Any], message: str

--- a/server/services/change_gating/protocol.py
+++ b/server/services/change_gating/protocol.py
@@ -27,8 +27,8 @@ Normalization contract (what the core expects back)
   requirement).
 - Reviews are GitHub-shaped dicts: ``id``, ``state`` (``APPROVED`` /
   ``COMMENTED`` / ``DISMISSED``), ``body``, ``user``. Providers without
-  first-class reviews (Bitbucket) synthesize them from marker comments +
-  approval state inside the adapter.
+  first-class reviews (Bitbucket) synthesize them from marker comments
+  inside the adapter.
 """
 
 from __future__ import annotations
@@ -95,8 +95,15 @@ class PRAdapter(Protocol):
         by providers without inline support)."""
 
     def dismiss_review(self, pr_number: int, review_id: Any, message: str) -> Any:
-        """Retract a legacy APPROVE posted before Aurora stopped approving
-        (GitHub: dismissal; Bitbucket: unapprove)."""
+        """Mark a prior Aurora review stale. ``review_id`` MUST come from
+        :meth:`find_aurora_reviews` — the underlying provider APIs can act
+        on any review, so caller discipline is what keeps human reviews
+        untouched. GitHub: dismiss the review by id (retracts a legacy
+        APPROVE posted before Aurora stopped approving). Bitbucket: note
+        on the marker comment only — approvals are never touched
+        (unapprove is account-level and could strip a human's own
+        approval), so this is currently never invoked (Bitbucket reviews
+        never surface as APPROVED)."""
 
     def supersede_review(
         self, pr_number: int, prior_review: Dict[str, Any], message: str

--- a/server/tasks/change_gating.py
+++ b/server/tasks/change_gating.py
@@ -372,9 +372,10 @@ def _run_investigation(
             provider="github",
             log_key="investigate_pr",
             post_review_reject_hint=(
-                "common cause: the GitHub App lacks the "
-                "'Pull requests: write' permission (upgrade in App settings, "
-                "org admin must accept)."
+                "on 403 the GitHub App likely lacks the 'Pull requests: "
+                "write' permission (upgrade in App settings, org admin must "
+                "accept); on 422 GitHub rejected the review payload (e.g. "
+                "stale commit_id after a force-push, or an oversized body)."
             ),
         )
     finally:
@@ -467,8 +468,8 @@ def _run_bitbucket_investigation(
             provider="bitbucket",
             log_key="investigate_bitbucket_pr",
             post_review_reject_hint=(
-                "common cause: the Bitbucket token lacks write:pullrequest "
-                "scope."
+                "on 403 the Bitbucket token likely lacks write:pullrequest "
+                "scope; on 422 Bitbucket rejected the comment payload."
             ),
         )
     finally:
@@ -919,12 +920,16 @@ def _run_investigation_core(
             )
         elif incremental:
             # Retract any stale whole-PR APPROVE (posted before Aurora stopped
-            # approving) regardless of this slice's verdict — a legacy approval
-            # must never keep satisfying required-approval merge checks, and
-            # the full-path supersede above doesn't run on incremental
-            # reviews. COMMENT reviews are valid per-slice history, left
-            # intact (dismissing skips non-APPROVED reviews, so this is a
-            # no-op when no legacy approval exists).
+            # approving) regardless of this slice's verdict, since the
+            # full-path supersede above doesn't run on incremental reviews.
+            # Best-effort and GitHub-only in practice: retraction happens on
+            # the next review run of the PR (a failed dismissal is retried on
+            # the next push), and Bitbucket never reaches this branch — its
+            # adapter has no incremental path and never surfaces APPROVED, so
+            # legacy Bitbucket approvals must be removed by hand (see the
+            # bitbucket_adapter module docstring). COMMENT reviews are valid
+            # per-slice history, left intact (dismissing skips non-APPROVED
+            # reviews, so this is a no-op when no legacy approval exists).
             dismiss_message = (
                 "Later changes introduce incident risk — see the latest review."
                 if verdict["verdict"] == "RISKY"

--- a/server/tasks/change_gating.py
+++ b/server/tasks/change_gating.py
@@ -16,8 +16,10 @@ Each task:
 4. Runs a full agentic investigation through the existing
    ``run_background_chat`` task — SYNCHRONOUSLY via ``.apply()`` so this
    task owns the whole review lifecycle — in read-only ``mode="ask"``.
-5. Parses the agent's final message as a verdict JSON and posts a review:
-   APPROVE when SAFE, COMMENT with findings when RISKY.
+5. Parses the agent's final message as a verdict JSON and posts a COMMENT
+   review carrying the verdict (SAFE, or RISKY with findings). Aurora never
+   approves PRs — approval stays with human reviewers, so the verdict can
+   never satisfy a required-approval branch protection / merge check.
 
 Everything provider-specific stays behind the adapter
 (``services.change_gating.protocol.PRAdapter``); the shared flow lives in
@@ -370,10 +372,9 @@ def _run_investigation(
             provider="github",
             log_key="investigate_pr",
             post_review_reject_hint=(
-                "common causes: the GitHub App lacks the "
+                "common cause: the GitHub App lacks the "
                 "'Pull requests: write' permission (upgrade in App settings, "
-                "org admin must accept), or APPROVE was attempted on a PR "
-                "authored by the App itself."
+                "org admin must accept)."
             ),
         )
     finally:
@@ -466,8 +467,8 @@ def _run_bitbucket_investigation(
             provider="bitbucket",
             log_key="investigate_bitbucket_pr",
             post_review_reject_hint=(
-                "common causes: the Bitbucket token lacks write:pullrequest "
-                "scope, or approve was attempted on the token owner's own PR."
+                "common cause: the Bitbucket token lacks write:pullrequest "
+                "scope."
             ),
         )
     finally:
@@ -742,7 +743,7 @@ def _run_investigation_core(
                 # The input rail blocked the (attacker-controllable) PR
                 # title/body. The session's final message is just the block
                 # notice — there was NO investigation, so posting any verdict
-                # (especially an APPROVE) would be wrong. Post nothing.
+                # would be wrong. Post nothing.
                 logger.warning(
                     "change_gating=%s %s session_id=%s status=guardrail_blocked",
                     log_key, log_ctx, session_id,
@@ -843,7 +844,7 @@ def _run_investigation_core(
         anchored, unanchored = anchor_findings(verdict["findings"], hunks)
 
         # Only fetch existing comments when there's something to reconcile:
-        # no anchored findings (SAFE/APPROVE) or no prior Aurora reviews
+        # no anchored findings (SAFE) or no prior Aurora reviews
         # (first review) means live_fingerprints is provably empty, so skip
         # the paginated /comments GET entirely.
         aurora_review_ids = {
@@ -875,17 +876,12 @@ def _run_investigation_core(
             verdict["verdict"], verdict.get("summary", ""), verdict["findings"],
             head_sha, incremental=incremental,
         )
-        # Incremental reviews never APPROVE: they assessed only the latest
-        # commits, so a clean delta must not post a whole-PR green sign-off
-        # while earlier findings may still be open. Only a full-PR review
-        # (first pass / fallback) approves on SAFE.
-        if incremental:
-            event = "COMMENT"
-        else:
-            event = "APPROVE" if verdict["verdict"] == "SAFE" else "COMMENT"
-
         # --------------------------------------------------------------
-        # 11. Post the new review. Inline comments = net-new findings only;
+        # 11. Post the new review — always a COMMENT, never an approval
+        #     (an approval would count toward required-approval branch
+        #     protection / merge checks, letting an LLM verdict stand in
+        #     for human review; adapters cannot approve).
+        #     Inline comments = net-new findings only;
         #     prior comments are never touched (fixed findings go outdated
         #     on their own). In INCREMENTAL mode each review covers a
         #     distinct slice of commits, so prior reviews are a valid
@@ -896,7 +892,7 @@ def _run_investigation_core(
         _gh(
             "post_review",
             lambda: adapter.post_review(
-                pr_number, commit_id=head_sha, event=event, body=body, comments=comments
+                pr_number, commit_id=head_sha, body=body, comments=comments
             ),
         )
 
@@ -921,11 +917,20 @@ def _run_investigation_core(
                 "change_gating=%s %s status=superseded superseded=%d prior_reviews=%d",
                 log_key, log_ctx, superseded, len(prior_aurora_reviews),
             )
-        elif incremental and verdict["verdict"] == "RISKY":
-            # An incremental review found NEW risk: retract any stale whole-PR
-            # APPROVE (from an earlier full review) so the PR does not show a
-            # false "Aurora approved" green check while risk is open. COMMENT
-            # reviews are valid per-slice history and are left intact.
+        elif incremental:
+            # Retract any stale whole-PR APPROVE (posted before Aurora stopped
+            # approving) regardless of this slice's verdict — a legacy approval
+            # must never keep satisfying required-approval merge checks, and
+            # the full-path supersede above doesn't run on incremental
+            # reviews. COMMENT reviews are valid per-slice history, left
+            # intact (dismissing skips non-APPROVED reviews, so this is a
+            # no-op when no legacy approval exists).
+            dismiss_message = (
+                "Later changes introduce incident risk — see the latest review."
+                if verdict["verdict"] == "RISKY"
+                else "Aurora reviews are advisory-only and no longer approve — "
+                "see the latest review."
+            )
             dismissed = 0
             for prior_review in prior_aurora_reviews:
                 if prior_review.get("state") != "APPROVED":
@@ -934,7 +939,7 @@ def _run_investigation_core(
                     adapter.dismiss_review(
                         pr_number,
                         prior_review.get("id"),
-                        "Later changes introduce incident risk — see the latest review.",
+                        dismiss_message,
                     )
                     dismissed += 1
                 except Exception as exc:

--- a/server/tests/services/test_bitbucket_change_gating_adapter.py
+++ b/server/tests/services/test_bitbucket_change_gating_adapter.py
@@ -10,7 +10,7 @@ Pins the provider-normalization contract of ``BitbucketPRAdapter``
   status_code) instead of flowing through as data.
 - ``find_aurora_reviews`` requires marker AND allowlisted author UUID —
   a marker alone (paste attack) never qualifies.
-- SAFE posting keeps the comment when the approve step fails.
+- ``post_review`` posts a marker comment only — approve is never called.
 - ``get_compare`` / ``get_compare_diff`` return None (full-PR fallback).
 - ``parse_files_from_diff`` yields GitHub ``list_files``-shaped dicts.
 
@@ -171,36 +171,23 @@ class TestAuroraIdentity:
 
 
 class TestPosting:
-    def test_safe_posts_comment_and_approves(self):
+    def test_safe_posts_comment_never_approves(self):
         adapter, _, post = _adapter()
         post.add_pr_comment.return_value = {"id": 42}
-        post.approve_pull_request.return_value = {"approved": True}
 
         result = adapter.post_review(
-            7, commit_id="abc123", event="APPROVE", body="SAFE body", comments=[]
+            7, commit_id="abc123", body="SAFE body", comments=[]
         )
 
         assert result["id"] == 42
         post.add_pr_comment.assert_called_once()
-        post.approve_pull_request.assert_called_once()
-
-    def test_safe_keeps_comment_when_approve_fails(self):
-        adapter, _, post = _adapter()
-        post.add_pr_comment.return_value = {"id": 42}
-        post.approve_pull_request.return_value = {
-            "error": True, "status": 400, "message": "You cannot approve your own pull request",
-        }
-        # Must NOT raise — the comment is the review.
-        result = adapter.post_review(
-            7, commit_id="abc123", event="APPROVE", body="SAFE body", comments=[]
-        )
-        assert result["id"] == 42
+        post.approve_pull_request.assert_not_called()
 
     def test_risky_posts_comment_only(self):
         adapter, _, post = _adapter()
         post.add_pr_comment.return_value = {"id": 43}
         adapter.post_review(
-            7, commit_id="abc123", event="COMMENT", body="RISKY body",
+            7, commit_id="abc123", body="RISKY body",
             comments=[{"path": "a.py", "line": 3, "body": "x"}],
         )
         post.add_pr_comment.assert_called_once()
@@ -210,7 +197,7 @@ class TestPosting:
         adapter, _, post = _adapter()
         post.add_pr_comment.return_value = {"error": True, "status": 403, "message": "forbidden"}
         with pytest.raises(BitbucketAPIError):
-            adapter.post_review(7, commit_id="abc", event="COMMENT", body="b", comments=[])
+            adapter.post_review(7, commit_id="abc", body="b", comments=[])
 
     def test_dismiss_unapproves(self):
         adapter, read, post = _adapter()
@@ -290,7 +277,7 @@ class TestMarkerHiding:
         post.add_pr_comment.return_value = {"id": 42}
         marker = encode_marker([], "abc123")
         adapter.post_review(
-            7, commit_id="abc123", event="COMMENT",
+            7, commit_id="abc123",
             body=f"RISKY body\n\n{marker}", comments=[],
         )
         sent_body = post.add_pr_comment.call_args[0][3]

--- a/server/tests/services/test_bitbucket_change_gating_adapter.py
+++ b/server/tests/services/test_bitbucket_change_gating_adapter.py
@@ -10,7 +10,8 @@ Pins the provider-normalization contract of ``BitbucketPRAdapter``
   status_code) instead of flowing through as data.
 - ``find_aurora_reviews`` requires marker AND allowlisted author UUID —
   a marker alone (paste attack) never qualifies.
-- ``post_review`` posts a marker comment only — approve is never called.
+- ``post_review`` posts a marker comment only — approve is never called;
+  dismiss/supersede prepend a note only — unapprove is never called.
 - ``get_compare`` / ``get_compare_diff`` return None (full-PR fallback).
 - ``parse_files_from_diff`` yields GitHub ``list_files``-shaped dicts.
 
@@ -58,7 +59,6 @@ def _bb_pr(state="OPEN", head="abc123", dest="main", draft=False):
         "author": {"nickname": "octocat", "display_name": "Octo Cat"},
         "source": {"commit": {"hash": head}, "branch": {"name": "feature/x"}},
         "destination": {"commit": {"hash": "base456"}, "branch": {"name": dest}},
-        "participants": [],
     }
 
 
@@ -144,30 +144,23 @@ class TestAuroraIdentity:
         aurora = adapter.find_aurora_reviews(reviews)
         assert [r["id"] for r in aurora] == [1]
 
-    def test_last_review_marked_approved_when_aurora_approves(self):
+    def test_reviews_always_commented_never_synthetic_approved(self):
         adapter, read, _ = _adapter()
+        # An approving allowlisted participant on the PR must NOT promote
+        # any synthesized review to APPROVED — the old synthetic-APPROVED
+        # path read participants from get_pull_request; it must stay gone.
+        read.get_pull_request.return_value = {
+            **_bb_pr(),
+            "participants": [{"approved": True, "user": {"uuid": _BOT_UUID}}],
+        }
+        adapter.get_pull_request(7)
         marker_body = encode_marker([], "abc123")
         read.list_pr_comments.return_value = [
             self._comment(1, marker_body, _BOT_UUID),
             self._comment(2, marker_body, _BOT_UUID),
         ]
-        adapter._last_participants = [
-            {"approved": True, "user": {"uuid": _BOT_UUID}},
-        ]
         aurora = adapter.find_aurora_reviews(adapter.list_reviews(7))
-        assert aurora[0]["state"] == "COMMENTED"
-        assert aurora[-1]["state"] == "APPROVED"
-
-    def test_other_users_approval_does_not_mark_aurora(self):
-        adapter, read, _ = _adapter()
-        read.list_pr_comments.return_value = [
-            self._comment(1, encode_marker([], "abc123"), _BOT_UUID),
-        ]
-        adapter._last_participants = [
-            {"approved": True, "user": {"uuid": _OTHER_UUID}},
-        ]
-        aurora = adapter.find_aurora_reviews(adapter.list_reviews(7))
-        assert aurora[-1]["state"] == "COMMENTED"
+        assert [r["state"] for r in aurora] == ["COMMENTED", "COMMENTED"]
 
 
 class TestPosting:
@@ -199,18 +192,16 @@ class TestPosting:
         with pytest.raises(BitbucketAPIError):
             adapter.post_review(7, commit_id="abc", body="b", comments=[])
 
-    def test_dismiss_unapproves(self):
+    def test_dismiss_prepends_note_never_unapproves(self):
         adapter, read, post = _adapter()
-        post.unapprove_pull_request.return_value = {"success": True}
-        read.list_pr_comments.return_value = []
+        read.list_pr_comments.return_value = [
+            {"id": 42, "content": {"raw": "old body"}},
+        ]
+        post.update_pr_comment.return_value = {"id": 42}
         adapter.dismiss_review(7, 42, "stale")
-        post.unapprove_pull_request.assert_called_once()
-
-    def test_dismiss_tolerates_404_no_approval(self):
-        adapter, read, post = _adapter()
-        post.unapprove_pull_request.return_value = {"error": True, "status": 404, "message": "gone"}
-        read.list_pr_comments.return_value = []
-        adapter.dismiss_review(7, 42, "stale")  # must not raise
+        post.unapprove_pull_request.assert_not_called()
+        args = post.update_pr_comment.call_args[0]
+        assert args[4].startswith("**stale**")
 
     def test_supersede_prepends_note_and_is_idempotent(self):
         adapter, _, post = _adapter()
@@ -225,14 +216,14 @@ class TestPosting:
         adapter.supersede_review(7, prior_noted, "Superseded by updated review")
         post.update_pr_comment.assert_not_called()
 
-    def test_supersede_approved_also_unapproves(self):
+    def test_supersede_approved_never_unapproves(self):
         adapter, _, post = _adapter()
         post.update_pr_comment.return_value = {"id": 42}
-        post.unapprove_pull_request.return_value = {"success": True}
         adapter.supersede_review(
             7, {"id": 42, "state": "APPROVED", "body": "b"}, "Superseded"
         )
-        post.unapprove_pull_request.assert_called_once()
+        post.unapprove_pull_request.assert_not_called()
+        post.update_pr_comment.assert_called_once()
 
 
 class TestProgressComment:

--- a/server/tests/services/test_change_gating_adapter.py
+++ b/server/tests/services/test_change_gating_adapter.py
@@ -130,12 +130,11 @@ class TestGitHubPRAdapter:
         adapter, http = self._adapter_and_http(mock_requests)
         http.post.return_value = _response(json_data={"id": 99})
         comments = [{"path": "a.py", "line": 3, "side": "RIGHT", "body": "x"}]
-        result = adapter.post_review(
-            7, commit_id="abc", event="COMMENT", body="b", comments=comments
-        )
+        result = adapter.post_review(7, commit_id="abc", body="b", comments=comments)
         assert result == {"id": 99}
         call = http.post.call_args
         assert call.args[0].endswith("/repos/acme/widgets/pulls/7/reviews")
+        # event is hardcoded to COMMENT — Aurora must never approve a PR.
         assert call.kwargs["json"] == {
             "commit_id": "abc",
             "event": "COMMENT",
@@ -157,7 +156,7 @@ class TestGitHubPRAdapter:
 
         with caplog.at_level(logging.DEBUG):
             result = adapter.post_review(
-                7, commit_id="abc", event="COMMENT", body="b", comments=comments
+                7, commit_id="abc", body="b", comments=comments
             )
 
         assert result == {"id": 99}
@@ -174,9 +173,7 @@ class TestGitHubPRAdapter:
         adapter, http = self._adapter_and_http(mock_requests)
         http.post.return_value = _response(status=422, text="bad")
         with pytest.raises(_HTTPError):
-            adapter.post_review(
-                7, commit_id="abc", event="APPROVE", body="b", comments=[]
-            )
+            adapter.post_review(7, commit_id="abc", body="b", comments=[])
         assert http.post.call_count == 1
 
     def test_post_review_other_error_logs_and_raises(
@@ -189,7 +186,6 @@ class TestGitHubPRAdapter:
                 adapter.post_review(
                     7,
                     commit_id="abc",
-                    event="COMMENT",
                     body="b",
                     comments=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "x"}],
                 )
@@ -366,7 +362,6 @@ class TestGitHubPRAdapter:
             adapter.post_review(
                 7,
                 commit_id="abc",
-                event="COMMENT",
                 body="b",
                 comments=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "x"}],
             )

--- a/website/docs/integrations/connectors.md
+++ b/website/docs/integrations/connectors.md
@@ -1438,7 +1438,7 @@ Restart Aurora after setting these, then connect via **Connectors** > **Bitbucke
 
 #### Incident Prevention (pre-merge PR review)
 
-Aurora can review pull requests that target the default branch of an enrolled Bitbucket Cloud repository and post an advisory review (a comment, plus an approval when the change looks safe) before merge — the same feature as GitHub Incident Prevention.
+Aurora can review pull requests that target the default branch of an enrolled Bitbucket Cloud repository and post an advisory review comment before merge — the same feature as GitHub Incident Prevention. Aurora never approves (or blocks) a PR: approval stays with human reviewers.
 
 Requirements: a connected Bitbucket account (either auth method above), `NEXT_PUBLIC_ENABLE_INCIDENT_PREVENTION=true` (the default) on **both** the server and the Celery worker, and Aurora's API reachable from the public internet (Bitbucket must be able to deliver webhooks to it).
 
@@ -1468,12 +1468,12 @@ Verification is recorded against Aurora's public URL at the time. If that URL ch
 Notes and limits:
 
 - Reviews run only for PRs targeting the repository's **default branch**; drafts are skipped. A draft marked ready **without new commits** is reviewed on the next push.
-- Reviews post as the **connected Bitbucket account** by default. Bitbucket forbids approving your own PR, so a SAFE verdict on a PR authored by the connected account keeps the review comment but skips the approval.
+- Reviews post as the **connected Bitbucket account** by default. Both SAFE and RISKY verdicts post as a review comment only — Aurora never approves the PR.
 - Disabling the toggle (or deselecting/disconnecting the repo) deletes the webhook when Aurora created it via API; manually created hooks must be removed manually.
 
 ##### Optional: dedicated bot account
 
-To have reviews appear as "Aurora" instead of a team member — and to avoid the own-PR approval limit — create a separate Atlassian account:
+To have reviews appear as "Aurora" instead of a team member, create a separate Atlassian account:
 
 1. Create the Atlassian user (e.g. `aurora-bot@yourcompany.com`), invite it to the workspace/repos with **pull request write** access
 2. Create a scoped API token for it with at least `read:pullrequest:bitbucket` and `write:pullrequest:bitbucket`
@@ -1490,7 +1490,7 @@ aws secretsmanager create-secret --name aurora/system/bitbucket-bot/credentials 
   --region "$AWS_SM_REGION"
 ```
 
-Only **posting** (comments/approvals) uses the bot; investigation reads always use the org's connected account. Bot credentials are never exposed to agent tools.
+Only **posting** (review comments) uses the bot; investigation reads always use the org's connected account. Bot credentials are never exposed to agent tools.
 
 #### Troubleshooting
 
@@ -1505,7 +1505,6 @@ Only **posting** (comments/approvals) uses the bot; investigation reads always u
 | Badge stuck on "Awaiting first delivery" | No PR event has arrived yet. Bitbucket sends no test event on save, so push to a PR. If it still does not flip, check **Repository settings → Webhooks → View requests** for the delivery attempts and their response codes |
 | Badge reads "Webhook URL changed" (red) | Aurora's public URL changed since the hook was verified, so the hook now points at an unreachable address. Click the badge for the current URL and update the existing hook in Bitbucket |
 | PRs never get reviewed | Check the webhook in Bitbucket shows recent 2xx deliveries; confirm the PR targets the default branch and is not a draft; confirm the same org secret was pasted into the repo hook |
-| Review comment posted but no approval on SAFE | The posting account authored the PR (Bitbucket forbids self-approval) — configure the dedicated bot account |
 
 ---
 

--- a/website/docs/integrations/connectors.md
+++ b/website/docs/integrations/connectors.md
@@ -1438,7 +1438,7 @@ Restart Aurora after setting these, then connect via **Connectors** > **Bitbucke
 
 #### Incident Prevention (pre-merge PR review)
 
-Aurora can review pull requests that target the default branch of an enrolled Bitbucket Cloud repository and post an advisory review comment before merge — the same feature as GitHub Incident Prevention. Aurora never approves (or blocks) a PR: approval stays with human reviewers.
+Aurora can review pull requests that target the default branch of an enrolled Bitbucket Cloud repository and post an advisory review comment before merge — the same feature as GitHub Incident Prevention. The Incident Prevention review never approves (or blocks) a PR: approval stays with human reviewers.
 
 Requirements: a connected Bitbucket account (either auth method above), `NEXT_PUBLIC_ENABLE_INCIDENT_PREVENTION=true` (the default) on **both** the server and the Celery worker, and Aurora's API reachable from the public internet (Bitbucket must be able to deliver webhooks to it).
 
@@ -1469,6 +1469,7 @@ Notes and limits:
 
 - Reviews run only for PRs targeting the repository's **default branch**; drafts are skipped. A draft marked ready **without new commits** is reviewed on the next push.
 - Reviews post as the **connected Bitbucket account** by default. Both SAFE and RISKY verdicts post as a review comment only — Aurora never approves the PR.
+- Approvals posted by older Aurora versions (which approved on SAFE verdicts) are **not retracted automatically**: Bitbucket approvals are account-level, so unapproving could strip an approval the connected user made themselves — remove legacy Aurora approvals by hand on any still-open PRs. (On GitHub, Aurora dismisses its own legacy approvals the next time it reviews the PR.)
 - Disabling the toggle (or deselecting/disconnecting the repo) deletes the webhook when Aurora created it via API; manually created hooks must be removed manually.
 
 ##### Optional: dedicated bot account


### PR DESCRIPTION
## Summary

Incident Prevention no longer approves PRs. Every verdict — SAFE or RISKY — posts as a COMMENT review on both GitHub and Bitbucket. Previously a full-PR SAFE verdict posted an APPROVE, which counts toward required-approval branch protection / merge checks — on a repo requiring one approval, the bot's verdict could stand in for human review entirely (and with no dedicated Bitbucket bot account, the approval posts from the connected user's own account). The reviewer is now purely advisory: it reports its verdict, approval stays with humans.

## Changes

- `PRAdapter.post_review` drops the `event` parameter — the contract is comment-only, so no caller can turn a verdict into an approval
- GitHub adapter hardcodes `"event": "COMMENT"` in the review payload
- Bitbucket adapter never touches approvals in either direction (review feedback): no approve on post, and dismiss/supersede only prepend a note on the prior marker comment — unapprove is account-level and could strip a manual approval the connected user made themselves. The synthetic APPROVED-state machinery is removed
- Legacy GitHub approvals (posted before this change) are dismissed lazily on the PR's next review — full re-reviews supersede them, incremental reviews dismiss them on any verdict; a dormant PR keeps its stale approval until it is reviewed again. Legacy Bitbucket approvals are not auto-retracted and must be removed by hand (documented as a migration note)
- Docs updated: Incident Prevention sections rewritten to advisory-comment-only, legacy-approval migration note, removed the approve-on-SAFE troubleshooting guidance
- Side benefit: the Bitbucket self-approval failure mode (posting account authored the PR) is gone, since commenting on your own PR is allowed

## Testing

- All 195 change-gating unit tests pass
- Adapter tests assert approve/unapprove are never called (Bitbucket) and the review event is hardcoded to COMMENT (GitHub); the never-synthetic-APPROVED test feeds an approving participant through `get_pull_request` so a revert would fail it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Reviews now appear as advisory comments only; pull requests are never automatically approved or blocked.
  * SAFE and RISKY results are both posted as comments with relevant findings.
  * Stale approvals are withdrawn during incremental reviews when applicable.

* **Documentation**
  * Updated connector guidance to describe comment-only reviews and account usage.
  * Removed troubleshooting guidance for missing automatic approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->