### PR TITLE
fix(recommender): Gemini thinking-mode content silently breaks suggestion generation

### DIFF
--- a/server/chat/background/recommender.py
+++ b/server/chat/background/recommender.py
@@ -26,6 +26,8 @@ from chat.background.suggestion_extractor import Suggestion, is_command_safe
 
 from chat.background.citation_extractor import _TOOL_NAME_MAPPING
 
+from utils.llm_response import extract_text_from_response
+
 logger = logging.getLogger(__name__)
 
 _MAX_TRACE_CHARS = 30_000
@@ -288,7 +290,9 @@ Return ONLY the JSON object."""
     try:
         llm = create_chat_model(ModelConfig.SUGGESTION_MODEL, temperature=0.1)
         response = llm.invoke([HumanMessage(content=prompt)])
-        text = _strip_code_fences(str(response.content).strip())
+        # Gemini thinking models return content as a list of blocks; extract the text
+        # (and drop thinking blocks) before parsing, or json.loads gets a stringified list.
+        text = _strip_code_fences(_extract_text_from_content(response.content))
 
         data = json.loads(text)
 
@@ -552,7 +556,8 @@ Return ONLY the JSON array."""
     try:
         llm = create_chat_model(ModelConfig.SUGGESTION_MODEL, temperature=0.1)
         response = llm.invoke([HumanMessage(content=prompt)])
-        commands_to_run = _parse_json_list_response(str(response.content))
+        # Extract text from (possibly list) content before JSON parsing — see note above.
+        commands_to_run = _parse_json_list_response(_extract_text_from_content(response.content))
     except Exception as e:
         logger.warning("[Recommender] Self-exec planning failed: %s", e)
         return []
@@ -762,21 +767,10 @@ def _is_redundant(suggestion: Suggestion, executed_commands: set) -> bool:
     return False
 
 
-def _extract_text_part(part: Any) -> str:
-    """Extract text from a single content block, filtering out thinking blocks."""
-    if isinstance(part, str):
-        return part
-    if isinstance(part, dict) and part.get("type") not in ("thinking", "reasoning"):
-        text = part.get("text", "")
-        return str(text) if text else ""
-    return ""
-
-
 def _extract_text_from_content(content: Any) -> str:
     """Extract plain text from LLM response content (handles Gemini thinking blocks)."""
-    if isinstance(content, list):
-        return "".join(_extract_text_part(part) for part in content).strip()
-    return str(content).strip()
+    # Delegates to the shared helper; kept as a thin wrapper for local call sites.
+    return extract_text_from_response(content)
 
 
 def _parse_item_to_suggestion(item: dict) -> Optional[Suggestion]:
@@ -930,7 +924,7 @@ Return in this exact format (one block per suggestion):
             model_name=_ENRICHMENT_MODEL,
             request_type="suggestion_enrichment",
         )
-        _apply_enrichment_response(str(response.content).strip(), suggestions)
+        _apply_enrichment_response(_extract_text_from_content(response.content), suggestions)
     except Exception as e:
         logger.warning("[Recommender] Validated fix enrichment failed (non-fatal): %s", e)
         _generate_summaries(suggestions, user_id, session_id)
@@ -993,7 +987,7 @@ Return one summary per line, numbered:"""
             model_name=_ENRICHMENT_MODEL,
             request_type="suggestion_summary",
         )
-        text = str(response.content).strip()
+        text = _extract_text_from_content(response.content)
         lines = [l.strip() for l in text.split("\n") if l.strip()]
 
         for line in lines:

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from celery_config import celery_app
@@ -18,35 +18,8 @@ from utils.auth.stateless_auth import set_rls_context
 from utils.db.connection_pool import db_pool
 
 
-def _extract_text_from_response(content: Union[str, List[Any]]) -> str:
-    """Extract text content from LLM response, filtering out thinking blocks.
-
-    Gemini thinking models return content as a list with thinking and text blocks.
-    This extracts only the actual response text.
-    """
-    if isinstance(content, str):
-        return content.strip()
-
-    if isinstance(content, list):
-        text_parts = []
-        for part in content:
-            if isinstance(part, dict):
-                part_type = part.get("type", "")
-                if part_type in ("thinking", "reasoning"):
-                    continue
-                elif part_type == "text":
-                    text = part.get("text", "")
-                    if text:
-                        text_parts.append(str(text))
-                else:
-                    text = part.get("text", "")
-                    if text:
-                        text_parts.append(str(text))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        return "".join(text_parts).strip()
-
-    return str(content).strip()
+# Re-exported for backwards compatibility; other modules import this name from here.
+from utils.llm_response import extract_text_from_response as _extract_text_from_response
 
 
 from chat.background.citation_extractor import (

--- a/server/routes/github/github_repo_metadata.py
+++ b/server/routes/github/github_repo_metadata.py
@@ -11,30 +11,14 @@ the row (no retry — re-auth is a user action, not a transient failure).
 import base64
 import json
 import logging
-from typing import Any, List, Union
+from typing import Any
 import requests
 from celery_config import celery_app
 
+from utils.llm_response import extract_text_from_response
+
 logger = logging.getLogger(__name__)
 
-
-def _extract_text_from_response(content: Union[str, List[Any]]) -> str:
-    """Extract text from a LangChain AIMessage content payload."""
-    if isinstance(content, str):
-        return content.strip()
-    if isinstance(content, list):
-        text_parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict):
-                if part.get("type") in ("thinking", "reasoning"):
-                    continue
-                text = part.get("text", "")
-                if text:
-                    text_parts.append(str(text))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        return "".join(text_parts).strip()
-    return str(content).strip()
 
 METADATA_PROMPT = (
     "Write a 2-3 sentence summary of this GitHub repository. "
@@ -182,7 +166,7 @@ def generate_repo_metadata(self, user_id: str, repo_full_name: str):
             request_type="github_repo_metadata",
         )
 
-        summary = _extract_text_from_response(response.content) if response.content else "No summary generated"
+        summary = extract_text_from_response(response.content) if response.content else "No summary generated"
         if not summary:
             summary = "No summary generated"
         _update_metadata(user_id, repo_full_name, summary, "ready")

--- a/server/tests/utils/test_llm_response.py
+++ b/server/tests/utils/test_llm_response.py
@@ -1,0 +1,48 @@
+"""Tests for the shared LLM response text extractor.
+
+Gemini 2.5/3.x thinking models (google/vertex) return ``response.content`` as a
+list of ``thinking`` + ``text`` blocks. ``str(content)`` stringifies the whole
+list (thinking blocks and all), which then breaks downstream JSON/regex parsing.
+:func:`extract_text_from_response` must drop the thinking blocks and return only
+the real text so callers can parse it.
+"""
+
+from utils.llm_response import extract_text_from_response
+
+
+def test_plain_string_is_stripped():
+    assert extract_text_from_response("  hello world  ") == "hello world"
+
+
+def test_thinking_list_yields_text_only():
+    content = [
+        {"type": "thinking", "thinking": "Let me reason about this..."},
+        {"type": "text", "text": '  {"hypotheses": []}  '},
+    ]
+    assert extract_text_from_response(content) == '{"hypotheses": []}'
+
+
+def test_multiple_text_blocks_are_concatenated():
+    content = [
+        {"type": "text", "text": "foo"},
+        {"type": "thinking", "thinking": "ignore me"},
+        {"type": "text", "text": "bar"},
+    ]
+    assert extract_text_from_response(content) == "foobar"
+
+
+def test_bare_string_parts_are_kept():
+    assert extract_text_from_response(["a", "b"]) == "ab"
+
+
+def test_thinking_only_content_is_empty():
+    assert extract_text_from_response([{"type": "thinking", "thinking": "only thoughts"}]) == ""
+
+
+def test_empty_content_is_empty():
+    assert extract_text_from_response("") == ""
+    assert extract_text_from_response([]) == ""
+
+
+def test_non_str_non_list_is_coerced():
+    assert extract_text_from_response(None) == "None"

--- a/server/utils/llm_response.py
+++ b/server/utils/llm_response.py
@@ -1,0 +1,47 @@
+"""Helpers for reading text out of LLM response content.
+
+Gemini 2.5/3.x thinking models (google and vertex providers) return message
+``content`` as a *list* of blocks (``{"type": "thinking", ...}`` +
+``{"type": "text", ...}``) rather than a plain string. Calling ``.strip()`` on
+that list crashes, and ``str(list)`` silently stringifies the thinking blocks
+into garbage that then fails downstream JSON/regex parsing. Route every LLM
+reply through :func:`extract_text_from_response` before parsing it.
+"""
+
+from typing import Any, List, Union
+
+
+def _extract_text_part(part: Any) -> str:
+    """Extract text from a single content block, dropping thinking/reasoning blocks."""
+    # Plain string block — already text.
+    if isinstance(part, str):
+        return part
+
+    # Structured block — keep everything except thinking/reasoning blocks.
+    if isinstance(part, dict) and part.get("type") not in ("thinking", "reasoning"):
+        text = part.get("text", "")
+        return str(text) if text else ""
+
+    # Thinking/reasoning block (or unknown non-text type) — drop it.
+    return ""
+
+
+def extract_text_from_response(content: Union[str, List[Any], Any]) -> str:
+    """Extract the human-readable text from an LLM response's ``content``.
+
+    Handles the three shapes ``content`` can take:
+    - ``str``: returned stripped (the common non-thinking case).
+    - ``list``: thinking/reasoning blocks are dropped and the remaining text
+      blocks are concatenated (Gemini/Anthropic thinking models).
+    - anything else: coerced with ``str()`` as a last resort.
+    """
+    # Plain string — the common non-thinking case.
+    if isinstance(content, str):
+        return content.strip()
+
+    # List of blocks — thinking model output; keep only the text blocks.
+    if isinstance(content, list):
+        return "".join(_extract_text_part(part) for part in content).strip()
+
+    # Unexpected shape — coerce rather than crash.
+    return str(content).strip()


### PR DESCRIPTION
## What

Follow-up to #612. That PR fixed `response.content.strip()` crashing on Gemini thinking-mode responses in the repo-metadata path. While reviewing it, I found **four more spots** in `server/chat/background/recommender.py` with the same root cause in a quieter form.

They call `str(response.content)` on content that, for Gemini 2.5/3.x thinking models, is a *list* of thinking/text blocks. Unlike `.strip()`, `str(list)` doesn't crash — it stringifies the entire list (thinking blocks and all) into a Python `repr`, which then fails the downstream `json.loads`/regex parse. Every one of those failures is swallowed by a surrounding `try/except` or no-match path, so the recommender **silently degrades** instead of erroring:

| Line | Function | Failure mode |
|------|----------|--------------|
| L295 | `_infer_investigation_state` | `json.loads` fails → empty hypothesis ledger |
| L560 | `_self_execute_safe_diagnostics` | `json.loads` fails → no self-exec diagnostics |
| L927 | `_enrich_validated_fixes` | regex no-match → suggestions not enriched |
| L990 | `_generate_summaries` | regex no-match → no summaries |

L295 and L560 use `SUGGESTION_MODEL` (= `MAIN_MODEL`), so they trigger on the exact Gemini thinking setup Bombora is running. L927/L990 use `_ENRICHMENT_MODEL` (defaults to Claude Haiku), so they only bite if `ENRICHMENT_MODEL` is overridden to a thinking model.

## Changes

- Route all four spots through the text extractor before parsing.
- Consolidate the **three** duplicate extraction helpers into one shared `server/utils/llm_response.py`:
  - `_extract_text_from_response` in `summarization.py` (now re-exports the shared one for backwards compat — `repo_metadata.py` still imports it by name)
  - `_extract_text_from_response` in `github_repo_metadata.py` (was a verbatim copy)
  - `_extract_text_from_content` in `recommender.py` (now a thin wrapper)
  - Left `workflow.py`'s variant alone — it has an `include_thinking` flag and handles OpenAI reasoning `summary` blocks, so it's a superset, not a duplicate.

This is the dedup that would have prevented needing two separate fixes: four near-identical copies meant #612 fixed one and missed the rest.

## Verified

- New `server/tests/utils/test_llm_response.py` covers list/thinking content, plain strings, multiple text blocks, thinking-only, empty, and non-str/non-list coercion. Passes.
- Byte-compiled all touched modules.

Refs DEV-1489

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI-generated responses across recommendations, summaries, enrichment, planning, and repository metadata.
  - Structured responses are now handled consistently, with internal thinking and reasoning content excluded from user-facing text.
  - Plain text, multi-part responses, and unexpected response formats are processed more reliably, reducing formatting issues and preventing internal reasoning from appearing in displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->