### PR TITLE
Root-cause dedup layer 2: recurrence grouping and UI

### DIFF
--- a/client/src/app/api/incidents/route.ts
+++ b/client/src/app/api/incidents/route.ts
@@ -1,41 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getAuthenticatedUser } from '@/lib/auth-helper';
+import { NextRequest } from 'next/server';
+import { forwardAuthenticatedGet } from '@/lib/backend-proxy';
 
-const API_BASE_URL = process.env.BACKEND_URL;
-
+// Query string (?groups=1, limit, offset, status) is forwarded to Flask.
 export async function GET(request: NextRequest) {
-  try {
-    if (!API_BASE_URL) {
-      return NextResponse.json(
-        { error: 'BACKEND_URL not configured' },
-        { status: 500 }
-      );
-    }
-
-    const authResult = await getAuthenticatedUser();
-
-    if (authResult instanceof NextResponse) {
-      return authResult;
-    }
-
-    const { headers: authHeaders } = authResult;
-
-    const response = await fetch(`${API_BASE_URL}/api/incidents`, {
-      method: 'GET',
-      headers: authHeaders,
-      credentials: 'include',
-      cache: 'no-store',
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      return NextResponse.json({ error: text || 'Failed to fetch incidents' }, { status: response.status });
-    }
-
-    const data = await response.json();
-    return NextResponse.json(data);
-  } catch (error) {
-    console.error('[api/incidents] Error:', error);
-    return NextResponse.json({ error: 'Failed to load incidents' }, { status: 500 });
-  }
+  return forwardAuthenticatedGet(request, '/api/incidents', 'incidents');
 }

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { incidentsService, Incident, StreamingThought } from '@/lib/services/incidents';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, AlertTriangle, GitMerge } from 'lucide-react';
+import { ArrowLeft, AlertTriangle, GitMerge, Repeat } from 'lucide-react';
 import IncidentCard from '../components/IncidentCard';
 import ThoughtsPanel, { PANEL_WIDTH_DEFAULT } from '../components/ThoughtsPanel';
 
@@ -160,6 +160,29 @@ export default function IncidentDetailPage() {
               </p>
               <p className="text-xs text-zinc-600 mt-1">
                 Its RCA investigation has been stopped. View the main incident to see the combined analysis.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Recurrence banner — this incident was folded into an earlier anchor (root-cause dedup) */}
+      {incident.recurrenceOf && (
+        <div className="bg-zinc-900/50 border-b border-zinc-800 px-6 py-4">
+          <div className="max-w-5xl mx-auto flex items-center gap-3 text-zinc-400">
+            <Repeat className="w-5 h-5 text-zinc-500" />
+            <div>
+              <p className="text-sm">
+                Occurrence of{' '}
+                <Link
+                  href={`/incidents/${incident.recurrenceOf}`}
+                  className="text-blue-400 hover:text-blue-300 font-medium"
+                >
+                  &quot;{incident.recurrenceOfTitle || 'an earlier incident'}&quot;
+                </Link>
+              </p>
+              <p className="text-xs text-zinc-600 mt-1">
+                Aurora matched this alert to an earlier root cause. This occurrence&apos;s own investigation is kept below.
               </p>
             </div>
           </div>

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -38,6 +38,7 @@ export default function IncidentDetailPage() {
     if (unseenThoughts.length > 0) {
       setThoughts(prev => [...prev, ...unseenThoughts]);
     }
+    setError(null);
     setIncident(data);
     if (data.status === 'investigating' && !userClosedThoughtsRef.current) {
       setShowThoughts(true);
@@ -53,12 +54,12 @@ export default function IncidentDetailPage() {
 
     const fetchAndSchedule = async (isInitial: boolean) => {
       if (!active || !params.id) return;
+      const seq = ++fetchSeqRef.current;
       try {
-        const seq = ++fetchSeqRef.current;
         const data = await incidentsService.getIncident(params.id as string);
         if (!active) return;
         if (!data) {
-          if (isInitial) setError('Incident not found');
+          if (isInitial && seq === fetchSeqRef.current) setError('Incident not found');
           return;
         }
         if (seq === fetchSeqRef.current) applyIncidentData(data);
@@ -79,8 +80,11 @@ export default function IncidentDetailPage() {
       } catch (e) {
         if (!active) return;
         if (isInitial) {
-          setError('Failed to load incident');
-          console.error('Failed to load incident:', e instanceof Error ? e.message : 'Unknown error');
+          // A newer request may already have rendered the page; only the latest may show the error.
+          if (seq === fetchSeqRef.current) {
+            setError('Failed to load incident');
+            console.error('Failed to load incident:', e instanceof Error ? e.message : 'Unknown error');
+          }
         } else {
           if (!pollStartRef.current) pollStartRef.current = Date.now();
           if (Date.now() - pollStartRef.current > STALE_POLL_MS) {

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -95,6 +95,26 @@ export default function IncidentDetailPage() {
     return () => { active = false; clearTimeout(timer); };
   }, [params.id, applyIncidentData]);
 
+  // A fold lands after the RCA completes, i.e. after the poll loop above has
+  // stopped, so refetch on incident events naming this incident as member or
+  // anchor; this keeps the recurrence banner and the occurrences list current.
+  useEffect(() => {
+    const id = params.id as string;
+    if (!id) return;
+    let active = true;
+    const es = new EventSource('/api/incidents/stream');
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.incident_id !== id && data.recurrence_of_incident_id !== id) return;
+        incidentsService.getIncident(id)
+          .then(fresh => { if (active && fresh) applyIncidentData(fresh); })
+          .catch(() => { /* the next event or a manual refresh retries */ });
+      } catch { /* ignore malformed messages */ }
+    };
+    return () => { active = false; es.close(); };
+  }, [params.id, applyIncidentData]);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-background p-6">

--- a/client/src/app/incidents/[id]/page.tsx
+++ b/client/src/app/incidents/[id]/page.tsx
@@ -25,6 +25,8 @@ export default function IncidentDetailPage() {
   const userClosedThoughtsRef = useRef<boolean>(false);
   const pollStartRef = useRef<number>(0);
   const lastUpdatedAtRef = useRef<string>('');
+  // Poll, SSE and manual refresh all call getIncident; only the newest request may apply.
+  const fetchSeqRef = useRef(0);
 
   const applyIncidentData = useCallback((data: Incident) => {
     const newThoughts = data.streamingThoughts || [];
@@ -52,13 +54,14 @@ export default function IncidentDetailPage() {
     const fetchAndSchedule = async (isInitial: boolean) => {
       if (!active || !params.id) return;
       try {
+        const seq = ++fetchSeqRef.current;
         const data = await incidentsService.getIncident(params.id as string);
         if (!active) return;
         if (!data) {
           if (isInitial) setError('Incident not found');
           return;
         }
-        applyIncidentData(data);
+        if (seq === fetchSeqRef.current) applyIncidentData(data);
 
         const needsPoll = data.status === 'investigating' || data.auroraStatus === 'summarizing';
         if (!needsPoll || !active) { pollStartRef.current = 0; return; }
@@ -107,8 +110,9 @@ export default function IncidentDetailPage() {
       try {
         const data = JSON.parse(event.data);
         if (data.incident_id !== id && data.recurrence_of_incident_id !== id) return;
+        const seq = ++fetchSeqRef.current;
         incidentsService.getIncident(id)
-          .then(fresh => { if (active && fresh) applyIncidentData(fresh); })
+          .then(fresh => { if (active && fresh && seq === fetchSeqRef.current) applyIncidentData(fresh); })
           .catch(() => { /* the next event or a manual refresh retries */ });
       } catch { /* ignore malformed messages */ }
     };
@@ -152,8 +156,9 @@ export default function IncidentDetailPage() {
 
   const refreshIncident = async () => {
     try {
+      const seq = ++fetchSeqRef.current;
       const data = await incidentsService.getIncident(params.id as string);
-      if (data) {
+      if (data && seq === fetchSeqRef.current) {
         setIncident(data);
       }
     } catch (e) {

--- a/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
+++ b/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import { CorrelatedAlert, incidentsService, getSourceIconSrc, getSourceIconBgColor } from '@/lib/services/incidents';
-import { ChevronDown, Link2, Clock, Server, Zap, Target, Type } from 'lucide-react';
+import { Link2, Clock, Server, Zap, Target, Type } from 'lucide-react';
 import Image from 'next/image';
+import ExpandablePanel, { ExpandChevron } from './ExpandablePanel';
 
 interface CorrelatedAlertsSectionProps {
   alerts: CorrelatedAlert[];
@@ -139,18 +140,9 @@ function CorrelatedAlertCard({ alert, isNew }: { alert: CorrelatedAlert; isNew: 
 
 export default function CorrelatedAlertsSection({ alerts }: CorrelatedAlertsSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [contentHeight, setContentHeight] = useState(0);
   
   // Filter out primary alerts (those with strategy 'primary' or score of 1)
   const correlatedAlerts = alerts.filter(a => a.correlationStrategy !== 'primary');
-  
-  // Measure content height when alerts change or expansion state changes
-  useEffect(() => {
-    if (contentRef.current) {
-      setContentHeight(contentRef.current.scrollHeight);
-    }
-  }, [correlatedAlerts, isExpanded]);
   
   if (correlatedAlerts.length === 0) {
     return null;
@@ -221,52 +213,26 @@ export default function CorrelatedAlertsSection({ alerts }: CorrelatedAlertsSect
         </div>
         
         <div className={`p-1 rounded transition-all duration-200 ${isExpanded ? 'bg-zinc-700' : 'hover:bg-zinc-800'}`}>
-          <ChevronDown 
-            className={`w-4 h-4 text-zinc-400 transition-transform duration-300 ease-out ${
-              isExpanded ? 'rotate-180' : ''
-            }`} 
-          />
+          <ExpandChevron open={isExpanded} className="text-zinc-400" />
         </div>
       </button>
       
       {/* Expandable content with smooth height animation */}
-      <div 
-        className={`overflow-hidden transition-all duration-300 ease-out ${
-          hasNewAlerts 
-            ? 'border-amber-500/30' 
-            : 'border-zinc-800'
-        } ${isExpanded ? 'border border-t-0 rounded-b-lg' : ''}`}
-        style={{ 
-          maxHeight: isExpanded ? `${contentHeight + 24}px` : '0px',
-          opacity: isExpanded ? 1 : 0,
-        }}
+      <ExpandablePanel
+        open={isExpanded}
+        className={`${hasNewAlerts ? 'border-amber-500/30' : 'border-zinc-800'} ${
+          isExpanded ? 'border border-t-0 rounded-b-lg' : ''
+        }`}
+        contentClassName={`p-3 space-y-2 ${hasNewAlerts ? 'bg-amber-500/[0.02]' : 'bg-zinc-900/30'}`}
       >
-        <div 
-          ref={contentRef}
-          className={`p-3 space-y-2 ${
-            hasNewAlerts ? 'bg-amber-500/[0.02]' : 'bg-zinc-900/30'
-          }`}
-        >
-          {sortedAlerts.map((alert, index) => (
-            <div
-              key={alert.id}
-              style={{
-                transitionDelay: isExpanded ? `${index * 50}ms` : '0ms',
-              }}
-              className={`transition-all duration-300 ease-out ${
-                isExpanded 
-                  ? 'opacity-100 translate-y-0' 
-                  : 'opacity-0 -translate-y-2'
-              }`}
-            >
-              <CorrelatedAlertCard 
-                alert={alert} 
-                isNew={isRecent(alert.receivedAt)}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
+        {sortedAlerts.map(alert => (
+          <CorrelatedAlertCard
+            key={alert.id}
+            alert={alert}
+            isNew={isRecent(alert.receivedAt)}
+          />
+        ))}
+      </ExpandablePanel>
     </div>
   );
 }

--- a/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
+++ b/client/src/app/incidents/components/CorrelatedAlertsSection.tsx
@@ -141,8 +141,12 @@ function CorrelatedAlertCard({ alert, isNew }: { alert: CorrelatedAlert; isNew: 
 export default function CorrelatedAlertsSection({ alerts }: CorrelatedAlertsSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   
-  // Filter out primary alerts (those with strategy 'primary' or score of 1)
-  const correlatedAlerts = alerts.filter(a => a.correlationStrategy !== 'primary');
+  // Filter out primary alerts (those with strategy 'primary' or score of 1) and
+  // the 'recurrence' rows a fold copies onto the anchor — OccurrencesSection
+  // already lists those as occurrences.
+  const correlatedAlerts = alerts.filter(
+    a => a.correlationStrategy !== 'primary' && a.correlationStrategy !== 'recurrence',
+  );
   
   if (correlatedAlerts.length === 0) {
     return null;

--- a/client/src/app/incidents/components/ExpandablePanel.tsx
+++ b/client/src/app/incidents/components/ExpandablePanel.tsx
@@ -35,7 +35,8 @@ export default function ExpandablePanel({ open, children, className = '', conten
     >
       <div className="min-h-0 overflow-hidden">
         <div className={contentClassName}>
-          {Children.map(children, (child, index) => (
+          {/* Children.map also visits `false`/null slots (`{cond && ...}`); skip them so no empty wrapper is rendered. */}
+          {Children.map(children, (child, index) => child == null ? null : (
             <div
               style={{ transitionDelay: open ? `${Math.min(index, MAX_STAGGER_INDEX) * 50}ms` : '0ms' }}
               className={`transition-all duration-300 ease-out ${

--- a/client/src/app/incidents/components/ExpandablePanel.tsx
+++ b/client/src/app/incidents/components/ExpandablePanel.tsx
@@ -23,7 +23,7 @@ const MAX_STAGGER_INDEX = 8;
  * the accessibility tree (it flips only after the close transition ends).
  * Each direct child staggers in by 50ms.
  */
-export default function ExpandablePanel({ open, children, className = '', contentClassName = '' }: ExpandablePanelProps) {
+export default function ExpandablePanel({ open, children, className = '', contentClassName = '' }: Readonly<ExpandablePanelProps>) {
   return (
     <div
       className={`grid overflow-hidden transition-all duration-300 ease-out ${className}`}
@@ -51,7 +51,7 @@ export default function ExpandablePanel({ open, children, className = '', conten
   );
 }
 
-export function ExpandChevron({ open, className = '' }: { open: boolean; className?: string }) {
+export function ExpandChevron({ open, className = '' }: Readonly<{ open: boolean; className?: string }>) {
   return (
     <ChevronDown
       className={`h-4 w-4 transition-transform duration-300 ease-out ${open ? 'rotate-180' : ''} ${className}`}

--- a/client/src/app/incidents/components/ExpandablePanel.tsx
+++ b/client/src/app/incidents/components/ExpandablePanel.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Children, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface ExpandablePanelProps {
+  open: boolean;
+  children: ReactNode;
+  /** Classes on the animated outer wrapper (borders, rounding, margins). */
+  className?: string;
+  /** Classes on the inner content (padding, background). */
+  contentClassName?: string;
+}
+
+/** Rows past this index share one delay so a long list finishes animating together. */
+const MAX_STAGGER_INDEX = 8;
+
+/**
+ * Height + opacity expand animation shared by the recurrence group card, the
+ * "Fired N times" section and Correlated Alerts. The outer grid animates
+ * 0fr -> 1fr, so nothing is measured and content that grows while open is
+ * never clipped. `visibility` keeps collapsed links out of the tab order and
+ * the accessibility tree (it flips only after the close transition ends).
+ * Each direct child staggers in by 50ms.
+ */
+export default function ExpandablePanel({ open, children, className = '', contentClassName = '' }: ExpandablePanelProps) {
+  return (
+    <div
+      className={`grid overflow-hidden transition-all duration-300 ease-out ${className}`}
+      style={{
+        gridTemplateRows: open ? '1fr' : '0fr',
+        opacity: open ? 1 : 0,
+        visibility: open ? 'visible' : 'hidden',
+      }}
+    >
+      <div className="min-h-0 overflow-hidden">
+        <div className={contentClassName}>
+          {Children.map(children, (child, index) => (
+            <div
+              style={{ transitionDelay: open ? `${Math.min(index, MAX_STAGGER_INDEX) * 50}ms` : '0ms' }}
+              className={`transition-all duration-300 ease-out ${
+                open ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'
+              }`}
+            >
+              {child}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ExpandChevron({ open, className = '' }: { open: boolean; className?: string }) {
+  return (
+    <ChevronDown
+      className={`h-4 w-4 transition-transform duration-300 ease-out ${open ? 'rotate-180' : ''} ${className}`}
+    />
+  );
+}

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -31,6 +31,7 @@ import SuggestionModal from './SuggestionModal';
 import FixSuggestionModal from './FixSuggestionModal';
 import IncidentFeedback from './IncidentFeedback';
 import CorrelatedAlertsSection from './CorrelatedAlertsSection';
+import OccurrencesSection from './OccurrencesSection';
 import PostmortemPanel from './PostmortemPanel';
 import InfrastructureVisualization from '@/components/incidents/InfrastructureVisualization';
 import IncidentActionRuns from './IncidentActionRuns';
@@ -405,6 +406,11 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
             )}
           </div>
         )}
+
+        {/* Recurrences folded into this anchor (root-cause dedup) */}
+        {incident.occurrences?.length ? (
+          <OccurrencesSection occurrences={incident.occurrences} />
+        ) : null}
       </div>
 
       {/* Separator */}

--- a/client/src/app/incidents/components/IncidentCard.tsx
+++ b/client/src/app/incidents/components/IncidentCard.tsx
@@ -409,7 +409,10 @@ export default function IncidentCard({ incident, duration, showThoughts, onToggl
 
         {/* Recurrences folded into this anchor (root-cause dedup) */}
         {incident.occurrences?.length ? (
-          <OccurrencesSection occurrences={incident.occurrences} />
+          <OccurrencesSection
+            occurrences={incident.occurrences}
+            total={incident.occurrencesTotal ?? incident.occurrences.length}
+          />
         ) : null}
       </div>
 

--- a/client/src/app/incidents/components/IncidentGroupRow.tsx
+++ b/client/src/app/incidents/components/IncidentGroupRow.tsx
@@ -122,7 +122,7 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
         </div>
 
         <ExpandablePanel open={expanded} className="mx-4" contentClassName="py-3 border-t border-border space-y-1">
-          {group.occurrences.slice(0, anchorIndex + 1).map(renderOccurrence)}
+          {group.occurrences.slice(0, anchorIndex + 1).map((occurrence, index) => renderOccurrence(occurrence, index))}
           {group.notLoaded > 0 && (
             <Link
               href={`/incidents/${anchor.id}`}

--- a/client/src/app/incidents/components/IncidentGroupRow.tsx
+++ b/client/src/app/incidents/components/IncidentGroupRow.tsx
@@ -45,6 +45,25 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
   // Severity is typed as a closed union but the API can still send 'unknown'.
   const severity: string = anchor.alert.severity;
   const showSeverity = (severity && severity !== 'unknown') || anchor.status === 'analyzed';
+  // Members the server cut are the oldest, so they sit between the anchor and
+  // the first loaded member: ordinals after the anchor skip them, and the
+  // "not shown" row is rendered in that gap.
+  const anchorIndex = group.occurrences.findIndex(o => o.id === anchor.id);
+  const renderOccurrence = (occurrence: Incident, index: number) => (
+    <Link
+      key={occurrence.id}
+      href={`/incidents/${occurrence.id}`}
+      className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm hover:bg-muted/60 transition-colors"
+    >
+      <span className="w-32 shrink-0 tabular-nums text-muted-foreground whitespace-nowrap">{formatFireTime(occurrence)}</span>
+      <span className="flex-1 min-w-0 truncate">
+        occurrence {index + 1 + (index > anchorIndex ? group.notLoaded : 0)}
+        {index === 0 && <span className="text-muted-foreground"> · first</span>}
+      </span>
+      <OccurrenceStatusIcon incident={occurrence} now={now} />
+      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+    </Link>
+  );
 
   return (
     <Card className={`hover:border-primary/50 transition-colors ${isActive ? 'border-l-4 border-l-muted-foreground' : ''}`}>
@@ -70,6 +89,9 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
                   <Repeat className="h-3 w-3" />
                   fired {group.occurrenceCount} times
                 </span>
+                {/* Time since the newest fire. No "N related" here: correlatedAlertCount is the
+                    old correlator's counter and folds bump it, so it would double as a second
+                    occurrence count (design doc: do not show it on the group header). */}
                 <span className="flex items-center gap-1">
                   <Clock className="h-3 w-3" />
                   {incidentsService.formatDuration(new Date(group.lastFiredAt).toISOString())}
@@ -100,32 +122,19 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
         </div>
 
         <ExpandablePanel open={expanded} className="mx-4" contentClassName="py-3 border-t border-border space-y-1">
-          {group.occurrences.map((occurrence, index) => (
-            <Link
-              key={occurrence.id}
-              href={`/incidents/${occurrence.id}`}
-              className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm hover:bg-muted/60 transition-colors"
-            >
-              <span className="w-32 shrink-0 tabular-nums text-muted-foreground whitespace-nowrap">{formatFireTime(occurrence)}</span>
-              <span className="flex-1 min-w-0 truncate">
-                occurrence {index + 1}
-                {index === 0 && <span className="text-muted-foreground"> · first</span>}
-              </span>
-              <OccurrenceStatusIcon incident={occurrence} now={now} />
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-            </Link>
-          ))}
+          {group.occurrences.slice(0, anchorIndex + 1).map(renderOccurrence)}
           {group.notLoaded > 0 && (
             <Link
               href={`/incidents/${anchor.id}`}
               className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted/60 transition-colors"
             >
               <span className="flex-1 min-w-0 truncate">
-                {group.notLoaded} older {group.notLoaded === 1 ? 'occurrence' : 'occurrences'} not shown here · open the incident for the full list
+                {group.notLoaded} {group.notLoaded === 1 ? 'occurrence' : 'occurrences'} not shown here · open the incident for the full list
               </span>
               <ChevronRight className="h-4 w-4" />
             </Link>
           )}
+          {group.occurrences.slice(anchorIndex + 1).map((occurrence, i) => renderOccurrence(occurrence, anchorIndex + 1 + i))}
         </ExpandablePanel>
       </CardContent>
     </Card>

--- a/client/src/app/incidents/components/IncidentGroupRow.tsx
+++ b/client/src/app/incidents/components/IncidentGroupRow.tsx
@@ -22,7 +22,7 @@ function formatFireTime(incident: Incident): string {
     : fired.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
 
-function OccurrenceStatusIcon({ incident, now }: { incident: Incident; now: number }) {
+function OccurrenceStatusIcon({ incident, now }: Readonly<{ incident: Incident; now: number }>) {
   if (isStalled(incident, now)) {
     return <AlertTriangle className="h-3.5 w-3.5 text-red-400" aria-label="Investigation stalled" />;
   }
@@ -37,7 +37,7 @@ function OccurrenceStatusIcon({ incident, now }: { incident: Incident; now: numb
  * anchor; the chevron expands the chronological occurrence list without
  * navigating.
  */
-export default function IncidentGroupRow({ group, expanded, onToggle }: IncidentGroupRowProps) {
+export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly<IncidentGroupRowProps>) {
   const { anchor } = group;
   const now = Date.now();
   const isActive = group.section === 'investigating';
@@ -115,6 +115,17 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Incident
               <ChevronRight className="h-4 w-4 text-muted-foreground" />
             </Link>
           ))}
+          {group.notLoaded > 0 && (
+            <Link
+              href={`/incidents/${anchor.id}`}
+              className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted/60 transition-colors"
+            >
+              <span className="flex-1 min-w-0 truncate">
+                {group.notLoaded} older {group.notLoaded === 1 ? 'occurrence' : 'occurrences'} not shown here · open the incident for the full list
+              </span>
+              <ChevronRight className="h-4 w-4" />
+            </Link>
+          )}
         </ExpandablePanel>
       </CardContent>
     </Card>

--- a/client/src/app/incidents/components/IncidentGroupRow.tsx
+++ b/client/src/app/incidents/components/IncidentGroupRow.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertTriangle, CheckCircle2, ChevronRight, Clock, Loader2, Repeat } from 'lucide-react';
+import { Incident, incidentsService } from '@/lib/services/incidents';
+import { IncidentGroup, isGroupStalled, isInvestigating, isStalled, lastFire } from '@/lib/incident-grouping';
+import ExpandablePanel, { ExpandChevron } from './ExpandablePanel';
+
+interface IncidentGroupRowProps {
+  group: IncidentGroup;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function formatFireTime(incident: Incident): string {
+  const fired = new Date(lastFire(incident));
+  const sameDay = fired.toDateString() === new Date().toDateString();
+  return sameDay
+    ? fired.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : fired.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function OccurrenceStatusIcon({ incident, now }: { incident: Incident; now: number }) {
+  if (isStalled(incident, now)) {
+    return <AlertTriangle className="h-3.5 w-3.5 text-red-400" aria-label="Investigation stalled" />;
+  }
+  if (isInvestigating(incident) || incident.status === 'investigating') {
+    return <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" aria-label="Investigating" />;
+  }
+  return <CheckCircle2 className="h-3.5 w-3.5 text-muted-foreground" aria-label="Analyzed" />;
+}
+
+/**
+ * One card per recurrence group on /incidents. The title row links to the
+ * anchor; the chevron expands the chronological occurrence list without
+ * navigating.
+ */
+export default function IncidentGroupRow({ group, expanded, onToggle }: IncidentGroupRowProps) {
+  const { anchor } = group;
+  const now = Date.now();
+  const isActive = group.section === 'investigating';
+  const stalled = isGroupStalled(group, now);
+  // Severity is typed as a closed union but the API can still send 'unknown'.
+  const severity: string = anchor.alert.severity;
+  const showSeverity = (severity && severity !== 'unknown') || anchor.status === 'analyzed';
+
+  return (
+    <Card className={`hover:border-primary/50 transition-colors ${isActive ? 'border-l-4 border-l-muted-foreground' : ''}`}>
+      <CardContent className="p-0">
+        {/* The link carries the row padding so the whole header (bar the chevron) navigates, like IncidentRow. */}
+        <div className="flex items-center">
+          <Link
+            href={`/incidents/${anchor.id}`}
+            aria-label={`View incident: ${anchor.alert.title}`}
+            className="flex-1 min-w-0 flex items-center gap-4 py-3 pl-4 pr-2"
+          >
+            {showSeverity && (
+              <Badge className={incidentsService.getSeverityColor(anchor.alert.severity)}>
+                {anchor.alert.severity} severity
+              </Badge>
+            )}
+
+            <div className="flex-1 min-w-0">
+              <p className="font-medium truncate">{anchor.alert.title}</p>
+              <div className="flex items-center gap-3 text-sm text-muted-foreground mt-0.5">
+                {anchor.alert.service !== 'unknown' && <span>{anchor.alert.service}</span>}
+                <span className="flex items-center gap-1">
+                  <Repeat className="h-3 w-3" />
+                  fired {group.occurrenceCount} times
+                </span>
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {incidentsService.formatDuration(new Date(group.lastFiredAt).toISOString())}
+                </span>
+                {stalled && (
+                  <span className="flex items-center gap-1">
+                    <AlertTriangle className="h-3 w-3 text-red-400" /> Investigation stalled
+                  </span>
+                )}
+                {!stalled && (isActive || group.investigating) && (
+                  <span className="flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" /> Aurora investigating
+                  </span>
+                )}
+              </div>
+            </div>
+          </Link>
+
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Hide occurrences' : 'Show occurrences'}
+            onClick={onToggle}
+            className={`mr-3 p-1 rounded transition-colors ${expanded ? 'bg-muted' : 'hover:bg-muted'}`}
+          >
+            <ExpandChevron open={expanded} className="text-muted-foreground" />
+          </button>
+        </div>
+
+        <ExpandablePanel open={expanded} className="mx-4" contentClassName="py-3 border-t border-border space-y-1">
+          {group.occurrences.map((occurrence, index) => (
+            <Link
+              key={occurrence.id}
+              href={`/incidents/${occurrence.id}`}
+              className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm hover:bg-muted/60 transition-colors"
+            >
+              <span className="w-32 shrink-0 tabular-nums text-muted-foreground whitespace-nowrap">{formatFireTime(occurrence)}</span>
+              <span className="flex-1 min-w-0 truncate">
+                occurrence {index + 1}
+                {index === 0 && <span className="text-muted-foreground"> · first</span>}
+              </span>
+              <OccurrenceStatusIcon incident={occurrence} now={now} />
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </Link>
+          ))}
+        </ExpandablePanel>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/app/incidents/components/IncidentGroupRow.tsx
+++ b/client/src/app/incidents/components/IncidentGroupRow.tsx
@@ -1,11 +1,20 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { AlertTriangle, CheckCircle2, ChevronRight, Clock, Loader2, Repeat } from 'lucide-react';
 import { Incident, incidentsService } from '@/lib/services/incidents';
-import { IncidentGroup, isGroupStalled, isInvestigating, isStalled, lastFire } from '@/lib/incident-grouping';
+import {
+  IncidentGroup,
+  isGroupStalled,
+  isInvestigating,
+  isStalled,
+  lastFire,
+  occurrenceOrdinal,
+  omittedGapIndex,
+} from '@/lib/incident-grouping';
 import ExpandablePanel, { ExpandChevron } from './ExpandablePanel';
 
 interface IncidentGroupRowProps {
@@ -45,25 +54,43 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
   // Severity is typed as a closed union but the API can still send 'unknown'.
   const severity: string = anchor.alert.severity;
   const showSeverity = (severity && severity !== 'unknown') || anchor.status === 'analyzed';
-  // Members the server cut are the oldest, so they sit between the anchor and
-  // the first loaded member: ordinals after the anchor skip them, and the
-  // "not shown" row is rendered in that gap.
-  const anchorIndex = group.occurrences.findIndex(o => o.id === anchor.id);
-  const renderOccurrence = (occurrence: Incident, index: number) => (
+  // Members the server cut are the oldest on the fire timeline, so the "not
+  // shown" row goes just before the oldest loaded member and later ordinals
+  // skip the cut ones (both computed by the grouping helper).
+  const gapIndex = omittedGapIndex(group);
+  const notShownRow = (
     <Link
-      key={occurrence.id}
-      href={`/incidents/${occurrence.id}`}
-      className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm hover:bg-muted/60 transition-colors"
+      key="not-shown"
+      href={`/incidents/${anchor.id}`}
+      className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted/60 transition-colors"
     >
-      <span className="w-32 shrink-0 tabular-nums text-muted-foreground whitespace-nowrap">{formatFireTime(occurrence)}</span>
       <span className="flex-1 min-w-0 truncate">
-        occurrence {index + 1 + (index > anchorIndex ? group.notLoaded : 0)}
-        {index === 0 && <span className="text-muted-foreground"> · first</span>}
+        {group.notLoaded} {group.notLoaded === 1 ? 'occurrence' : 'occurrences'} not shown here · open the incident for the full list
       </span>
-      <OccurrenceStatusIcon incident={occurrence} now={now} />
-      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+      <ChevronRight className="h-4 w-4" />
     </Link>
   );
+  const rows: ReactNode[] = [];
+  group.occurrences.forEach((occurrence, index) => {
+    if (index === gapIndex) rows.push(notShownRow);
+    const ordinal = occurrenceOrdinal(group, index);
+    rows.push(
+      <Link
+        key={occurrence.id}
+        href={`/incidents/${occurrence.id}`}
+        className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm hover:bg-muted/60 transition-colors"
+      >
+        <span className="w-32 shrink-0 tabular-nums text-muted-foreground whitespace-nowrap">{formatFireTime(occurrence)}</span>
+        <span className="flex-1 min-w-0 truncate">
+          occurrence {ordinal}
+          {ordinal === 1 && <span className="text-muted-foreground"> · first</span>}
+        </span>
+        <OccurrenceStatusIcon incident={occurrence} now={now} />
+        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+      </Link>,
+    );
+  });
+  if (gapIndex === group.occurrences.length) rows.push(notShownRow);
 
   return (
     <Card className={`hover:border-primary/50 transition-colors ${isActive ? 'border-l-4 border-l-muted-foreground' : ''}`}>
@@ -122,19 +149,7 @@ export default function IncidentGroupRow({ group, expanded, onToggle }: Readonly
         </div>
 
         <ExpandablePanel open={expanded} className="mx-4" contentClassName="py-3 border-t border-border space-y-1">
-          {group.occurrences.slice(0, anchorIndex + 1).map((occurrence, index) => renderOccurrence(occurrence, index))}
-          {group.notLoaded > 0 && (
-            <Link
-              href={`/incidents/${anchor.id}`}
-              className="flex items-center gap-3 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted/60 transition-colors"
-            >
-              <span className="flex-1 min-w-0 truncate">
-                {group.notLoaded} {group.notLoaded === 1 ? 'occurrence' : 'occurrences'} not shown here · open the incident for the full list
-              </span>
-              <ChevronRight className="h-4 w-4" />
-            </Link>
-          )}
-          {group.occurrences.slice(anchorIndex + 1).map((occurrence, i) => renderOccurrence(occurrence, anchorIndex + 1 + i))}
+          {rows}
         </ExpandablePanel>
       </CardContent>
     </Card>

--- a/client/src/app/incidents/components/OccurrencesSection.tsx
+++ b/client/src/app/incidents/components/OccurrencesSection.tsx
@@ -7,13 +7,16 @@ import { IncidentOccurrence, incidentsService } from '@/lib/services/incidents';
 import ExpandablePanel, { ExpandChevron } from './ExpandablePanel';
 
 interface OccurrencesSectionProps {
-  /** Recurrences folded into this anchor; the anchor itself is occurrence 1. */
+  /** Recurrences folded into this anchor (newest N); the anchor itself is occurrence 1. */
   occurrences: IncidentOccurrence[];
+  /** Full member count from the server; larger than occurrences.length when the list was capped. */
+  total: number;
 }
 
-export default function OccurrencesSection({ occurrences }: Readonly<OccurrencesSectionProps>) {
+export default function OccurrencesSection({ occurrences, total }: Readonly<OccurrencesSectionProps>) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const total = 1 + occurrences.length;
+  const notShown = total - occurrences.length;
+  const fired = 1 + total;
 
   return (
     <div className="mt-4">
@@ -30,7 +33,7 @@ export default function OccurrencesSection({ occurrences }: Readonly<Occurrences
             <Repeat className="w-4 h-4 text-zinc-400" />
           </div>
           <div className="text-left">
-            <span className="text-sm font-medium text-zinc-300">Fired {total} times</span>
+            <span className="text-sm font-medium text-zinc-300">Fired {fired} times</span>
             <p className="text-xs text-zinc-500 mt-0.5">Later occurrences of this root cause</p>
           </div>
         </div>
@@ -44,6 +47,12 @@ export default function OccurrencesSection({ occurrences }: Readonly<Occurrences
         className={`border-zinc-800 ${isExpanded ? 'border border-t-0 rounded-b-lg' : ''}`}
         contentClassName="p-3 space-y-1 bg-zinc-900/20"
       >
+        {/* The list is oldest-first and the server cut the oldest members, so the gap precedes the first row. */}
+        {notShown > 0 && (
+          <p className="px-3 py-2 text-xs text-zinc-500">
+            {notShown} older {notShown === 1 ? 'occurrence' : 'occurrences'} not shown
+          </p>
+        )}
         {occurrences.map(occurrence => (
           <Link
             key={occurrence.id}

--- a/client/src/app/incidents/components/OccurrencesSection.tsx
+++ b/client/src/app/incidents/components/OccurrencesSection.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ChevronRight, Repeat } from 'lucide-react';
+import { IncidentOccurrence, incidentsService } from '@/lib/services/incidents';
+import ExpandablePanel, { ExpandChevron } from './ExpandablePanel';
+
+interface OccurrencesSectionProps {
+  /** Recurrences folded into this anchor; the anchor itself is occurrence 1. */
+  occurrences: IncidentOccurrence[];
+}
+
+export default function OccurrencesSection({ occurrences }: OccurrencesSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const total = 1 + occurrences.length;
+
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded(v => !v)}
+        className={`w-full flex items-center justify-between px-4 py-3 rounded-lg border bg-zinc-900/50 border-zinc-800 hover:bg-zinc-800/50 hover:border-zinc-700 transition-all duration-200 ${
+          isExpanded ? 'rounded-b-none border-b-0' : ''
+        }`}
+      >
+        <div className="flex items-center gap-3">
+          <div className="p-1.5 rounded-md bg-zinc-800">
+            <Repeat className="w-4 h-4 text-zinc-400" />
+          </div>
+          <div className="text-left">
+            <span className="text-sm font-medium text-zinc-300">Fired {total} times</span>
+            <p className="text-xs text-zinc-500 mt-0.5">Later occurrences of this root cause</p>
+          </div>
+        </div>
+        <div className={`p-1 rounded transition-all duration-200 ${isExpanded ? 'bg-zinc-700' : 'hover:bg-zinc-800'}`}>
+          <ExpandChevron open={isExpanded} className="text-zinc-400" />
+        </div>
+      </button>
+
+      <ExpandablePanel
+        open={isExpanded}
+        className={`border-zinc-800 ${isExpanded ? 'border border-t-0 rounded-b-lg' : ''}`}
+        contentClassName="p-3 space-y-1 bg-zinc-900/20"
+      >
+        {occurrences.map(occurrence => (
+          <Link
+            key={occurrence.id}
+            href={`/incidents/${occurrence.id}`}
+            className="flex items-center gap-3 px-3 py-2 rounded-md text-sm hover:bg-zinc-800/50 transition-colors"
+          >
+            <span className="w-20 shrink-0 text-xs text-zinc-500">
+              {incidentsService.formatTimeAgo(occurrence.alertFiredAt ?? occurrence.startedAt)}
+            </span>
+            <span className="flex-1 min-w-0 truncate text-zinc-200">{occurrence.alertTitle}</span>
+            <span className="text-xs text-zinc-500 capitalize">{occurrence.status}</span>
+            <ChevronRight className="w-4 h-4 text-zinc-500" />
+          </Link>
+        ))}
+      </ExpandablePanel>
+    </div>
+  );
+}

--- a/client/src/app/incidents/components/OccurrencesSection.tsx
+++ b/client/src/app/incidents/components/OccurrencesSection.tsx
@@ -11,7 +11,7 @@ interface OccurrencesSectionProps {
   occurrences: IncidentOccurrence[];
 }
 
-export default function OccurrencesSection({ occurrences }: OccurrencesSectionProps) {
+export default function OccurrencesSection({ occurrences }: Readonly<OccurrencesSectionProps>) {
   const [isExpanded, setIsExpanded] = useState(false);
   const total = 1 + occurrences.length;
 

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -6,6 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Zap, Clock, ChevronRight, Loader2, CheckCircle2, Link2, GitMerge, Plus, AlertTriangle } from 'lucide-react';
 import { Incident, incidentsService } from '@/lib/services/incidents';
+import { groupIncidents, IncidentGroup, isStalled } from '@/lib/incident-grouping';
+import IncidentGroupRow from './components/IncidentGroupRow';
 import { useConnectedAccounts } from '@/hooks/useConnectedAccounts';
 import { connectorRegistry } from '@/components/connectors/ConnectorRegistry';
 import { useQuery } from '@/lib/query';
@@ -58,8 +60,10 @@ const incidentsFetcher = async (key: string, signal: AbortSignal) => {
     postMortem: inc.postMortem ?? undefined,
     startedAt: inc.startedAt,
     analyzedAt: inc.analyzedAt,
+    alertFiredAt: inc.alertFiredAt,
     createdAt: inc.createdAt,
     updatedAt: inc.updatedAt,
+    recurrenceOf: inc.recurrenceOf ?? null,
   }));
 };
 
@@ -71,8 +75,9 @@ export default function IncidentsPage() {
     [providerIds],
   );
 
+  // groups=1: the server completes every recurrence group touched by the page.
   const { data: incidents = [], isLoading, mutate } = useQuery<Incident[]>(
-    '/api/incidents',
+    '/api/incidents?groups=1',
     incidentsFetcher,
     { staleTime: 10_000, revalidateOnFocus: true },
   );
@@ -84,14 +89,29 @@ export default function IncidentsPage() {
   useEffect(() => {
     let es: EventSource | null = null;
 
+    // Coalesce bursts (a fold emits incident_update + recurrence_folded per
+    // alert) into one refetch; each mutate() aborts and restarts the request.
+    let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefetch = () => {
+      if (refetchTimer) clearTimeout(refetchTimer);
+      refetchTimer = setTimeout(() => {
+        refetchTimer = null;
+        mutateRef.current();
+      }, 300);
+    };
+
     const connect = () => {
       es?.close();
       es = new EventSource('/api/incidents/stream');
       es.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          if (data.type === 'incident_update') {
-            mutateRef.current();
+          if (
+            data.type === 'incident_update' ||
+            data.type === 'recurrence_folded' ||
+            data.type === 'recurrence_unfolded'
+          ) {
+            scheduleRefetch();
           }
         } catch { /* ignore malformed messages */ }
       };
@@ -107,14 +127,38 @@ export default function IncidentsPage() {
     window.addEventListener('aurora:connection-stale', onStale);
 
     return () => {
+      if (refetchTimer) clearTimeout(refetchTimer);
       es?.close();
       window.removeEventListener('aurora:connection-stale', onStale);
     };
   }, []);
 
-  const activeIncidents = useMemo(() => incidents.filter(i => i.status === 'investigating'), [incidents]);
-  const analyzedIncidents = useMemo(() => incidents.filter(i => i.status === 'analyzed' || i.status === 'resolved'), [incidents]);
-  const mergedIncidents = useMemo(() => incidents.filter(i => i.status === 'merged'), [incidents]);
+  const groups = useMemo(() => groupIncidents(incidents), [incidents]);
+  const activeGroups = useMemo(() => groups.filter(g => g.section === 'investigating'), [groups]);
+  const analyzedGroups = useMemo(() => groups.filter(g => g.section === 'analyzed'), [groups]);
+  const mergedGroups = useMemo(() => groups.filter(g => g.section === 'merged'), [groups]);
+
+  // Keyed by group (anchor) id so an SSE refetch never collapses an open card.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const toggleExpanded = (groupId: string) =>
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+
+  const renderGroup = (group: IncidentGroup) =>
+    group.occurrenceCount === 1 ? (
+      <IncidentRow key={group.id} incident={group.anchor} />
+    ) : (
+      <IncidentGroupRow
+        key={group.id}
+        group={group}
+        expanded={expanded.has(group.id)}
+        onToggle={() => toggleExpanded(group.id)}
+      />
+    );
 
   return (
     <div className="max-w-4xl mx-auto py-8 px-4">
@@ -135,47 +179,41 @@ export default function IncidentsPage() {
             <DisconnectedBanner />
           )}
 
-          {activeIncidents.length > 0 && (
+          {activeGroups.length > 0 && (
             <div>
               <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
                 <span className="relative flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-muted-foreground opacity-75"></span>
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-muted-foreground"></span>
                 </span>
-                Investigating ({activeIncidents.length})
+                Investigating ({activeGroups.length})
               </h2>
               <div className="space-y-2">
-                {activeIncidents.map(incident => (
-                  <IncidentRow key={incident.id} incident={incident} />
-                ))}
+                {activeGroups.map(renderGroup)}
               </div>
             </div>
           )}
 
-          {analyzedIncidents.length > 0 && (
+          {analyzedGroups.length > 0 && (
             <div>
               <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
                 <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
                 Analyzed
               </h2>
               <div className="space-y-2">
-                {analyzedIncidents.map(incident => (
-                  <IncidentRow key={incident.id} incident={incident} />
-                ))}
+                {analyzedGroups.map(renderGroup)}
               </div>
             </div>
           )}
 
-          {mergedIncidents.length > 0 && (
+          {mergedGroups.length > 0 && (
             <div>
               <h2 className="text-sm font-medium text-zinc-600 uppercase tracking-wide mb-3 flex items-center gap-2">
                 <GitMerge className="h-4 w-4 text-zinc-600" />
                 Merged
               </h2>
               <div className="space-y-2">
-                {mergedIncidents.map(incident => (
-                  <IncidentRow key={incident.id} incident={incident} />
-                ))}
+                {mergedGroups.map(renderGroup)}
               </div>
             </div>
           )}
@@ -236,7 +274,7 @@ function IncidentRow({ incident }: { incident: Incident }) {
                 )}
                 {isActive && (
                   <span className="flex items-center gap-1 text-muted-foreground">
-                    {Date.now() - new Date(incident.startedAt).getTime() > 30 * 60 * 1000 ? (
+                    {isStalled(incident, Date.now()) ? (
                       <><AlertTriangle className="h-3 w-3 text-red-400" /> Investigation stalled</>
                     ) : (
                       <><Loader2 className="h-3 w-3 animate-spin" /> Aurora investigating</>

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -64,6 +64,7 @@ const incidentsFetcher = async (key: string, signal: AbortSignal) => {
     createdAt: inc.createdAt,
     updatedAt: inc.updatedAt,
     recurrenceOf: inc.recurrenceOf ?? null,
+    occurrenceTotal: inc.occurrenceTotal,
   }));
 };
 

--- a/client/src/app/incidents/page.tsx
+++ b/client/src/app/incidents/page.tsx
@@ -32,6 +32,10 @@ const ALERT_PROVIDERS = new Set([
   'aws',
 ]);
 
+// SSE refetch coalescing: wait for a burst to settle, but never longer than MAX_WAIT.
+const REFETCH_DEBOUNCE_MS = 300;
+const REFETCH_MAX_WAIT_MS = 2000;
+
 interface IncidentsResponse { incidents: any[] }
 
 const incidentsFetcher = async (key: string, signal: AbortSignal) => {
@@ -91,31 +95,30 @@ export default function IncidentsPage() {
     let es: EventSource | null = null;
 
     // Coalesce bursts (a fold emits incident_update + recurrence_folded per
-    // alert) into one refetch; each mutate() aborts and restarts the request.
+    // alert) into one refetch. Each mutate() aborts and restarts the request,
+    // so under a sustained stream the deferral is capped at MAX_WAIT to let a
+    // refetch land instead of resetting forever.
     let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+    let firstPendingAt = 0;
     const scheduleRefetch = () => {
+      const now = Date.now();
+      if (!firstPendingAt) firstPendingAt = now;
       if (refetchTimer) clearTimeout(refetchTimer);
+      const wait = Math.min(REFETCH_DEBOUNCE_MS, Math.max(0, firstPendingAt + REFETCH_MAX_WAIT_MS - now));
       refetchTimer = setTimeout(() => {
         refetchTimer = null;
+        firstPendingAt = 0;
         mutateRef.current();
-      }, 300);
+      }, wait);
     };
 
     const connect = () => {
       es?.close();
       es = new EventSource('/api/incidents/stream');
-      es.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          if (
-            data.type === 'incident_update' ||
-            data.type === 'recurrence_folded' ||
-            data.type === 'recurrence_unfolded'
-          ) {
-            scheduleRefetch();
-          }
-        } catch { /* ignore malformed messages */ }
-      };
+      // Every message on this stream (incident_update, alert_correlated,
+      // recurrence_folded) changes what the list shows; keepalives are SSE
+      // comments and never reach onmessage.
+      es.onmessage = () => scheduleRefetch();
       es.onerror = () => { /* EventSource reconnects automatically */ };
     };
 

--- a/client/src/lib/incident-grouping.ts
+++ b/client/src/lib/incident-grouping.ts
@@ -59,6 +59,24 @@ function sectionFor(anchor: Incident, members: Incident[], occurrences: Incident
   return null;
 }
 
+/**
+ * Where the members the server did not send sit in `occurrences`: the server
+ * cuts the oldest members on this same fire timeline, so the gap is just before
+ * the oldest loaded member (the anchor may be on either side of it). -1 when
+ * nothing was cut; occurrences.length when only the anchor was loaded.
+ */
+export function omittedGapIndex(group: IncidentGroup): number {
+  if (group.notLoaded === 0) return -1;
+  const firstMember = group.occurrences.findIndex(o => o.id !== group.anchor.id);
+  return firstMember === -1 ? group.occurrences.length : firstMember;
+}
+
+/** 1-based chronological ordinal of `occurrences[index]`, counting the omitted members. */
+export function occurrenceOrdinal(group: IncidentGroup, index: number): number {
+  const gap = omittedGapIndex(group);
+  return index + 1 + (gap !== -1 && index >= gap ? group.notLoaded : 0);
+}
+
 function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup | null {
   const occurrences = [anchor, ...members].sort((a, b) => lastFire(a) - lastFire(b));
   const section = sectionFor(anchor, members, occurrences);

--- a/client/src/lib/incident-grouping.ts
+++ b/client/src/lib/incident-grouping.ts
@@ -50,16 +50,19 @@ export function isGroupStalled(group: IncidentGroup, now: number): boolean {
   return group.occurrences.some(i => isStalled(i, now));
 }
 
-function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup {
-  const occurrences = [anchor, ...members].sort((a, b) => lastFire(a) - lastFire(b));
+/** Section for a group, or null when no occurrence has a status the list shows (e.g. 'failed'). */
+function sectionFor(anchor: Incident, members: Incident[], occurrences: Incident[]): IncidentSection | null {
+  if (occurrences.some(i => i.status === 'investigating')) return 'investigating';
+  // Only a standalone can sit in Merged; recurrences are never `merged`.
+  if (members.length === 0 && anchor.status === 'merged') return 'merged';
+  if (occurrences.some(i => i.status === 'analyzed' || i.status === 'resolved')) return 'analyzed';
+  return null;
+}
 
-  let section: IncidentSection = 'analyzed';
-  if (occurrences.some(i => i.status === 'investigating')) {
-    section = 'investigating';
-  } else if (members.length === 0 && anchor.status === 'merged') {
-    // Only a standalone can sit in Merged; recurrences are never `merged`.
-    section = 'merged';
-  }
+function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup | null {
+  const occurrences = [anchor, ...members].sort((a, b) => lastFire(a) - lastFire(b));
+  const section = sectionFor(anchor, members, occurrences);
+  if (!section) return null;
 
   // The server's group size belongs to a real anchor only. An orphan (its anchor
   // missing from the fetch) carries its original group's total, which is not
@@ -98,6 +101,6 @@ export function groupIncidents(incidents: Incident[]): IncidentGroup[] {
   }
 
   return anchors
-    .map(anchor => buildGroup(anchor, membersByAnchor.get(anchor.id) ?? []))
+    .flatMap(anchor => buildGroup(anchor, membersByAnchor.get(anchor.id) ?? []) ?? [])
     .sort((a, b) => b.lastFiredAt - a.lastFiredAt);
 }

--- a/client/src/lib/incident-grouping.ts
+++ b/client/src/lib/incident-grouping.ts
@@ -61,7 +61,11 @@ function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup {
     section = 'merged';
   }
 
-  const occurrenceCount = Math.max(occurrences.length, anchor.occurrenceTotal ?? 0);
+  // The server's group size belongs to a real anchor only. An orphan (its anchor
+  // missing from the fetch) carries its original group's total, which is not
+  // this singleton's, so it falls back to the rows actually loaded.
+  const serverTotal = anchor.recurrenceOf ? 0 : (anchor.occurrenceTotal ?? 0);
+  const occurrenceCount = Math.max(occurrences.length, serverTotal);
 
   return {
     id: anchor.id,

--- a/client/src/lib/incident-grouping.ts
+++ b/client/src/lib/incident-grouping.ts
@@ -1,0 +1,94 @@
+import type { Incident } from '@/lib/services/incidents';
+
+/**
+ * Root-cause dedup, layer 2: fold recurrences (incidents whose `recurrenceOf`
+ * points at an anchor) into one group per anchor for the /incidents list.
+ * Pure — no React, no fetch. Mirrors the "Grouping formula" in the design doc
+ * root-cause-dedup/02-grouping-ui.md (design-docs repo; not checked in here).
+ */
+
+export type IncidentSection = 'investigating' | 'analyzed' | 'merged';
+
+export interface IncidentGroup {
+  /** Anchor id (or the incident's own id for a standalone / orphan). */
+  id: string;
+  anchor: Incident;
+  /**
+   * Anchor + members, chronological by lastFire. The anchor is usually — not
+   * always — first: a member can fire earlier and still fold into a root
+   * whose RCA completed later.
+   */
+  occurrences: Incident[];
+  /** occurrences.length */
+  occurrenceCount: number;
+  /** Newest fire time across the group (epoch ms). */
+  lastFiredAt: number;
+  section: IncidentSection;
+  /** Any occurrence has auroraStatus running/summarizing. */
+  investigating: boolean;
+}
+
+const STALL_MS = 30 * 60 * 1000;
+
+export function lastFire(incident: Incident): number {
+  const t = Date.parse(incident.alertFiredAt ?? incident.startedAt);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export function isInvestigating(incident: Incident): boolean {
+  return incident.auroraStatus === 'running' || incident.auroraStatus === 'summarizing';
+}
+
+export function isStalled(incident: Incident, now: number): boolean {
+  return incident.status === 'investigating' && now - Date.parse(incident.startedAt) > STALL_MS;
+}
+
+/** Time-dependent, so evaluated at render time rather than baked into the group. */
+export function isGroupStalled(group: IncidentGroup, now: number): boolean {
+  return group.occurrences.some(i => isStalled(i, now));
+}
+
+function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup {
+  const occurrences = [anchor, ...members].sort((a, b) => lastFire(a) - lastFire(b));
+
+  let section: IncidentSection = 'analyzed';
+  if (occurrences.some(i => i.status === 'investigating')) {
+    section = 'investigating';
+  } else if (members.length === 0 && anchor.status === 'merged') {
+    // Only a standalone can sit in Merged; recurrences are never `merged`.
+    section = 'merged';
+  }
+
+  return {
+    id: anchor.id,
+    anchor,
+    occurrences,
+    occurrenceCount: occurrences.length,
+    lastFiredAt: lastFire(occurrences[occurrences.length - 1]),
+    section,
+    investigating: occurrences.some(isInvestigating),
+  };
+}
+
+export function groupIncidents(incidents: Incident[]): IncidentGroup[] {
+  const byId = new Map(incidents.map(i => [i.id, i]));
+  const membersByAnchor = new Map<string, Incident[]>();
+  const anchors: Incident[] = [];
+
+  for (const incident of incidents) {
+    const anchor = incident.recurrenceOf ? byId.get(incident.recurrenceOf) : undefined;
+    // A member joins its anchor only when the anchor is in the fetch and is
+    // itself top-level; anything else becomes its own row so nothing is hidden.
+    if (anchor && !anchor.recurrenceOf) {
+      const list = membersByAnchor.get(anchor.id) ?? [];
+      list.push(incident);
+      membersByAnchor.set(anchor.id, list);
+    } else {
+      anchors.push(incident);
+    }
+  }
+
+  return anchors
+    .map(anchor => buildGroup(anchor, membersByAnchor.get(anchor.id) ?? []))
+    .sort((a, b) => b.lastFiredAt - a.lastFiredAt);
+}

--- a/client/src/lib/incident-grouping.ts
+++ b/client/src/lib/incident-grouping.ts
@@ -19,8 +19,10 @@ export interface IncidentGroup {
    * whose RCA completed later.
    */
   occurrences: Incident[];
-  /** occurrences.length */
+  /** Full group size: loaded occurrences, or the server's count when the group was capped. */
   occurrenceCount: number;
+  /** Older occurrences the list response did not include (0 unless the group was capped). */
+  notLoaded: number;
   /** Newest fire time across the group (epoch ms). */
   lastFiredAt: number;
   section: IncidentSection;
@@ -59,12 +61,15 @@ function buildGroup(anchor: Incident, members: Incident[]): IncidentGroup {
     section = 'merged';
   }
 
+  const occurrenceCount = Math.max(occurrences.length, anchor.occurrenceTotal ?? 0);
+
   return {
     id: anchor.id,
     anchor,
     occurrences,
-    occurrenceCount: occurrences.length,
-    lastFiredAt: lastFire(occurrences[occurrences.length - 1]),
+    occurrenceCount,
+    notLoaded: occurrenceCount - occurrences.length,
+    lastFiredAt: lastFire(occurrences.at(-1) ?? anchor),
     section,
     investigating: occurrences.some(isInvestigating),
   };

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -216,6 +216,15 @@ export interface CorrelatedAlert {
   receivedAt: string;
 }
 
+/** A later incident folded into an anchor by the recurrence detector (detail view of the anchor). */
+export interface IncidentOccurrence {
+  id: string;
+  alertTitle: string;
+  status: IncidentStatus;
+  startedAt: string;
+  alertFiredAt?: string;
+}
+
 export interface Incident {
   id: string;
   alert: Alert;
@@ -230,6 +239,9 @@ export interface Incident {
   correlatedAlertCount?: number; // Count of correlated alerts (for list view)
   mergedIntoIncidentId?: string; // ID of incident this was merged into
   mergedIntoTitle?: string; // Title of incident this was merged into
+  recurrenceOf?: string | null; // Anchor incident id when this is a recurrence (root-cause dedup)
+  recurrenceOfTitle?: string; // Anchor's title (detail view only)
+  occurrences?: IncidentOccurrence[]; // Recurrences folded into this anchor (detail view only)
   postMortem?: PostmortemData;
   startedAt: string;
   analyzedAt?: string;
@@ -285,6 +297,7 @@ export const incidentsService = {
         correlatedAlertCount: inc.correlatedAlertCount || 0,
         mergedIntoIncidentId: inc.mergedIntoIncidentId,
         mergedIntoTitle: inc.mergedIntoTitle,
+        recurrenceOf: inc.recurrenceOf ?? null,
         postMortem: inc.postMortem ?? undefined,
         startedAt: inc.startedAt,
         analyzedAt: inc.analyzedAt,
@@ -371,6 +384,15 @@ export const incidentsService = {
         })),
         mergedIntoIncidentId: inc.mergedIntoIncidentId,
         mergedIntoTitle: inc.mergedIntoTitle,
+        recurrenceOf: inc.recurrenceOf ?? null,
+        recurrenceOfTitle: inc.recurrenceOfTitle,
+        occurrences: (inc.occurrences || []).map((o: any): IncidentOccurrence => ({
+          id: o.id,
+          alertTitle: o.alertTitle,
+          status: o.status as IncidentStatus,
+          startedAt: o.startedAt,
+          alertFiredAt: o.alertFiredAt ?? undefined,
+        })),
         postMortem: inc.postMortem ?? undefined,
         startedAt: inc.startedAt,
         analyzedAt: inc.analyzedAt,

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -243,6 +243,7 @@ export interface Incident {
   recurrenceOfTitle?: string; // Anchor's title (detail view only)
   occurrences?: IncidentOccurrence[]; // Recurrences folded into this anchor (detail view only)
   occurrenceTotal?: number; // Full group size from the server (list ?groups=1 only); exceeds loaded rows when the group was capped
+  occurrencesTotal?: number; // Full member count (detail view); exceeds occurrences.length when the detail list was capped
   postMortem?: PostmortemData;
   startedAt: string;
   analyzedAt?: string;
@@ -395,6 +396,7 @@ export const incidentsService = {
           startedAt: o.startedAt,
           alertFiredAt: o.alertFiredAt ?? undefined,
         })),
+        occurrencesTotal: inc.occurrencesTotal,
         postMortem: inc.postMortem ?? undefined,
         startedAt: inc.startedAt,
         analyzedAt: inc.analyzedAt,
@@ -427,7 +429,8 @@ export const incidentsService = {
   formatDuration(startTime: string): string {
     const start = new Date(startTime).getTime();
     const end = Date.now();
-    const diffMs = end - start;
+    // Provider fire times can run slightly ahead of this clock; never print "-1m".
+    const diffMs = Math.max(0, end - start);
     const diffMins = Math.floor(diffMs / 60000);
     const hours = Math.floor(diffMins / 60);
     const days = Math.floor(hours / 24);
@@ -445,7 +448,7 @@ export const incidentsService = {
   },
 
   formatTimeAgo(timestamp: string): string {
-    const diffMs = Date.now() - new Date(timestamp).getTime();
+    const diffMs = Math.max(0, Date.now() - new Date(timestamp).getTime());
     const diffMins = Math.floor(diffMs / 60000);
     const hours = Math.floor(diffMins / 60);
     const days = Math.floor(hours / 24);

--- a/client/src/lib/services/incidents.ts
+++ b/client/src/lib/services/incidents.ts
@@ -242,6 +242,7 @@ export interface Incident {
   recurrenceOf?: string | null; // Anchor incident id when this is a recurrence (root-cause dedup)
   recurrenceOfTitle?: string; // Anchor's title (detail view only)
   occurrences?: IncidentOccurrence[]; // Recurrences folded into this anchor (detail view only)
+  occurrenceTotal?: number; // Full group size from the server (list ?groups=1 only); exceeds loaded rows when the group was capped
   postMortem?: PostmortemData;
   startedAt: string;
   analyzedAt?: string;
@@ -298,6 +299,7 @@ export const incidentsService = {
         mergedIntoIncidentId: inc.mergedIntoIncidentId,
         mergedIntoTitle: inc.mergedIntoTitle,
         recurrenceOf: inc.recurrenceOf ?? null,
+        occurrenceTotal: inc.occurrenceTotal,
         postMortem: inc.postMortem ?? undefined,
         startedAt: inc.startedAt,
         analyzedAt: inc.analyzedAt,

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -288,8 +288,7 @@ def _format_incident_response(
 
 # Column list shared by the list and detail endpoints; the tuple order must
 # match the include_merge_target branch of _format_incident_response.
-_INCIDENT_SELECT = """
-    SELECT
+_INCIDENT_COLUMNS = """
         i.id, i.user_id, i.source_type, i.source_alert_id, i.status, i.severity,
         i.alert_title, i.alert_service, i.alert_environment, i.aurora_status, i.aurora_summary,
         i.aurora_chat_session_id, i.started_at, i.analyzed_at, i.active_tab, i.created_at, i.updated_at,
@@ -297,10 +296,13 @@ _INCIDENT_SELECT = """
         i.alert_metadata, i.correlated_alert_count, i.affected_services,
         i.merged_into_incident_id, target.alert_title AS merged_into_title,
         i.recurrence_of_incident_id, anchor.alert_title AS recurrence_of_title
+"""
+_INCIDENT_FROM = """
     FROM incidents i
     LEFT JOIN incidents target ON i.merged_into_incident_id = target.id
     LEFT JOIN incidents anchor ON i.recurrence_of_incident_id = anchor.id
 """
+_INCIDENT_SELECT = "SELECT" + _INCIDENT_COLUMNS + _INCIDENT_FROM
 
 # Upper bound on rows returned by ``groups=1`` completion. Layer 1 caps a group
 # only by 24h idle time, so a flapping alert can fold thousands of members
@@ -349,7 +351,8 @@ def get_incidents(user_id):
                     page_tail += " OFFSET %s"
                     page_params.append(offset)
 
-                if request.args.get("groups") in ("1", "true"):
+                include_groups = request.args.get("groups") in ("1", "true")
+                if include_groups:
                     # Group completion: the page (limit/offset/status) only
                     # decides which recurrence groups are visible; every
                     # non-merged anchor and member of those groups is then
@@ -360,14 +363,19 @@ def get_incidents(user_id):
                     # The writer (recurrence_fold) keeps pointers depth-1 —
                     # only that depth is completed here. Anchors sort first so
                     # the _GROUPS_MAX_ROWS cut drops the oldest members, never
-                    # the group root.
+                    # the group root. group_size is a window count, evaluated
+                    # before the LIMIT, so each row carries the full non-merged
+                    # size of its group and the client can tell when members
+                    # were cut.
                     query = (
                         "WITH roots AS ("
                         "SELECT COALESCE(i.recurrence_of_incident_id, i.id) AS root_id FROM incidents i"
                         + page_where
                         + page_tail
-                        + ")"
-                        + _INCIDENT_SELECT
+                        + ") SELECT"
+                        + _INCIDENT_COLUMNS
+                        + ", COUNT(*) OVER (PARTITION BY COALESCE(i.recurrence_of_incident_id, i.id)) AS group_size"
+                        + _INCIDENT_FROM
                         + """
                     WHERE i.org_id = %s
                       AND i.status != 'merged'
@@ -386,16 +394,23 @@ def get_incidents(user_id):
                 rows = cursor.fetchall()
 
                 source_urls: Dict[str, str] = {}
-                incidents = [
-                    _format_incident_response(
+                incidents = []
+                for row in rows:
+                    group_size = None
+                    if include_groups:
+                        row, group_size = row[:-1], row[-1]
+                    incident = _format_incident_response(
                         row,
                         include_metadata=True,
                         include_correlation=True,
                         include_merge_target=True,
                         source_url_cache=source_urls,
                     )
-                    for row in rows
-                ]
+                    if include_groups:
+                        # Anchor + members in the DB; larger than the rows
+                        # returned when the group was cut at _GROUPS_MAX_ROWS.
+                        incident["occurrenceTotal"] = group_size
+                    incidents.append(incident)
 
                 logger.info(
                     "[INCIDENTS] Retrieved %d incidents for user %s",

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -375,9 +375,11 @@ def get_incidents(user_id):
                     # The writer (recurrence_fold) keeps pointers depth-1 —
                     # only that depth is completed here; UNION (not UNION ALL)
                     # keeps a depth-2 node from coming back twice. Anchors sort
-                    # first, then members by rank within their group, so the
-                    # _GROUPS_MAX_ROWS cut trims the largest groups' oldest
-                    # members first and never a group root or a small group.
+                    # first, then members by rank within their group on the
+                    # fire timeline the client sorts by (alert_fired_at, else
+                    # started_at), so the _GROUPS_MAX_ROWS cut trims the largest
+                    # groups' oldest members first and never a group root or a
+                    # small group.
                     # group_size is a window count, evaluated before the LIMIT,
                     # so each row carries the full non-merged size of its group
                     # and the client can tell when members were cut.
@@ -403,8 +405,8 @@ def get_incidents(user_id):
                       AND i.status != 'merged'
                     ORDER BY (i.recurrence_of_incident_id IS NULL) DESC,
                              ROW_NUMBER() OVER (PARTITION BY COALESCE(i.recurrence_of_incident_id, i.id)
-                                                ORDER BY i.started_at DESC),
-                             i.started_at DESC
+                                                ORDER BY COALESCE(i.alert_fired_at, i.started_at) DESC),
+                             COALESCE(i.alert_fired_at, i.started_at) DESC
                     LIMIT %s
                         """
                     )

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -11,7 +11,7 @@ from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.log_sanitizer import hash_for_log, sanitize
 from chat.background.task import run_background_chat
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from utils.validation import is_valid_uuid
 from chat.background.task import create_background_chat_session, run_background_chat
 
@@ -102,13 +102,14 @@ def _format_incident_response(
     include_metadata: bool = False,
     include_correlation: bool = False,
     include_merge_target: bool = False,
-    source_url_cache: Optional[Dict[str, str]] = None,
+    source_url_cache: Optional[Dict[Tuple[str, str], str]] = None,
 ) -> Dict[str, Any]:
     """Format database row into incident response object.
 
-    ``source_url_cache`` (keyed by source_type) lets a caller formatting many
-    rows resolve each provider's URL once instead of once per row —
-    ``_build_source_url`` opens its own DB connection.
+    ``source_url_cache`` (keyed by ``(source_type, user_id)``) lets a caller
+    formatting many rows resolve each provider URL once per user instead of
+    once per row — ``_build_source_url`` opens its own DB connection and reads
+    that user's integration settings, so the key must include the user.
     """
     if include_merge_target:
         (
@@ -227,12 +228,13 @@ def _format_incident_response(
         recurrence_of_incident_id = None
         recurrence_of_title = None
 
-    if source_url_cache is not None and source_type in source_url_cache:
-        source_url = source_url_cache[source_type]
+    cache_key = (source_type, user_id)
+    if source_url_cache is not None and cache_key in source_url_cache:
+        source_url = source_url_cache[cache_key]
     else:
         source_url = _build_source_url(source_type, user_id)
         if source_url_cache is not None:
-            source_url_cache[source_type] = source_url
+            source_url_cache[cache_key] = source_url
 
     result = {
         "id": str(incident_id),
@@ -393,7 +395,7 @@ def get_incidents(user_id):
                 cursor.execute(query, tuple(params))
                 rows = cursor.fetchall()
 
-                source_urls: Dict[str, str] = {}
+                source_urls: Dict[Tuple[str, str], str] = {}
                 incidents = []
                 for row in rows:
                     group_size = None

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -98,9 +98,18 @@ def _record_lifecycle_event(cursor, incident_id, user_id, event_type, previous_v
 
 
 def _format_incident_response(
-    row: tuple, include_metadata: bool = False, include_correlation: bool = False, include_merge_target: bool = False
+    row: tuple,
+    include_metadata: bool = False,
+    include_correlation: bool = False,
+    include_merge_target: bool = False,
+    source_url_cache: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
-    """Format database row into incident response object."""
+    """Format database row into incident response object.
+
+    ``source_url_cache`` (keyed by source_type) lets a caller formatting many
+    rows resolve each provider's URL once instead of once per row —
+    ``_build_source_url`` opens its own DB connection.
+    """
     if include_merge_target:
         (
             incident_id,
@@ -127,6 +136,8 @@ def _format_incident_response(
             affected_services,
             merged_into_incident_id,
             merged_into_title,
+            recurrence_of_incident_id,
+            recurrence_of_title,
         ) = row
     elif include_correlation:
         (
@@ -155,6 +166,8 @@ def _format_incident_response(
         ) = row
         merged_into_incident_id = None
         merged_into_title = None
+        recurrence_of_incident_id = None
+        recurrence_of_title = None
     elif include_metadata:
         (
             incident_id,
@@ -182,6 +195,8 @@ def _format_incident_response(
         affected_services = None
         merged_into_incident_id = None
         merged_into_title = None
+        recurrence_of_incident_id = None
+        recurrence_of_title = None
     else:
         (
             incident_id,
@@ -209,6 +224,15 @@ def _format_incident_response(
         affected_services = None
         merged_into_incident_id = None
         merged_into_title = None
+        recurrence_of_incident_id = None
+        recurrence_of_title = None
+
+    if source_url_cache is not None and source_type in source_url_cache:
+        source_url = source_url_cache[source_type]
+    else:
+        source_url = _build_source_url(source_type, user_id)
+        if source_url_cache is not None:
+            source_url_cache[source_type] = source_url
 
     result = {
         "id": str(incident_id),
@@ -220,7 +244,7 @@ def _format_incident_response(
             "title": alert_title,
             "service": alert_service or "unknown",
             "source": source_type,
-            "sourceUrl": _build_source_url(source_type, user_id),
+            "sourceUrl": source_url,
         },
         "auroraStatus": aurora_status or "idle",
         "summary": aurora_summary or "",
@@ -253,7 +277,35 @@ def _format_incident_response(
         result["mergedIntoIncidentId"] = str(merged_into_incident_id)
         result["mergedIntoTitle"] = merged_into_title
 
+    # Recurrence pointer (root-cause dedup layer 1). Always emitted so the
+    # list view can group without a second lookup; title only when set.
+    result["recurrenceOf"] = str(recurrence_of_incident_id) if recurrence_of_incident_id else None
+    if recurrence_of_incident_id is not None:
+        result["recurrenceOfTitle"] = recurrence_of_title
+
     return result
+
+
+# Column list shared by the list and detail endpoints; the tuple order must
+# match the include_merge_target branch of _format_incident_response.
+_INCIDENT_SELECT = """
+    SELECT
+        i.id, i.user_id, i.source_type, i.source_alert_id, i.status, i.severity,
+        i.alert_title, i.alert_service, i.alert_environment, i.aurora_status, i.aurora_summary,
+        i.aurora_chat_session_id, i.started_at, i.analyzed_at, i.active_tab, i.created_at, i.updated_at,
+        i.resolved_at, i.alert_fired_at,
+        i.alert_metadata, i.correlated_alert_count, i.affected_services,
+        i.merged_into_incident_id, target.alert_title AS merged_into_title,
+        i.recurrence_of_incident_id, anchor.alert_title AS recurrence_of_title
+    FROM incidents i
+    LEFT JOIN incidents target ON i.merged_into_incident_id = target.id
+    LEFT JOIN incidents anchor ON i.recurrence_of_incident_id = anchor.id
+"""
+
+# Upper bound on rows returned by ``groups=1`` completion. Layer 1 caps a group
+# only by 24h idle time, so a flapping alert can fold thousands of members
+# under one anchor; without this the list response is unbounded.
+_GROUPS_MAX_ROWS = 1000
 
 
 @incidents_bp.route("/api/incidents", methods=["GET"])
@@ -267,54 +319,80 @@ def get_incidents(user_id):
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
 
-                query = """
-                    SELECT 
-                        i.id, i.user_id, i.source_type, i.source_alert_id, i.status, i.severity,
-                        i.alert_title, i.alert_service, i.alert_environment, i.aurora_status, i.aurora_summary,
-                        i.aurora_chat_session_id, i.started_at, i.analyzed_at, i.active_tab, i.created_at, i.updated_at,
-                        i.resolved_at, i.alert_fired_at,
-                        i.alert_metadata, i.correlated_alert_count, i.affected_services,
-                        i.merged_into_incident_id, target.alert_title as merged_into_title
-                    FROM incidents i
-                    LEFT JOIN incidents target ON i.merged_into_incident_id = target.id
+                # Filters for the page of newest incidents. In `groups` mode the
+                # same page is used only to pick which recurrence groups to load.
+                page_where = """
                     WHERE i.org_id = %s
                       AND i.status != 'merged'
                 """
-                params = [org_id]
+                page_params = [org_id]
 
                 status_filter = request.args.get("status")
                 if status_filter:
-                    query += " AND i.status = %s"
-                    params.append(status_filter)
+                    page_where += " AND i.status = %s"
+                    page_params.append(status_filter)
 
-                query += " ORDER BY i.started_at DESC"
-
-                # Get total count for pagination before applying LIMIT/OFFSET
-                count_query = "SELECT COUNT(*) FROM incidents i WHERE i.org_id = %s AND i.status != 'merged'"
-                count_params = [org_id]
-                if status_filter:
-                    count_query += " AND i.status = %s"
-                    count_params.append(status_filter)
-                cursor.execute(count_query, tuple(count_params))
+                # Total for pagination: same predicate as the page, before LIMIT/OFFSET.
+                cursor.execute("SELECT COUNT(*) FROM incidents i" + page_where, tuple(page_params))
                 total_count = cursor.fetchone()[0]
+
+                page_tail = " ORDER BY i.started_at DESC"
 
                 limit = request.args.get("limit", 100, type=int)
                 limit = max(1, min(limit, 100))
-                query += " LIMIT %s"
-                params.append(limit)
+                page_tail += " LIMIT %s"
+                page_params.append(limit)
 
                 offset = request.args.get("offset", 0, type=int)
                 offset = max(0, offset)
                 if offset > 0:
-                    query += " OFFSET %s"
-                    params.append(offset)
+                    page_tail += " OFFSET %s"
+                    page_params.append(offset)
+
+                if request.args.get("groups") in ("1", "true"):
+                    # Group completion: the page (limit/offset/status) only
+                    # decides which recurrence groups are visible; every
+                    # non-merged anchor and member of those groups is then
+                    # returned so a group never straddles the LIMIT. Result
+                    # stays a flat list. Contract consequences: rows of other
+                    # statuses can appear, consecutive offsets can repeat a
+                    # group, and `total` still counts page-eligible incidents.
+                    # The writer (recurrence_fold) keeps pointers depth-1 —
+                    # only that depth is completed here. Anchors sort first so
+                    # the _GROUPS_MAX_ROWS cut drops the oldest members, never
+                    # the group root.
+                    query = (
+                        "WITH roots AS ("
+                        "SELECT COALESCE(i.recurrence_of_incident_id, i.id) AS root_id FROM incidents i"
+                        + page_where
+                        + page_tail
+                        + ")"
+                        + _INCIDENT_SELECT
+                        + """
+                    WHERE i.org_id = %s
+                      AND i.status != 'merged'
+                      AND (i.id IN (SELECT root_id FROM roots)
+                           OR i.recurrence_of_incident_id IN (SELECT root_id FROM roots))
+                    ORDER BY (i.recurrence_of_incident_id IS NULL) DESC, i.started_at DESC
+                    LIMIT %s
+                        """
+                    )
+                    params = page_params + [org_id, _GROUPS_MAX_ROWS]
+                else:
+                    query = _INCIDENT_SELECT + page_where + page_tail
+                    params = page_params
 
                 cursor.execute(query, tuple(params))
                 rows = cursor.fetchall()
 
+                source_urls: Dict[str, str] = {}
                 incidents = [
                     _format_incident_response(
-                        row, include_metadata=True, include_correlation=True, include_merge_target=True
+                        row,
+                        include_metadata=True,
+                        include_correlation=True,
+                        include_merge_target=True,
+                        source_url_cache=source_urls,
                     )
                     for row in rows
                 ]
@@ -349,18 +427,7 @@ def get_incident(user_id, incident_id: str):
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
                 # Get incident details
                 cursor.execute(
-                    """
-                    SELECT 
-                        i.id, i.user_id, i.source_type, i.source_alert_id, i.status, i.severity,
-                        i.alert_title, i.alert_service, i.alert_environment, i.aurora_status, i.aurora_summary,
-                        i.aurora_chat_session_id, i.started_at, i.analyzed_at, i.active_tab, i.created_at, i.updated_at,
-                        i.resolved_at, i.alert_fired_at,
-                        i.alert_metadata, i.correlated_alert_count, i.affected_services,
-                        i.merged_into_incident_id, target.alert_title as merged_into_title
-                    FROM incidents i
-                    LEFT JOIN incidents target ON i.merged_into_incident_id = target.id
-                    WHERE i.id = %s AND i.org_id = %s
-                    """,
+                    _INCIDENT_SELECT + " WHERE i.id = %s AND i.org_id = %s",
                     (incident_id, org_id),
                 )
                 row = cursor.fetchone()
@@ -635,6 +702,27 @@ def get_incident(user_id, incident_id: str):
                         }
                     )
                 incident["correlatedAlerts"] = correlated_alerts
+
+                # Later occurrences folded into this incident (root-cause dedup).
+                # Only anchors carry the list; members link back via recurrenceOf.
+                if incident["recurrenceOf"] is None:
+                    cursor.execute(
+                        """SELECT id, alert_title, status, started_at, alert_fired_at
+                           FROM incidents
+                           WHERE recurrence_of_incident_id = %s AND org_id = %s
+                           ORDER BY COALESCE(alert_fired_at, started_at) ASC""",
+                        (incident_id, org_id),
+                    )
+                    incident["occurrences"] = [
+                        {
+                            "id": str(orow[0]),
+                            "alertTitle": orow[1],
+                            "status": orow[2],
+                            "startedAt": iso_utc(orow[3]),
+                            "alertFiredAt": iso_utc(orow[4]),
+                        }
+                        for orow in cursor.fetchall()
+                    ]
 
                 # Get suggestions (including fix-type fields)
                 cursor.execute(

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -111,6 +111,7 @@ def _format_incident_response(
     once per row — ``_build_source_url`` opens its own DB connection and reads
     that user's integration settings, so the key must include the user.
     """
+    recurrence_of_incident_id = recurrence_of_title = None  # only the merge-target row carries them
     if include_merge_target:
         (
             incident_id,
@@ -167,8 +168,6 @@ def _format_incident_response(
         ) = row
         merged_into_incident_id = None
         merged_into_title = None
-        recurrence_of_incident_id = None
-        recurrence_of_title = None
     elif include_metadata:
         (
             incident_id,
@@ -196,8 +195,6 @@ def _format_incident_response(
         affected_services = None
         merged_into_incident_id = None
         merged_into_title = None
-        recurrence_of_incident_id = None
-        recurrence_of_title = None
     else:
         (
             incident_id,
@@ -225,16 +222,12 @@ def _format_incident_response(
         affected_services = None
         merged_into_incident_id = None
         merged_into_title = None
-        recurrence_of_incident_id = None
-        recurrence_of_title = None
 
+    cache = source_url_cache if source_url_cache is not None else {}
     cache_key = (source_type, user_id)
-    if source_url_cache is not None and cache_key in source_url_cache:
-        source_url = source_url_cache[cache_key]
-    else:
-        source_url = _build_source_url(source_type, user_id)
-        if source_url_cache is not None:
-            source_url_cache[cache_key] = source_url
+    if cache_key not in cache:
+        cache[cache_key] = _build_source_url(source_type, user_id)
+    source_url = cache[cache_key]
 
     result = {
         "id": str(incident_id),
@@ -299,17 +292,29 @@ _INCIDENT_COLUMNS = """
         i.merged_into_incident_id, target.alert_title AS merged_into_title,
         i.recurrence_of_incident_id, anchor.alert_title AS recurrence_of_title
 """
-_INCIDENT_FROM = """
-    FROM incidents i
+_INCIDENT_JOINS = """
     LEFT JOIN incidents target ON i.merged_into_incident_id = target.id
     LEFT JOIN incidents anchor ON i.recurrence_of_incident_id = anchor.id
 """
+_INCIDENT_FROM = "\n    FROM incidents i" + _INCIDENT_JOINS
 _INCIDENT_SELECT = "SELECT" + _INCIDENT_COLUMNS + _INCIDENT_FROM
+
+# ``groups=1`` feeds only the list page, which never renders the RCA summary or
+# the raw alert payload; a completed response can hold _GROUPS_MAX_ROWS rows,
+# so those two columns are left NULL there (tuple order unchanged).
+_GROUP_LIST_COLUMNS = _INCIDENT_COLUMNS.replace("i.aurora_summary,", "NULL AS aurora_summary,").replace(
+    "i.alert_metadata,", "NULL AS alert_metadata,"
+)
 
 # Upper bound on rows returned by ``groups=1`` completion. Layer 1 caps a group
 # only by 24h idle time, so a flapping alert can fold thousands of members
 # under one anchor; without this the list response is unbounded.
 _GROUPS_MAX_ROWS = 1000
+
+# Upper bound on ``occurrences`` returned by the anchor detail (newest first);
+# the response also carries ``occurrencesTotal`` so the page can say how many
+# were cut.
+_OCCURRENCES_MAX_ROWS = 200
 
 
 @incidents_bp.route("/api/incidents", methods=["GET"])
@@ -323,8 +328,9 @@ def get_incidents(user_id):
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
 
-                # Filters for the page of newest incidents. In `groups` mode the
-                # same page is used only to pick which recurrence groups to load.
+                # Filters shared by the page and its total. In `groups` mode the
+                # page is a page of recurrence groups (roots), not incidents.
+                include_groups = request.args.get("groups") in ("1", "true")
                 page_where = """
                     WHERE i.org_id = %s
                       AND i.status != 'merged'
@@ -337,59 +343,74 @@ def get_incidents(user_id):
                     page_params.append(status_filter)
 
                 # Total for pagination: same predicate as the page, before LIMIT/OFFSET.
-                cursor.execute("SELECT COUNT(*) FROM incidents i" + page_where, tuple(page_params))
+                # In groups mode it counts groups, matching what limit/offset page over.
+                count_expr = (
+                    "COUNT(DISTINCT COALESCE(i.recurrence_of_incident_id, i.id))" if include_groups else "COUNT(*)"
+                )
+                cursor.execute("SELECT " + count_expr + " FROM incidents i" + page_where, tuple(page_params))
                 total_count = cursor.fetchone()[0]
 
-                page_tail = " ORDER BY i.started_at DESC"
+                # groups mode: one row per group, newest fire first (same key the
+                # client sorts groups by), so a flapping group cannot fill the page.
+                order_sql = " GROUP BY 1 ORDER BY 2 DESC" if include_groups else " ORDER BY i.started_at DESC"
 
                 limit = request.args.get("limit", 100, type=int)
                 limit = max(1, min(limit, 100))
-                page_tail += " LIMIT %s"
+                order_sql += " LIMIT %s"
                 page_params.append(limit)
 
                 offset = request.args.get("offset", 0, type=int)
                 offset = max(0, offset)
                 if offset > 0:
-                    page_tail += " OFFSET %s"
+                    order_sql += " OFFSET %s"
                     page_params.append(offset)
 
-                include_groups = request.args.get("groups") in ("1", "true")
                 if include_groups:
-                    # Group completion: the page (limit/offset/status) only
-                    # decides which recurrence groups are visible; every
-                    # non-merged anchor and member of those groups is then
-                    # returned so a group never straddles the LIMIT. Result
-                    # stays a flat list. Contract consequences: rows of other
-                    # statuses can appear, consecutive offsets can repeat a
-                    # group, and `total` still counts page-eligible incidents.
+                    # Group completion: limit/offset/status pick a page of
+                    # recurrence groups (roots); every non-merged anchor and
+                    # member of those groups is then returned so a group never
+                    # straddles the page. Result stays a flat list. Contract
+                    # consequences: rows of other statuses can appear inside a
+                    # selected group, and limit/offset/total count groups.
                     # The writer (recurrence_fold) keeps pointers depth-1 —
-                    # only that depth is completed here. Anchors sort first so
-                    # the _GROUPS_MAX_ROWS cut drops the oldest members, never
-                    # the group root. group_size is a window count, evaluated
-                    # before the LIMIT, so each row carries the full non-merged
-                    # size of its group and the client can tell when members
-                    # were cut.
+                    # only that depth is completed here; UNION (not UNION ALL)
+                    # keeps a depth-2 node from coming back twice. Anchors sort
+                    # first, then members by rank within their group, so the
+                    # _GROUPS_MAX_ROWS cut trims the largest groups' oldest
+                    # members first and never a group root or a small group.
+                    # group_size is a window count, evaluated before the LIMIT,
+                    # so each row carries the full non-merged size of its group
+                    # and the client can tell when members were cut.
                     query = (
                         "WITH roots AS ("
-                        "SELECT COALESCE(i.recurrence_of_incident_id, i.id) AS root_id FROM incidents i"
+                        "SELECT COALESCE(i.recurrence_of_incident_id, i.id) AS root_id,"
+                        " MAX(COALESCE(i.alert_fired_at, i.started_at)) AS last_fired FROM incidents i"
                         + page_where
-                        + page_tail
-                        + ") SELECT"
-                        + _INCIDENT_COLUMNS
+                        + order_sql
+                        # Completion as two index joins (pkey, idx_incidents_recurrence);
+                        # an OR of two IN-subqueries here scans the whole org.
+                        + "), members AS ("
+                        "SELECT i.* FROM roots r JOIN incidents i ON i.id = r.root_id"
+                        " UNION "
+                        "SELECT i.* FROM roots r JOIN incidents i ON i.recurrence_of_incident_id = r.root_id"
+                        ") SELECT"
+                        + _GROUP_LIST_COLUMNS
                         + ", COUNT(*) OVER (PARTITION BY COALESCE(i.recurrence_of_incident_id, i.id)) AS group_size"
-                        + _INCIDENT_FROM
+                        + " FROM members i"
+                        + _INCIDENT_JOINS
                         + """
                     WHERE i.org_id = %s
                       AND i.status != 'merged'
-                      AND (i.id IN (SELECT root_id FROM roots)
-                           OR i.recurrence_of_incident_id IN (SELECT root_id FROM roots))
-                    ORDER BY (i.recurrence_of_incident_id IS NULL) DESC, i.started_at DESC
+                    ORDER BY (i.recurrence_of_incident_id IS NULL) DESC,
+                             ROW_NUMBER() OVER (PARTITION BY COALESCE(i.recurrence_of_incident_id, i.id)
+                                                ORDER BY i.started_at DESC),
+                             i.started_at DESC
                     LIMIT %s
                         """
                     )
                     params = page_params + [org_id, _GROUPS_MAX_ROWS]
                 else:
-                    query = _INCIDENT_SELECT + page_where + page_tail
+                    query = _INCIDENT_SELECT + page_where + order_sql
                     params = page_params
 
                 cursor.execute(query, tuple(params))
@@ -723,13 +744,19 @@ def get_incident(user_id, incident_id: str):
                 # Later occurrences folded into this incident (root-cause dedup).
                 # Only anchors carry the list; members link back via recurrenceOf.
                 if incident["recurrenceOf"] is None:
+                    # Newest _OCCURRENCES_MAX_ROWS members; the window count runs
+                    # before the LIMIT so occurrencesTotal is the full member count.
                     cursor.execute(
-                        """SELECT id, alert_title, status, started_at, alert_fired_at
+                        """SELECT id, alert_title, status, started_at, alert_fired_at,
+                                  COUNT(*) OVER () AS total
                            FROM incidents
                            WHERE recurrence_of_incident_id = %s AND org_id = %s
-                           ORDER BY COALESCE(alert_fired_at, started_at) ASC""",
-                        (incident_id, org_id),
+                           ORDER BY COALESCE(alert_fired_at, started_at) DESC
+                           LIMIT %s""",
+                        (incident_id, org_id, _OCCURRENCES_MAX_ROWS),
                     )
+                    occurrence_rows = cursor.fetchall()
+                    # Emitted oldest-first to match the list card's chronological rows.
                     incident["occurrences"] = [
                         {
                             "id": str(orow[0]),
@@ -738,8 +765,9 @@ def get_incident(user_id, incident_id: str):
                             "startedAt": iso_utc(orow[3]),
                             "alertFiredAt": iso_utc(orow[4]),
                         }
-                        for orow in cursor.fetchall()
+                        for orow in reversed(occurrence_rows)
                     ]
+                    incident["occurrencesTotal"] = occurrence_rows[0][5] if occurrence_rows else 0
 
                 # Get suggestions (including fix-type fields)
                 cursor.execute(

--- a/server/routes/incidents_routes.py
+++ b/server/routes/incidents_routes.py
@@ -11,7 +11,7 @@ from utils.auth.rbac_decorators import require_permission
 from utils.auth.stateless_auth import get_org_id_from_request, set_rls_context
 from utils.log_sanitizer import hash_for_log, sanitize
 from chat.background.task import run_background_chat
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 from utils.validation import is_valid_uuid
 from chat.background.task import create_background_chat_session, run_background_chat
 
@@ -102,8 +102,8 @@ def _format_incident_response(
     include_metadata: bool = False,
     include_correlation: bool = False,
     include_merge_target: bool = False,
-    source_url_cache: Optional[Dict[Tuple[str, str], str]] = None,
-) -> Dict[str, Any]:
+    source_url_cache: Optional[dict[tuple[str, str], str]] = None,
+) -> dict[str, Any]:
     """Format database row into incident response object.
 
     ``source_url_cache`` (keyed by ``(source_type, user_id)``) lets a caller
@@ -395,7 +395,7 @@ def get_incidents(user_id):
                 cursor.execute(query, tuple(params))
                 rows = cursor.fetchall()
 
-                source_urls: Dict[Tuple[str, str], str] = {}
+                source_urls: dict[tuple[str, str], str] = {}
                 incidents = []
                 for row in rows:
                     group_size = None

--- a/server/tests/auth/test_rls_cross_tenant.py
+++ b/server/tests/auth/test_rls_cross_tenant.py
@@ -166,7 +166,7 @@ class TestCrossTenantIncidentAccess:
         """Control case: same route returns 200 for a valid org-A incident
         (verifies the fixture actually exercises the route, not a shortcut).
         """
-        # Build a minimal 24-column row that _format_incident_response expects.
+        # Build a minimal 26-column row that _format_incident_response expects.
         fake_row = (
             ORG_A_INCIDENT_UUID,  # id
             ORG_A_USER_ID,        # user_id
@@ -192,6 +192,8 @@ class TestCrossTenantIncidentAccess:
             None,                 # affected_services
             None,                 # merged_into_incident_id
             None,                 # merged_into_title
+            None,                 # recurrence_of_incident_id
+            None,                 # recurrence_of_title
         )
         cursor = _make_cursor_returning(fake_row)
         _patch_auth_and_pool(monkeypatch, cursor=cursor)

--- a/server/tests/routes/test_incidents_recurrence_fields.py
+++ b/server/tests/routes/test_incidents_recurrence_fields.py
@@ -1,0 +1,81 @@
+"""Pure-function tests for the recurrence fields emitted by
+``routes.incidents_routes._format_incident_response`` (root-cause dedup, layer 2).
+
+The list/detail SELECTs append ``recurrence_of_incident_id`` and the anchor's
+title as the last two columns of the ``include_merge_target`` tuple; the
+narrower branches must default the pointer to ``None``.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+ANCHOR_ID = uuid.uuid4()
+INCIDENT_ID = uuid.uuid4()
+NOW = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _base_row():
+    """The 19 leading columns shared by every formatter branch."""
+    return [
+        INCIDENT_ID, "user-1", "datadog", "alert-1", "analyzed", "high",
+        "CPU high", "api", "prod", "idle", "summary", None,
+        NOW, NOW, "thoughts", NOW, NOW, None, NOW,
+    ]
+
+
+def _merge_target_row(recurrence_of=None, recurrence_title=None):
+    return tuple(
+        _base_row()
+        + [
+            {"k": "v"}, 2, ["api"],  # alert_metadata, correlated_alert_count, affected_services
+            None, None,  # merged_into_incident_id, merged_into_title
+            recurrence_of, recurrence_title,
+        ]
+    )
+
+
+@pytest.fixture
+def fmt(monkeypatch):
+    from routes import incidents_routes
+
+    # The formatter resolves the alert's source URL through the DB; stub it so
+    # these stay pure-function tests (CI runs without Postgres).
+    monkeypatch.setattr(incidents_routes, "_build_source_url", lambda *_: "")
+    return incidents_routes._format_incident_response
+
+
+def test_member_row_emits_pointer_and_anchor_title(fmt):
+    result = fmt(
+        _merge_target_row(ANCHOR_ID, "Earlier CPU high"),
+        include_metadata=True, include_correlation=True, include_merge_target=True,
+    )
+    assert result["recurrenceOf"] == str(ANCHOR_ID)
+    assert result["recurrenceOfTitle"] == "Earlier CPU high"
+    assert "mergedIntoIncidentId" not in result
+    assert result["correlatedAlertCount"] == 2
+
+
+def test_anchor_row_emits_null_pointer_without_title(fmt):
+    result = fmt(
+        _merge_target_row(),
+        include_metadata=True, include_correlation=True, include_merge_target=True,
+    )
+    assert result["recurrenceOf"] is None
+    assert "recurrenceOfTitle" not in result
+
+
+@pytest.mark.parametrize(
+    "kwargs, extra_columns",
+    [
+        ({"include_correlation": True}, [{"k": "v"}, 2, ["api"]]),
+        ({"include_metadata": True}, [{"k": "v"}]),
+        ({}, []),
+    ],
+)
+def test_narrower_branches_default_pointer_to_null(fmt, kwargs, extra_columns):
+    result = fmt(tuple(_base_row() + extra_columns), **kwargs)
+    assert result["id"] == str(INCIDENT_ID)
+    assert result["recurrenceOf"] is None
+    assert "recurrenceOfTitle" not in result

--- a/server/tests/routes/test_incidents_recurrence_fields.py
+++ b/server/tests/routes/test_incidents_recurrence_fields.py
@@ -79,3 +79,25 @@ def test_narrower_branches_default_pointer_to_null(fmt, kwargs, extra_columns):
     assert result["id"] == str(INCIDENT_ID)
     assert result["recurrenceOf"] is None
     assert "recurrenceOfTitle" not in result
+
+
+def test_source_url_cache_is_keyed_by_user(monkeypatch):
+    """Two users on the same provider must each get their own URL — the cache
+    must not hand user A's Datadog site to user B's incident."""
+    from routes import incidents_routes
+
+    calls = []
+    monkeypatch.setattr(
+        incidents_routes, "_build_source_url",
+        lambda source_type, user_id: calls.append((source_type, user_id)) or f"https://{user_id}.example",
+    )
+    cache = {}
+    rows = [
+        tuple(["id-1", "user-a", "datadog"] + _base_row()[3:]),
+        tuple(["id-2", "user-b", "datadog"] + _base_row()[3:]),
+        tuple(["id-3", "user-a", "datadog"] + _base_row()[3:]),
+    ]
+    urls = [incidents_routes._format_incident_response(r, source_url_cache=cache)["alert"]["sourceUrl"] for r in rows]
+
+    assert urls == ["https://user-a.example", "https://user-b.example", "https://user-a.example"]
+    assert calls == [("datadog", "user-a"), ("datadog", "user-b")]  # second user-a row served from cache


### PR DESCRIPTION
## Summary

Layer 2 of root-cause dedup. Layer 1 (#610) writes `incidents.recurrence_of_incident_id` when the correlation agent folds a recurrence into its anchor; nothing read it yet, so `/incidents` still showed one card per incident. This PR turns the pointer into one expandable card per group and surfaces the relationship on the detail page. Layer 3 (Slack threading) is out of scope.

## API

- `_format_incident_response` always emits `recurrenceOf` (plus `recurrenceOfTitle` when set). List and detail share one `_INCIDENT_SELECT`.
- `GET /api/incidents?groups=1` pages over recurrence groups: `limit`/`offset`/`status` select distinct roots (newest fire first) and `total` counts groups, then every non-merged anchor and member of those groups is returned as a flat list, capped at 1000 rows with anchors first and the largest group trimmed first. Each row carries `occurrenceTotal` (full group size) so the client can show how many members were cut. `aurora_summary` and `alert_metadata` are NULL in this mode. Without `groups` the existing query path is unchanged, so MCP paging is unaffected.
- Anchor detail gets `occurrences[{id, alertTitle, status, startedAt, alertFiredAt}]` (newest 200, emitted oldest-first) plus `occurrencesTotal`; members get `recurrenceOf` + `recurrenceOfTitle` and stay fully GET-able.

## UI

- `/incidents` groups via a pure helper (`incident-grouping.ts`): anchor + members become one card showing `fired N times` and time since the last fire; the chevron expands a chronological occurrence list without navigating. Standalones keep the existing row. Orphans (anchor not in the fetch) are never hidden.
- Expand state lives at page level keyed by anchor id, so SSE refetches (`incident_update`, `recurrence_folded`) never collapse an open card. Refetches are coalesced.
- Member detail shows an "Occurrence of …" banner linking to the anchor; its own investigation stays visible. Anchor detail gets an expandable "Fired N times" section listing the members.
- `ExpandablePanel` extracts the expand animation; `CorrelatedAlertsSection` now uses it and no longer lists the fold's `recurrence` rows (the occurrences section covers them).
- Detail page subscribes to the incident stream so a fold that lands after the RCA finishes updates an open page.

## Verification

- Server suite: 1372 passed; the 3 `test_rls_cross_tenant` failures are the known dev-container Casbin denials.
- API smoke against the dev group: `groups=1&limit=1` returns the whole 4-row group, `limit=1` alone returns 1 row, anchor detail has 3 chronological occurrences, member detail has pointer + title and no `occurrences` key.
- 14-case check of `groupIncidents` (orphans, depth-2 chains, `alertFiredAt` fallback, sections, sort, stalled).
- Chrome: group card expands/collapses without navigating, refetch keeps it open, member banner links to the anchor, "Fired 4 times" expands to 3, Correlated Alerts still renders. No console errors.

## Follow-ups (not this PR)

- `recurrence_unfolded` is recorded as a lifecycle event but never broadcast over SSE.
- Depth-1 pointer invariant is assumed here; `recurrence_fold._check_locked_pair` does not yet reject a child that already has dependents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Incidents are grouped by recurrence, with occurrence counts, timing, status, and investigation state.
  - Expandable groups and incident cards show individual occurrences, links, and notices for older occurrences not loaded.
  - Incident details identify recurring alerts and link to the original incident.

- **Improvements**
  - Incident and recurrence updates refresh automatically.
  - Expandable sections provide smoother interactions.
  - Time and duration displays no longer show negative values.
  - Newer refresh results take precedence over older responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
