### PR TITLE
fix(bitbucket): paged file reads and edit_file for Actions

### DIFF
--- a/server/chat/backend/agent/skills/core/tool_selection.md
+++ b/server/chat/backend/agent/skills/core/tool_selection.md
@@ -47,7 +47,7 @@ AGENT INTELLIGENCE: You decide which approach based on the user's request and co
 SMART DELETION WORKFLOW:
 When asked to delete, remove, stop, or destroy resources:
 1. TERRAFORM-MANAGED RESOURCES: If terraform state exists, use terraform deletion
-   - iac_tool(action="write", path='vm.tf', content='# VM removed')
+   - Remove the resource block from the .tf file (do not replace it with comments — a comments-only config file is never a valid change)
    - iac_tool(action="apply") - Terraform will delete the resource using its state
 2. UNMANAGED RESOURCES: Use direct deletion via cloud_exec
    - GCP: cloud_exec('gcp', 'compute instances delete INSTANCE --zone ZONE --quiet')

--- a/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
@@ -35,8 +35,10 @@ Workspace and repository auto-resolve from saved user selection if not passed ex
 ### Tools (6 tools, 42 actions)
 
 **bitbucket_repos** -- Repository, File & Code Operations:
-- `list_repos`, `get_repo`, `get_file_contents`, `create_or_update_file`, `delete_file`
+- `list_repos`, `get_repo`, `get_file_contents`, `edit_file`, `create_or_update_file`, `delete_file`
 - `get_directory_tree`, `search_code`, `list_workspaces`, `get_workspace`
+- Prefer `edit_file` (anchored search-and-replace) for existing files. Use `create_or_update_file` only to create **new** files.
+- `get_file_contents` returns verbatim pages; if you see `pass start_line=N to continue`, call again with that `start_line`.
 
 **bitbucket_branches** -- Branch & Commit Operations:
 - `list_branches`, `create_branch`, `delete_branch`, `list_commits`, `get_commit`, `get_diff`, `compare`
@@ -81,15 +83,16 @@ Workspace and repository auto-resolve from saved user selection if not passed ex
 - `list_repos` and `list_workspaces` return only the repos/workspaces the user has connected — not everything in their Bitbucket account.
 - When user asks about PRs, issues, repos, or branches WITHOUT specifying a repository, use the selected workspace/repo from context.
 - Workspace and `repo_slug` auto-resolve from saved selection if not passed explicitly.
-- **During background RCA**: tools are READ-ONLY. Do NOT manually create branches, commit files, or create PRs. Use `bitbucket_fix` to propose code changes — it saves suggestions for user review.
+- **During background RCA**: tools are READ-ONLY for writes. Do NOT create branches, commit files, or create PRs. Use `bitbucket_fix` to propose code changes — it saves suggestions for user review.
+- **During Actions / interactive chat**: edit existing files with `edit_file`; use `create_or_update_file` only for new files; then `create_branch` + `create_pr` as needed. Never overwrite an existing file via `create_or_update_file`.
 - Destructive actions (delete branch, delete file, merge PR, decline PR, trigger/stop pipeline) require user confirmation and will prompt automatically.
 - Non-destructive operations (create branch, create PR, update PR, approve, comment, create issue) proceed without extra confirmation.
-- `bitbucket_fix` does NOT modify the repo directly — it saves the suggestion for user review. No confirmation needed.
+- `bitbucket_fix` does NOT modify the repo directly — it saves the suggestion for user review. No confirmation needed. Only available during RCA.
 - If no repository is selected and user doesn't specify one, ask which repository they want to work with.
 
 ### Important Rules
 - Look for: config changes, k8s manifests, Terraform, dependency updates.
 - Check pipeline logs when builds fail near the incident time.
 - Cross-reference commit history with deployment timing.
-- When you identify the problematic code change, use `bitbucket_fix` to propose a revert or correction.
-- **NEVER** manually create a branch + commit file + create PR. Always use `bitbucket_fix` instead — the user will create the PR from the Incidents UI after reviewing your suggestion.
+- **RCA**: when you identify the problematic code change, use `bitbucket_fix` to propose a revert or correction. Never manually create a branch + commit + PR during RCA.
+- **Actions**: commit real code via `edit_file` (or `create_or_update_file` for brand-new paths only), then open the PR. Comments-only config files are never a valid change.

--- a/server/chat/backend/agent/tools/bitbucket/fix_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/fix_tool.py
@@ -19,6 +19,7 @@ from .utils import (
     get_default_branch,
     build_error_response,
     build_success_response,
+    apply_edits_checked,
 )
 
 from chat.backend.agent.tools.vcs_rca_utils import resolve_repository as _vcs_resolve_repository
@@ -240,18 +241,10 @@ def bitbucket_fix(
                 "The file does not exist. To create a new file, set old_string to an empty string."
             )
     else:
-        # File exists — apply edits using the shared replacer chain from github_fix_tool
-        from chat.backend.agent.tools.github_fix_tool import _apply_edits
-
-        suggested_content, apply_err = _apply_edits(original_content, edits)
+        suggested_content, apply_err = apply_edits_checked(original_content, edits)
         if apply_err or suggested_content is None:
             logger.warning("%s edit application failed for %s: %s", _LOG_PREFIX, file_path, apply_err)
             return build_error_response(apply_err or "edit application failed")
-
-        if suggested_content == original_content:
-            return build_error_response(
-                "Applied edits produced no change to the file. Double-check old_string/new_string."
-            )
 
     if not suggested_content.strip():
         return build_error_response(

--- a/server/chat/backend/agent/tools/bitbucket/repos_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/repos_tool.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from .fix_tool import FixEdit
 from .utils import (
     get_bb_client_for_user,
     get_default_branch,
@@ -14,6 +15,8 @@ from .utils import (
     build_error_response,
     build_success_response,
     confirm_or_cancel,
+    page_file_content,
+    apply_edits_checked,
 )
 
 from utils.db.connection_pool import db_pool
@@ -28,6 +31,7 @@ class BitbucketReposArgs(BaseModel):
         "get_repo",
         "get_file_contents",
         "create_or_update_file",
+        "edit_file",
         "delete_file",
         "get_directory_tree",
         "search_code",
@@ -38,10 +42,18 @@ class BitbucketReposArgs(BaseModel):
     repo_slug: Optional[str] = Field(None, description="Repository slug (required for repo-scoped actions).")
     path: Optional[str] = Field(None, description="File or directory path (for file/directory operations).")
     content: Optional[str] = Field(None, description="File content (for create_or_update_file).")
-    message: Optional[str] = Field(None, description="Commit message (for create_or_update_file, delete_file).")
+    message: Optional[str] = Field(None, description="Commit message (for create_or_update_file, edit_file, delete_file).")
     branch: Optional[str] = Field(None, description="Branch name (for file operations). Defaults to saved branch.")
     commit: Optional[str] = Field(None, description="Commit hash or branch ref (for get_file_contents, get_directory_tree). Defaults to HEAD.")
     query: Optional[str] = Field(None, description="Search query (for search_code).")
+    start_line: Optional[int] = Field(
+        None,
+        description="1-indexed start line for get_file_contents paging. Defaults to 1. Pass the continue hint to read more.",
+    )
+    edits: Optional[list[FixEdit]] = Field(
+        None,
+        description="Anchored search-and-replace edits for edit_file (old_string/new_string/replace_all).",
+    )
 
 
 def bitbucket_repos(
@@ -54,6 +66,8 @@ def bitbucket_repos(
     branch: Optional[str] = None,
     commit: Optional[str] = None,
     query: Optional[str] = None,
+    start_line: Optional[int] = None,
+    edits: Optional[list] = None,
     user_id: Optional[str] = None,
     **kwargs,
 ) -> str:
@@ -68,7 +82,7 @@ def bitbucket_repos(
 
     repo_scoped = action in (
         "get_repo", "get_file_contents", "create_or_update_file",
-        "delete_file", "get_directory_tree",
+        "edit_file", "delete_file", "get_directory_tree",
     )
     if repo_scoped and ws and repo:
         if not branch:
@@ -145,7 +159,12 @@ def bitbucket_repos(
             if not path:
                 return build_error_response("path is required")
             ref = commit or branch or "HEAD"
-            return json.dumps(client.get_file_contents(ws, repo, path, commit=ref), default=str)
+            result = client.get_file_contents(ws, repo, path, commit=ref)
+            if err := forward_if_error(result):
+                return err
+            if isinstance(result, dict) and isinstance(result.get("content"), str):
+                result = {**result, "content": page_file_content(result["content"], start_line or 1)}
+            return json.dumps(result, default=str)
 
         if action == "create_or_update_file":
             if err := require_repo(ws, repo):
@@ -166,6 +185,35 @@ def bitbucket_repos(
             if err := forward_if_error(result):
                 return err
             return build_success_response(message=f"File '{path}' committed to {branch}", result=result)
+
+        if action == "edit_file":
+            if err := require_repo(ws, repo):
+                return build_error_response(err)
+            if not path:
+                return build_error_response("path is required")
+            if not edits:
+                return build_error_response("edits is required")
+            if not message:
+                return build_error_response("message (commit message) is required")
+            if not branch:
+                return build_error_response("branch is required")
+            fetched = client.get_file_contents(ws, repo, path, commit=branch)
+            if err := forward_if_error(fetched):
+                return err
+            original = fetched.get("content") if isinstance(fetched, dict) else None
+            if not isinstance(original, str):
+                return build_error_response(f"Could not read current contents of {path}")
+            suggested, apply_err = apply_edits_checked(original, edits)
+            if apply_err or suggested is None:
+                return build_error_response(apply_err or "edit application failed")
+            if cancelled := confirm_or_cancel(user_id,
+                    f"Commit edit to '{path}' on branch '{branch}' in {ws}/{repo}",
+                    "bitbucket:commit_file"):
+                return cancelled
+            result = client.create_or_update_file(ws, repo, path, suggested, message, branch)
+            if err := forward_if_error(result):
+                return err
+            return build_success_response(message=f"File '{path}' edited on {branch}", result=result)
 
         if action == "delete_file":
             if err := require_repo(ws, repo):

--- a/server/chat/backend/agent/tools/bitbucket/utils.py
+++ b/server/chat/backend/agent/tools/bitbucket/utils.py
@@ -11,10 +11,72 @@ from connectors.bitbucket_connector.oauth_utils import refresh_token_if_needed
 from utils.auth.token_management import store_tokens_in_db
 from utils.secrets.secret_ref_utils import get_token_owner_id
 from utils.auth.command_gate import gate_action
+from chat.backend.agent.tools.github_fix_tool import _apply_edits
 
 logger = logging.getLogger(__name__)
 
 DIFF_TRUNCATE_LIMIT = 50_000
+
+# Under tool_output_cap PASS_THROUGH_CHARS (40K) and ~10K-token capture threshold.
+_FILE_PAGE_CHARS = 30_000
+
+
+def page_file_content(content: str, start_line: int = 1) -> str:
+    """Return a verbatim slice under _FILE_PAGE_CHARS so summarizers never fire.
+
+    Files that fit from line 1 are returned unchanged (no header). Larger files
+    (or continuations) get a ``lines X-Y of N`` header and a continue hint.
+    """
+    if start_line < 1:
+        start_line = 1
+    if start_line == 1 and len(content) <= _FILE_PAGE_CHARS:
+        return content
+
+    lines = content.splitlines(keepends=True)
+    n = len(lines)
+    if start_line > n:
+        return f"lines {start_line}-{start_line} of {n} (start_line past end of file)\n"
+
+    out: list[str] = []
+    chars = 0
+    i = start_line - 1
+    while i < n:
+        line = lines[i]
+        if out and chars + len(line) > _FILE_PAGE_CHARS:
+            break
+        if not out and len(line) > _FILE_PAGE_CHARS:
+            line = line[:_FILE_PAGE_CHARS]
+            out.append(line)
+            i += 1
+            break
+        out.append(line)
+        chars += len(line)
+        i += 1
+
+    last = i  # 1-indexed last line included
+    header = f"lines {start_line}-{last} of {n}"
+    if last < n:
+        header += f" — pass start_line={last + 1} to continue"
+    return header + "\n" + "".join(out)
+
+
+def apply_edits_checked(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:
+    """Apply anchored edits; reject no-op and empty/whitespace-only results."""
+    suggested, err = _apply_edits(original, edits)
+    if err or suggested is None:
+        return None, err or "edit application failed"
+    if suggested == original:
+        return None, (
+            "Applied edits produced no change to the file. "
+            "Double-check old_string/new_string."
+        )
+    if not suggested.strip():
+        return None, (
+            "Applied edits produced an empty (or whitespace-only) file. If you "
+            "really intend to empty this file, do it manually — Bitbucket tools "
+            "are for targeted code changes."
+        )
+    return suggested, None
 
 
 def get_bb_client_for_user(user_id: str):

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -2344,7 +2344,7 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                      f"Query Bitbucket repositories and files (READ-ONLY during {_ro_reason}). "
                      "Actions: list_repos, get_repo, get_file_contents, get_directory_tree, "
                      "search_code, list_workspaces, get_workspace. "
-                     "Do NOT use create_or_update_file or delete_file."),
+                     "Do NOT use create_or_update_file, edit_file, or delete_file."),
                     (bitbucket_branches, "bitbucket_branches", BitbucketBranchesArgs,
                      f"Query Bitbucket branches and commits (READ-ONLY during {_ro_reason}). "
                      "Actions: list_branches, list_commits, get_commit, get_diff, compare. "
@@ -2362,8 +2362,9 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                 _bb_tools = [
                     (bitbucket_repos, "bitbucket_repos", BitbucketReposArgs,
                      "Manage Bitbucket repositories, files, and code. Actions: list_repos, get_repo, "
-                     "get_file_contents, create_or_update_file, delete_file, get_directory_tree, "
-                     "search_code, list_workspaces, get_workspace. Workspace and repo auto-resolve "
+                     "get_file_contents, edit_file, create_or_update_file, delete_file, get_directory_tree, "
+                     "search_code, list_workspaces, get_workspace. Prefer edit_file for existing files; "
+                     "create_or_update_file only for new files. Workspace and repo auto-resolve "
                      "from saved selection if not specified."),
                     (bitbucket_branches, "bitbucket_branches", BitbucketBranchesArgs,
                      "Manage Bitbucket branches and view commits/diffs. Actions: list_branches, create_branch, "
@@ -2383,7 +2384,7 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
             # FUNCTIONS reject Bitbucket write actions, so a prompt-injected
             # diff can't talk the agent into merging/approving/pushing.
             _BB_WRITE_ACTIONS = {
-                "create_or_update_file", "delete_file",
+                "create_or_update_file", "edit_file", "delete_file",
                 "create_branch", "delete_branch",
                 "create_pr", "update_pr", "merge_pr", "approve_pr",
                 "unapprove_pr", "decline_pr", "add_pr_comment",

--- a/server/services/actions/alert_gap_action.py
+++ b/server/services/actions/alert_gap_action.py
@@ -69,7 +69,8 @@ Hard anti-slop rules:
 - First check for existing open PRs/MRs from prior runs of this action.
   Do not open a second one if a previous proposal is still pending review.
 - Create a branch, commit the alert definitions, and open a PR (GitHub/Bitbucket)
-  or MR (GitLab) using the appropriate VCS tools.
+  or MR (GitLab) using the appropriate VCS tools. For existing files prefer
+  `edit_file` (anchored edits); use `create_or_update_file` only for brand-new paths.
 - PR/MR body: for each proposed alert, one sentence on the gap it fills and why it matters.
   No filler, no essay. Reviewers are busy.
 - If you found no gaps worth proposing, do not open an empty or low-value PR. Instead,

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -193,6 +193,7 @@ def build_action_prompt(
         "## Guidelines",
         "- Use your available tools to complete the task.",
         "- If you need to make infrastructure changes, open a PR rather than applying directly.",
+        "- When editing an existing VCS file, use edit_file (anchored search-and-replace). Use create_or_update_file only to create new files — never to overwrite a file you already read.",
         "- Report what you did and any issues encountered.",
     ]
 

--- a/server/services/actions/hpa_vpa_action.py
+++ b/server/services/actions/hpa_vpa_action.py
@@ -176,6 +176,7 @@ it will assume we simply missed it.
 
 - One workload per PR. A reviewer should be able to accept or reject a single decision.
 - Change only what your evidence supports. Do not tidy adjacent config.
+- Prefer `edit_file` on existing manifests; use `create_or_update_file` only for brand-new paths.
 - Match the repo's branch naming, title style, and label conventions.
 - At most one short inline comment, and only where a number would otherwise look arbitrary.
 - PR body, a few lines per dimension: current value, recommended value, the p95, the max, the

--- a/server/tests/chat/test_bitbucket_file_ops.py
+++ b/server/tests/chat/test_bitbucket_file_ops.py
@@ -1,0 +1,80 @@
+"""Bitbucket file-op helpers: paged verbatim reads + edit guards."""
+
+import os
+import sys
+
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+from chat.backend.agent.tools.bitbucket.utils import (  # noqa: E402
+    _FILE_PAGE_CHARS,
+    apply_edits_checked,
+    page_file_content,
+)
+
+
+def test_page_file_content_small_file_unchanged():
+    body = "hello\nworld\n"
+    assert page_file_content(body) == body
+
+
+def test_page_file_content_large_is_verbatim_prefix():
+    lines = [f"line-{i:05d}-{'x' * 40}\n" for i in range(2000)]
+    content = "".join(lines)
+    assert len(content) > _FILE_PAGE_CHARS
+
+    page = page_file_content(content, start_line=1)
+    assert "Summarized from longer output" not in page
+    assert "Summarized from larger output" not in page
+    assert page.startswith("lines 1-")
+    assert "pass start_line=" in page
+
+    header, _, body = page.partition("\n")
+    assert body == content[: len(body)]
+    assert len(body) <= _FILE_PAGE_CHARS
+
+
+def test_page_file_content_contiguous_pages_rebuild_original():
+    lines = [f"L{i:04d}\n" for i in range(8000)]
+    content = "".join(lines)
+    assert len(content) > _FILE_PAGE_CHARS
+
+    chunks: list[str] = []
+    start = 1
+    while True:
+        page = page_file_content(content, start_line=start)
+        header, _, body = page.partition("\n")
+        chunks.append(body)
+        if "pass start_line=" not in header:
+            break
+        start = int(header.split("pass start_line=")[1].split()[0])
+
+    assert "".join(chunks) == content
+
+
+def test_apply_edits_checked_rejects_noop():
+    original = "alpha\nbeta\n"
+    result, err = apply_edits_checked(
+        original, [{"old_string": "beta", "new_string": "beta"}]
+    )
+    assert result is None
+    assert err and ("no-op" in err or "no change" in err)
+
+
+def test_apply_edits_checked_rejects_empty():
+    original = "only\n"
+    result, err = apply_edits_checked(
+        original, [{"old_string": "only\n", "new_string": "   \n"}]
+    )
+    assert result is None
+    assert err and "empty" in err.lower()
+
+
+def test_apply_edits_checked_applies_real_edit():
+    original = "foo = 1\nbar = 2\n"
+    result, err = apply_edits_checked(
+        original, [{"old_string": "foo = 1", "new_string": "foo = 3"}]
+    )
+    assert err is None
+    assert result == "foo = 3\nbar = 2\n"


### PR DESCRIPTION
## Summary
- Page `get_file_contents` into verbatim ~30k-char slices so tool-output summarizers never replace large Terraform/config with `[Summarized from longer output]` mid-edit.
- Add `bitbucket_repos` `edit_file` (anchored search-and-replace, same guards as `bitbucket_fix`) and steer Actions toward it for existing files; keep `create_or_update_file` for new paths only.
- Update Bitbucket skill, generic Action guidelines (`executor.py`), stock alert-gap / HPA-VPA prompts, and remove the comment-only `.tf` example that modeled bad commits.

## Test plan
- [ ] `cd server && python -m pytest tests/chat/test_bitbucket_file_ops.py tests/chat/test_tool_output_cap.py -q`
- [ ] Action path: read a large Bitbucket file via `get_file_contents` — confirm verbatim page header / `start_line` continue, no summarization marker
- [ ] Action path: `edit_file` on an existing file → branch → PR; confirm real diff (not comments-only)
- [ ] RCA path: writes still described as forbidden; `bitbucket_fix` still available for suggestions
- [ ] PR-review path: `edit_file` rejected by the existing read-only write gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anchored `edit_file` support for modifying existing Bitbucket files.
  * Added paginated file-content retrieval for large files.
  * Added validation to reject ineffective or empty file edits.
* **Bug Fixes**
  * Improved safeguards for read-only review workflows and prevented invalid Terraform deletion changes.
* **Documentation**
  * Clarified when to use file editing versus creating new files across supported actions.
* **Tests**
  * Added coverage for file pagination, continuation, successful edits, and rejected no-op changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->