### PR TITLE
feat(bitbucket): paged reads + surgical edit_file for large files

### DIFF
--- a/server/chat/backend/agent/skills/core/tool_selection.md
+++ b/server/chat/backend/agent/skills/core/tool_selection.md
@@ -47,7 +47,7 @@ AGENT INTELLIGENCE: You decide which approach based on the user's request and co
 SMART DELETION WORKFLOW:
 When asked to delete, remove, stop, or destroy resources:
 1. TERRAFORM-MANAGED RESOURCES: If terraform state exists, use terraform deletion
-   - iac_tool(action="write", path='vm.tf', content='# VM removed')
+   - iac_tool(action="write", path='vm.tf', content='<the file with the VM resource block removed>') - delete the resource block itself; a comments-only config file is never a valid change
    - iac_tool(action="apply") - Terraform will delete the resource using its state
 2. UNMANAGED RESOURCES: Use direct deletion via cloud_exec
    - GCP: cloud_exec('gcp', 'compute instances delete INSTANCE --zone ZONE --quiet')

--- a/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
@@ -101,5 +101,5 @@ Workspace and repository auto-resolve from saved user selection if not passed ex
 - Look for: config changes, k8s manifests, Terraform, dependency updates.
 - Check pipeline logs when builds fail near the incident time.
 - Cross-reference commit history with deployment timing.
-- When you identify the problematic code change, use `bitbucket_fix` to propose a revert or correction.
-- **NEVER** manually create a branch + commit file + create PR. Always use `bitbucket_fix` instead — the user will create the PR from the Incidents UI after reviewing your suggestion.
+- When you identify the problematic code change during RCA, use `bitbucket_fix` to propose a revert or correction.
+- **During background RCA, NEVER** manually create a branch + commit file + create PR — use `bitbucket_fix` instead; the user will create the PR from the Incidents UI after reviewing your suggestion. During Aurora Actions / interactive chat, the branch → `edit_file` → PR workflow described above IS the correct way to ship a change.

--- a/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
+++ b/server/chat/backend/agent/skills/integrations/bitbucket/SKILL.md
@@ -14,7 +14,7 @@ tools:
   - bitbucket_issues
   - bitbucket_pipelines
   - bitbucket_fix
-index: "Code repo -- manage Bitbucket repos, branches, PRs, issues, CI/CD pipelines, and suggest code fixes (6 tools, 42 actions)"
+index: "Code repo -- manage Bitbucket repos, branches, PRs, issues, CI/CD pipelines, and suggest code fixes (6 tools, 44 actions)"
 rca_priority: 2
 allowed-tools: bitbucket_repos, bitbucket_branches, bitbucket_pull_requests, bitbucket_issues, bitbucket_pipelines, bitbucket_fix
 metadata:
@@ -32,10 +32,10 @@ Workspace and repository auto-resolve from saved user selection if not passed ex
 
 ## Instructions
 
-### Tools (6 tools, 42 actions)
+### Tools (6 tools, 44 actions)
 
 **bitbucket_repos** -- Repository, File & Code Operations:
-- `list_repos`, `get_repo`, `get_file_contents`, `create_or_update_file`, `delete_file`
+- `list_repos`, `get_repo`, `get_file_contents`, `find_in_file`, `edit_file`, `create_or_update_file`, `delete_file`
 - `get_directory_tree`, `search_code`, `list_workspaces`, `get_workspace`
 
 **bitbucket_branches** -- Branch & Commit Operations:
@@ -51,6 +51,16 @@ Workspace and repository auto-resolve from saved user selection if not passed ex
 **bitbucket_pipelines** -- CI/CD Pipeline Operations:
 - `list_pipelines`, `get_pipeline`, `trigger_pipeline`, `stop_pipeline`
 - `list_pipeline_steps`, `get_step_log`, `get_pipeline_step`
+
+### Reading & Editing Repo Files
+
+- **Prefer `edit_file`** (anchored search-and-replace applied server-side against the true current file) for ANY change to an existing file. Use `create_or_update_file` ONLY for brand-new paths — never to overwrite a file you already read via a full-content upload.
+- **First read the file** with `get_file_contents` and copy `old_string` byte-for-byte from the output. Keep `old_string` narrow — the changed lines plus 1-3 lines of surrounding context. Do NOT pass the whole file as `old_string`.
+- Large files come back in verbatim pages. The page header says `[lines X-Y of N — pass start_line=<n> commit=<sha> to continue]` (or `start_char=<offset>` for one oversized line) — follow it verbatim to read further; the `commit=<sha>` pin keeps every page on the same file version even if the branch moves. Every page is exact file content, never a summary.
+- **Big-file workflow**: `find_in_file` (locate the lines to change, returns `L<line>: <text>` matches plus the resolved `commit`) → `get_file_contents` with `start_line=<match line>` and that `commit` (read that region verbatim) → `edit_file` with narrow anchors. You do not need the whole file in context to edit it. `find_in_file` matches your query as a literal substring first, then as a regex.
+- One `edit_file` call can carry several edits (scattered locations = one commit); multiple files = multiple `edit_file` calls on the same branch = one PR.
+- A comments-only config file is never a valid change. To remove a resource, delete its block; to change a value, edit it — do not replace file contents with a comment.
+- **During Aurora Actions / interactive chat**: create a branch, apply `edit_file` on that branch, then open a PR. **During background RCA**: repo tools are read-only — use `bitbucket_fix` to propose changes instead.
 
 **bitbucket_fix** -- Suggest Code Fixes During RCA:
 - Use when you identify a specific code change that would fix the root cause

--- a/server/chat/backend/agent/tools/bitbucket/apply_fix_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/apply_fix_tool.py
@@ -66,6 +66,46 @@ def _resolve_base_hash(client, workspace: str, repo_slug: str, base_branch: str)
     return None, f"Could not find base branch '{base_branch}' in {workspace}/{repo_slug}"
 
 
+def _check_suggestion_not_stale(client, workspace: str, repo_slug: str, file_path: str,
+                                base_branch: str, original_content) -> Optional[str]:
+    """Verify the file on ``base_branch`` still matches the content the
+    suggestion was rendered from. Returns an error string, or None if safe."""
+    result = client.get_file_contents(workspace, repo_slug, file_path, commit=base_branch)
+    current = None
+    if isinstance(result, dict):
+        if result.get("error"):
+            if result.get("status") != 404:
+                return (
+                    f"Could not verify the current state of {file_path} on "
+                    f"'{base_branch}': {result.get('message')}. Retry, or regenerate the fix."
+                )
+            # 404 → the file does not exist on the base branch
+        else:
+            content = result.get("content")
+            current = content if isinstance(content, str) else None
+
+    if original_content is None:
+        # New-file suggestion: the path must still be absent.
+        if current is not None:
+            return (
+                f"{file_path} now exists on '{base_branch}' but this suggestion would "
+                "create it from scratch, overwriting the current file. Regenerate the fix."
+            )
+        return None
+    if current is None:
+        return (
+            f"{file_path} is no longer readable on '{base_branch}' (deleted or moved "
+            "since this fix was suggested). Regenerate the fix against the current repo."
+        )
+    if current != original_content:
+        return (
+            f"{file_path} has changed on '{base_branch}' since this fix was suggested — "
+            "applying it would overwrite those newer changes. Regenerate the fix "
+            "against the current file."
+        )
+    return None
+
+
 def _create_branch_and_commit(client, workspace: str, repo_slug: str, branch_name: str,
                               base_hash: str, file_path: str, content: str, commit_message: str) -> Optional[str]:
     """Create branch and push the fix. Returns error string or None on success."""
@@ -74,9 +114,14 @@ def _create_branch_and_commit(client, workspace: str, repo_slug: str, branch_nam
     if err := forward_if_error(result):
         return f"Failed to create branch: {result.get('message', err)}"
 
+    # The fresh branch's tip is the commit we branched from; passing it as
+    # parents makes the commit a compare-and-swap (rejected if the tip moved).
+    branch_tip = (result.get("target") or {}).get("hash") if isinstance(result, dict) else None
+
     logger.info(f"{_LOG_PREFIX} Pushing fix to {file_path} on branch {branch_name}")
     result = client.create_or_update_file(
-        workspace, repo_slug, file_path, content, commit_message, branch_name
+        workspace, repo_slug, file_path, content, commit_message, branch_name,
+        parents=branch_tip or base_hash,
     )
     if err := forward_if_error(result):
         return f"Failed to push fix: {result.get('message', err)}"
@@ -153,6 +198,15 @@ def bitbucket_apply_fix(
         return build_error_response(err)
     if not base_hash:
         return build_error_response(f"No commit hash found for branch '{base_branch}'")
+
+    # Staleness guard: suggested_content is a WHOLE-FILE body rendered from
+    # the file as it was at suggestion time. If the file has changed on the
+    # base branch since, pushing it would silently revert those changes —
+    # the parents CAS below only protects against races during the apply.
+    err = _check_suggestion_not_stale(client, workspace, repo_slug, file_path,
+                                      base_branch, suggestion.get("original_content"))
+    if err:
+        return build_error_response(err)
 
     err = _create_branch_and_commit(
         client, workspace, repo_slug, branch_name, base_hash, file_path, content, commit_message

--- a/server/chat/backend/agent/tools/bitbucket/fix_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/fix_tool.py
@@ -19,6 +19,8 @@ from .utils import (
     get_default_branch,
     build_error_response,
     build_success_response,
+    apply_edits_checked,
+    is_commit_sha_like,
 )
 
 from chat.backend.agent.tools.vcs_rca_utils import resolve_repository as _vcs_resolve_repository
@@ -96,11 +98,21 @@ def _get_file_content(
     repo_slug: str,
     file_path: str,
     branch: Optional[str],
-) -> Optional[str]:
-    """Fetch file contents from Bitbucket. Returns text content or None."""
+) -> tuple[Optional[str], Optional[str], bool]:
+    """Fetch file contents from Bitbucket.
+
+    Returns ``(content, error_message, is_missing)``:
+    - ``(str, None, False)`` on success
+    - ``(None, None, True)`` when the FILE does not exist (HTTP 404 with a
+      resolvable ref) — the only case where the new-file creation path is
+      allowed
+    - ``(None, str, False)`` on any other failure (auth, network, bad
+      branch, directory path) — must surface as a hard error, never as
+      "file doesn't exist"
+    """
     client = get_bb_client_for_user(user_id)
     if not client:
-        return None
+        return None, "Bitbucket is not connected", False
 
     ref = branch or "HEAD"
     result = client.get_file_contents(workspace, repo_slug, file_path, commit=ref)
@@ -111,13 +123,37 @@ def _get_file_content(
                 "%s Failed to fetch %s from %s/%s: %s",
                 _LOG_PREFIX, file_path, workspace, repo_slug, result.get("message"),
             )
-            return None
-        return result.get("content")
+            if result.get("status") == 404:
+                # /src returns 404 both for a missing FILE and for a missing
+                # BRANCH/ref (e.g. a typo). Only a resolvable ref may take
+                # the new-file path — otherwise the "new file" would shadow
+                # a file that exists on the real branch.
+                if _ref_resolves(client, workspace, repo_slug, ref):
+                    return None, None, True
+                return None, (
+                    f"branch or ref '{ref}' not found (or could not be resolved)"
+                ), False
+            return None, str(result.get("message") or "Bitbucket API error"), False
+        file_content = result.get("content")
+        if isinstance(file_content, str):
+            return file_content, None, False
 
-    if isinstance(result, str):
-        return result
+    return None, "Unexpected response from Bitbucket (is the path a directory?)", False
 
-    return None
+
+def _ref_resolves(client, workspace: str, repo_slug: str, ref: str) -> bool:
+    """True when ``ref`` resolves to a commit, so a /src 404 means the FILE
+    is missing. Fails closed (False) on resolution errors — a bad branch
+    must never masquerade as a missing file."""
+    try:
+        resolved = client._resolve_commit(workspace, repo_slug, ref)
+    except Exception:
+        return False
+    if resolved != ref:
+        return True  # resolved to a commit hash — the ref exists
+    # Unchanged ref: either it already looks like a commit SHA (passed
+    # through as-is) or resolution failed.
+    return is_commit_sha_like(ref)
 
 
 def _save_fix_suggestion(
@@ -216,8 +252,18 @@ def bitbucket_fix(
     if not effective_branch:
         effective_branch = get_default_branch(user_id, workspace, repo_slug)
 
-    original_content = _get_file_content(user_id, workspace, repo_slug, file_path, effective_branch)
-    if original_content is None:
+    original_content, fetch_err, is_missing = _get_file_content(
+        user_id, workspace, repo_slug, file_path, effective_branch
+    )
+    if fetch_err:
+        # Any failure other than a confirmed 404 is a hard error: falling
+        # through to the new-file path here would silently replace the whole
+        # file with content built only from the edits' new_string values.
+        return build_error_response(
+            f"Could not fetch current contents of {file_path} from {full_repo}: {fetch_err}. "
+            "Verify the path and branch, then retry."
+        )
+    if is_missing:
         # Support creating new files: if all edits have empty old_string, treat as new file
         all_empty_old = all(
             (e.get("old_string", "") if isinstance(e, dict) else getattr(e, "old_string", "")) == ""
@@ -229,6 +275,11 @@ def bitbucket_fix(
                 e.get("new_string", "") if isinstance(e, dict) else getattr(e, "new_string", "")
                 for e in edits
             )
+            if not suggested_content.strip():
+                return build_error_response(
+                    "Refusing to create an empty (or whitespace-only) file. "
+                    "Provide the new file's content in new_string."
+                )
             original_content = None
             logger.info(
                 "%s File %s does not exist, creating new file (%d bytes)",
@@ -236,29 +287,16 @@ def bitbucket_fix(
             )
         else:
             return build_error_response(
-                f"Could not fetch current contents of {file_path} from {full_repo}. "
-                "The file does not exist. To create a new file, set old_string to an empty string."
+                f"File {file_path} does not exist in {full_repo}. "
+                "To create a new file, set old_string to an empty string."
             )
     else:
-        # File exists — apply edits using the shared replacer chain from github_fix_tool
-        from chat.backend.agent.tools.github_fix_tool import _apply_edits
-
-        suggested_content, apply_err = _apply_edits(original_content, edits)
+        # File exists — apply edits using the shared replacer chain (which
+        # also rejects no-op and empty/whitespace-only results).
+        suggested_content, apply_err = apply_edits_checked(original_content, edits)
         if apply_err or suggested_content is None:
             logger.warning("%s edit application failed for %s: %s", _LOG_PREFIX, file_path, apply_err)
             return build_error_response(apply_err or "edit application failed")
-
-        if suggested_content == original_content:
-            return build_error_response(
-                "Applied edits produced no change to the file. Double-check old_string/new_string."
-            )
-
-    if not suggested_content.strip():
-        return build_error_response(
-            "Applied edits produced an empty (or whitespace-only) file. If you "
-            "really intend to empty this file, do it manually — bitbucket_fix is "
-            "for targeted code changes."
-        )
 
     final_commit_message = commit_message or f"fix: {fix_description[:100]}"
     title = _build_title(file_path, fix_description)

--- a/server/chat/backend/agent/tools/bitbucket/repos_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/repos_tool.py
@@ -4,7 +4,16 @@ import json
 import logging
 import re
 import threading
+import time
 from typing import Literal, Optional
+
+try:
+    # Supports a true per-call timeout for the find_in_file regex fallback.
+    # Transitively present via tiktoken; the daemon-thread deadline below
+    # covers its absence.
+    import regex as _regex_mod
+except ImportError:  # pragma: no cover — regex ships with tiktoken
+    _regex_mod = None
 
 from pydantic import BaseModel, Field
 
@@ -99,33 +108,51 @@ def _scan_lines(lines: list, matches) -> tuple[list[str], int]:
     return formatted, total
 
 
-def _find_in_content(file_content: str, query: str) -> tuple[list[str], int]:
-    """Return (formatted match lines, total match count) for ``query``.
+def _regex_timeout_message(query: str) -> str:
+    return (
+        f"Regex search for {query!r} timed out after "
+        f"{_FIND_REGEX_TIMEOUT_S:.0f}s (catastrophic backtracking). "
+        "Retry with a literal code snippet or a simpler pattern."
+    )
 
-    Literal substring matching runs first: it is exact (no regex misreads of
-    code like ``arr[0]`` or ``foo.bar``) and immune to backtracking. Only
-    when the query never occurs literally is it tried as a regex — and since
-    stdlib ``re`` has no timeout and a pathological pattern (e.g. ``(x+)+y``)
-    backtracks exponentially on long lines, the regex scan runs in a worker
-    thread with a hard deadline and raises _RegexSearchTimeout on overrun.
-    At most _FIND_MAX_MATCHES lines are formatted as ``L<line_no>: <line>``
-    (truncated), so the output stays small.
-    """
-    lines = file_content.split("\n")
-    formatted, total = _scan_lines(lines, lambda line: query in line)
-    if total:
-        return formatted, total
 
+def _regex_scan_with_module_timeout(lines: list, query: str) -> tuple[list[str], int]:
+    """Regex fallback scan using the ``regex`` module's native per-call
+    timeout — a genuinely cancellable boundary: the engine checks the
+    deadline DURING matching, so a catastrophic pattern stops burning CPU
+    at the deadline instead of running to completion in an abandoned
+    thread."""
+    try:
+        pattern = _regex_mod.compile(query)
+    except _regex_mod.error:
+        return [], 0  # not a regex either — genuinely no matches
+
+    deadline = time.monotonic() + _FIND_REGEX_TIMEOUT_S
+
+    def matches(line: str) -> bool:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError
+        return pattern.search(line, timeout=remaining) is not None
+
+    try:
+        return _scan_lines(lines, matches)
+    except TimeoutError:
+        raise _RegexSearchTimeout(_regex_timeout_message(query)) from None
+
+
+def _regex_scan_with_thread_deadline(lines: list, query: str) -> tuple[list[str], int]:
+    """Stdlib fallback when the ``regex`` module is absent. A daemon thread
+    (NOT concurrent.futures: its non-daemon workers are joined at
+    interpreter exit, so an abandoned catastrophic scan would block process
+    shutdown). On timeout the runaway thread is abandoned — it burns CPU
+    until the scan finishes but never blocks exit, and it holds only this
+    call's line list."""
     try:
         pattern = re.compile(query)
     except re.error:
-        return formatted, total  # not a regex either — genuinely no matches
+        return [], 0  # not a regex either — genuinely no matches
 
-    # A daemon thread (NOT concurrent.futures: its non-daemon workers are
-    # joined at interpreter exit, so an abandoned catastrophic scan would
-    # block process shutdown). On timeout the runaway thread is abandoned —
-    # it burns CPU until the scan finishes but never blocks exit, and it
-    # holds only this call's line list.
     outcome: dict = {}
 
     def _regex_scan():
@@ -143,11 +170,29 @@ def _find_in_content(file_content: str, query: str) -> tuple[list[str], int]:
         return outcome["result"]
     if "error" in outcome:
         raise outcome["error"]
-    raise _RegexSearchTimeout(
-        f"Regex search for {query!r} timed out after "
-        f"{_FIND_REGEX_TIMEOUT_S:.0f}s (catastrophic backtracking). "
-        "Retry with a literal code snippet or a simpler pattern."
-    )
+    raise _RegexSearchTimeout(_regex_timeout_message(query))
+
+
+def _find_in_content(file_content: str, query: str) -> tuple[list[str], int]:
+    """Return (formatted match lines, total match count) for ``query``.
+
+    Literal substring matching runs first: it is exact (no regex misreads of
+    code like ``arr[0]`` or ``foo.bar``) and immune to backtracking. Only
+    when the query never occurs literally is it tried as a regex, under a
+    hard deadline: via the ``regex`` module's native timeout when available
+    (truly cancellable mid-match), else a daemon-thread deadline. Both raise
+    _RegexSearchTimeout on overrun. At most _FIND_MAX_MATCHES lines are
+    formatted as ``L<line_no>: <line>`` (truncated), so the output stays
+    small.
+    """
+    lines = file_content.split("\n")
+    formatted, total = _scan_lines(lines, lambda line: query in line)
+    if total:
+        return formatted, total
+
+    if _regex_mod is not None:
+        return _regex_scan_with_module_timeout(lines, query)
+    return _regex_scan_with_thread_deadline(lines, query)
 
 
 def bitbucket_repos(

--- a/server/chat/backend/agent/tools/bitbucket/repos_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/repos_tool.py
@@ -95,6 +95,19 @@ class _RegexSearchTimeout(Exception):
     """Raised when a find_in_file regex scan exceeds its deadline."""
 
 
+class _InvalidFindQuery(Exception):
+    """Raised when a find_in_file query has no literal matches AND does not
+    compile as a regex — a bad argument, not a genuine zero-match result."""
+
+
+def _invalid_query_message(query: str, exc) -> str:
+    return (
+        f"No literal matches for {query!r}, and it does not compile as a "
+        f"regex ({exc}). Fix the pattern, or search for an exact code snippet "
+        "copied from the file."
+    )
+
+
 def _scan_lines(lines: list, matches) -> tuple[list[str], int]:
     """Scan ``lines`` with predicate ``matches``; format up to the cap."""
     formatted: list[str] = []
@@ -124,8 +137,8 @@ def _regex_scan_with_module_timeout(lines: list, query: str) -> tuple[list[str],
     thread."""
     try:
         pattern = _regex_mod.compile(query)
-    except _regex_mod.error:
-        return [], 0  # not a regex either — genuinely no matches
+    except _regex_mod.error as exc:
+        raise _InvalidFindQuery(_invalid_query_message(query, exc)) from None
 
     deadline = time.monotonic() + _FIND_REGEX_TIMEOUT_S
 
@@ -150,8 +163,8 @@ def _regex_scan_with_thread_deadline(lines: list, query: str) -> tuple[list[str]
     call's line list."""
     try:
         pattern = re.compile(query)
-    except re.error:
-        return [], 0  # not a regex either — genuinely no matches
+    except re.error as exc:
+        raise _InvalidFindQuery(_invalid_query_message(query, exc)) from None
 
     outcome: dict = {}
 
@@ -181,7 +194,9 @@ def _find_in_content(file_content: str, query: str) -> tuple[list[str], int]:
     when the query never occurs literally is it tried as a regex, under a
     hard deadline: via the ``regex`` module's native timeout when available
     (truly cancellable mid-match), else a daemon-thread deadline. Both raise
-    _RegexSearchTimeout on overrun. At most _FIND_MAX_MATCHES lines are
+    _RegexSearchTimeout on overrun; a query that also fails to compile
+    raises _InvalidFindQuery (a bad argument, distinct from a genuine
+    zero-match result). At most _FIND_MAX_MATCHES lines are
     formatted as ``L<line_no>: <line>`` (truncated), so the output stays
     small.
     """
@@ -332,7 +347,7 @@ def bitbucket_repos(
                 return build_error_response(f"'{path}' is not a readable file")
             try:
                 matches, total = _find_in_content(file_content, query)
-            except _RegexSearchTimeout as exc:
+            except (_RegexSearchTimeout, _InvalidFindQuery) as exc:
                 return build_error_response(str(exc))
             read_commit = result.get("commit")
             pin = f" commit={read_commit}" if is_full_commit_sha(read_commit) else ""

--- a/server/chat/backend/agent/tools/bitbucket/repos_tool.py
+++ b/server/chat/backend/agent/tools/bitbucket/repos_tool.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import re
+import threading
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -14,7 +16,11 @@ from .utils import (
     build_error_response,
     build_success_response,
     confirm_or_cancel,
+    page_file_content,
+    apply_edits_checked,
+    is_full_commit_sha,
 )
+from .fix_tool import FixEdit
 
 from utils.db.connection_pool import db_pool
 from utils.auth.stateless_auth import set_rls_context
@@ -27,6 +33,8 @@ class BitbucketReposArgs(BaseModel):
         "list_repos",
         "get_repo",
         "get_file_contents",
+        "find_in_file",
+        "edit_file",
         "create_or_update_file",
         "delete_file",
         "get_directory_tree",
@@ -38,10 +46,108 @@ class BitbucketReposArgs(BaseModel):
     repo_slug: Optional[str] = Field(None, description="Repository slug (required for repo-scoped actions).")
     path: Optional[str] = Field(None, description="File or directory path (for file/directory operations).")
     content: Optional[str] = Field(None, description="File content (for create_or_update_file).")
-    message: Optional[str] = Field(None, description="Commit message (for create_or_update_file, delete_file).")
-    branch: Optional[str] = Field(None, description="Branch name (for file operations). Defaults to saved branch.")
-    commit: Optional[str] = Field(None, description="Commit hash or branch ref (for get_file_contents, get_directory_tree). Defaults to HEAD.")
-    query: Optional[str] = Field(None, description="Search query (for search_code).")
+    message: Optional[str] = Field(None, description="Commit message (for edit_file, create_or_update_file, delete_file).")
+    branch: Optional[str] = Field(None, description="Branch name (for file operations). Defaults to saved branch — except edit_file, which requires an explicit branch (create one first, then open a PR).")
+    commit: Optional[str] = Field(None, description="Commit hash or branch ref (for get_file_contents, find_in_file, get_directory_tree). Defaults to HEAD.")
+    query: Optional[str] = Field(None, description="Search query (for search_code) or pattern (for find_in_file — matched as a literal substring first, then as a regex).")
+    start_line: Optional[int] = Field(
+        None,
+        description=(
+            "For get_file_contents: 1-based line to start reading from. Large "
+            "files are returned in verbatim pages; follow the continue hint in "
+            "the page header to read further."
+        ),
+    )
+    start_char: Optional[int] = Field(
+        None,
+        description=(
+            "For get_file_contents: character offset within start_line, used to "
+            "continue an oversized single line (copy it from the page header's "
+            "continue hint)."
+        ),
+    )
+    edits: Optional[list[FixEdit]] = Field(
+        None,
+        description=(
+            "For edit_file: list of anchored search-and-replace edits "
+            "({old_string, new_string, replace_all}). Copy old_string exactly "
+            "from get_file_contents output and keep it narrow — the changed "
+            "lines plus 1-3 lines of context, never the whole file."
+        ),
+    )
+
+
+_FIND_MAX_MATCHES = 50
+_FIND_LINE_TRUNCATE = 200
+_FIND_REGEX_TIMEOUT_S = 2.0
+
+
+class _RegexSearchTimeout(Exception):
+    """Raised when a find_in_file regex scan exceeds its deadline."""
+
+
+def _scan_lines(lines: list, matches) -> tuple[list[str], int]:
+    """Scan ``lines`` with predicate ``matches``; format up to the cap."""
+    formatted: list[str] = []
+    total = 0
+    for line_no, line in enumerate(lines, 1):
+        if matches(line):
+            total += 1
+            if len(formatted) < _FIND_MAX_MATCHES:
+                text = line if len(line) <= _FIND_LINE_TRUNCATE else line[:_FIND_LINE_TRUNCATE] + "..."
+                formatted.append(f"L{line_no}: {text}")
+    return formatted, total
+
+
+def _find_in_content(file_content: str, query: str) -> tuple[list[str], int]:
+    """Return (formatted match lines, total match count) for ``query``.
+
+    Literal substring matching runs first: it is exact (no regex misreads of
+    code like ``arr[0]`` or ``foo.bar``) and immune to backtracking. Only
+    when the query never occurs literally is it tried as a regex — and since
+    stdlib ``re`` has no timeout and a pathological pattern (e.g. ``(x+)+y``)
+    backtracks exponentially on long lines, the regex scan runs in a worker
+    thread with a hard deadline and raises _RegexSearchTimeout on overrun.
+    At most _FIND_MAX_MATCHES lines are formatted as ``L<line_no>: <line>``
+    (truncated), so the output stays small.
+    """
+    lines = file_content.split("\n")
+    formatted, total = _scan_lines(lines, lambda line: query in line)
+    if total:
+        return formatted, total
+
+    try:
+        pattern = re.compile(query)
+    except re.error:
+        return formatted, total  # not a regex either — genuinely no matches
+
+    # A daemon thread (NOT concurrent.futures: its non-daemon workers are
+    # joined at interpreter exit, so an abandoned catastrophic scan would
+    # block process shutdown). On timeout the runaway thread is abandoned —
+    # it burns CPU until the scan finishes but never blocks exit, and it
+    # holds only this call's line list.
+    outcome: dict = {}
+
+    def _regex_scan():
+        try:
+            outcome["result"] = _scan_lines(
+                lines, lambda line: pattern.search(line) is not None
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=_regex_scan, daemon=True, name="bb-find-regex")
+    worker.start()
+    worker.join(timeout=_FIND_REGEX_TIMEOUT_S)
+    if "result" in outcome:
+        return outcome["result"]
+    if "error" in outcome:
+        raise outcome["error"]
+    raise _RegexSearchTimeout(
+        f"Regex search for {query!r} timed out after "
+        f"{_FIND_REGEX_TIMEOUT_S:.0f}s (catastrophic backtracking). "
+        "Retry with a literal code snippet or a simpler pattern."
+    )
 
 
 def bitbucket_repos(
@@ -54,6 +160,9 @@ def bitbucket_repos(
     branch: Optional[str] = None,
     commit: Optional[str] = None,
     query: Optional[str] = None,
+    start_line: Optional[int] = None,
+    start_char: Optional[int] = None,
+    edits: Optional[list] = None,
     user_id: Optional[str] = None,
     **kwargs,
 ) -> str:
@@ -66,11 +175,14 @@ def bitbucket_repos(
 
     ws, repo = workspace, repo_slug
 
-    repo_scoped = action in (
-        "get_repo", "get_file_contents", "create_or_update_file",
-        "delete_file", "get_directory_tree",
+    # edit_file is deliberately absent: it REQUIRES an explicit branch (see
+    # its handler) — auto-filling the saved/default branch here would let an
+    # agent that omits `branch` commit straight to the default branch.
+    branch_defaulted = action in (
+        "get_repo", "get_file_contents", "find_in_file",
+        "create_or_update_file", "delete_file", "get_directory_tree",
     )
-    if repo_scoped and ws and repo:
+    if branch_defaulted and ws and repo:
         if not branch:
             branch = get_default_branch(user_id, ws, repo)
 
@@ -145,7 +257,105 @@ def bitbucket_repos(
             if not path:
                 return build_error_response("path is required")
             ref = commit or branch or "HEAD"
-            return json.dumps(client.get_file_contents(ws, repo, path, commit=ref), default=str)
+            result = client.get_file_contents(ws, repo, path, commit=ref)
+            if err := forward_if_error(result):
+                return err
+            if isinstance(result, dict) and isinstance(result.get("content"), str):
+                result = dict(result)
+                # Pin continue hints to the resolved commit so follow-up
+                # pages read the same file version even if the branch moves.
+                read_commit = result.get("commit")
+                result["content"] = page_file_content(
+                    result["content"], start_line or 1, start_char or 0,
+                    ref=read_commit if is_full_commit_sha(read_commit) else None,
+                )
+            return json.dumps(result, default=str)
+
+        if action == "find_in_file":
+            if err := require_repo(ws, repo):
+                return build_error_response(err)
+            if not path:
+                return build_error_response("path is required")
+            if not query:
+                return build_error_response("query is required")
+            ref = commit or branch or "HEAD"
+            result = client.get_file_contents(ws, repo, path, commit=ref)
+            if err := forward_if_error(result):
+                return err
+            file_content = result.get("content") if isinstance(result, dict) else None
+            if not isinstance(file_content, str):
+                return build_error_response(f"'{path}' is not a readable file")
+            try:
+                matches, total = _find_in_content(file_content, query)
+            except _RegexSearchTimeout as exc:
+                return build_error_response(str(exc))
+            read_commit = result.get("commit")
+            pin = f" commit={read_commit}" if is_full_commit_sha(read_commit) else ""
+            return build_success_response(
+                path=path,
+                query=query,
+                commit=read_commit,
+                total_matches=total,
+                shown=len(matches),
+                matches=matches,
+                hint=(
+                    "Jump to a match with get_file_contents "
+                    f"start_line=<line number>{pin}."
+                ),
+            )
+
+        if action == "edit_file":
+            if err := require_repo(ws, repo):
+                return build_error_response(err)
+            if not path:
+                return build_error_response("path is required")
+            if not edits:
+                return build_error_response("edits is required (list of {old_string, new_string} edits)")
+            if not message:
+                return build_error_response("message (commit message) is required")
+            if not branch:
+                return build_error_response("branch is required")
+            fetched = client.get_file_contents(ws, repo, path, commit=branch)
+            if err := forward_if_error(fetched):
+                return err
+            original = fetched.get("content") if isinstance(fetched, dict) else None
+            if not isinstance(original, str):
+                return build_error_response(
+                    f"Could not read '{path}' on branch '{branch}' — it may be a directory. "
+                    "edit_file only works on existing files; use create_or_update_file for new files."
+                )
+            # The compare-and-swap below is only real if the read was pinned
+            # to an actual commit SHA. When ref resolution fell back (the
+            # envelope echoes the raw branch name), fail closed instead of
+            # sending Bitbucket a non-SHA `parents` (400) or silently
+            # voiding the CAS.
+            read_commit = fetched.get("commit")
+            if not is_full_commit_sha(read_commit):
+                return build_error_response(
+                    f"Could not pin the current tip of branch '{branch}' for a safe "
+                    "compare-and-swap commit (ref resolution failed). Retry the edit; "
+                    "if it persists, verify the branch name."
+                )
+            new_content, apply_err = apply_edits_checked(original, edits)
+            if apply_err or new_content is None:
+                return build_error_response(apply_err or "edit application failed")
+            if cancelled := confirm_or_cancel(user_id,
+                    f"Commit edit to '{path}' on branch '{branch}' in {ws}/{repo}",
+                    "bitbucket:commit_file"):
+                return cancelled
+            # parents = the commit the file was read at → compare-and-swap:
+            # Bitbucket rejects the write if the branch tip moved since the read.
+            result = client.create_or_update_file(
+                ws, repo, path, new_content, message, branch,
+                parents=read_commit,
+            )
+            if err := forward_if_error(result):
+                return err
+            return build_success_response(
+                message=f"Applied {len(edits)} edit(s) to '{path}' on {branch}",
+                edits_applied=len(edits),
+                result=result,
+            )
 
         if action == "create_or_update_file":
             if err := require_repo(ws, repo):

--- a/server/chat/backend/agent/tools/bitbucket/utils.py
+++ b/server/chat/backend/agent/tools/bitbucket/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Optional
 
 from utils.db.connection_pool import db_pool
@@ -11,10 +12,32 @@ from connectors.bitbucket_connector.oauth_utils import refresh_token_if_needed
 from utils.auth.token_management import store_tokens_in_db
 from utils.secrets.secret_ref_utils import get_token_owner_id
 from utils.auth.command_gate import gate_action
+from chat.backend.agent.utils.tool_output_cap import PASS_THROUGH_CHARS as _PASS_THROUGH_CHARS
 
 logger = logging.getLogger(__name__)
 
 DIFF_TRUNCATE_LIMIT = 50_000
+
+# Budget for one page of file content, measured on the JSON-ESCAPED form of
+# the text (what actually lands in the serialized tool output). Derived from
+# tool_output_cap.PASS_THROUGH_CHARS with a 10K margin for the JSON envelope,
+# so a file read is returned verbatim and never replaced by an LLM summary —
+# even if the pass-through threshold is later lowered.
+PAGE_CONTENT_BUDGET = min(30_000, _PASS_THROUGH_CHARS - 10_000)
+
+_SHA40_RE = re.compile(r"[0-9a-f]{40}", re.IGNORECASE)
+# Mirrors api_client._COMMIT_SHA_RE: what _resolve_commit passes through as-is.
+_SHA_LIKE_RE = re.compile(r"[0-9a-f]{7,40}", re.IGNORECASE)
+
+
+def is_full_commit_sha(value) -> bool:
+    """True when ``value`` is a full 40-hex commit SHA (not a ref name)."""
+    return isinstance(value, str) and bool(_SHA40_RE.fullmatch(value))
+
+
+def is_commit_sha_like(value) -> bool:
+    """True when ``value`` looks like a (possibly abbreviated) commit SHA."""
+    return isinstance(value, str) and bool(_SHA_LIKE_RE.fullmatch(value))
 
 
 def get_bb_client_for_user(user_id: str):
@@ -83,6 +106,141 @@ def get_default_branch(user_id: str, workspace: str, repo_slug: str) -> Optional
     except Exception as e:
         logger.warning(f"Failed to look up default branch for {workspace}/{repo_slug}: {e}")
     return None
+
+
+def _escaped_len(text: str) -> int:
+    """Length of ``text`` once JSON-escaped inside a serialized string."""
+    return len(json.dumps(text)) - 2
+
+
+def _slice_to_escaped_budget(text: str, budget: int) -> str:
+    """Longest prefix of ``text`` whose JSON-escaped length fits ``budget``."""
+    # Escaped length >= raw length, so no prefix longer than ``budget`` raw
+    # chars can ever fit — capping ``hi`` keeps the binary-search probes small.
+    lo, hi = 0, min(len(text), budget)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if _escaped_len(text[:mid]) <= budget:
+            lo = mid
+        else:
+            hi = mid - 1
+    # Never return an empty slice: paging must always make progress.
+    return text[: max(lo, 1)]
+
+
+def page_file_content(content: str, start_line: int = 1, start_char: int = 0,
+                      ref: Optional[str] = None) -> str:
+    """Return a verbatim page of ``content`` starting at ``start_line``.
+
+    The page is sized so its JSON-escaped form stays under
+    PAGE_CONTENT_BUDGET, which keeps the serialized tool output under the
+    pass-through summarizer threshold — file reads are never summarized. A
+    file that fits in one page from line 1 is returned unchanged (no header).
+    Otherwise the page is prefixed with a header line:
+
+        [lines X-Y of N — pass start_line=<Y+1> to continue]
+
+    A single line longer than the budget is sliced and continued WITHIN the
+    line via ``start_char``:
+
+        [lines X-X of N — pass start_line=<X> start_char=<offset> to continue]
+
+    When ``ref`` is given (the resolved commit SHA the content was read at),
+    continue hints include ``commit=<ref>`` so follow-up pages are pinned to
+    the same file version even if the branch tip moves mid-read.
+
+    Concatenating the header-stripped pages reproduces the file
+    byte-for-byte (each page carries its own line terminators).
+    """
+    start_line = max(start_line or 1, 1)
+    start_char = max(start_char or 0, 0)
+
+    # Raw length is a lower bound on escaped length, so only files that are
+    # candidates for single-page return pay the whole-file escape check.
+    if (start_line == 1 and start_char == 0
+            and len(content) <= PAGE_CONTENT_BUDGET
+            and _escaped_len(content) <= PAGE_CONTENT_BUDGET):
+        return content
+
+    ref_hint = f" commit={ref}" if ref else ""
+
+    lines = content.split("\n")
+    total = len(lines)
+    idx = start_line - 1
+    if idx >= total:
+        return f"[start_line {start_line} is past the end of the file ({total} lines)]"
+
+    first = start_line
+    parts: list[str] = []
+    used = 0
+    continue_hint = None
+    last = total
+    while idx < total:
+        line = lines[idx]
+        offset = start_char if idx == start_line - 1 else 0
+        if offset:
+            if offset > len(line):
+                # A stale or invented hint: never return a page whose header
+                # claims a range while silently dropping part of a line.
+                return (
+                    f"[start_char {start_char} is past the end of line "
+                    f"{start_line} ({len(line)} chars)]"
+                )
+            line = line[offset:]
+        terminator = "\n" if idx < total - 1 else ""
+        piece = line + terminator
+        cost = _escaped_len(piece)
+        if used + cost > PAGE_CONTENT_BUDGET:
+            if not parts:
+                # A single line bigger than the whole budget: slice within it.
+                sliced = _slice_to_escaped_budget(line, PAGE_CONTENT_BUDGET)
+                parts.append(sliced)
+                continue_hint = (
+                    f"pass start_line={idx + 1} "
+                    f"start_char={offset + len(sliced)}{ref_hint} to continue"
+                )
+                last = idx + 1
+            else:
+                continue_hint = f"pass start_line={idx + 1}{ref_hint} to continue"
+                last = idx
+            break
+        parts.append(piece)
+        used += cost
+        idx += 1
+
+    if continue_hint:
+        header = f"[lines {first}-{last} of {total} — {continue_hint}]\n"
+    else:
+        header = f"[lines {first}-{last} of {total} — end of file]\n"
+    return header + "".join(parts)
+
+
+def apply_edits_checked(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:
+    """Apply anchored search-and-replace edits to ``original``.
+
+    Wraps the shared replacer chain from github_fix_tool (exact through
+    fuzzy matching, whole-file old_string ratio guard, overlap rejection)
+    and additionally rejects no-op and empty/whitespace-only results.
+
+    Returns ``(new_content, None)`` on success or ``(None, error)``.
+    """
+    from chat.backend.agent.tools.github_fix_tool import _apply_edits
+
+    suggested, apply_err = _apply_edits(original, edits)
+    if apply_err or suggested is None:
+        return None, apply_err or "edit application failed"
+    if suggested == original:
+        return None, (
+            "Applied edits produced no change to the file. "
+            "Double-check old_string/new_string."
+        )
+    if not suggested.strip():
+        return None, (
+            "Applied edits produced an empty (or whitespace-only) file. If you "
+            "really intend to empty this file, do it manually — anchored edits "
+            "are for targeted code changes."
+        )
+    return suggested, None
 
 
 def require_repo(ws: Optional[str], repo: Optional[str]) -> Optional[str]:

--- a/server/chat/backend/agent/tools/bitbucket/utils.py
+++ b/server/chat/backend/agent/tools/bitbucket/utils.py
@@ -162,57 +162,58 @@ def page_file_content(content: str, start_line: int = 1, start_char: int = 0,
             and _escaped_len(content) <= PAGE_CONTENT_BUDGET):
         return content
 
-    ref_hint = f" commit={ref}" if ref else ""
-
     lines = content.split("\n")
     total = len(lines)
     idx = start_line - 1
     if idx >= total:
         return f"[start_line {start_line} is past the end of the file ({total} lines)]"
+    if start_char > len(lines[idx]):
+        # A stale or invented hint: never return a page whose header claims
+        # a range while silently dropping part of a line.
+        return (
+            f"[start_char {start_char} is past the end of line "
+            f"{start_line} ({len(lines[idx])} chars)]"
+        )
 
-    first = start_line
+    ref_hint = f" commit={ref}" if ref else ""
+    parts, last, continue_hint = _collect_page(lines, idx, start_char, ref_hint)
+    return _page_header(start_line, last, total, continue_hint) + "".join(parts)
+
+
+def _collect_page(lines: list, start_idx: int, start_char: int,
+                  ref_hint: str) -> tuple[list[str], int, Optional[str]]:
+    """Accumulate whole lines (with terminators) from ``start_idx`` until the
+    escaped budget is spent. Returns ``(parts, last_line_1based,
+    continue_hint)``; ``continue_hint`` is None at end of file."""
+    total = len(lines)
     parts: list[str] = []
     used = 0
-    continue_hint = None
-    last = total
+    idx = start_idx
     while idx < total:
-        line = lines[idx]
-        offset = start_char if idx == start_line - 1 else 0
-        if offset:
-            if offset > len(line):
-                # A stale or invented hint: never return a page whose header
-                # claims a range while silently dropping part of a line.
-                return (
-                    f"[start_char {start_char} is past the end of line "
-                    f"{start_line} ({len(line)} chars)]"
-                )
-            line = line[offset:]
-        terminator = "\n" if idx < total - 1 else ""
-        piece = line + terminator
+        offset = start_char if idx == start_idx else 0
+        line = lines[idx][offset:] if offset else lines[idx]
+        piece = line + ("\n" if idx < total - 1 else "")
         cost = _escaped_len(piece)
         if used + cost > PAGE_CONTENT_BUDGET:
             if not parts:
                 # A single line bigger than the whole budget: slice within it.
                 sliced = _slice_to_escaped_budget(line, PAGE_CONTENT_BUDGET)
-                parts.append(sliced)
-                continue_hint = (
+                hint = (
                     f"pass start_line={idx + 1} "
                     f"start_char={offset + len(sliced)}{ref_hint} to continue"
                 )
-                last = idx + 1
-            else:
-                continue_hint = f"pass start_line={idx + 1}{ref_hint} to continue"
-                last = idx
-            break
+                return [sliced], idx + 1, hint
+            return parts, idx, f"pass start_line={idx + 1}{ref_hint} to continue"
         parts.append(piece)
         used += cost
         idx += 1
+    return parts, total, None
 
-    if continue_hint:
-        header = f"[lines {first}-{last} of {total} — {continue_hint}]\n"
-    else:
-        header = f"[lines {first}-{last} of {total} — end of file]\n"
-    return header + "".join(parts)
+
+def _page_header(first: int, last: int, total: int,
+                 continue_hint: Optional[str]) -> str:
+    tail = continue_hint or "end of file"
+    return f"[lines {first}-{last} of {total} — {tail}]\n"
 
 
 def apply_edits_checked(original: str, edits: list) -> tuple[Optional[str], Optional[str]]:

--- a/server/chat/backend/agent/tools/bitbucket/utils.py
+++ b/server/chat/backend/agent/tools/bitbucket/utils.py
@@ -23,7 +23,7 @@ DIFF_TRUNCATE_LIMIT = 50_000
 # tool_output_cap.PASS_THROUGH_CHARS with a 10K margin for the JSON envelope,
 # so a file read is returned verbatim and never replaced by an LLM summary —
 # even if the pass-through threshold is later lowered.
-PAGE_CONTENT_BUDGET = min(30_000, _PASS_THROUGH_CHARS - 10_000)
+PAGE_CONTENT_BUDGET = max(1, min(30_000, _PASS_THROUGH_CHARS - 10_000))
 
 _SHA40_RE = re.compile(r"[0-9a-f]{40}", re.IGNORECASE)
 # Mirrors api_client._COMMIT_SHA_RE: what _resolve_commit passes through as-is.

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -1005,6 +1005,40 @@ def _is_background_rca(state_context, is_background: bool) -> bool:
     return bool(rca_source) and rca_source not in _NON_RCA_SOURCES
 
 
+# Bitbucket tool actions that mutate state. Read-only sessions (PR change-
+# gating reviews, background RCA) hard-reject these at the tool FUNCTION
+# level — not just via descriptions — so a prompt-injected diff can't talk
+# the agent into merging/approving/pushing.
+_BB_WRITE_ACTIONS = frozenset({
+    "create_or_update_file", "edit_file", "delete_file",
+    "create_branch", "delete_branch",
+    "create_pr", "update_pr", "merge_pr", "approve_pr",
+    "unapprove_pr", "decline_pr", "add_pr_comment",
+    "create_issue", "update_issue", "add_issue_comment",
+    "trigger_pipeline", "stop_pipeline",
+})
+
+
+def _bb_read_only_gate(func, tool_name, reason):
+    """Wrap a Bitbucket tool so write actions are rejected during read-only
+    sessions. ``reason`` names the session type in the error ("PR review",
+    "RCA")."""
+    def gated(*args, **kwargs):
+        _action = kwargs.get("action") or (args[0] if args else None)
+        if _action in _BB_WRITE_ACTIONS:
+            return json.dumps({
+                "error": True,
+                "message": (
+                    f"Action '{_action}' is not permitted: {reason} "
+                    "sessions are read-only on Bitbucket."
+                ),
+            })
+        return func(*args, **kwargs)
+    gated.__name__ = getattr(func, "__name__", tool_name)
+    gated.__doc__ = func.__doc__
+    return gated
+
+
 def get_cloud_tools():
     """Get all cloud management tools including both Aurora native tools and REAL MCP tools."""
     # Import required classes at function start to avoid scope issues
@@ -2332,19 +2366,22 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
             )
 
             _is_rca_background = _is_background_rca(state_context, is_background)
+            _bb_read_only = _is_rca_background or is_pr_review
+            _ro_reason = "PR review" if is_pr_review else "RCA"
 
             # PR change-gating reviews are strictly read-only: the review
             # agent must never merge/approve/decline PRs, push files, or
             # trigger pipelines. Reuse the RCA read-only descriptor set
             # (minus bitbucket_fix, which is RCA-card-only — see below).
-            if _is_rca_background or is_pr_review:
-                _ro_reason = "PR review" if is_pr_review else "RCA"
+            if _bb_read_only:
                 _bb_tools = [
                     (bitbucket_repos, "bitbucket_repos", BitbucketReposArgs,
                      f"Query Bitbucket repositories and files (READ-ONLY during {_ro_reason}). "
-                     "Actions: list_repos, get_repo, get_file_contents, get_directory_tree, "
-                     "search_code, list_workspaces, get_workspace. "
-                     "Do NOT use create_or_update_file or delete_file."),
+                     "Actions: list_repos, get_repo, get_file_contents, find_in_file, "
+                     "get_directory_tree, search_code, list_workspaces, get_workspace. "
+                     "Large files come back in verbatim pages — follow the start_line "
+                     "continue hint in the page header; use find_in_file to locate lines. "
+                     "Do NOT use edit_file, create_or_update_file, or delete_file."),
                     (bitbucket_branches, "bitbucket_branches", BitbucketBranchesArgs,
                      f"Query Bitbucket branches and commits (READ-ONLY during {_ro_reason}). "
                      "Actions: list_branches, list_commits, get_commit, get_diff, compare. "
@@ -2362,9 +2399,14 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                 _bb_tools = [
                     (bitbucket_repos, "bitbucket_repos", BitbucketReposArgs,
                      "Manage Bitbucket repositories, files, and code. Actions: list_repos, get_repo, "
-                     "get_file_contents, create_or_update_file, delete_file, get_directory_tree, "
-                     "search_code, list_workspaces, get_workspace. Workspace and repo auto-resolve "
-                     "from saved selection if not specified."),
+                     "get_file_contents, find_in_file, edit_file, create_or_update_file, delete_file, "
+                     "get_directory_tree, search_code, list_workspaces, get_workspace. "
+                     "Prefer edit_file (anchored old_string/new_string edits applied server-side "
+                     "against the current file) for existing files; use create_or_update_file only "
+                     "for brand-new files. Large files come back in verbatim pages — follow the "
+                     "start_line/start_char continue hint in the page header; use find_in_file to "
+                     "locate lines, then get_file_contents with start_line to read that region. "
+                     "Workspace and repo auto-resolve from saved selection if not specified."),
                     (bitbucket_branches, "bitbucket_branches", BitbucketBranchesArgs,
                      "Manage Bitbucket branches and view commits/diffs. Actions: list_branches, create_branch, "
                      "delete_branch, list_commits, get_commit, get_diff, compare."),
@@ -2379,37 +2421,12 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
                      "Manage Bitbucket Pipelines CI/CD. Actions: list_pipelines, get_pipeline, "
                      "trigger_pipeline, stop_pipeline, list_pipeline_steps, get_step_log, get_pipeline_step."),
                 ]
-            # Hard gate (not just descriptions): during a PR review the tool
-            # FUNCTIONS reject Bitbucket write actions, so a prompt-injected
-            # diff can't talk the agent into merging/approving/pushing.
-            _BB_WRITE_ACTIONS = {
-                "create_or_update_file", "delete_file",
-                "create_branch", "delete_branch",
-                "create_pr", "update_pr", "merge_pr", "approve_pr",
-                "unapprove_pr", "decline_pr", "add_pr_comment",
-                "create_issue", "update_issue", "add_issue_comment",
-                "trigger_pipeline", "stop_pipeline",
-            }
-
-            def _read_only_gate(func, tool_name):
-                def gated(*args, **kwargs):
-                    _action = kwargs.get("action") or (args[0] if args else None)
-                    if _action in _BB_WRITE_ACTIONS:
-                        return json.dumps({
-                            "error": True,
-                            "message": (
-                                f"Action '{_action}' is not permitted: PR risk "
-                                "reviews are read-only on Bitbucket."
-                            ),
-                        })
-                    return func(*args, **kwargs)
-                gated.__name__ = getattr(func, "__name__", tool_name)
-                gated.__doc__ = func.__doc__
-                return gated
-
+            # Hard gate (not just descriptions): during a PR review or a
+            # background RCA the tool FUNCTIONS reject Bitbucket write
+            # actions (_bb_read_only_gate / _BB_WRITE_ACTIONS, module level).
             for _func, _name, _schema, _desc in _bb_tools:
-                if is_pr_review:
-                    _func = _read_only_gate(_func, _name)
+                if _bb_read_only:
+                    _func = _bb_read_only_gate(_func, _name, _ro_reason)
                 _ctx = with_user_context(_func)
                 _notif = with_completion_notification(_ctx)
                 _final = wrap_func_with_capture(_notif, _name) if tool_capture else _notif

--- a/server/chat/backend/agent/tools/cloud_tools.py
+++ b/server/chat/backend/agent/tools/cloud_tools.py
@@ -2369,10 +2369,12 @@ Once you identify which account has the issue, pass account_id (e.g. 'account') 
             _bb_read_only = _is_rca_background or is_pr_review
             _ro_reason = "PR review" if is_pr_review else "RCA"
 
-            # PR change-gating reviews are strictly read-only: the review
-            # agent must never merge/approve/decline PRs, push files, or
-            # trigger pipelines. Reuse the RCA read-only descriptor set
-            # (minus bitbucket_fix, which is RCA-card-only — see below).
+            # PR change-gating reviews AND background RCA are both hard
+            # read-only for Bitbucket writes: the agent must never
+            # merge/approve/decline PRs, push files, or trigger pipelines.
+            # The shared read-only descriptor set below (minus bitbucket_fix,
+            # which is RCA-card-only — see below) is backed by the
+            # _bb_read_only_gate function-level rejection in both modes.
             if _bb_read_only:
                 _bb_tools = [
                     (bitbucket_repos, "bitbucket_repos", BitbucketReposArgs,

--- a/server/connectors/bitbucket_connector/api_client.py
+++ b/server/connectors/bitbucket_connector/api_client.py
@@ -118,6 +118,21 @@ class BitbucketAPIClient:
             return self._handle_error(response)
         return response.json()
 
+    @staticmethod
+    def _default_to_utf8(response):
+        """Default an undeclared response charset to UTF-8.
+
+        Bitbucket serves file/diff bytes as ``text/plain`` with NO charset;
+        ``requests`` then falls back to ISO-8859-1 (the HTTP default), which
+        mojibakes UTF-8 content — and a subsequent write would re-encode the
+        mojibake, corrupting every non-ASCII character. Repo files are
+        conventionally UTF-8, so decode them as such unless the response
+        explicitly declares a charset.
+        """
+        content_type = response.headers.get("Content-Type", "")
+        if "charset" not in content_type.lower():
+            response.encoding = "utf-8"
+
     def _get_raw(self, url, params=None):
         """GET that returns raw text (for diffs, logs). Returns string or error dict."""
         _validate_bitbucket_url(url)
@@ -127,6 +142,7 @@ class BitbucketAPIClient:
         if response.status_code != 200:
             logger.error(f"Bitbucket GET (raw) {_sanitize_url(url)} failed: {response.status_code}")
             return self._handle_error(response)
+        self._default_to_utf8(response)
         return response.text
 
     def _post(self, url, json_data=None, data=None, files=None):
@@ -315,11 +331,34 @@ class BitbucketAPIClient:
             return self._handle_error(response)
         content_type = response.headers.get("Content-Type", "")
         if "application/json" in content_type:
-            return response.json()
+            # /src answers with JSON for a DIRECTORY listing — but also for a
+            # .json FILE, whose parsed body has no "content" key and would look
+            # like a nonexistent file to callers. Only pass through an actual
+            # paginated directory listing: top-level "values"+"pagelen" AND
+            # every entry typed commit_file/commit_directory (so a stored
+            # pagination fixture of, say, PRs is still treated as file text).
+            try:
+                parsed = response.json()
+            except ValueError:
+                parsed = None
+            if isinstance(parsed, dict) and "values" in parsed and "pagelen" in parsed:
+                values = parsed.get("values")
+                if isinstance(values, list) and all(
+                    isinstance(v, dict) and str(v.get("type", "")).startswith("commit_")
+                    for v in values
+                ):
+                    return parsed
+        self._default_to_utf8(response)
         return {"content": response.text, "path": path, "commit": commit}
 
-    def create_or_update_file(self, workspace, repo_slug, path, content, message, branch, author=None):
-        """Create or update a file via multipart form POST to /src."""
+    def create_or_update_file(self, workspace, repo_slug, path, content, message, branch, author=None, parents=None):
+        """Create or update a file via multipart form POST to /src.
+
+        ``parents`` (a commit hash) makes the write a compare-and-swap:
+        Bitbucket rejects the commit (400, "parent commit ... is not the
+        head of branch") if ``branch`` no longer points at that commit,
+        instead of silently clobbering newer work.
+        """
         url = (
             f"{BITBUCKET_API_BASE}/repositories/"
             f"{quote(workspace, safe='')}/{quote(repo_slug, safe='')}/src"
@@ -330,6 +369,8 @@ class BitbucketAPIClient:
         }
         if author:
             form_data["author"] = author
+        if parents:
+            form_data["parents"] = parents
         files = {path: (path, content)}
         return self._post(url, data=form_data, files=files)
 

--- a/server/services/actions/alert_gap_action.py
+++ b/server/services/actions/alert_gap_action.py
@@ -70,6 +70,9 @@ Hard anti-slop rules:
   Do not open a second one if a previous proposal is still pending review.
 - Create a branch, commit the alert definitions, and open a PR (GitHub/Bitbucket)
   or MR (GitLab) using the appropriate VCS tools.
+- When modifying an existing alert/rules file, use the provider's anchored edit
+  operation where available (Bitbucket: `edit_file`) instead of re-uploading the
+  whole file.
 - PR/MR body: for each proposed alert, one sentence on the gap it fills and why it matters.
   No filler, no essay. Reviewers are busy.
 - If you found no gaps worth proposing, do not open an empty or low-value PR. Instead,

--- a/server/services/actions/executor.py
+++ b/server/services/actions/executor.py
@@ -193,6 +193,7 @@ def build_action_prompt(
         "## Guidelines",
         "- Use your available tools to complete the task.",
         "- If you need to make infrastructure changes, open a PR rather than applying directly.",
+        "- When editing an existing repo file, use the provider's anchored edit operation where available (Bitbucket: the `edit_file` action); never overwrite a file you already read via a full-content upload.",
         "- Report what you did and any issues encountered.",
     ]
 

--- a/server/services/actions/hpa_vpa_action.py
+++ b/server/services/actions/hpa_vpa_action.py
@@ -176,6 +176,8 @@ it will assume we simply missed it.
 
 - One workload per PR. A reviewer should be able to accept or reject a single decision.
 - Change only what your evidence supports. Do not tidy adjacent config.
+- When changing an existing IaC file, use the provider's anchored edit operation where
+  available (Bitbucket: `edit_file`) instead of re-uploading the whole file.
 - Match the repo's branch naming, title style, and label conventions.
 - At most one short inline comment, and only where a number would otherwise look arbitrary.
 - PR body, a few lines per dimension: current value, recommended value, the p95, the max, the

--- a/server/tests/chat/test_bitbucket_file_ops.py
+++ b/server/tests/chat/test_bitbucket_file_ops.py
@@ -1,0 +1,704 @@
+"""Tests for the Bitbucket large-file edit path.
+
+Pins the behaviour that makes surgical edits on huge files safe by
+construction: paged verbatim reads that never trip the tool-output
+summarizer (page_file_content), in-file search for navigation
+(find_in_file), the anchored edit_file action with read-SHA
+compare-and-swap, the RCA read-failure contract (_get_file_content must
+never turn a fetch failure into "file doesn't exist"), the api-client
+Content-Type fix for .json files, and the read-only session gate.
+"""
+
+import json
+import os
+import re
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+from chat.backend.agent.tools.bitbucket.utils import (  # noqa: E402
+    PAGE_CONTENT_BUDGET,
+    apply_edits_checked,
+    page_file_content,
+)
+from chat.backend.agent.utils.tool_output_cap import PASS_THROUGH_CHARS  # noqa: E402
+from chat.backend.agent.tools.bitbucket import repos_tool  # noqa: E402
+from chat.backend.agent.tools.bitbucket.repos_tool import (  # noqa: E402
+    _find_in_content,
+    bitbucket_repos,
+)
+from chat.backend.agent.tools.bitbucket import fix_tool  # noqa: E402
+from chat.backend.agent.tools.bitbucket import apply_fix_tool  # noqa: E402
+from connectors.bitbucket_connector import api_client as bb_api  # noqa: E402
+
+
+_SHA = "a" * 40
+
+_HEADER_RE = re.compile(
+    r"^\[lines (\d+)-(\d+) of (\d+) — "
+    r"(?:pass start_line=(\d+)(?: start_char=(\d+))?(?: commit=[0-9a-f]{40})?"
+    r" to continue|end of file)\]\n"
+)
+
+
+def _build_big_file(num_lines: int = 5000) -> str:
+    """~400K chars for the default 5000 lines; every line unique."""
+    return "\n".join(f"line {i:05d} " + "x" * 70 for i in range(1, num_lines + 1))
+
+
+def _read_all_pages(content: str) -> tuple[list[str], list[str]]:
+    """Follow continue hints; return (header-stripped pages, raw pages)."""
+    stripped, raw = [], []
+    start_line, start_char = 1, 0
+    for _ in range(1000):
+        page = page_file_content(content, start_line, start_char)
+        raw.append(page)
+        m = _HEADER_RE.match(page)
+        if not m:
+            stripped.append(page)  # single-page file, no header
+            return stripped, raw
+        stripped.append(page[m.end():])
+        if m.group(4) is None:  # "end of file"
+            return stripped, raw
+        start_line = int(m.group(4))
+        start_char = int(m.group(5)) if m.group(5) else 0
+    pytest.fail("paging did not terminate")
+
+
+# ---------------------------------------------------------------------------
+# page_file_content
+# ---------------------------------------------------------------------------
+
+
+def test_small_file_returned_unchanged_without_header():
+    content = "line one\nline two\n"
+    assert page_file_content(content) == content
+
+
+def test_big_file_pages_reconstruct_byte_identical():
+    content = _build_big_file()
+    assert len(content) > 390_000
+    stripped, raw = _read_all_pages(content)
+    assert len(stripped) > 1
+    assert "".join(stripped) == content
+    # Every serialized page stays under the 40K summarizer threshold.
+    for page in raw:
+        assert len(json.dumps({"content": page})) < PASS_THROUGH_CHARS
+
+
+def test_page_headers_carry_correct_line_ranges():
+    content = _build_big_file(3000)
+    first = page_file_content(content, 1, 0)
+    m = _HEADER_RE.match(first)
+    assert m is not None
+    assert m.group(1) == "1"
+    assert m.group(3) == "3000"
+    next_line = int(m.group(4))
+    assert int(m.group(2)) == next_line - 1
+    second = page_file_content(content, next_line, 0)
+    m2 = _HEADER_RE.match(second)
+    assert m2 is not None
+    assert int(m2.group(1)) == next_line
+
+
+def test_escape_heavy_content_stays_under_cap():
+    # Quotes, backslashes, and non-ASCII all expand when JSON-escaped; the
+    # raw-length budget of a naive pager would overshoot the 40K cap here.
+    line = ('"\\' * 30 + "é") * 5
+    content = "\n".join(line for _ in range(2000))
+    stripped, raw = _read_all_pages(content)
+    assert len(raw) > 1
+    assert "".join(stripped) == content
+    for page in raw:
+        assert len(json.dumps({"content": page})) < PASS_THROUGH_CHARS
+
+
+def test_single_oversized_line_continues_via_start_char():
+    content = "x" * (PAGE_CONTENT_BUDGET * 3 + 1000)  # one line, no newlines
+    first = page_file_content(content, 1, 0)
+    m = _HEADER_RE.match(first)
+    assert m is not None
+    assert m.group(4) == "1"  # continue on the SAME line...
+    assert m.group(5) is not None  # ...at a character offset
+    stripped, _raw = _read_all_pages(content)
+    assert len(stripped) >= 3
+    assert "".join(stripped) == content
+
+
+def test_start_line_past_end_of_file():
+    out = page_file_content("a\nb", start_line=10)
+    assert "past the end" in out
+
+
+def test_start_char_past_end_of_line_is_an_explicit_error():
+    # A stale/invented start_char must never silently drop part of a line
+    # while the header claims a verbatim range.
+    out = page_file_content("short\nrest", start_line=1, start_char=1000)
+    assert "past the end of line 1" in out
+    assert "rest" not in out
+
+
+def test_continue_hints_carry_commit_pin_when_ref_given():
+    content = _build_big_file(3000)
+    first = page_file_content(content, 1, 0, ref=_SHA)
+    m = _HEADER_RE.match(first)
+    assert m is not None
+    assert f" commit={_SHA} to continue]" in first.split("\n", 1)[0]
+
+
+# ---------------------------------------------------------------------------
+# apply_edits_checked — the core surgical-edit scenario
+# ---------------------------------------------------------------------------
+
+
+def test_scattered_edits_on_400k_file():
+    """3 anchored edits at scattered locations in one call: all hunks land,
+    every byte outside the edited spans is untouched."""
+    content = _build_big_file(5000)
+    lines = content.split("\n")
+
+    spans = [(0, 5), (499, 520), (1999, 2005)]  # lines 1-5, 500-520, 2000-2005
+    edits = []
+    expected = content
+    for i, (lo, hi) in enumerate(spans, 1):
+        old = "\n".join(lines[lo:hi])
+        new = f"# EDIT {i} BEGIN\n" + old.replace("x" * 70, f"edited_{i}") + f"\n# EDIT {i} END"
+        edits.append({"old_string": old, "new_string": new})
+        assert expected.count(old) == 1
+        expected = expected.replace(old, new)
+
+    result, err = apply_edits_checked(content, edits)
+    assert err is None
+    assert result == expected
+    for i in range(1, 4):
+        assert f"# EDIT {i} BEGIN" in result
+
+
+def test_whole_file_old_string_rejected_by_ratio_guard():
+    content = _build_big_file(5000)
+    whole = content[: int(len(content) * 0.6)]
+    result, err = apply_edits_checked(content, [{"old_string": whole, "new_string": whole + "\n# extra"}])
+    assert result is None
+    assert "regenerating the whole file" in err
+
+
+def test_wrong_anchor_fails_loudly_on_big_file():
+    content = _build_big_file(5000)
+    result, err = apply_edits_checked(
+        content, [{"old_string": "zzz_not_in_file", "new_string": "replacement"}]
+    )
+    assert result is None
+    assert "old_string not found" in err
+
+
+def test_wrong_anchor_returns_closest_line_hints():
+    content = "\n".join(f"resource_block_{i} = value_{i}" for i in range(1, 301))
+    result, err = apply_edits_checked(
+        # Close to line 42 but not an actual match for any replacer stage.
+        content, [{"old_string": "resource_block_42 = value_43", "new_string": "changed"}]
+    )
+    assert result is None
+    assert "old_string not found" in err
+    assert "Closest lines" in err
+    assert "resource_block_42" in err
+
+
+def test_apply_edits_checked_noop_rejected():
+    result, err = apply_edits_checked("alpha\nbeta\n", [{"old_string": "alpha", "new_string": "alpha"}])
+    assert result is None
+    assert err
+
+
+def test_apply_edits_checked_empty_result_rejected():
+    result, err = apply_edits_checked("only line", [{"old_string": "only line", "new_string": " "}])
+    assert result is None
+    assert "empty" in err
+
+
+# ---------------------------------------------------------------------------
+# find_in_file
+# ---------------------------------------------------------------------------
+
+
+def test_find_in_content_line_numbers():
+    content = "alpha\nbeta\ngamma beta\ndelta"
+    matches, total = _find_in_content(content, "beta")
+    assert total == 2
+    assert matches == ["L2: beta", "L3: gamma beta"]
+
+
+def test_find_in_content_regex_and_literal_fallback():
+    matches, total = _find_in_content("foo(1)\nbar(2)", r"foo\(\d\)")
+    assert total == 1
+    assert matches[0].startswith("L1:")
+    # An invalid regex falls back to literal substring matching.
+    matches, total = _find_in_content("a[b\nc", "a[b")
+    assert total == 1
+    assert matches == ["L1: a[b"]
+
+
+def test_find_in_content_literal_wins_over_regex_reading():
+    # 'arr[0]' is a valid regex that would match 'arr0', never the literal
+    # text — literal-first matching must find the actual code.
+    matches, total = _find_in_content("x = arr[0]\ny = arr0\n", "arr[0]")
+    assert total == 1
+    assert matches == ["L1: x = arr[0]"]
+
+
+def test_find_in_content_caps_matches_and_line_length():
+    content = "\n".join("needle " + "x" * 500 for _ in range(500))
+    matches, total = _find_in_content(content, "needle")
+    assert total == 500
+    assert len(matches) == 50
+    assert all(len(m) < 230 for m in matches)
+
+
+# ---------------------------------------------------------------------------
+# bitbucket_repos handlers (mocked client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBBClient:
+    def __init__(self, content="hello world\n"):
+        self.content = content
+        self.read_result = None  # overrides the content envelope when set
+        self.write_result = {"success": True, "status": 201}
+        self.write_calls = []
+
+    def get_file_contents(self, ws, repo, path, commit="HEAD"):
+        if self.read_result is not None:
+            return self.read_result
+        return {"content": self.content, "path": path, "commit": _SHA}
+
+    def create_or_update_file(self, ws, repo, path, content, message, branch,
+                              author=None, parents=None):
+        self.write_calls.append({
+            "path": path, "content": content, "message": message,
+            "branch": branch, "parents": parents,
+        })
+        return self.write_result
+
+
+@pytest.fixture()
+def fake_bb(monkeypatch):
+    client = _FakeBBClient()
+    monkeypatch.setattr(repos_tool, "get_bb_client_for_user", lambda uid: client)
+    monkeypatch.setattr(repos_tool, "get_default_branch", lambda uid, ws, repo: "main")
+    monkeypatch.setattr(repos_tool, "confirm_or_cancel", lambda *a, **k: None)
+    return client
+
+
+def test_get_file_contents_pages_large_files(fake_bb):
+    fake_bb.content = _build_big_file(3000)
+    out = json.loads(bitbucket_repos(
+        action="get_file_contents", workspace="ws", repo_slug="r",
+        path="big.py", user_id="u1",
+    ))
+    assert out["content"].startswith("[lines 1-")
+    # Continue hints are pinned to the commit the read resolved to.
+    assert f" commit={_SHA} to continue]" in out["content"].split("\n", 1)[0]
+    assert len(json.dumps(out)) < PASS_THROUGH_CHARS
+
+    out2 = json.loads(bitbucket_repos(
+        action="get_file_contents", workspace="ws", repo_slug="r",
+        path="big.py", start_line=2500, user_id="u1",
+    ))
+    assert out2["content"].startswith("[lines 2500-")
+
+
+def test_get_file_contents_small_file_unchanged(fake_bb):
+    fake_bb.content = "tiny\nfile\n"
+    out = json.loads(bitbucket_repos(
+        action="get_file_contents", workspace="ws", repo_slug="r",
+        path="s.txt", user_id="u1",
+    ))
+    assert out["content"] == "tiny\nfile\n"
+
+
+def test_find_in_file_handler(fake_bb):
+    fake_bb.content = "\n".join(f"row {i}" for i in range(1, 101))
+    out = json.loads(bitbucket_repos(
+        action="find_in_file", workspace="ws", repo_slug="r",
+        path="f.txt", query="row 42", user_id="u1",
+    ))
+    assert out["success"] is True
+    assert out["total_matches"] == 1
+    assert out["matches"] == ["L42: row 42"]
+    assert "start_line" in out["hint"]
+
+
+def test_edit_file_applies_edits_and_passes_read_sha_as_parents(fake_bb):
+    fake_bb.content = "aaa\nbbb\nccc\n"
+    out = json.loads(bitbucket_repos(
+        action="edit_file", workspace="ws", repo_slug="r", path="f.txt",
+        branch="feature", message="fix: change bbb",
+        edits=[{"old_string": "bbb", "new_string": "BBB"}], user_id="u1",
+    ))
+    assert out["success"] is True
+    assert len(fake_bb.write_calls) == 1
+    call = fake_bb.write_calls[0]
+    assert call["content"] == "aaa\nBBB\nccc\n"
+    assert call["parents"] == _SHA
+    assert call["branch"] == "feature"
+
+
+def test_edit_file_requires_confirmation(fake_bb, monkeypatch):
+    cancelled = json.dumps({"success": True, "cancelled": True,
+                            "message": "Operation cancelled by user"})
+    monkeypatch.setattr(repos_tool, "confirm_or_cancel", lambda *a, **k: cancelled)
+    out = json.loads(bitbucket_repos(
+        action="edit_file", workspace="ws", repo_slug="r", path="f.txt",
+        branch="feature", message="m",
+        edits=[{"old_string": "hello", "new_string": "goodbye"}], user_id="u1",
+    ))
+    assert out.get("cancelled") is True
+    assert fake_bb.write_calls == []
+
+
+def test_edit_file_forwards_read_errors(fake_bb):
+    fake_bb.read_result = {"error": True, "status": 403, "message": "forbidden"}
+    out = json.loads(bitbucket_repos(
+        action="edit_file", workspace="ws", repo_slug="r", path="f.txt",
+        branch="feature", message="m",
+        edits=[{"old_string": "a", "new_string": "b"}], user_id="u1",
+    ))
+    assert out["error"] is True
+    assert fake_bb.write_calls == []
+
+
+def test_edit_file_bad_anchor_never_commits(fake_bb):
+    fake_bb.content = "aaa\nbbb\n"
+    out = json.loads(bitbucket_repos(
+        action="edit_file", workspace="ws", repo_slug="r", path="f.txt",
+        branch="feature", message="m",
+        edits=[{"old_string": "zzz", "new_string": "yyy"}], user_id="u1",
+    ))
+    assert out["error"] is True
+    assert fake_bb.write_calls == []
+
+
+def test_edit_file_requires_branch_message_and_edits(fake_bb):
+    base = dict(action="edit_file", workspace="ws", repo_slug="r",
+                path="f.txt", user_id="u1")
+    out = json.loads(bitbucket_repos(**base, edits=[{"old_string": "a", "new_string": "b"}]))
+    assert out["error"] is True  # missing message
+    out = json.loads(bitbucket_repos(**base, message="m"))
+    assert out["error"] is True  # missing edits
+    # branch must be EXPLICIT for edit_file: the saved/default branch (the
+    # fixture resolves 'main') must NOT be auto-filled into a commit.
+    out = json.loads(bitbucket_repos(
+        **base, message="m", edits=[{"old_string": "a", "new_string": "b"}],
+    ))
+    assert out["error"] is True
+    assert "branch" in out["message"]
+    assert fake_bb.write_calls == []
+
+
+def test_edit_file_fails_closed_when_read_commit_is_not_a_sha(fake_bb):
+    # If ref resolution fell back, the envelope echoes the branch name —
+    # committing with parents=<branch-name> would 400 or void the CAS.
+    fake_bb.read_result = {"content": "aaa\nbbb\n", "path": "f.txt",
+                           "commit": "feature"}
+    out = json.loads(bitbucket_repos(
+        action="edit_file", workspace="ws", repo_slug="r", path="f.txt",
+        branch="feature", message="m",
+        edits=[{"old_string": "bbb", "new_string": "BBB"}], user_id="u1",
+    ))
+    assert out["error"] is True
+    assert "compare-and-swap" in out["message"]
+    assert fake_bb.write_calls == []
+
+
+# ---------------------------------------------------------------------------
+# fix_tool._get_file_content — missing vs failed
+# ---------------------------------------------------------------------------
+
+
+class _StaticClient:
+    def __init__(self, result, resolved=_SHA):
+        self._result = result
+        self._resolved = resolved  # None → resolution fails (ref echoed back)
+
+    def get_file_contents(self, *args, **kwargs):
+        return self._result
+
+    def _resolve_commit(self, ws, repo, ref):
+        return self._resolved if self._resolved is not None else ref
+
+
+def test_get_file_content_404_means_missing(monkeypatch):
+    monkeypatch.setattr(fix_tool, "get_bb_client_for_user",
+                        lambda uid: _StaticClient({"error": True, "status": 404, "message": "not found"}))
+    content, err, missing = fix_tool._get_file_content("u", "ws", "r", "f.py", "main")
+    assert content is None
+    assert err is None
+    assert missing is True
+
+
+def test_get_file_content_404_on_unresolvable_branch_is_hard_error(monkeypatch):
+    # /src 404s identically for a missing FILE and a missing BRANCH (typo).
+    # Only a resolvable ref may take the new-file path — otherwise a branch
+    # typo fabricates a whole-file 'new file' suggestion.
+    monkeypatch.setattr(fix_tool, "get_bb_client_for_user",
+                        lambda uid: _StaticClient(
+                            {"error": True, "status": 404, "message": "not found"},
+                            resolved=None))
+    content, err, missing = fix_tool._get_file_content("u", "ws", "r", "f.py", "mian")
+    assert content is None
+    assert err and "mian" in err
+    assert missing is False
+
+
+@pytest.mark.parametrize("status", [401, 403, 429, 500])
+def test_get_file_content_non_404_is_hard_error(monkeypatch, status):
+    monkeypatch.setattr(fix_tool, "get_bb_client_for_user",
+                        lambda uid: _StaticClient({"error": True, "status": status, "message": "boom"}))
+    content, err, missing = fix_tool._get_file_content("u", "ws", "r", "f.py", "main")
+    assert content is None
+    assert err  # hard error — never the new-file fallback
+    assert missing is False
+
+
+def test_get_file_content_success(monkeypatch):
+    monkeypatch.setattr(fix_tool, "get_bb_client_for_user",
+                        lambda uid: _StaticClient({"content": "data", "path": "f.py", "commit": _SHA}))
+    content, err, missing = fix_tool._get_file_content("u", "ws", "r", "f.py", "main")
+    assert content == "data"
+    assert err is None
+    assert missing is False
+
+
+def test_get_file_content_directory_listing_is_hard_error(monkeypatch):
+    monkeypatch.setattr(fix_tool, "get_bb_client_for_user",
+                        lambda uid: _StaticClient({"pagelen": 10, "values": []}))
+    content, err, missing = fix_tool._get_file_content("u", "ws", "r", "somedir", "main")
+    assert content is None
+    assert err
+    assert missing is False
+
+
+# ---------------------------------------------------------------------------
+# apply_fix_tool — stale-suggestion guard
+# ---------------------------------------------------------------------------
+
+
+def test_apply_fix_stale_suggestion_is_refused():
+    # suggested_content is a whole-file body rendered at RCA time; if the
+    # file moved on the base branch since, applying would revert that work.
+    client = _StaticClient({"content": "CURRENT", "path": "f.py", "commit": _SHA})
+    err = apply_fix_tool._check_suggestion_not_stale(client, "ws", "r", "f.py", "main", "ORIGINAL")
+    assert err and "changed" in err
+    assert apply_fix_tool._check_suggestion_not_stale(
+        client, "ws", "r", "f.py", "main", "CURRENT") is None
+
+
+def test_apply_fix_new_file_suggestion_refused_if_file_now_exists():
+    client = _StaticClient({"content": "CURRENT", "path": "f.py", "commit": _SHA})
+    err = apply_fix_tool._check_suggestion_not_stale(client, "ws", "r", "f.py", "main", None)
+    assert err and "exists" in err
+    missing = _StaticClient({"error": True, "status": 404, "message": "nf"})
+    assert apply_fix_tool._check_suggestion_not_stale(
+        missing, "ws", "r", "f.py", "main", None) is None
+
+
+# ---------------------------------------------------------------------------
+# api_client.get_file_contents — Content-Type handling
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, text="", json_data=None, content_type="text/plain"):
+        self.status_code = 200
+        self.text = text
+        self._json = json_data
+        self.headers = {"Content-Type": content_type}
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("no json body")
+        return self._json
+
+
+def test_json_file_returns_text_envelope(monkeypatch):
+    body = '{"name": "cfg", "values": {"nested": 1}}'
+    resp = _FakeResponse(text=body, json_data=json.loads(body),
+                         content_type="application/json")
+    monkeypatch.setattr(bb_api.requests, "get", lambda *a, **k: resp)
+    client = bb_api.BitbucketAPIClient("tok")
+    result = client.get_file_contents("ws", "r", "cfg.json", commit=_SHA)
+    assert result == {"content": body, "path": "cfg.json", "commit": _SHA}
+
+
+def test_directory_listing_passes_through_parsed(monkeypatch):
+    listing = {"pagelen": 10, "values": [{"path": "a.py", "type": "commit_file"}], "page": 1}
+    resp = _FakeResponse(text=json.dumps(listing), json_data=listing,
+                         content_type="application/json")
+    monkeypatch.setattr(bb_api.requests, "get", lambda *a, **k: resp)
+    client = bb_api.BitbucketAPIClient("tok")
+    result = client.get_file_contents("ws", "r", "somedir", commit=_SHA)
+    assert result == listing
+
+
+def test_pagination_shaped_json_file_is_still_file_text(monkeypatch):
+    # A stored API-response fixture has top-level values+pagelen but its
+    # entries are not commit_file/commit_directory — it is a FILE, not a
+    # directory listing, and must stay readable/editable.
+    body = json.dumps({"pagelen": 10, "values": [{"id": 1, "type": "pullrequest"}]})
+    resp = _FakeResponse(text=body, json_data=json.loads(body),
+                         content_type="application/json")
+    monkeypatch.setattr(bb_api.requests, "get", lambda *a, **k: resp)
+    client = bb_api.BitbucketAPIClient("tok")
+    result = client.get_file_contents("ws", "r", "fixtures/prs.json", commit=_SHA)
+    assert result == {"content": body, "path": "fixtures/prs.json", "commit": _SHA}
+
+
+def test_create_or_update_file_sends_parents(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, data=None, files=None, timeout=None):
+        captured.update({"data": data, "files": files})
+        return _FakeResponse(text="{}", json_data={}, content_type="application/json")
+
+    monkeypatch.setattr(bb_api.requests, "post", fake_post)
+    client = bb_api.BitbucketAPIClient("tok")
+    client.create_or_update_file("ws", "r", "f.py", "body", "msg", "feature", parents=_SHA)
+    assert captured["data"]["parents"] == _SHA
+    client.create_or_update_file("ws", "r", "f.py", "body", "msg", "feature")
+    assert "parents" not in captured["data"]
+
+
+# ---------------------------------------------------------------------------
+# Read-only session gate (RCA + PR review)
+# ---------------------------------------------------------------------------
+
+
+# Modules that tests/auth/conftest.py replaces with bare MagicMock()s and
+# never cleans up. A MagicMock is not a package, so once tests/auth/ has run,
+# importing cloud_tools (which transitively imports weaviate.classes, celery
+# tasks, etc.) fails in a full-suite run. Evict the leaked mocks so the real
+# (or session-stubbed) modules load; real modules are never MagicMocks, so
+# this is a no-op outside the polluted case.
+_AUTH_CONFTEST_MOCKED_ROOTS = ("weaviate", "celery", "celery_config", "openai", "anthropic")
+
+
+def _cloud_tools():
+    if "chat.backend.agent.tools.cloud_tools" not in sys.modules:
+        for name in list(sys.modules):
+            if name.split(".")[0] in _AUTH_CONFTEST_MOCKED_ROOTS and isinstance(sys.modules[name], MagicMock):
+                del sys.modules[name]
+    return pytest.importorskip("chat.backend.agent.tools.cloud_tools")
+
+
+def test_edit_file_is_a_gated_write_action():
+    ct = _cloud_tools()
+    assert "edit_file" in ct._BB_WRITE_ACTIONS
+    assert "find_in_file" not in ct._BB_WRITE_ACTIONS
+    assert "get_file_contents" not in ct._BB_WRITE_ACTIONS
+
+
+@pytest.mark.parametrize("reason", ["RCA", "PR review"])
+def test_read_only_gate_blocks_edit_file(reason):
+    ct = _cloud_tools()
+    inner = MagicMock(return_value="should not run")
+    gated = ct._bb_read_only_gate(inner, "bitbucket_repos", reason)
+    out = json.loads(gated(action="edit_file"))
+    assert out["error"] is True
+    assert reason in out["message"]
+    inner.assert_not_called()
+
+
+def test_read_only_gate_allows_read_actions():
+    ct = _cloud_tools()
+    inner = MagicMock(return_value="ok")
+    gated = ct._bb_read_only_gate(inner, "bitbucket_repos", "RCA")
+    assert gated(action="find_in_file") == "ok"
+    assert gated(action="get_file_contents") == "ok"
+    assert inner.call_count == 2
+
+
+# Every action any Bitbucket tool accepts must be consciously classified:
+# either a write (hard-gated in read-only sessions) or a known read. A new
+# action that lands in a tool's Literal without touching this list fails
+# here instead of silently passing the security gate.
+_BB_READ_ONLY_ACTIONS = {
+    "list_repos", "get_repo", "get_file_contents", "find_in_file",
+    "get_directory_tree", "search_code", "list_workspaces", "get_workspace",
+    "list_branches", "list_commits", "get_commit", "get_diff", "compare",
+    "list_prs", "get_pr", "list_pr_comments", "get_pr_diff", "get_pr_activity",
+    "list_issues", "get_issue", "list_issue_comments",
+    "list_pipelines", "get_pipeline", "list_pipeline_steps", "get_step_log",
+    "get_pipeline_step",
+}
+
+
+def test_every_bitbucket_action_is_classified_read_or_write():
+    from typing import get_args
+
+    ct = _cloud_tools()
+    from chat.backend.agent.tools.bitbucket.repos_tool import BitbucketReposArgs
+    from chat.backend.agent.tools.bitbucket.branches_tool import BitbucketBranchesArgs
+    from chat.backend.agent.tools.bitbucket.prs_tool import BitbucketPullRequestsArgs
+    from chat.backend.agent.tools.bitbucket.issues_tool import BitbucketIssuesArgs
+    from chat.backend.agent.tools.bitbucket.pipelines_tool import BitbucketPipelinesArgs
+
+    for schema in (BitbucketReposArgs, BitbucketBranchesArgs,
+                   BitbucketPullRequestsArgs, BitbucketIssuesArgs,
+                   BitbucketPipelinesArgs):
+        for action in get_args(schema.model_fields["action"].annotation):
+            assert (action in ct._BB_WRITE_ACTIONS) != (action in _BB_READ_ONLY_ACTIONS), (
+                f"action '{action}' ({schema.__name__}) must be in exactly one of "
+                "_BB_WRITE_ACTIONS (cloud_tools) or _BB_READ_ONLY_ACTIONS (this test)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# api_client.get_file_contents — charset handling (found by live smoke test:
+# Bitbucket serves /src file bytes as text/plain with NO charset; requests
+# then decodes as ISO-8859-1 and mojibakes UTF-8 content, which a later
+# edit_file write-back would re-encode into permanent corruption)
+# ---------------------------------------------------------------------------
+
+
+class _EncodingAwareResponse:
+    """Mimics requests' charset behavior: .text decodes .content with
+    .encoding, which requests sets to ISO-8859-1 for text/* responses
+    that declare no charset."""
+
+    def __init__(self, content: bytes, content_type: str, encoding: str):
+        self.status_code = 200
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+        self.encoding = encoding
+
+    @property
+    def text(self):
+        return self.content.decode(self.encoding, errors="replace")
+
+    def json(self):
+        raise ValueError("not json")
+
+
+def test_undeclared_charset_defaults_to_utf8(monkeypatch):
+    body = "# config — naïve café\n"
+    resp = _EncodingAwareResponse(body.encode("utf-8"),
+                                  content_type="text/plain",
+                                  encoding="ISO-8859-1")  # requests' fallback
+    monkeypatch.setattr(bb_api.requests, "get", lambda *a, **k: resp)
+    client = bb_api.BitbucketAPIClient("tok")
+    result = client.get_file_contents("ws", "r", "cfg.py", commit=_SHA)
+    assert result["content"] == body  # not 'â€”' mojibake
+
+
+def test_declared_charset_is_honored(monkeypatch):
+    resp = _EncodingAwareResponse("café\n".encode("iso-8859-1"),
+                                  content_type="text/plain; charset=iso-8859-1",
+                                  encoding="iso-8859-1")
+    monkeypatch.setattr(bb_api.requests, "get", lambda *a, **k: resp)
+    client = bb_api.BitbucketAPIClient("tok")
+    result = client.get_file_contents("ws", "r", "cfg.py", commit=_SHA)
+    assert result["content"] == "café\n"

--- a/server/tests/chat/test_bitbucket_file_ops.py
+++ b/server/tests/chat/test_bitbucket_file_ops.py
@@ -68,6 +68,7 @@ def _read_all_pages(content: str) -> tuple[list[str], list[str]]:
         start_line = int(m.group(4))
         start_char = int(m.group(5)) if m.group(5) else 0
     pytest.fail("paging did not terminate")
+    raise AssertionError("unreachable")  # pytest.fail raises; appeases linters
 
 
 # ---------------------------------------------------------------------------
@@ -702,3 +703,15 @@ def test_declared_charset_is_honored(monkeypatch):
     client = bb_api.BitbucketAPIClient("tok")
     result = client.get_file_contents("ws", "r", "cfg.py", commit=_SHA)
     assert result["content"] == "café\n"
+
+
+def test_regex_fallback_timeout_is_cancellable_and_loud(monkeypatch):
+    # A catastrophic pattern must surface as _RegexSearchTimeout at the
+    # deadline (with the regex module, the engine itself stops mid-match
+    # instead of burning an abandoned thread).
+    if repos_tool._regex_mod is None:
+        pytest.skip("regex module not installed")
+    monkeypatch.setattr(repos_tool, "_FIND_REGEX_TIMEOUT_S", 0.2)
+    content = "x" * 5000 + "\nno match here"
+    with pytest.raises(repos_tool._RegexSearchTimeout, match="timed out"):
+        repos_tool._find_in_content(content, r"(x+)+z")

--- a/server/tests/chat/test_bitbucket_file_ops.py
+++ b/server/tests/chat/test_bitbucket_file_ops.py
@@ -715,3 +715,24 @@ def test_regex_fallback_timeout_is_cancellable_and_loud(monkeypatch):
     content = "x" * 5000 + "\nno match here"
     with pytest.raises(repos_tool._RegexSearchTimeout, match="timed out"):
         repos_tool._find_in_content(content, r"(x+)+z")
+
+
+def test_invalid_regex_with_no_literal_match_is_a_loud_error(fake_bb):
+    # An unclosed bracket that also never occurs literally is a bad
+    # argument, not a genuine zero-match result — the model must be told
+    # to fix the query instead of concluding the code isn't there.
+    fake_bb.content = "alpha\nbeta\n"
+    out = json.loads(bitbucket_repos(
+        action="find_in_file", workspace="ws", repo_slug="r",
+        path="f.txt", query="gamma[", user_id="u1",
+    ))
+    assert out.get("error") is True
+    assert "does not compile" in out["message"]
+    # ...but the same broken pattern that DOES occur literally still matches.
+    fake_bb.content = "x = gamma[0]\n"
+    out = json.loads(bitbucket_repos(
+        action="find_in_file", workspace="ws", repo_slug="r",
+        path="f.txt", query="gamma[", user_id="u1",
+    ))
+    assert out.get("success") is True
+    assert out["total_matches"] == 1


### PR DESCRIPTION
Fixes two Bitbucket change-application bugs (fresh implementation of the design from #606, with review feedback incorporated):

1. **Big files were summarized before editing** — any file read over 40K chars was replaced by an LLM prose summary, so the agent couldn't anchor a real edit and fell back to trivial/comment-only changes. `get_file_contents` now returns verbatim pages (~30K escaped chars, always under the summarizer threshold) with `start_line`/`start_char` continue hints pinned to the read commit, plus a `find_in_file` action to locate lines in huge files.
2. **Whole-file rewrites instead of surgical edits** — the only write path during Actions was a full-body upload. New `edit_file` action applies anchored old/new edits server-side against the true file (shared replacer chain), commits with `parents` set to the read SHA so a moved branch tip rejects the write instead of being clobbered.

Also fixed along the way:

- **UTF-8 corruption on all Bitbucket file reads**: `/src` serves `text/plain` with no charset, so reads were decoded as ISO-8859-1 and mojibaked non-ASCII content; a subsequent write would have re-encoded the damage permanently. Undeclared charsets now default to UTF-8.
- `.json` files read as "nonexistent" (parsed-dict Content-Type path) — directory-listing detection is now shape-checked.
- `bitbucket_fix` silently replaced files when a read failed for any reason — only a confirmed 404 (with the ref verified to resolve) reaches the new-file path now; everything else is a hard error.
- The Bitbucket read-only gate now hard-enforces during background RCA, not just PR review, and `find_in_file` is regex-timeout-guarded.

Verification: 50-test suite (`tests/chat/test_bitbucket_file_ops.py`), full server suite green, plus a live smoke against Bitbucket Cloud — one `edit_file` call with 4 edits scattered across a 278K-char/10K-line file committed a byte-identical result with exactly 4 hunks, and a stale-`parents` write was rejected by Bitbucket with the file unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bitbucket file search and anchored editing for safer, targeted repository updates.
  * Added support for navigating large files with paginated content and continuation guidance.
* **Bug Fixes**
  * Improved handling of missing files, invalid references, authentication failures, and file types.
  * Prevented stale suggestions and conflicting edits from overwriting newer repository changes.
  * Added safeguards against empty, no-op, or invalid file updates.
* **Documentation**
  * Updated repository editing guidance and Terraform deletion instructions.
  * Clarified read-only behavior and file-editing recommendations across automated actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->