### PR TITLE
feat(slack): team-identity auth for @mentions from any workspace member (DEV-1496)

### DIFF
--- a/server/routes/slack/slack_events.py
+++ b/server/routes/slack/slack_events.py
@@ -17,7 +17,8 @@ from routes.slack.slack_events_helpers import (
     get_thread_messages,
     get_channel_context_with_threads,
     get_session_from_thread,
-    send_message_to_aurora
+    send_message_to_aurora,
+    get_workspace_member,
 )
 from utils.secrets.secret_ref_utils import get_user_token_data
 from chat.background.task import run_background_chat
@@ -93,6 +94,7 @@ def slack_events():
                 response_text = None
                 trigger_background = False
                 user_id = None # Aurora user ID
+                asked_by = None  # Slack display name of the sender when using the team identity
 
                 try:
                     # 1. Resolve Identity and Client
@@ -103,19 +105,37 @@ def slack_events():
                         client = get_slack_client_for_user(user_id)
                         if not client:
                             logger.error(f"Failed to create client for user {user_id}")
+                    elif event.get('bot_id') or event.get('subtype') == 'bot_message':
+                        # Never answer other bots (prevents bot-to-bot loops)
+                        logger.info("Ignoring @mention from a bot in team %s", sanitize(team_id))
                     else:
-                        # User not connected. Check if workspace is connected by anyone else.
+                        # Sender has no Aurora account linked to this Slack ID. Fall back to
+                        # the Aurora user who connected this workspace as a shared, read-only
+                        # "team identity" so anyone in the workspace can ask questions.
+                        # Mentions run background chats in "ask" (read-only) mode; button
+                        # actions below keep their own per-user authentication.
                         workspace_user_id = get_user_id_from_slack_team(team_id)
                         if workspace_user_id:
-                            # Use workspace credentials to send a helpful error message
-                            token_data = get_user_token_data(workspace_user_id, "slack")
-                            if token_data:
-                                client = SlackClient(token_data.get('access_token'))
-                                response_text = (
-                                    "You're not authenticated in Aurora.\n\n"
-                                    f"To use Aurora in this Slack workspace, please connect your Aurora account:\n{FRONTEND_URL}/settings/integrations\n\n"
-                                    "Click 'Connect' for Slack and authorize this workspace."
-                                )
+                            client = get_slack_client_for_user(workspace_user_id)
+                            if not client:
+                                logger.error(f"Failed to create client for workspace user {workspace_user_id}")
+                            else:
+                                # Only full members of this workspace may use the team identity.
+                                # Guests, Slack Connect users from other workspaces and bots are refused.
+                                member = get_workspace_member(client, slack_user_id, team_id)
+                                if member:
+                                    user_id = workspace_user_id
+                                    asked_by = member["display_name"]
+                                    logger.info(
+                                        "Slack user %s has no linked Aurora account; answering read-only via workspace team identity",
+                                        sanitize(slack_user_id),
+                                    )
+                                else:
+                                    logger.info(
+                                        "Slack user %s is not a full member of workspace %s; refusing",
+                                        sanitize(slack_user_id), sanitize(team_id),
+                                    )
+                                    response_text = "Aurora is only available to members of this Slack workspace."
                     
                     # 2. Logic processing (if no errors yet and client exists)
                     if client and not response_text:
@@ -132,7 +152,10 @@ def slack_events():
                             response_text = "Thinking..."
                             trigger_background = True
                             # Update text to cleaned version for background task
-                            text = clean_msg 
+                            text = clean_msg
+                            if asked_by:
+                                # Keep attribution visible in the session title and prompt
+                                text = f"Asked by {asked_by}: {clean_msg}"
 
                     # 3. Execution
                     if client:

--- a/server/routes/slack/slack_events_helpers.py
+++ b/server/routes/slack/slack_events_helpers.py
@@ -199,6 +199,45 @@ def _get_user_display_name(client, user_id: str) -> str:
         return user_id
 
 
+def get_workspace_member(client, slack_user_id: str, team_id: str) -> Optional[dict]:
+    """
+    Return {"display_name": ...} if slack_user_id is a full member of the Slack
+    workspace team_id, otherwise None.
+
+    "Full member" excludes deleted users, bots, Slack Connect users from other
+    workspaces (team_id mismatch / is_stranger) and guest accounts
+    (is_restricted / is_ultra_restricted). Used before answering an @mention
+    under the shared team identity so that only people who belong to the org
+    can get answers about its infrastructure.
+    """
+    if not slack_user_id or not team_id:
+        return None
+    try:
+        result = client._make_request("GET", "users.info", {"user": slack_user_id}) or {}
+    except Exception as e:
+        logger.warning(f"users.info failed for Slack user {sanitize(slack_user_id)}: {e}")
+        return None
+
+    user = result.get("user") or {}
+    if not result.get("ok") or not user:
+        return None
+    if user.get("team_id") != team_id:
+        return None  # Slack Connect / external workspace
+    if user.get("deleted") or user.get("is_bot") or user.get("id") == "USLACKBOT":
+        return None
+    if user.get("is_stranger") or user.get("is_restricted") or user.get("is_ultra_restricted"):
+        return None  # external user or guest account
+
+    profile = user.get("profile", {})
+    display_name = (
+        profile.get("display_name")
+        or profile.get("real_name")
+        or user.get("name")
+        or slack_user_id
+    )
+    return {"display_name": display_name.strip()}
+
+
 def _resolve_user_display_name(client, user_id: str, is_bot: bool, user_name_cache: dict) -> str:
     """
     Resolve display name for a user with caching.


### PR DESCRIPTION
## Summary
Bombora (DEV-1496): anyone who @mentions Aurora in Slack without a linked Aurora account gets "You're not authenticated in Aurora", and Juan does not want an Aurora account per engineer. This lets any full member of the installing Slack workspace ask questions through the account that connected the workspace. Button actions keep their per-user auth.

## Changes
- `slack_events_helpers.py`: new `get_workspace_member(client, slack_user_id, team_id)`. One `users.info` call with the workspace bot token. Returns the sender's display name only if they are a full member of the installing workspace. Deleted users, bots, Slack Connect users from other workspaces (`team_id` mismatch / `is_stranger`) and guests (`is_restricted` / `is_ultra_restricted`) are rejected, and any lookup error rejects.
- `slack_events.py` app_mention handler: when the sender has no linked Aurora account, resolve the user who connected the workspace, run the membership check, and answer under that user with the prompt prefixed `Asked by <display name>:` (also visible in the session title). Non-members get "Aurora is only available to members of this Slack workspace." Mentions from bots are ignored. Button handlers untouched.

Mentions already ran as background chats in `ask` mode; unchanged.

## Tested locally (prod image, own Slack app)
- Linked Aurora user: answers as before.
- Full workspace member without an Aurora account: answered, session titled `Slack: Asked by <name>: …`.
- Same account converted to a guest: refused, no session created (log: `is not a full member of workspace … refusing`).
- In-process checks: bots, Slackbot, nonexistent user, other-workspace user, stranger, deactivated account, lookup failure all refused.

## Note
`ask` mode is not hard read-only for Bitbucket: an asker can still have Aurora create branches or open PRs under the connected account (file commits are blocked by the action gate). Pre-existing, unchanged by this PR; separate ticket.

Linear: DEV-1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWRrqWxA3uDi83UhVTFYwr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slack users without linked Aurora accounts can receive read-only background answers when they are full workspace members.
  - Responses use the member’s Slack display name for attribution.

- **Bug Fixes**
  - Bot messages, guests, external users, deleted accounts, and non-members are no longer processed.
  - Users who cannot be served are refused instead of receiving a workspace-account connection error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->