### PR TITLE
chore(release): 1.2.19

### DIFF
--- a/deploy/helm/aurora/Chart.yaml
+++ b/deploy/helm/aurora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aurora-oss
 description: Aurora – AI-powered cloud operations platform (on-prem deployment)
 type: application
-version: 1.2.18
-appVersion: "1.2.18"
+version: 1.2.19
+appVersion: "1.2.19"
 home: https://github.com/Arvo-AI/aurora
 sources:
   - https://github.com/Arvo-AI/aurora


### PR DESCRIPTION
## Summary
- bump the `aurora-oss` Helm chart version from `1.2.18` to `1.2.19`
- keep `appVersion` aligned with the chart version
- prepare the tag-triggered GitHub Pages and GHCR chart release

## Test plan
- [x] `helm lint deploy/helm/aurora`
- [x] `helm template aurora-oss deploy/helm/aurora`
- [x] confirm the publish workflow expects tag `v1.2.19`

## After merge
Tag the merged commit with `v1.2.19` and push that tag to trigger `.github/workflows/publish-helm.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Aurora deployment chart and application version to 1.2.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->