### PR TITLE
fix(docker): migrate from deprecated google-cloud-sdk package to google-cloud-cli

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -145,7 +145,7 @@ EOF
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
         | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin && \
+    apt-get update && apt-get install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (multi-arch support)

--- a/server/Dockerfile-chatbot-dev.dockerfile
+++ b/server/Dockerfile-chatbot-dev.dockerfile
@@ -86,7 +86,7 @@ RUN ARCH=$(uname -m) && \
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
         | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin && \
+    apt-get update && apt-get install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (multi-arch support)

--- a/server/Dockerfile-user-terminal
+++ b/server/Dockerfile-user-terminal
@@ -39,7 +39,7 @@ RUN ARCH=$(uname -m) && \
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
         | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin && \
+    apt-get update && apt-get install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (multi-arch support) - matches chatbot exactly


### PR DESCRIPTION
## Summary
- Replaces the deprecated and unavailable `google-cloud-sdk` and `google-cloud-sdk-gke-gcloud-auth-plugin` packages with their current replacements `google-cloud-cli` and `google-cloud-cli-gke-gcloud-auth-plugin`.
- Fixes the recent CI failures on `main` branch under the `Publish Airtight Bundles` and `Publish Docker Images` workflows, where image building crashed during apt package installation.

## Test plan
- Dockerfile building verified.
- The package migration is confirmed to resolve the Debian package installation issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google Cloud tooling packages to their current names across deployment and development environments.
  * Improved compatibility with Google Kubernetes Engine authentication tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->