### PR TITLE
Root-cause dedup layer 3: Slack thread consolidation

### DIFF
--- a/server/chat/backend/agent/tools/introspection_tools.py
+++ b/server/chat/backend/agent/tools/introspection_tools.py
@@ -101,7 +101,10 @@ def _require_uuid(value: Optional[str], field: str = "id") -> str:
 class ListIncidentsArgs(BaseModel):
     status: Optional[str] = Field(
         default=None,
-        description="Filter by incident status: investigating, analyzed, merged, or resolved.",
+        description=(
+            "Filter by incident status: investigating (RCA running), analyzed (RCA finished), "
+            "resolved (closed by a user), or merged. Omit to list every non-merged incident."
+        ),
     )
     limit: int = Field(default=20, description="Max incidents to return (1–100, default 20).")
     offset: int = Field(default=0, description="Paging offset (>= 0, default 0).")

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -718,15 +718,25 @@ def generate_incident_summary_from_chat(
     incident_id: str,
     user_id: str,
     session_id: str,
-    send_notifications: bool = True,
+    announce_completion: bool = True,
 ) -> Dict[str, Any]:
     """Regenerate incident summary after RCA using the RCA chat transcript with citations.
 
-    send_notifications: False for follow-up chats (Slack/Google Chat replies on
-    an existing incident) so re-summarizing does not re-announce completion —
-    for a folded recurrence that would post another "Still firing" reply.
+    announce_completion: False when the summary is being regenerated after a
+    follow-up chat (Slack/Google Chat reply on an existing incident). The
+    summary is still written; the "investigation completed" announcement
+    (email, Slack card) is skipped since the investigation already completed
+    once — for a folded recurrence it would otherwise post another "Still
+    firing" reply — and only the Google Chat card, which is edited in place,
+    is refreshed to match the new summary.
     """
     from celery.exceptions import SoftTimeLimitExceeded
+
+    def _notify_completed() -> None:
+        from utils.notifications.dispatcher import notify_investigation_completed
+        if not announce_completion:
+            logger.info(f"{_LOG_PREFIX} Follow-up summary for {incident_id}; completion already announced, refreshing cards only")
+        notify_investigation_completed(user_id, incident_id, session_id=session_id, refresh_only=not announce_completion)
 
     logger.info(
         f"{_LOG_PREFIX} Regenerating summary from chat for incident {incident_id} (user={user_id}, session={session_id})"
@@ -899,11 +909,7 @@ def generate_incident_summary_from_chat(
             )
 
         # Send completion notifications via centralized dispatcher
-        if send_notifications:
-            from utils.notifications.dispatcher import notify_investigation_completed
-            notify_investigation_completed(user_id, incident_id, session_id=session_id)
-        else:
-            logger.info(f"{_LOG_PREFIX} Follow-up summary for {incident_id}; completion notifications skipped")
+        _notify_completed()
 
         return {
             "incident_id": incident_id,
@@ -922,9 +928,7 @@ def generate_incident_summary_from_chat(
             # overwrite the good summary with an error — send the completion
             # notification the task guarantees and finish.
             try:
-                if send_notifications:
-                    from utils.notifications.dispatcher import notify_investigation_completed
-                    notify_investigation_completed(user_id, incident_id, session_id=session_id)
+                _notify_completed()
             except Exception:
                 logger.exception(
                     f"{_LOG_PREFIX} Failed to notify after soft-limit for {incident_id}"

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -718,8 +718,14 @@ def generate_incident_summary_from_chat(
     incident_id: str,
     user_id: str,
     session_id: str,
+    send_notifications: bool = True,
 ) -> Dict[str, Any]:
-    """Regenerate incident summary after RCA using the RCA chat transcript with citations."""
+    """Regenerate incident summary after RCA using the RCA chat transcript with citations.
+
+    send_notifications: False for follow-up chats (Slack/Google Chat replies on
+    an existing incident) so re-summarizing does not re-announce completion —
+    for a folded recurrence that would post another "Still firing" reply.
+    """
     from celery.exceptions import SoftTimeLimitExceeded
 
     logger.info(
@@ -874,8 +880,8 @@ def generate_incident_summary_from_chat(
         summary_written = True
 
         # Root-cause recurrence check (dedup layer 1): runs post-summary-write,
-        # pre-notification — fold-then-notify is the ordering Slack threading
-        # (layer 3) needs later. run_recurrence_check never raises internally
+        # pre-notification — fold-then-notify is the ordering that Slack threading
+        # (layer 3) reads. run_recurrence_check never raises internally
         # and is bounded by its own asyncio.wait_for; this guard is belt and
         # braces so notifications stay guaranteed. On task retry the existing
         # verdict row makes the re-run a no-op.
@@ -893,8 +899,11 @@ def generate_incident_summary_from_chat(
             )
 
         # Send completion notifications via centralized dispatcher
-        from utils.notifications.dispatcher import notify_investigation_completed
-        notify_investigation_completed(user_id, incident_id, session_id=session_id)
+        if send_notifications:
+            from utils.notifications.dispatcher import notify_investigation_completed
+            notify_investigation_completed(user_id, incident_id, session_id=session_id)
+        else:
+            logger.info(f"{_LOG_PREFIX} Follow-up summary for {incident_id}; completion notifications skipped")
 
         return {
             "incident_id": incident_id,
@@ -913,8 +922,9 @@ def generate_incident_summary_from_chat(
             # overwrite the good summary with an error — send the completion
             # notification the task guarantees and finish.
             try:
-                from utils.notifications.dispatcher import notify_investigation_completed
-                notify_investigation_completed(user_id, incident_id, session_id=session_id)
+                if send_notifications:
+                    from utils.notifications.dispatcher import notify_investigation_completed
+                    notify_investigation_completed(user_id, incident_id, session_id=session_id)
             except Exception:
                 logger.exception(
                     f"{_LOG_PREFIX} Failed to notify after soft-limit for {incident_id}"

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -766,7 +766,7 @@ def run_background_chat(
                         incident_id=incident_id,
                         user_id=user_id,
                         session_id=session_id,
-                        send_notifications=send_notifications,
+                        announce_completion=send_notifications,
                     )
                 except Exception:
                     logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization for incident %s", incident_id)
@@ -841,11 +841,12 @@ def run_background_chat(
         if incident_id and not is_action_source:
             _update_incident_aurora_status(incident_id, "error", user_id=user_id)
             _mark_inflight_findings_failed(incident_id, user_id, "parent task timed out after 30 minutes")
-            try:
-                from utils.notifications.dispatcher import notify_investigation_failed
-                notify_investigation_failed(user_id, incident_id, error_message="Investigation timed out after 30 minutes")
-            except Exception:
-                logger.debug("[BackgroundChat] Failed to send investigation failed notification after timeout")
+            if send_notifications:  # a follow-up chat failing is not the investigation failing
+                try:
+                    from utils.notifications.dispatcher import notify_investigation_failed
+                    notify_investigation_failed(user_id, incident_id, error_message="Investigation timed out after 30 minutes")
+                except Exception:
+                    logger.debug("[BackgroundChat] Failed to send investigation failed notification after timeout")
         if trigger_metadata and trigger_metadata.get('source') == 'action':
             try:
                 from services.actions.executor import update_action_run_status
@@ -870,11 +871,12 @@ def run_background_chat(
         if incident_id and not is_action_source:
             _update_incident_aurora_status(incident_id, "error", user_id=user_id)
             _mark_inflight_findings_failed(incident_id, user_id, f"parent task failed: {e}")
-            try:
-                from utils.notifications.dispatcher import notify_investigation_failed
-                notify_investigation_failed(user_id, incident_id, error_message=str(e))
-            except Exception:
-                logger.debug("[BackgroundChat] Failed to send investigation failed notification")
+            if send_notifications:  # a follow-up chat failing is not the investigation failing
+                try:
+                    from utils.notifications.dispatcher import notify_investigation_failed
+                    notify_investigation_failed(user_id, incident_id, error_message=str(e))
+                except Exception:
+                    logger.debug("[BackgroundChat] Failed to send investigation failed notification")
         if trigger_metadata and trigger_metadata.get('source') == 'action':
             try:
                 from services.actions.executor import update_action_run_status
@@ -1516,7 +1518,7 @@ async def _execute_background_chat(
                     incident_id=incident_id,
                     user_id=user_id,
                     session_id=session_id,
-                    send_notifications=send_notifications,
+                    announce_completion=send_notifications,
                 )
             except Exception as e:
                 logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization")

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -766,6 +766,7 @@ def run_background_chat(
                         incident_id=incident_id,
                         user_id=user_id,
                         session_id=session_id,
+                        send_notifications=send_notifications,
                     )
                 except Exception:
                     logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization for incident %s", incident_id)
@@ -1515,6 +1516,7 @@ async def _execute_background_chat(
                     incident_id=incident_id,
                     user_id=user_id,
                     session_id=session_id,
+                    send_notifications=send_notifications,
                 )
             except Exception as e:
                 logger.exception("[BackgroundChat] Failed to enqueue post-RCA summarization")

--- a/server/connectors/slack_connector/client.py
+++ b/server/connectors/slack_connector/client.py
@@ -13,6 +13,21 @@ logger = logging.getLogger(__name__)
 SLACK_API_BASE = "https://slack.com/api"
 
 
+class SlackAPIError(ValueError):
+    """Slack answered ok=false; `error` is the API error code (e.g. not_in_channel).
+    Transport failures stay plain ValueError so callers can tell "Slack rejected
+    it" (safe to retry differently) from "the request may have gone through"."""
+
+    def __init__(self, error: str):
+        # args holds the bare code so cls(*args) (pickle, copy, Celery's
+        # exception reconstruction) rebuilds the same instance.
+        super().__init__(error)
+        self.error = error
+
+    def __str__(self) -> str:
+        return f"Slack API error: {self.error}"
+
+
 class SlackClient:
     """
     Slack API client for Aurora integration.
@@ -46,7 +61,7 @@ class SlackClient:
         error = result.get('error', 'unknown_error')
         if not (error == 'name_taken' and endpoint == 'conversations.create'):
             logger.error("Slack API error on %s: %s", endpoint, error)
-        raise ValueError(f"Slack API error: {error}")
+        raise SlackAPIError(error)
 
     def _make_request(self, method: str, endpoint: str, data: Optional[Dict] = None, timeout: int = 30, max_retries: int = 3) -> Dict[str, Any]:
         """Make a request to Slack API with retry on 429 rate limits."""
@@ -98,8 +113,26 @@ class SlackClient:
         return self._make_request("POST", "chat.update", data)
 
     def delete_message(self, channel: str, ts: str) -> None:
-        """Delete a message from a Slack channel. Raises ValueError on failure."""
-        self._make_request("POST", "chat.delete", {"channel": channel, "ts": ts})
+        """Delete a message from a Slack channel. Raises ValueError on failure.
+        Best-effort housekeeping for callers, so it gets a short budget."""
+        self._make_request("POST", "chat.delete", {"channel": channel, "ts": ts}, timeout=10, max_retries=1)
+
+    def get_message(self, channel: str, ts: str) -> Optional[Dict[str, Any]]:
+        """The message `ts` in `channel` (via conversations.replies, so a thread
+        parent carries `reply_count`), or None when Slack no longer has it.
+        Other failures raise ValueError. Short budget: callers treat a failed
+        lookup as "still present" and move on."""
+        try:
+            result = self._make_request(
+                "GET", "conversations.replies", {"channel": channel, "ts": ts, "limit": 1},
+                timeout=10, max_retries=1,
+            )
+        except SlackAPIError as e:
+            if e.error == "thread_not_found":
+                return None
+            raise
+        messages = result.get('messages') or []
+        return messages[0] if messages and messages[0].get('ts') == ts else None
     
     def set_channel_topic(self, channel: str, topic: str) -> Dict[str, Any]:
         """Set channel topic/description."""

--- a/server/connectors/slack_connector/client.py
+++ b/server/connectors/slack_connector/client.py
@@ -59,7 +59,12 @@ class SlackClient:
         if result.get('ok', False):
             return result
         error = result.get('error', 'unknown_error')
-        if not (error == 'name_taken' and endpoint == 'conversations.create'):
+        # Answers the caller expects and handles itself: not an ERROR line.
+        expected = (
+            (error == 'name_taken' and endpoint == 'conversations.create')
+            or (error == 'thread_not_found' and endpoint == 'conversations.replies')
+        )
+        if not expected:
             logger.error("Slack API error on %s: %s", endpoint, error)
         raise SlackAPIError(error)
 
@@ -106,9 +111,11 @@ class SlackClient:
         return result
     
     def update_message(self, channel: str, ts: str, text: str, blocks: Optional[List[Dict]] = None) -> Dict[str, Any]:
-        """Update an existing message in a Slack channel."""
+        """Update an existing message in a Slack channel. Pass blocks=[] to
+        replace a Block Kit message with plain text (omitting blocks keeps the
+        old ones)."""
         data = {"channel": channel, "ts": ts, "text": text}
-        if blocks:
+        if blocks is not None:
             data["blocks"] = blocks
         return self._make_request("POST", "chat.update", data)
 
@@ -119,8 +126,9 @@ class SlackClient:
 
     def get_message(self, channel: str, ts: str) -> Optional[Dict[str, Any]]:
         """The message `ts` in `channel` (via conversations.replies, so a thread
-        parent carries `reply_count`), or None when Slack no longer has it.
-        Other failures raise ValueError. Short budget: callers treat a failed
+        parent carries `reply_count`), or None when Slack no longer has it —
+        including the tombstone Slack leaves at the same ts for a deleted
+        parent that had replies. Other failures raise ValueError. Short budget: callers treat a failed
         lookup as "still present" and move on."""
         try:
             result = self._make_request(
@@ -132,7 +140,10 @@ class SlackClient:
                 return None
             raise
         messages = result.get('messages') or []
-        return messages[0] if messages and messages[0].get('ts') == ts else None
+        message = messages[0] if messages and messages[0].get('ts') == ts else None
+        if message is None or message.get('subtype') == 'tombstone':
+            return None
+        return message
     
     def set_channel_topic(self, channel: str, topic: str) -> Dict[str, Any]:
         """Set channel topic/description."""

--- a/server/routes/slack/slack_events_helpers.py
+++ b/server/routes/slack/slack_events_helpers.py
@@ -9,6 +9,7 @@ import hashlib
 import time
 from typing import Optional
 from utils.db.connection_pool import db_pool
+from utils.auth.stateless_auth import set_rls_context
 from utils.log_sanitizer import sanitize
 import re
 from datetime import datetime
@@ -535,26 +536,28 @@ def get_incident_by_slack_message(user_id: str, slack_message_ts: str):
     Find an incident by its Slack notification message timestamp.
     Returns (incident_id, session_id) or (None, None) if not found.
 
-    The lookup is org-wide (RLS below): the incidents channel is shared by
-    the org and a recurrence's completion lands in its anchor's thread, which
-    may belong to another member. The incident's RCA session is only reused
-    for its owner; anyone else gets a fresh session linked to the incident.
+    The lookup is org-wide: the incidents channel is shared by the org and a
+    recurrence's completion lands in its anchor's thread, which may belong to
+    another member. It is scoped to the caller's org twice — by RLS and by an
+    explicit org_id predicate — because a Slack ts is only unique within a
+    channel, so two workspaces can hold the same value. The incident's RCA
+    session is only reused for its owner; anyone else gets a fresh session
+    linked to the incident.
     """
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute(
-                    "SET myapp.current_org_id = (SELECT org_id FROM users WHERE id = %s)",
-                    (user_id,)
-                )
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix="[SlackEvents:incident_by_ts]")
+                if not org_id:
+                    return None, None
                 cursor.execute(
                     """
                     SELECT id, aurora_chat_session_id, user_id
                     FROM incidents
-                    WHERE slack_message_ts = %s
+                    WHERE slack_message_ts = %s AND org_id = %s
                     LIMIT 1
                     """,
-                    (slack_message_ts,)
+                    (slack_message_ts, org_id)
                 )
                 result = cursor.fetchone()
 
@@ -575,23 +578,26 @@ def get_incident_by_slack_message(user_id: str, slack_message_ts: str):
 def get_session_from_thread(user_id: str, channel_id: str, thread_ts: str):
     """
     Find the session_id associated with a Slack thread.
-    First checks if thread_ts matches an incident notification message.
-    Then looks up chat sessions by thread_ts in trigger_metadata.
-    Returns (session_id, incident_id) or (None, None) if not found.
+    First checks if thread_ts matches an incident notification message; its
+    RCA session is reused only by the incident's owner. Otherwise looks up
+    this user's own earlier chat session in the thread (a plain Slack chat,
+    or their Q&A on someone else's incident).
+    Returns (session_id, incident_id), where incident_id is set only when
+    session_id is that incident's RCA session — so a non-owner's first
+    mention on an incident thread returns (None, incident_id) and the caller
+    starts a Q&A session about it. (None, None) if nothing matches.
     """
     try:
         # First, check if this thread is from an incident notification
         incident_id, session_id = get_incident_by_slack_message(user_id, thread_ts)
-        if incident_id:
+        if session_id:
             return session_id, incident_id
         
         # Otherwise, look up by thread_ts in chat session metadata
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute(
-                    "SET myapp.current_org_id = (SELECT org_id FROM users WHERE id = %s)",
-                    (user_id,)
-                )
+                if not set_rls_context(cursor, conn, user_id, log_prefix="[SlackEvents:session_by_thread]"):
+                    return None, incident_id
                 cursor.execute(
                     """
                     SELECT id, ui_state
@@ -609,6 +615,9 @@ def get_session_from_thread(user_id: str, channel_id: str, thread_ts: str):
                 
                 if result:
                     session_id = str(result[0])
+                    if incident_id:
+                        # This user's Q&A session on an incident they do not own.
+                        return session_id, None
                     
                     cursor.execute(
                         """
@@ -624,7 +633,7 @@ def get_session_from_thread(user_id: str, channel_id: str, thread_ts: str):
                     
                     return session_id, incident_id
                 
-                return None, None
+                return None, incident_id
                 
     except Exception as e:
         logger.error(f"Error looking up session from thread: {e}", exc_info=True)
@@ -643,6 +652,12 @@ def send_message_to_aurora(user_id: str, message_text: str, channel: str, thread
     from chat.background.task import run_background_chat, create_background_chat_session
     
     try:
+        # Only the incident's own RCA session (its owner continuing it) runs as
+        # the incident's investigation. A fresh session is a Q&A about the
+        # incident: linked for context through chat_sessions.incident_id like
+        # the incident chat in the UI, but it must not re-run the RCA lifecycle
+        # (re-link aurora_chat_session_id, re-summarize, re-dispatch actions).
+        rca_incident_id = incident_id if session_id else None
         # Create session if not exists
         if not session_id:
             # Generate a title from the message (first TITLE_MAX_LENGTH chars)
@@ -659,7 +674,8 @@ def send_message_to_aurora(user_id: str, message_text: str, channel: str, thread
             session_id = create_background_chat_session(
                 user_id=user_id,
                 title=title,
-                trigger_metadata=trigger_metadata
+                trigger_metadata=trigger_metadata,
+                incident_id=incident_id,
             )
         
         # Build context from thread messages or channel messages
@@ -702,7 +718,7 @@ def send_message_to_aurora(user_id: str, message_text: str, channel: str, thread
             initial_message=full_message,
             trigger_metadata=trigger_metadata,
             provider_preference=None,  # Use default providers
-            incident_id=incident_id,
+            incident_id=rca_incident_id,
             send_notifications=False  # Don't send investigation started notifications for Slack @mentions
         )
         

--- a/server/routes/slack/slack_events_helpers.py
+++ b/server/routes/slack/slack_events_helpers.py
@@ -534,6 +534,11 @@ def get_incident_by_slack_message(user_id: str, slack_message_ts: str):
     """
     Find an incident by its Slack notification message timestamp.
     Returns (incident_id, session_id) or (None, None) if not found.
+
+    The lookup is org-wide (RLS below): the incidents channel is shared by
+    the org and a recurrence's completion lands in its anchor's thread, which
+    may belong to another member. The incident's RCA session is only reused
+    for its owner; anyone else gets a fresh session linked to the incident.
     """
     try:
         with db_pool.get_admin_connection() as conn:
@@ -544,18 +549,19 @@ def get_incident_by_slack_message(user_id: str, slack_message_ts: str):
                 )
                 cursor.execute(
                     """
-                    SELECT id, aurora_chat_session_id
+                    SELECT id, aurora_chat_session_id, user_id
                     FROM incidents
-                    WHERE user_id = %s AND slack_message_ts = %s
+                    WHERE slack_message_ts = %s
                     LIMIT 1
                     """,
-                    (user_id, slack_message_ts)
+                    (slack_message_ts,)
                 )
                 result = cursor.fetchone()
-                
+
                 if result:
                     incident_id = str(result[0])
-                    session_id = str(result[1]) if result[1] else None
+                    is_owner = str(result[2]) == str(user_id)
+                    session_id = str(result[1]) if result[1] and is_owner else None
                     logger.info(f"Found incident {incident_id} (session: {session_id}) from slack_message_ts {slack_message_ts}")
                     return incident_id, session_id
                 

--- a/server/services/correlation/recurrence_agent.py
+++ b/server/services/correlation/recurrence_agent.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from services.correlation.recurrence_config import (
+    GROUP_IDLE_HOURS,
     MAX_TURNS,
     MODE_LIVE,
     MODE_OFF,
@@ -41,6 +42,12 @@ from utils.validation import is_valid_uuid
 logger = logging.getLogger(__name__)
 
 _LOG_PREFIX = "[RECURRENCE]"
+
+# Recent incidents handed to the agent in its input block: the only ones whose
+# group can still be joined (GROUP_IDLE_HOURS). Saves the agent from having to
+# discover them with list_incidents, where a wrong status filter (completed
+# investigations are 'analyzed', not 'resolved') returned nothing.
+RECENT_CANDIDATES_LIMIT = 15
 
 try:  # Celery soft-limit signal must reach the outer handler, not the
     # generic agent-failure catch (SoftTimeLimitExceeded subclasses Exception).
@@ -258,6 +265,7 @@ def _build_input_block(ctx: Dict[str, Any], incident_id: str, decision_point: st
             "",
             ctx.get("summary") or "(no summary available)",
         ]
+    lines += ["", *_recent_incidents_lines(ctx.get("recent"), truncated=bool(ctx.get("recent_truncated")))]
     hint = ctx.get("hint")
     if isinstance(hint, dict) and hint.get("incident_id"):
         lines += [
@@ -271,6 +279,77 @@ def _build_input_block(ctx: Dict[str, Any], incident_id: str, decision_point: st
             ),
         ]
     return "\n".join(lines)
+
+
+def _recent_incidents_lines(recent: Optional[list], *, truncated: bool = False) -> list:
+    """Input-block section listing the incidents eligible to be joined.
+    `truncated` says the window holds more than RECENT_CANDIDATES_LIMIT: the
+    list is then a sample, never presented as the complete set of open groups."""
+    header = f"### Recent incidents in this org (last {GROUP_IDLE_HOURS}h, newest first)"
+    if not recent:
+        return [
+            header,
+            "",
+            "(none) — no group is open to join; unless a tool call surfaces an "
+            f"incident that fired within the last {GROUP_IDLE_HOURS}h, answer new.",
+        ]
+    lines = [
+        header,
+        "",
+        f"Only incidents that fired within the last {GROUP_IDLE_HOURS}h, or the group roots of "
+        f"such incidents, can be claimed. A group with no activity in {GROUP_IDLE_HOURS}h is "
+        "closed and a claim on it is rejected.",
+        "",
+    ]
+    for r in recent:
+        line = (
+            f"- {r['id']} | fired {r.get('fired_at_iso') or '?'} | {r.get('status') or '?'}"
+            f" | {r.get('service') or '(no service)'} | {r.get('title') or '(no title)'}"
+        )
+        if r.get("recurrence_of"):
+            line += f" | recurrence of {r['recurrence_of']}"
+        lines.append(line)
+    if truncated:
+        lines.append(
+            f"- (more incidents fired in the last {GROUP_IDLE_HOURS}h than shown here — use "
+            "list_incidents without a status filter to see them; any of them, or their "
+            "group roots, can also be claimed)"
+        )
+    return lines
+
+
+def _fetch_recent_incidents(cursor, incident_id: str) -> Tuple[list, bool]:
+    """Incidents in the caller's org (RLS) that fired within GROUP_IDLE_HOURS,
+    newest first, excluding the one under examination, capped at
+    RECENT_CANDIDATES_LIMIT — plus whether the window held more than that.
+    Same window and clock as recurrence_fold._group_is_stale so what the agent
+    sees is what the fold will accept."""
+    cursor.execute(
+        """SELECT id, alert_title, alert_service, status,
+                  COALESCE(alert_fired_at, started_at) AS fired_at,
+                  recurrence_of_incident_id
+           FROM incidents
+           WHERE id <> %s
+             AND status <> 'merged'
+             AND COALESCE(alert_fired_at, started_at)
+                 >= (NOW() AT TIME ZONE 'UTC') - make_interval(hours => %s)
+           ORDER BY COALESCE(alert_fired_at, started_at) DESC
+           LIMIT %s""",
+        (incident_id, GROUP_IDLE_HOURS, RECENT_CANDIDATES_LIMIT + 1),
+    )
+    rows = cursor.fetchall()
+    truncated = len(rows) > RECENT_CANDIDATES_LIMIT
+    return [
+        {
+            "id": str(r[0]),
+            "title": r[1] or "",
+            "service": r[2] or "",
+            "status": r[3] or "",
+            "fired_at_iso": iso_utc(r[4]),
+            "recurrence_of": str(r[5]) if r[5] else None,
+        }
+        for r in rows[:RECENT_CANDIDATES_LIMIT]
+    ], truncated
 
 
 def _fetch_incident_context(incident_id: str, user_id: str) -> Optional[Dict[str, Any]]:
@@ -305,6 +384,7 @@ def _fetch_incident_context(incident_id: str, user_id: str) -> Optional[Dict[str
                         meta = {}
                 hint = meta.get("correlation_hint") if isinstance(meta, dict) else None
                 started_at, fired_at = row[4], row[5] or row[4]
+                recent, recent_truncated = _fetch_recent_incidents(cursor, incident_id)
                 return {
                     "org_id": org_id,
                     "title": row[0] or "",
@@ -315,6 +395,8 @@ def _fetch_incident_context(incident_id: str, user_id: str) -> Optional[Dict[str
                     "fired_at_iso": iso_utc(fired_at),
                     "summary": row[6] or "",
                     "hint": hint if isinstance(hint, dict) else None,
+                    "recent": recent,
+                    "recent_truncated": recent_truncated,
                 }
     except Exception:
         logger.exception(

--- a/server/services/correlation/recurrence_prompt.md
+++ b/server/services/correlation/recurrence_prompt.md
@@ -6,11 +6,13 @@ A recurrence means the **same underlying causal mechanism** is producing the fai
 
 The incident under examination is described in the input block of the first message. If a completed investigation conclusion is included, it is your strongest evidence — compare conclusions, not symptoms. If a correlator hint is included, it is a hint to verify, not a verdict: the rule correlator only sees titles, services, and timing.
 
+The input block also lists the **recent incidents** in this org (last 24 hours, newest first; the list is capped and says so when more exist). A group is open while any of its members fired within the last 24 hours; a group with no activity in 24 hours is closed, and a claim on it is rejected by the system. Completed investigations have status `analyzed` (not `resolved`); `investigating` incidents are still running.
+
 ## Method
 
-1. Find your own candidates. Use `list_incidents` (filter by service/status), `search_similar_rcas` (semantic search over past investigations), `knowledge_base_search`, and `get_incident` to read a candidate's conclusion in full.
+1. Start from the recent-incidents list. Use `get_incident` to read a candidate's conclusion in full, `search_similar_rcas` (semantic search over past investigations) and `knowledge_base_search` for context, and `list_incidents` if you need more — call it **without** a `status` filter unless you have a reason; a wrong filter hides the candidates.
 2. Distinguish look-alikes with specifics: Same component? Same failure mechanism? Was there a deploy, fix, or config change between the two? A fix shipped in between strongly suggests a new incident even if symptoms match.
-3. Prefer the group root: if the best match is itself marked as a recurrence of another incident, name that other (root) incident.
+3. Prefer the group root: if the best match is itself marked as a recurrence of another incident, name that root — a root older than 24 hours is fine when one of its recurrences is recent. If the mechanism matches only an incident whose group has had no activity in the last 24 hours, that group is closed: name a recent incident that shares the mechanism if there is one, otherwise answer new.
 
 ## Bias
 

--- a/server/tests/connectors/test_slack_client_get_message.py
+++ b/server/tests/connectors/test_slack_client_get_message.py
@@ -1,0 +1,57 @@
+"""SlackClient.get_message: what counts as "Slack no longer has it"."""
+
+from unittest.mock import patch
+
+import pytest
+
+from connectors.slack_connector.client import SlackAPIError, SlackClient
+
+TS = "1700000000.000001"
+
+
+def _client_answering(payload=None, error=None):
+    client = SlackClient("xoxb-test")
+
+    def fake_request(method, endpoint, data=None, timeout=30, max_retries=3):
+        assert (method, endpoint) == ("GET", "conversations.replies")
+        assert data == {"channel": "C1", "ts": TS, "limit": 1}
+        if error:
+            raise SlackAPIError(error)
+        return payload
+
+    return client, fake_request
+
+
+def test_present_message_is_returned():
+    client, req = _client_answering({"ok": True, "messages": [{"ts": TS, "text": "hi", "reply_count": 2}]})
+    with patch.object(client, "_make_request", side_effect=req):
+        assert client.get_message("C1", TS)["reply_count"] == 2
+
+
+def test_thread_not_found_is_gone():
+    client, req = _client_answering(error="thread_not_found")
+    with patch.object(client, "_make_request", side_effect=req):
+        assert client.get_message("C1", TS) is None
+
+
+def test_tombstone_of_a_deleted_parent_with_replies_is_gone():
+    # Slack keeps "This message was deleted." at the same ts when the parent had replies.
+    client, req = _client_answering({"ok": True, "messages": [
+        {"ts": TS, "subtype": "tombstone", "text": "This message was deleted.", "reply_count": 3},
+    ]})
+    with patch.object(client, "_make_request", side_effect=req):
+        assert client.get_message("C1", TS) is None
+
+
+def test_other_ts_in_reply_is_gone():
+    client, req = _client_answering({"ok": True, "messages": [{"ts": "1700000000.000009"}]})
+    with patch.object(client, "_make_request", side_effect=req):
+        assert client.get_message("C1", TS) is None
+
+
+def test_other_rejections_propagate():
+    client, req = _client_answering(error="not_in_channel")
+    with patch.object(client, "_make_request", side_effect=req):
+        with pytest.raises(SlackAPIError) as exc:
+            client.get_message("C1", TS)
+        assert exc.value.error == "not_in_channel"

--- a/server/tests/services/correlation/test_recurrence_candidates.py
+++ b/server/tests/services/correlation/test_recurrence_candidates.py
@@ -1,0 +1,107 @@
+"""Recent-incident candidate list handed to the recurrence agent (layer-1 fix:
+the agent no longer depends on picking the right list_incidents status filter,
+and only sees incidents whose group is still open)."""
+
+import os
+import sys
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+import services.correlation.recurrence_agent as ra  # noqa: E402
+from services.correlation.recurrence_config import GROUP_IDLE_HOURS  # noqa: E402
+
+ME = str(uuid.uuid4())
+ROOT = str(uuid.uuid4())
+CHILD = str(uuid.uuid4())
+_T0 = datetime(2026, 9, 8, 13, 49, 2)
+
+
+def _recent():
+    return [
+        {"id": CHILD, "title": "High memory", "service": "payments-api", "status": "analyzed",
+         "fired_at_iso": "2026-09-08T14:01:00Z", "recurrence_of": ROOT},
+        {"id": ROOT, "title": "High memory", "service": "payments-api", "status": "analyzed",
+         "fired_at_iso": "2026-09-08T13:49:02Z", "recurrence_of": None},
+    ]
+
+
+class TestRecentIncidentsLines:
+    def test_lists_candidates_with_root_pointer(self):
+        text = "\n".join(ra._recent_incidents_lines(_recent()))
+        assert f"last {GROUP_IDLE_HOURS}h" in text
+        assert f"- {CHILD} | fired 2026-09-08T14:01:00Z | analyzed | payments-api | High memory | recurrence of {ROOT}" in text
+        assert f"- {ROOT} | fired 2026-09-08T13:49:02Z | analyzed | payments-api | High memory" in text
+        assert "closed" in text
+
+    def test_empty_list_says_answer_new(self):
+        text = "\n".join(ra._recent_incidents_lines([]))
+        assert "(none)" in text
+        assert "answer new" in text
+
+    def test_truncated_list_is_not_presented_as_complete(self):
+        text = "\n".join(ra._recent_incidents_lines(_recent(), truncated=True))
+        assert "more incidents fired" in text
+        assert "list_incidents" in text
+        assert "Only these" not in text
+        assert "more incidents" not in "\n".join(ra._recent_incidents_lines(_recent()))
+
+    def test_input_block_carries_the_section(self):
+        ctx = {"title": "t", "service": "s", "source_type": "datadog", "severity": "critical",
+               "fired_at_iso": "x", "summary": "conclusion", "recent": _recent()}
+        block = ra._build_input_block(ctx, ME, "after")
+        assert "### Completed investigation conclusion" in block
+        assert "### Recent incidents in this org" in block
+        assert block.index("### Recent incidents") > block.index("conclusion")
+        assert CHILD in block
+
+
+class TestFetchRecentIncidents:
+    def test_query_excludes_self_and_merged_within_idle_window(self):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [
+            (uuid.UUID(CHILD), "High memory", "payments-api", "analyzed", _T0, uuid.UUID(ROOT)),
+            (uuid.UUID(ROOT), None, None, "investigating", _T0, None),
+        ]
+        recent, truncated = ra._fetch_recent_incidents(cursor, ME)
+        sql = " ".join(cursor.execute.call_args.args[0].split())
+        params = cursor.execute.call_args.args[1]
+        assert "id <> %s" in sql
+        assert "status <> 'merged'" in sql
+        assert "make_interval(hours => %s)" in sql
+        assert "ORDER BY COALESCE(alert_fired_at, started_at) DESC" in sql
+        # one extra row is fetched only to learn whether the window overflowed
+        assert params == (ME, GROUP_IDLE_HOURS, ra.RECENT_CANDIDATES_LIMIT + 1)
+        assert truncated is False
+        assert recent[0]["id"] == CHILD
+        assert recent[0]["recurrence_of"] == ROOT
+        assert recent[1] == {"id": ROOT, "title": "", "service": "", "status": "investigating",
+                             "fired_at_iso": recent[1]["fired_at_iso"], "recurrence_of": None}
+
+    def test_overflow_is_capped_and_flagged(self):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [
+            (uuid.uuid4(), "t", "svc", "analyzed", _T0, None) for _ in range(ra.RECENT_CANDIDATES_LIMIT + 1)
+        ]
+        recent, truncated = ra._fetch_recent_incidents(cursor, ME)
+        assert len(recent) == ra.RECENT_CANDIDATES_LIMIT
+        assert truncated is True
+
+    def test_context_includes_recent(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = ("title", "svc", "datadog", "critical", _T0, _T0, "summary", {})
+        cursor.fetchall.return_value = [(uuid.UUID(ROOT), "t", "svc", "analyzed", _T0, None)]
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cursor
+        pool = MagicMock()
+        pool.get_admin_connection.return_value.__enter__.return_value = conn
+        with patch.object(ra, "db_pool", pool), patch.object(ra, "set_rls_context", return_value="org-1"):
+            ctx = ra._fetch_incident_context(ME, "u1")
+        assert ctx["recent"] == [{"id": ROOT, "title": "t", "service": "svc", "status": "analyzed",
+                                  "fired_at_iso": ctx["recent"][0]["fired_at_iso"], "recurrence_of": None}]
+        assert ctx["recent_truncated"] is False
+        assert cursor.execute.call_count == 2

--- a/server/tests/utils/notifications/conftest.py
+++ b/server/tests/utils/notifications/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures for the Slack thread-consolidation tests (no DB, no network).
+
+Stubs ``routes.slack.slack_events_helpers`` in sys.modules so the service's
+function-local imports resolve without pulling the Flask routes package.
+sys.path and the inert POSTGRES_* env come from the root tests/conftest.py.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.notifications import dispatcher, slack_notification_service, slack_threading
+
+from .slack_fakes import FakePool, FakeSlackClient, folded_incident, standalone_incident
+
+
+@pytest.fixture
+def make_client():
+    return FakeSlackClient
+
+
+@pytest.fixture
+def folded():
+    return folded_incident
+
+
+@pytest.fixture
+def standalone():
+    return standalone_incident
+
+
+@pytest.fixture
+def fake_pool():
+    return FakePool()
+
+
+@pytest.fixture
+def patched_db(fake_pool, monkeypatch):
+    """Route every incidents write in the notification modules to fake_pool."""
+    for module in (slack_notification_service, slack_threading, dispatcher):
+        monkeypatch.setattr(module, "db_pool", fake_pool.pool)
+        monkeypatch.setattr(module, "set_rls_context", lambda *a, **k: "org-1")
+    return fake_pool
+
+
+@pytest.fixture
+def slack_helpers_stub(monkeypatch):
+    """Stub routes.slack.slack_events_helpers; yields the stub so tests can
+    flip validate_slack_blocks or assert on get_incident_suggestions."""
+    stub = types.ModuleType("routes.slack.slack_events_helpers")
+    stub.validate_slack_blocks = MagicMock(return_value=True)
+    stub.extract_summary_section = lambda text: text
+    stub.format_response_for_slack = lambda text: text
+    stub.get_incident_suggestions = MagicMock(return_value=[])
+    stub.build_suggestions_blocks = MagicMock(return_value=[])
+    monkeypatch.setitem(sys.modules, "routes.slack.slack_events_helpers", stub)
+    return stub

--- a/server/tests/utils/notifications/slack_fakes.py
+++ b/server/tests/utils/notifications/slack_fakes.py
@@ -43,18 +43,26 @@ class FakeSlackClient:
     its options; raises SlackAPIError the way SlackClient does on ok=false."""
 
     def __init__(self, *, fail_thread=False, fail_delete=False, fail_all=False, transport_error=False,
-                 ignore_thread=False, missing=(), replies=None, reject_with="cannot_reply_to_message"):
+                 ignore_thread=False, missing=(), replies=None, reject_with="cannot_reply_to_message",
+                 fail_update=False, cards=None):
         self.fail_thread = fail_thread  # ok=false on any threaded post
         self.fail_delete = fail_delete
+        self.fail_update = fail_update  # chat.update rejected with cant_update_message
         self.fail_all = fail_all  # ok=false on any post
         self.reject_with = reject_with  # the ok=false error code for fail_thread / fail_all
         self.transport_error = transport_error  # network failure: SlackClient wraps it in a plain ValueError
         self.ignore_thread = ignore_thread  # parent vanished after the lookup (race): replies land top-level
         self.missing = set(missing)  # ts values Slack no longer has: lookups return None, replies land top-level
         self.replies = dict(replies or {})  # ts -> reply_count of stored thread parents
+        # ts -> {"blocks", "text"} of existing messages; unknown ts get a default Started card.
+        # update_message writes back here so a later lookup sees the edited card.
+        self.cards = dict(cards or {})
         self.sent = []
         self.deleted = []
+        self.lookups = []  # ts of every get_message call
+        self.updated = []  # chat.update calls that succeeded
         self.attempts = 0  # every chat.postMessage call, including rejected ones
+        self.update_attempts = 0  # every chat.update call, including rejected ones
         self._n = 0
 
     def send_message(self, channel, text, thread_ts=None, blocks=None):
@@ -71,17 +79,39 @@ class FakeSlackClient:
             message["thread_ts"] = thread_ts
         return {"ok": True, "channel": channel, "ts": ts, "message": message}
 
+    def update_message(self, channel, ts, text, blocks=None):
+        self.update_attempts += 1
+        if self.transport_error:
+            raise ValueError("Failed to communicate with Slack: read timeout")
+        if self.fail_all:
+            raise SlackAPIError(self.reject_with)
+        if ts in self.missing:
+            raise SlackAPIError("message_not_found")
+        if self.fail_update:
+            raise SlackAPIError("cant_update_message")
+        self.updated.append({"channel": channel, "ts": ts, "text": text, "blocks": blocks})
+        self.cards[ts] = {"blocks": blocks, "text": text}
+        return {"ok": True, "channel": channel, "ts": ts, "text": text, "message": {"ts": ts}}
+
     def delete_message(self, channel, ts):
         if self.fail_delete:
             raise SlackAPIError("cant_delete_message")
         self.deleted.append((channel, ts))
 
     def get_message(self, channel, ts):
+        self.lookups.append(ts)
         if self.transport_error:
             raise ValueError("Failed to communicate with Slack: read timeout")
         if ts in self.missing:
             return None
-        message = {"ts": ts}
+        card = self.cards.get(ts) or {
+            "blocks": [
+                {"type": "header", "block_id": "hdr", "text": {"type": "plain_text", "text": "Investigation Started", "emoji": True}},
+                {"type": "section", "block_id": "body", "text": {"type": "mrkdwn", "text": "*Alert:* High CPU"}},
+            ],
+            "text": "Investigation Started: High CPU",
+        }
+        message = {"ts": ts, "blocks": card["blocks"], "text": card["text"]}
         if self.replies.get(ts):
             message["reply_count"] = self.replies[ts]
         return message

--- a/server/tests/utils/notifications/slack_fakes.py
+++ b/server/tests/utils/notifications/slack_fakes.py
@@ -77,6 +77,8 @@ class FakeSlackClient:
         self.deleted.append((channel, ts))
 
     def get_message(self, channel, ts):
+        if self.transport_error:
+            raise ValueError("Failed to communicate with Slack: read timeout")
         if ts in self.missing:
             return None
         message = {"ts": ts}

--- a/server/tests/utils/notifications/slack_fakes.py
+++ b/server/tests/utils/notifications/slack_fakes.py
@@ -1,0 +1,108 @@
+"""Fakes and incident_data builders shared by the Slack thread-consolidation tests."""
+
+import uuid
+from unittest.mock import MagicMock
+
+from connectors.slack_connector.client import SlackAPIError
+
+ANCHOR_ID = str(uuid.uuid4())
+CHILD_ID = str(uuid.uuid4())
+ANCHOR_TS = "1700000000.000001"
+CHILD_TS = "1700000000.000002"
+# ts values the fake hands out for posts use a different epoch from the stored
+# constants above, so an assertion on "which ts" can tell them apart.
+FIRST_POSTED_TS = "1800000000.000001"
+SECOND_POSTED_TS = "1800000000.000002"
+CHAN = "C123"
+
+
+def folded_incident(**over):
+    """CHILD_ID folded into ANCHOR_ID; both Started messages stored."""
+    data = {
+        'incident_id': CHILD_ID, 'alert_title': 'High CPU', 'severity': 'critical', 'service': 'api',
+        'source_type': 'datadog', 'aurora_summary': 'What happened.\n\nRoot cause: disk full.',
+        'slack_message_ts': CHILD_TS, 'recurrence_of': ANCHOR_ID, 'anchor_slack_message_ts': ANCHOR_TS,
+        'anchor_alert_title': 'High CPU', 'occurrence_number': 2, 'group_size': 3,
+    }
+    data.update(over)
+    return data
+
+
+def standalone_incident(**over):
+    """ANCHOR_ID on its own, with its Started message stored."""
+    data = folded_incident(
+        incident_id=ANCHOR_ID, slack_message_ts=ANCHOR_TS, recurrence_of=None,
+        anchor_slack_message_ts=None, anchor_alert_title=None, occurrence_number=1, group_size=1,
+    )
+    data.update(over)
+    return data
+
+
+class FakeSlackClient:
+    """Records chat.postMessage / chat.delete and answers message lookups from
+    its options; raises SlackAPIError the way SlackClient does on ok=false."""
+
+    def __init__(self, *, fail_thread=False, fail_delete=False, fail_all=False, transport_error=False,
+                 ignore_thread=False, missing=(), replies=None, reject_with="cannot_reply_to_message"):
+        self.fail_thread = fail_thread  # ok=false on any threaded post
+        self.fail_delete = fail_delete
+        self.fail_all = fail_all  # ok=false on any post
+        self.reject_with = reject_with  # the ok=false error code for fail_thread / fail_all
+        self.transport_error = transport_error  # network failure: SlackClient wraps it in a plain ValueError
+        self.ignore_thread = ignore_thread  # parent vanished after the lookup (race): replies land top-level
+        self.missing = set(missing)  # ts values Slack no longer has: lookups return None, replies land top-level
+        self.replies = dict(replies or {})  # ts -> reply_count of stored thread parents
+        self.sent = []
+        self.deleted = []
+        self.attempts = 0  # every chat.postMessage call, including rejected ones
+        self._n = 0
+
+    def send_message(self, channel, text, thread_ts=None, blocks=None):
+        self.attempts += 1
+        if self.transport_error:
+            raise ValueError("Failed to communicate with Slack: read timeout")
+        if self.fail_all or (self.fail_thread and thread_ts):
+            raise SlackAPIError(self.reject_with)
+        self._n += 1
+        self.sent.append({"channel": channel, "text": text, "thread_ts": thread_ts, "blocks": blocks})
+        ts = f"1800000000.{self._n:06d}"
+        message = {"ts": ts}
+        if thread_ts and not self.ignore_thread and thread_ts not in self.missing:
+            message["thread_ts"] = thread_ts
+        return {"ok": True, "channel": channel, "ts": ts, "message": message}
+
+    def delete_message(self, channel, ts):
+        if self.fail_delete:
+            raise SlackAPIError("cant_delete_message")
+        self.deleted.append((channel, ts))
+
+    def get_message(self, channel, ts):
+        if ts in self.missing:
+            return None
+        message = {"ts": ts}
+        if self.replies.get(ts):
+            message["reply_count"] = self.replies[ts]
+        return message
+
+
+class FakePool:
+    """db_pool stand-in: one MagicMock connection; every execute is recorded
+    and reports one changed row unless a test sets cursor.rowcount."""
+
+    def __init__(self):
+        self.conn = MagicMock(name="conn")
+        self.cursor = MagicMock(name="cursor")
+        self.cursor.fetchone.return_value = ("owner@example.com",)
+        self.cursor.rowcount = 1
+        self.conn.cursor.return_value.__enter__.return_value = self.cursor
+        self.pool = MagicMock(name="db_pool")
+        self.pool.get_admin_connection.return_value.__enter__.return_value = self.conn
+
+    @property
+    def executes(self):
+        return [(" ".join(c.args[0].split()), c.args[1] if len(c.args) > 1 else None)
+                for c in self.cursor.execute.call_args_list]
+
+    @property
+    def updates(self):
+        return [(sql, params) for sql, params in self.executes if sql.startswith("UPDATE incidents")]

--- a/server/tests/utils/notifications/test_dispatcher_incident_data.py
+++ b/server/tests/utils/notifications/test_dispatcher_incident_data.py
@@ -1,0 +1,64 @@
+"""dispatcher._get_incident_data: recurrence-group fields for Slack threading."""
+
+import uuid
+from datetime import datetime
+
+from utils.notifications import dispatcher
+
+A = str(uuid.uuid4())
+B = str(uuid.uuid4())
+_T0 = datetime(2026, 9, 1, 12, 0, 0)
+
+_EXISTING_KEYS = (
+    'incident_id', 'user_id', 'source_type', 'status', 'severity', 'alert_title',
+    'service', 'aurora_status', 'aurora_summary', 'started_at', 'analyzed_at',
+    'created_at', 'slack_message_ts', 'google_chat_message_name',
+)
+
+
+def _row(incident_id, *, recurrence_of=None, anchor_ts=None, anchor_title=None, n=1, size=1):
+    return (
+        uuid.UUID(incident_id), "u1", "datadog", "investigating", "critical", "High CPU",
+        "api", "completed", "summary text", _T0, _T0, _T0, "1700000000.000100", None,
+        uuid.UUID(recurrence_of) if recurrence_of else None, anchor_ts, anchor_title, n, size,
+    )
+
+
+def _fetch(row, incident_id, fake_pool):
+    fake_pool.cursor.fetchone.return_value = row
+    return dispatcher._get_incident_data(incident_id, "u1")
+
+
+def test_folded_row_populates_group_fields(patched_db):
+    fake_pool = patched_db
+    data = _fetch(_row(B, recurrence_of=A, anchor_ts="1700000000.000001", anchor_title="High CPU", n=2, size=3), B, fake_pool)
+    assert data['recurrence_of'] == A
+    assert data['anchor_slack_message_ts'] == "1700000000.000001"
+    assert data['anchor_alert_title'] == "High CPU"
+    assert data['occurrence_number'] == 2
+    assert data['group_size'] == 3
+    sql, params = fake_pool.executes[0]
+    assert params == (B, B)
+    assert "ROW_NUMBER() OVER" in sql
+    assert "LEFT JOIN incidents anchor" in sql
+    assert "JOIN grp ON grp.id = i.id" in sql  # the group always contains the incident itself
+    assert "g.id = me.root_id OR g.recurrence_of_incident_id = me.root_id" in sql
+
+
+def test_standalone_row_keeps_existing_keys(patched_db):
+    fake_pool = patched_db
+    data = _fetch(_row(A), A, fake_pool)
+    assert data['recurrence_of'] is None
+    assert data['anchor_slack_message_ts'] is None
+    assert data['occurrence_number'] == 1
+    assert data['group_size'] == 1
+    for key in _EXISTING_KEYS:
+        assert key in data
+    assert data['incident_id'] == A
+    assert data['slack_message_ts'] == "1700000000.000100"
+    assert data['service'] == "api"
+
+
+def test_no_row_returns_none(patched_db):
+    fake_pool = patched_db
+    assert _fetch(None, A, fake_pool) is None

--- a/server/tests/utils/notifications/test_dispatcher_incident_data.py
+++ b/server/tests/utils/notifications/test_dispatcher_incident_data.py
@@ -16,11 +16,14 @@ _EXISTING_KEYS = (
 )
 
 
-def _row(incident_id, *, recurrence_of=None, anchor_ts=None, anchor_title=None, n=1, size=1):
+_T1 = datetime(2026, 9, 1, 14, 0, 0)
+
+
+def _row(incident_id, *, recurrence_of=None, anchor_ts=None, anchor_title=None, n=1, size=1, last_fired=_T0):
     return (
         uuid.UUID(incident_id), "u1", "datadog", "investigating", "critical", "High CPU",
         "api", "completed", "summary text", _T0, _T0, _T0, "1700000000.000100", None,
-        uuid.UUID(recurrence_of) if recurrence_of else None, anchor_ts, anchor_title, n, size,
+        uuid.UUID(recurrence_of) if recurrence_of else None, anchor_ts, anchor_title, n, size, last_fired,
     )
 
 
@@ -31,15 +34,17 @@ def _fetch(row, incident_id, fake_pool):
 
 def test_folded_row_populates_group_fields(patched_db):
     fake_pool = patched_db
-    data = _fetch(_row(B, recurrence_of=A, anchor_ts="1700000000.000001", anchor_title="High CPU", n=2, size=3), B, fake_pool)
+    data = _fetch(_row(B, recurrence_of=A, anchor_ts="1700000000.000001", anchor_title="High CPU", n=2, size=3, last_fired=_T1), B, fake_pool)
     assert data['recurrence_of'] == A
     assert data['anchor_slack_message_ts'] == "1700000000.000001"
     assert data['anchor_alert_title'] == "High CPU"
     assert data['occurrence_number'] == 2
     assert data['group_size'] == 3
+    assert data['group_last_fired_at'] == _T1
     sql, params = fake_pool.executes[0]
     assert params == (B, B)
     assert "ROW_NUMBER() OVER" in sql
+    assert "MAX(COALESCE(g.alert_fired_at, g.started_at)) OVER ()" in sql
     assert "LEFT JOIN incidents anchor" in sql
     assert "JOIN grp ON grp.id = i.id" in sql  # the group always contains the incident itself
     assert "g.id = me.root_id OR g.recurrence_of_incident_id = me.root_id" in sql

--- a/server/tests/utils/notifications/test_dispatcher_incident_data.py
+++ b/server/tests/utils/notifications/test_dispatcher_incident_data.py
@@ -59,6 +59,7 @@ def test_standalone_row_keeps_existing_keys(patched_db):
     assert data['service'] == "api"
 
 
-def test_no_row_returns_none(patched_db):
+def test_no_row_returns_none(patched_db, caplog):
     fake_pool = patched_db
     assert _fetch(None, A, fake_pool) is None
+    assert not [r for r in caplog.records if r.exc_info]

--- a/server/tests/utils/notifications/test_dispatcher_refresh_only.py
+++ b/server/tests/utils/notifications/test_dispatcher_refresh_only.py
@@ -1,0 +1,55 @@
+"""dispatcher.notify_investigation_completed(refresh_only=True): a follow-up
+re-summary refreshes the Google Chat card in place and announces nothing."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.notifications import dispatcher, slack_notification_service as svc
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    calls = {"slack": MagicMock(return_value=True), "gchat": MagicMock(return_value=True), "email": MagicMock()}
+    monkeypatch.setattr(dispatcher, "get_org_id_for_user", lambda user_id: "org-1")
+    monkeypatch.setattr(dispatcher, "get_org_preference", lambda org_id, key, default=None: True)
+    monkeypatch.setattr(dispatcher, "_has_slack_connected", lambda user_id: True)
+    monkeypatch.setattr(dispatcher, "_has_google_chat_connected", lambda user_id: True)
+    monkeypatch.setattr(dispatcher, "_send_emails", calls["email"])
+    monkeypatch.setattr(dispatcher, "_enrich_incident_summary", lambda *a, **k: None)
+    monkeypatch.setattr(svc, "send_slack_investigation_completed_notification", calls["slack"])
+    gchat = types.ModuleType("utils.notifications.google_chat_notification_service")
+    gchat.send_google_chat_investigation_completed_notification = calls["gchat"]
+    monkeypatch.setitem(sys.modules, "utils.notifications.google_chat_notification_service", gchat)
+    return calls
+
+
+def _incident(**over):
+    data = {"incident_id": "i1", "alert_title": "High CPU", "google_chat_message_name": "spaces/s/messages/m"}
+    data.update(over)
+    return data
+
+
+def test_first_completion_announces_everywhere(wired, monkeypatch):
+    monkeypatch.setattr(dispatcher, "_get_incident_data", lambda incident_id, user_id: _incident())
+    dispatcher.notify_investigation_completed("u1", "i1", session_id="s1")
+    wired["email"].assert_called_once()
+    wired["slack"].assert_called_once()
+    wired["gchat"].assert_called_once_with("u1", _incident(), allow_new_message=True)
+
+
+def test_refresh_only_edits_the_google_chat_card_and_posts_nothing(wired, monkeypatch):
+    monkeypatch.setattr(dispatcher, "_get_incident_data", lambda incident_id, user_id: _incident())
+    dispatcher.notify_investigation_completed("u1", "i1", session_id="s1", refresh_only=True)
+    wired["email"].assert_not_called()
+    wired["slack"].assert_not_called()
+    wired["gchat"].assert_called_once_with("u1", _incident(), allow_new_message=False)
+
+
+def test_refresh_only_without_a_card_skips_google_chat(wired, monkeypatch):
+    monkeypatch.setattr(dispatcher, "_get_incident_data", lambda incident_id, user_id: _incident(google_chat_message_name=None))
+    dispatcher.notify_investigation_completed("u1", "i1", refresh_only=True)
+    wired["gchat"].assert_not_called()
+    wired["slack"].assert_not_called()

--- a/server/tests/utils/notifications/test_slack_notification_placement.py
+++ b/server/tests/utils/notifications/test_slack_notification_placement.py
@@ -5,10 +5,13 @@ routed to fake_pool by patched_db and routes.slack.slack_events_helpers is
 stubbed by the package conftest.
 """
 
+from datetime import datetime
+
 import pytest
 
 from utils.notifications import slack_notification_service as svc
 
+from utils.notifications.slack_threading import RECURRENCE_FOOTER_BLOCK_ID
 from .slack_fakes import ANCHOR_ID, ANCHOR_TS, CHAN, CHILD_ID, CHILD_TS, FIRST_POSTED_TS
 
 
@@ -33,14 +36,32 @@ def _section_text(blocks):
     return "\n".join(b["text"]["text"] for b in (blocks or []) if b["type"] == "section" and "text" in b)
 
 
+def _updated_card(client, ts):
+    cards = [u for u in client.updated if u["ts"] == ts]
+    assert len(cards) == 1, cards
+    return cards[0]
+
+
 def _null_cas(updates):
     return [(sql, params) for sql, params in updates if "SET slack_message_ts = NULL" in sql]
 
 
 class TestStandalone:
-    def test_threads_under_own_started_message(self, run, make_client, patched_db, standalone):
+    def test_updates_own_started_message_in_place(self, run, make_client, patched_db, standalone):
         client = make_client()
         assert run(standalone(), client) is True
+        assert client.sent == []
+        assert len(client.updated) == 1
+        assert client.updated[0]["ts"] == ANCHOR_TS
+        assert _header(client.updated[0]["blocks"]) == ["Analysis Complete"]
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_update_rejected_threads_under_own_started_message(self, run, make_client, patched_db, standalone):
+        # cant_update_message: the Started message is ours but not editable — reply in its thread.
+        client = make_client(fail_update=True)
+        assert run(standalone(), client) is True
+        assert client.updated == []
         assert len(client.sent) == 1
         assert client.sent[0]["thread_ts"] == ANCHOR_TS
         assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
@@ -64,9 +85,9 @@ class TestStandalone:
         assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, ANCHOR_TS)
 
     def test_thread_rejection_retries_top_level_but_keeps_live_parent(self, run, make_client, patched_db, standalone):
-        # cannot_reply_to_message: the card goes top-level, but the Started message
-        # still exists, so it stays the thread parent / @mention key.
-        client = make_client(fail_thread=True)
+        # Update rejected, then cannot_reply_to_message: the card goes top-level, but the
+        # Started message still exists, so it stays the thread parent / @mention key.
+        client = make_client(fail_update=True, fail_thread=True)
         assert run(standalone(), client) is True
         assert len(client.sent) == 1
         assert client.sent[0]["thread_ts"] is None
@@ -74,9 +95,10 @@ class TestStandalone:
         assert patched_db.updates == []
 
     def test_other_rejection_is_a_single_attempt(self, run, make_client, patched_db, standalone):
+        # not_in_channel fails the same way for update and post: no retry as a post.
         client = make_client(fail_all=True, reject_with="not_in_channel")
         assert run(standalone(), client) is False
-        assert client.attempts == 1
+        assert client.update_attempts + client.attempts == 1
         assert patched_db.updates == []
 
     def test_transport_error_is_a_single_attempt(self, run, make_client, patched_db, standalone):
@@ -85,15 +107,24 @@ class TestStandalone:
         assert client.sent == []
         assert patched_db.updates == []
 
+    def test_group_root_card_keeps_recurrence_footer(self, run, make_client, patched_db, standalone):
+        # Children folded in before the anchor completed: rebuilding its card keeps the footer.
+        client = make_client()
+        assert run(standalone(group_size=3), client) is True
+        card = client.updated[0]
+        assert _header(card["blocks"]) == ["Analysis Complete"]
+        assert card["blocks"][-1]["block_id"] == RECURRENCE_FOOTER_BLOCK_ID
+        assert "3 occurrences" in card["blocks"][-1]["elements"][0]["text"]
+
     def test_webhook_title_is_escaped_in_full_card(self, run, make_client, patched_db, standalone):
         client = make_client()
         assert run(standalone(alert_title="<!channel> down", service="<a|b>"), client) is True
-        section = _section_text(client.sent[0]["blocks"])
+        card = client.updated[0]
+        section = _section_text(card["blocks"])
         assert "<!channel>" not in section
         assert "&lt;!channel&gt; down" in section
         assert "&lt;a|b&gt;" in section
-        assert "<!channel>" not in client.sent[0]["text"]
-
+        assert "<!channel>" not in card["text"]
 
 class TestFoldedChild:
     def test_compact_reply_under_anchor_and_retire_started(self, run, make_client, patched_db, folded,
@@ -134,44 +165,109 @@ class TestFoldedChild:
         assert f"/incidents/{ANCHOR_ID}|" in pointer["text"]
         assert client.deleted == []
         assert patched_db.updates == []
+        # the kept card itself no longer reads "In Progress": it is edited into a pointer stub
+        stub = _updated_card(client, CHILD_TS)
+        assert _header(stub["blocks"]) == []
+        assert f"Folded into <{svc._get_incident_url(ANCHOR_ID)}|" in _section_text(stub["blocks"])
+        assert "occurrence 2 of 3" in _section_text(stub["blocks"])
+        assert stub["blocks"][0]["accessory"]["url"].endswith(CHILD_ID)
 
-    def test_anchor_without_ts_threads_full_card_under_own_started(self, run, make_client, patched_db, folded):
+    def test_compact_reply_marks_anchor_card_with_recurrence_footer(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(), client) is True
+        card = _updated_card(client, ANCHOR_TS)
+        assert _header(card["blocks"]) == ["Investigation Started"]  # existing blocks preserved
+        footer = card["blocks"][-1]
+        assert footer["block_id"] == RECURRENCE_FOOTER_BLOCK_ID
+        assert "3 occurrences" in footer["elements"][0]["text"]
+        assert card["text"] == "Investigation Started: High CPU"
+
+    def test_recurrence_footer_is_replaced_not_stacked(self, run, make_client, patched_db, folded):
+        old_footer = {"type": "context", "block_id": RECURRENCE_FOOTER_BLOCK_ID,
+                      "elements": [{"type": "mrkdwn", "text": "2 occurrences"}]}
+        header = {"type": "header", "block_id": "hdr", "text": {"type": "plain_text", "text": "Analysis Complete"}}
+        client = make_client(cards={ANCHOR_TS: {"blocks": [header, old_footer], "text": "Analysis Complete: High CPU"}})
+        assert run(folded(), client) is True
+        card = _updated_card(client, ANCHOR_TS)
+        footers = [b for b in card["blocks"] if b.get("block_id") == RECURRENCE_FOOTER_BLOCK_ID]
+        assert len(footers) == 1
+        assert "3 occurrences" in footers[0]["elements"][0]["text"]
+        assert _header(card["blocks"]) == ["Analysis Complete"]
+
+    def test_recurrence_footer_skips_plain_text_anchor(self, run, make_client, patched_db, folded):
+        client = make_client(cards={ANCHOR_TS: {"blocks": [{"type": "rich_text", "elements": []}], "text": "plain"}})
+        assert run(folded(), client) is True
+        assert [u for u in client.updated if u["ts"] == ANCHOR_TS] == []
+        assert client.deleted == [(CHAN, CHILD_TS)]
+
+    def test_recurrence_footer_failure_does_not_fail_the_notification(self, run, make_client, patched_db, folded):
+        client = make_client(fail_update=True)
+        assert run(folded(), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert client.updated == []
+        assert client.deleted == [(CHAN, CHILD_TS)]
+
+    def test_anchor_without_ts_updates_own_started_in_place(self, run, make_client, patched_db, folded):
         client = make_client()
         assert run(folded(anchor_slack_message_ts=None), client) is True
-        assert len(client.sent) == 1
-        assert client.sent[0]["thread_ts"] == CHILD_TS
-        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.sent == []
+        assert client.updated[0]["ts"] == CHILD_TS
+        assert _header(client.updated[0]["blocks"]) == ["Analysis Complete"]
         assert client.deleted == []
-        assert patched_db.updates == []  # threaded: nothing to seed
+        assert patched_db.updates == []  # own message kept: nothing to seed
 
-    def test_anchor_without_ts_and_top_level_card_seeds_anchor(self, run, make_client, patched_db, folded):
-        # The group has no thread parent: this top-level card becomes the anchor's,
-        # so later siblings thread under it instead of each posting a full card.
+    def test_anchor_without_ts_and_top_level_card_is_own_parent(self, run, make_client, patched_db, folded):
+        # The group has no thread parent: the child's top-level card becomes the
+        # CHILD's thread parent, never the anchor's — slack_message_ts also routes
+        # @mentions, and a card showing this incident must resolve to it.
         client = make_client()
         assert run(folded(anchor_slack_message_ts=None, slack_message_ts=None), client) is True
         assert client.sent[0]["thread_ts"] is None
         assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
-        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, CHILD_ID, None)
         assert "IS NOT DISTINCT FROM" in patched_db.updates[0][0]
 
     def test_thread_rejection_degrades_to_full_top_level_card(self, run, make_client, patched_db, folded):
-        client = make_client(fail_thread=True)
+        client = make_client(fail_thread=True, fail_update=True)
         assert run(folded(), client) is True
-        # compact attempt and own-thread attempt both rejected (not recorded); full card went top-level
+        # compact attempt and own-thread attempt both rejected (not recorded), the
+        # in-place update too; full card went top-level
         assert len(client.sent) == 1
         assert client.sent[0]["thread_ts"] is None
         assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
         assert client.deleted == []
         assert patched_db.updates == []  # the anchor still has a parent: nothing to seed
 
-    def test_anchor_parent_gone_is_forgotten_and_card_uses_own_thread(self, run, make_client, patched_db, folded):
-        # One lookup, no stray post: the anchor's stale ts is cleared so later siblings
-        # skip straight to their own thread.
-        client = make_client(missing={ANCHOR_TS})
+    def test_anchor_lookup_is_reused_for_the_footer(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(), client) is True
+        assert client.lookups.count(ANCHOR_TS) == 1
+        assert _updated_card(client, ANCHOR_TS)["blocks"][-1]["block_id"] == RECURRENCE_FOOTER_BLOCK_ID
+
+    def test_kept_replies_pointer_failure_does_not_fail_the_notification(self, run, make_client, patched_db, folded):
+        # The compact reply landed; the pointer into the kept Started thread is best effort.
+        client = make_client(replies={CHILD_TS: 1})
+        real_send = client.send_message
+
+        def flaky_send(*args, **kwargs):
+            if client.attempts >= 1:
+                raise ValueError("Failed to communicate with Slack: read timeout")
+            return real_send(*args, **kwargs)
+
+        client.send_message = flaky_send
         assert run(folded(), client) is True
         assert len(client.sent) == 1
-        assert client.sent[0]["thread_ts"] == CHILD_TS
-        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+
+    def test_anchor_parent_gone_is_forgotten_and_card_updates_own_started(self, run, make_client, patched_db, folded):
+        # One lookup, no stray post: the anchor's stale ts is cleared so later siblings
+        # skip straight to their own message, which is updated in place.
+        client = make_client(missing={ANCHOR_TS})
+        assert run(folded(), client) is True
+        assert client.sent == []
+        assert client.updated[0]["ts"] == CHILD_TS
+        assert _header(client.updated[0]["blocks"]) == ["Analysis Complete"]
         assert client.deleted == []
         assert _null_cas(patched_db.updates) == [(patched_db.updates[0][0], (ANCHOR_ID, ANCHOR_TS))]
         assert len(patched_db.updates) == 1
@@ -180,11 +276,11 @@ class TestFoldedChild:
         # Race: the parent was present at lookup time, Slack still placed the reply top-level.
         client = make_client(ignore_thread=True)
         assert run(folded(), client) is True
-        assert len(client.sent) == 2
+        assert len(client.sent) == 1
         assert "occurrence 2 of 3" in _section_text(client.sent[0]["blocks"])
-        assert client.sent[1]["thread_ts"] == CHILD_TS
-        assert _header(client.sent[1]["blocks"]) == ["Analysis Complete"]
-        # only the stray compact post is removed; the child's Started message is kept
+        assert client.updated[0]["ts"] == CHILD_TS
+        assert _header(client.updated[0]["blocks"]) == ["Analysis Complete"]
+        # only the stray compact post is removed; the child's Started message is kept (and updated)
         assert client.deleted == [(CHAN, FIRST_POSTED_TS)]
         assert patched_db.updates == []
 
@@ -213,9 +309,21 @@ class TestFoldedChild:
 
 
 class TestPlainTextFallback:
-    def test_invalid_blocks_keep_thread_placement(self, run, make_client, patched_db, standalone, slack_helpers_stub):
+    def test_invalid_blocks_update_in_place_as_plain_text(self, run, make_client, patched_db, standalone, slack_helpers_stub):
         slack_helpers_stub.validate_slack_blocks.return_value = False
         client = make_client()
+        assert run(standalone(), client) is True
+        assert client.sent == []
+        card = client.updated[0]
+        assert card["ts"] == ANCHOR_TS
+        assert card["blocks"] == []  # old Started blocks cleared, text shows
+        assert "Analysis Complete" in card["text"]
+        assert patched_db.updates == []
+
+    def test_invalid_blocks_keep_thread_placement_when_update_rejected(self, run, make_client, patched_db, standalone,
+                                                                        slack_helpers_stub):
+        slack_helpers_stub.validate_slack_blocks.return_value = False
+        client = make_client(fail_update=True)
         assert run(standalone(), client) is True
         assert len(client.sent) == 1
         assert client.sent[0]["blocks"] is None
@@ -243,15 +351,26 @@ class TestPlainTextFallback:
 
 
 class TestFailed:
-    def test_standalone_threads_under_own(self, run, make_client, patched_db, standalone):
+    def test_standalone_updates_own_started_in_place(self, run, make_client, patched_db, standalone):
         client = make_client()
         assert run(standalone(), client, kind="failed", error_message="boom <here>") is True
+        assert client.sent == []
+        assert client.updated[0]["ts"] == ANCHOR_TS
+        assert _header(client.updated[0]["blocks"]) == ["Investigation Failed"]
+        section = _section_text(client.updated[0]["blocks"])
+        assert "boom &lt;here&gt;" in section
+        assert "<here>" not in section
+        assert patched_db.updates == []
+
+    def test_does_not_replace_the_card_of_a_completed_investigation(self, run, make_client, patched_db, standalone):
+        # A follow-up chat (or the stall sweep) failing after the RCA completed: the
+        # Complete card stays; the Failed card goes into its thread.
+        client = make_client()
+        assert run(standalone(analyzed_at=datetime(2026, 9, 8, 12, 0)), client, kind="failed") is True
+        assert client.updated == []
         assert len(client.sent) == 1
         assert client.sent[0]["thread_ts"] == ANCHOR_TS
         assert _header(client.sent[0]["blocks"]) == ["Investigation Failed"]
-        section = _section_text(client.sent[0]["blocks"])
-        assert "boom &lt;here&gt;" in section
-        assert "<here>" not in section
         assert patched_db.updates == []
 
     def test_standalone_without_ts_backfills(self, run, make_client, patched_db, standalone):
@@ -271,14 +390,14 @@ class TestFailed:
         assert ":x: *Error:* boom" in text
         assert client.deleted == [(CHAN, CHILD_TS)]
 
-    def test_folded_anchor_without_ts_threads_under_own(self, run, make_client, patched_db, folded):
+    def test_folded_anchor_without_ts_updates_own_started(self, run, make_client, patched_db, folded):
         client = make_client()
         assert run(folded(anchor_slack_message_ts=None), client, kind="failed") is True
-        assert client.sent[0]["thread_ts"] == CHILD_TS
-        assert _header(client.sent[0]["blocks"]) == ["Investigation Failed"]
+        assert client.sent == []
+        assert client.updated[0]["ts"] == CHILD_TS
+        assert _header(client.updated[0]["blocks"]) == ["Investigation Failed"]
         assert client.deleted == []
         assert patched_db.updates == []
-
 
 class TestStarted:
     def test_top_level_and_becomes_thread_parent(self, run, make_client, patched_db, standalone):

--- a/server/tests/utils/notifications/test_slack_notification_placement.py
+++ b/server/tests/utils/notifications/test_slack_notification_placement.py
@@ -89,7 +89,8 @@ class TestStandalone:
         client = make_client()
         assert run(standalone(alert_title="<!channel> down", service="<a|b>"), client) is True
         section = _section_text(client.sent[0]["blocks"])
-        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section
+        assert "<!channel>" not in section
+        assert "&lt;!channel&gt; down" in section
         assert "&lt;a|b&gt;" in section
         assert "<!channel>" not in client.sent[0]["text"]
 
@@ -110,7 +111,8 @@ class TestFoldedChild:
         assert client.deleted == [(CHAN, CHILD_TS)]
         assert len(patched_db.updates) == 1
         sql, params = patched_db.updates[0]
-        assert "SET slack_message_ts = NULL" in sql and "recurrence_of_incident_id = %s" in sql
+        assert "SET slack_message_ts = NULL" in sql
+        assert "recurrence_of_incident_id = %s" in sql
         assert params == (CHILD_ID, CHILD_TS, ANCHOR_ID)
         slack_helpers_stub.get_incident_suggestions.assert_not_called()
 
@@ -128,7 +130,8 @@ class TestFoldedChild:
         assert client.sent[0]["thread_ts"] == ANCHOR_TS
         pointer = client.sent[1]
         assert pointer["thread_ts"] == CHILD_TS
-        assert "Folded into" in pointer["text"] and f"/incidents/{ANCHOR_ID}|" in pointer["text"]
+        assert "Folded into" in pointer["text"]
+        assert f"/incidents/{ANCHOR_ID}|" in pointer["text"]
         assert client.deleted == []
         assert patched_db.updates == []
 
@@ -247,7 +250,8 @@ class TestFailed:
         assert client.sent[0]["thread_ts"] == ANCHOR_TS
         assert _header(client.sent[0]["blocks"]) == ["Investigation Failed"]
         section = _section_text(client.sent[0]["blocks"])
-        assert "boom &lt;here&gt;" in section and "<here>" not in section
+        assert "boom &lt;here&gt;" in section
+        assert "<here>" not in section
         assert patched_db.updates == []
 
     def test_standalone_without_ts_backfills(self, run, make_client, patched_db, standalone):
@@ -302,4 +306,5 @@ class TestStarted:
         client = make_client()
         assert run(standalone(slack_message_ts=None, alert_title="<!channel> down"), client, kind="started") is True
         section = _section_text(client.sent[0]["blocks"])
-        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section
+        assert "<!channel>" not in section
+        assert "&lt;!channel&gt; down" in section

--- a/server/tests/utils/notifications/test_slack_notification_placement.py
+++ b/server/tests/utils/notifications/test_slack_notification_placement.py
@@ -1,0 +1,305 @@
+"""Started/completed/failed Slack notifications: thread placement per the layer-3 matrix.
+
+Patches the Slack client factory and channel lookup on the service; the DB is
+routed to fake_pool by patched_db and routes.slack.slack_events_helpers is
+stubbed by the package conftest.
+"""
+
+import pytest
+
+from utils.notifications import slack_notification_service as svc
+
+from .slack_fakes import ANCHOR_ID, ANCHOR_TS, CHAN, CHILD_ID, CHILD_TS, FIRST_POSTED_TS
+
+
+@pytest.fixture
+def run(monkeypatch, patched_db, slack_helpers_stub):
+    def _run(incident_data, client, *, kind="completed", error_message=None):
+        monkeypatch.setattr(svc, "get_slack_client_for_user", lambda user_id: client)
+        monkeypatch.setattr(svc, "_get_incidents_channel_id", lambda user_id, c: CHAN)
+        if kind == "failed":
+            return svc.send_slack_investigation_failed_notification("u1", incident_data, error_message=error_message)
+        if kind == "started":
+            return svc.send_slack_investigation_started_notification("u1", incident_data)
+        return svc.send_slack_investigation_completed_notification("u1", incident_data)
+    return _run
+
+
+def _header(blocks):
+    return [b["text"]["text"] for b in (blocks or []) if b["type"] == "header"]
+
+
+def _section_text(blocks):
+    return "\n".join(b["text"]["text"] for b in (blocks or []) if b["type"] == "section" and "text" in b)
+
+
+def _null_cas(updates):
+    return [(sql, params) for sql, params in updates if "SET slack_message_ts = NULL" in sql]
+
+
+class TestStandalone:
+    def test_threads_under_own_started_message(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_without_ts_posts_top_level_and_backfills(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(slack_message_ts=None), client) is True
+        assert client.sent[0]["thread_ts"] is None
+        assert patched_db.updates == [(patched_db.updates[0][0], (FIRST_POSTED_TS, ANCHOR_ID, None))]
+        assert "IS NOT DISTINCT FROM" in patched_db.updates[0][0]
+
+    def test_started_message_gone_posts_top_level_and_replaces_parent(self, run, make_client, patched_db, standalone):
+        # Slack ignored the stale thread_ts and the lookup confirms the parent is gone:
+        # the card is top-level and becomes the new thread parent.
+        client = make_client(missing={ANCHOR_TS})
+        assert run(standalone(), client) is True
+        assert len(client.sent) == 1
+        assert client.deleted == []
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, ANCHOR_TS)
+
+    def test_thread_rejection_retries_top_level_but_keeps_live_parent(self, run, make_client, patched_db, standalone):
+        # cannot_reply_to_message: the card goes top-level, but the Started message
+        # still exists, so it stays the thread parent / @mention key.
+        client = make_client(fail_thread=True)
+        assert run(standalone(), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] is None
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert patched_db.updates == []
+
+    def test_other_rejection_is_a_single_attempt(self, run, make_client, patched_db, standalone):
+        client = make_client(fail_all=True, reject_with="not_in_channel")
+        assert run(standalone(), client) is False
+        assert client.attempts == 1
+        assert patched_db.updates == []
+
+    def test_transport_error_is_a_single_attempt(self, run, make_client, patched_db, standalone):
+        client = make_client(transport_error=True)
+        assert run(standalone(), client) is False
+        assert client.sent == []
+        assert patched_db.updates == []
+
+    def test_webhook_title_is_escaped_in_full_card(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(alert_title="<!channel> down", service="<a|b>"), client) is True
+        section = _section_text(client.sent[0]["blocks"])
+        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section
+        assert "&lt;a|b&gt;" in section
+        assert "<!channel>" not in client.sent[0]["text"]
+
+
+class TestFoldedChild:
+    def test_compact_reply_under_anchor_and_retire_started(self, run, make_client, patched_db, folded,
+                                                            slack_helpers_stub):
+        client = make_client()
+        assert run(folded(), client) is True
+        assert len(client.sent) == 1
+        msg = client.sent[0]
+        assert msg["thread_ts"] == ANCHOR_TS
+        assert _header(msg["blocks"]) == []
+        assert "occurrence 2 of 3" in _section_text(msg["blocks"])
+        assert "Root Cause Analysis" not in _section_text(msg["blocks"])
+        assert msg["blocks"][-1]["type"] == "context"
+        assert f"/incidents/{ANCHOR_ID}|" in msg["blocks"][-1]["elements"][0]["text"]
+        assert client.deleted == [(CHAN, CHILD_TS)]
+        assert len(patched_db.updates) == 1
+        sql, params = patched_db.updates[0]
+        assert "SET slack_message_ts = NULL" in sql and "recurrence_of_incident_id = %s" in sql
+        assert params == (CHILD_ID, CHILD_TS, ANCHOR_ID)
+        slack_helpers_stub.get_incident_suggestions.assert_not_called()
+
+    def test_child_without_own_ts_skips_retire(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(slack_message_ts=None), client) is True
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_started_message_with_replies_is_kept_and_gets_a_pointer(self, run, make_client, patched_db, folded):
+        client = make_client(replies={CHILD_TS: 1})
+        assert run(folded(), client) is True
+        assert len(client.sent) == 2
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        pointer = client.sent[1]
+        assert pointer["thread_ts"] == CHILD_TS
+        assert "Folded into" in pointer["text"] and f"/incidents/{ANCHOR_ID}|" in pointer["text"]
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_anchor_without_ts_threads_full_card_under_own_started(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(anchor_slack_message_ts=None), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == CHILD_TS
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.deleted == []
+        assert patched_db.updates == []  # threaded: nothing to seed
+
+    def test_anchor_without_ts_and_top_level_card_seeds_anchor(self, run, make_client, patched_db, folded):
+        # The group has no thread parent: this top-level card becomes the anchor's,
+        # so later siblings thread under it instead of each posting a full card.
+        client = make_client()
+        assert run(folded(anchor_slack_message_ts=None, slack_message_ts=None), client) is True
+        assert client.sent[0]["thread_ts"] is None
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+        assert "IS NOT DISTINCT FROM" in patched_db.updates[0][0]
+
+    def test_thread_rejection_degrades_to_full_top_level_card(self, run, make_client, patched_db, folded):
+        client = make_client(fail_thread=True)
+        assert run(folded(), client) is True
+        # compact attempt and own-thread attempt both rejected (not recorded); full card went top-level
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] is None
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.deleted == []
+        assert patched_db.updates == []  # the anchor still has a parent: nothing to seed
+
+    def test_anchor_parent_gone_is_forgotten_and_card_uses_own_thread(self, run, make_client, patched_db, folded):
+        # One lookup, no stray post: the anchor's stale ts is cleared so later siblings
+        # skip straight to their own thread.
+        client = make_client(missing={ANCHOR_TS})
+        assert run(folded(), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == CHILD_TS
+        assert _header(client.sent[0]["blocks"]) == ["Analysis Complete"]
+        assert client.deleted == []
+        assert _null_cas(patched_db.updates) == [(patched_db.updates[0][0], (ANCHOR_ID, ANCHOR_TS))]
+        assert len(patched_db.updates) == 1
+
+    def test_anchor_parent_vanishing_after_lookup_removes_stray(self, run, make_client, patched_db, folded):
+        # Race: the parent was present at lookup time, Slack still placed the reply top-level.
+        client = make_client(ignore_thread=True)
+        assert run(folded(), client) is True
+        assert len(client.sent) == 2
+        assert "occurrence 2 of 3" in _section_text(client.sent[0]["blocks"])
+        assert client.sent[1]["thread_ts"] == CHILD_TS
+        assert _header(client.sent[1]["blocks"]) == ["Analysis Complete"]
+        # only the stray compact post is removed; the child's Started message is kept
+        assert client.deleted == [(CHAN, FIRST_POSTED_TS)]
+        assert patched_db.updates == []
+
+    def test_stray_that_cannot_be_removed_keeps_child_started(self, run, make_client, patched_db, folded):
+        # The stray compact card is visible, so no second card — but it is not a
+        # thread reply, so the child's Started message and ts must survive.
+        client = make_client(ignore_thread=True, fail_delete=True)
+        assert run(folded(), client) is True
+        assert len(client.sent) == 1
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_transport_error_on_compact_reply_is_a_single_attempt(self, run, make_client, patched_db, folded):
+        client = make_client(transport_error=True)
+        assert run(folded(), client) is False
+        assert client.sent == []
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_delete_failure_still_releases_ts(self, run, make_client, patched_db, folded):
+        client = make_client(fail_delete=True)
+        assert run(folded(), client) is True
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert client.deleted == []
+        assert [p for _, p in _null_cas(patched_db.updates)] == [(CHILD_ID, CHILD_TS, ANCHOR_ID)]
+
+
+class TestPlainTextFallback:
+    def test_invalid_blocks_keep_thread_placement(self, run, make_client, patched_db, standalone, slack_helpers_stub):
+        slack_helpers_stub.validate_slack_blocks.return_value = False
+        client = make_client()
+        assert run(standalone(), client) is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["blocks"] is None
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert "Analysis Complete" in client.sent[0]["text"]
+        assert patched_db.updates == []
+
+    def test_invalid_blocks_without_ts_still_backfills(self, run, make_client, patched_db, standalone,
+                                                       slack_helpers_stub):
+        slack_helpers_stub.validate_slack_blocks.return_value = False
+        client = make_client()
+        assert run(standalone(slack_message_ts=None), client) is True
+        assert client.sent[0]["thread_ts"] is None
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+
+    def test_folded_invalid_reply_blocks_still_threads_as_text(self, run, make_client, patched_db, folded,
+                                                               slack_helpers_stub):
+        slack_helpers_stub.validate_slack_blocks.return_value = False
+        client = make_client()
+        assert run(folded(), client) is True
+        assert client.sent[0]["blocks"] is None
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert "occurrence 2 of 3" in client.sent[0]["text"]
+        assert client.deleted == [(CHAN, CHILD_TS)]
+
+
+class TestFailed:
+    def test_standalone_threads_under_own(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(), client, kind="failed", error_message="boom <here>") is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert _header(client.sent[0]["blocks"]) == ["Investigation Failed"]
+        section = _section_text(client.sent[0]["blocks"])
+        assert "boom &lt;here&gt;" in section and "<here>" not in section
+        assert patched_db.updates == []
+
+    def test_standalone_without_ts_backfills(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(slack_message_ts=None), client, kind="failed") is True
+        assert client.sent[0]["thread_ts"] is None
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+
+    def test_folded_compact_failed_reply(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(), client, kind="failed", error_message="boom") is True
+        msg = client.sent[0]
+        assert msg["thread_ts"] == ANCHOR_TS
+        assert _header(msg["blocks"]) == []
+        text = _section_text(msg["blocks"])
+        assert "occurrence 2 of 3" in text
+        assert ":x: *Error:* boom" in text
+        assert client.deleted == [(CHAN, CHILD_TS)]
+
+    def test_folded_anchor_without_ts_threads_under_own(self, run, make_client, patched_db, folded):
+        client = make_client()
+        assert run(folded(anchor_slack_message_ts=None), client, kind="failed") is True
+        assert client.sent[0]["thread_ts"] == CHILD_TS
+        assert _header(client.sent[0]["blocks"]) == ["Investigation Failed"]
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+
+class TestStarted:
+    def test_top_level_and_becomes_thread_parent(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(slack_message_ts=None), client, kind="started") is True
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] is None
+        assert _header(client.sent[0]["blocks"]) == ["Investigation Started"]
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+        assert "IS NOT DISTINCT FROM" in patched_db.updates[0][0]
+
+    def test_joins_existing_thread_without_overwriting_parent(self, run, make_client, patched_db, standalone):
+        # e.g. the stall sweep already posted a Failed card that became the parent.
+        client = make_client()
+        assert run(standalone(), client, kind="started") is True
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert patched_db.updates == []
+
+    def test_stale_parent_is_replaced_only_when_gone(self, run, make_client, patched_db, standalone):
+        client = make_client(missing={ANCHOR_TS})
+        assert run(standalone(), client, kind="started") is True
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, ANCHOR_TS)
+
+    def test_webhook_title_is_escaped(self, run, make_client, patched_db, standalone):
+        client = make_client()
+        assert run(standalone(slack_message_ts=None, alert_title="<!channel> down"), client, kind="started") is True
+        section = _section_text(client.sent[0]["blocks"])
+        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section

--- a/server/tests/utils/notifications/test_slack_threading.py
+++ b/server/tests/utils/notifications/test_slack_threading.py
@@ -2,13 +2,14 @@
 
 import html
 import json
+from datetime import datetime
 
 import pytest
 
 from connectors.slack_connector.client import SlackAPIError
 from utils.notifications import slack_threading as st
 
-from .slack_fakes import ANCHOR_ID, ANCHOR_TS, CHAN, CHILD_ID, CHILD_TS, FIRST_POSTED_TS
+from .slack_fakes import ANCHOR_ID, ANCHOR_TS, CHAN, CHILD_ID, CHILD_TS, FIRST_POSTED_TS, folded_incident
 
 
 class TestIsFoldedChild:
@@ -73,6 +74,24 @@ class TestBuildFoldPointer:
         text = st.build_fold_pointer(folded(anchor_alert_title="<!channel> CPU"), anchor_url="http://a")
         assert "<http://a|&lt;!channel&gt; CPU>" in text
         assert "<!channel>" not in text
+
+
+class TestLookupMessage:
+    def test_failure_is_distinguishable_from_gone(self, make_client):
+        client = make_client()
+        client.get_message = lambda channel, ts: (_ for _ in ()).throw(ValueError("Slack API error: ratelimited"))
+        assert st.lookup_message(client, channel=CHAN, ts=ANCHOR_TS) is st.LOOKUP_FAILED
+        assert st.lookup_message(make_client(missing={ANCHOR_TS}), channel=CHAN, ts=ANCHOR_TS) is None
+        assert st.lookup_message(make_client(), channel=CHAN, ts=ANCHOR_TS)["ts"] == ANCHOR_TS
+
+
+class TestEscapedFields:
+    def test_defaults_escaping_and_caps(self):
+        title, severity, service = st.escaped_fields({"alert_title": None, "severity": None, "service": "<a|b>"})
+        assert (title, severity, service) == ("Unknown Alert", "Unknown", "&lt;a|b&gt;")
+        title, _, service = st.escaped_fields({"alert_title": "x" * 5000, "service": "y" * 5000})
+        assert len(title) == st._ALERT_TITLE_MAX + 1 and title.endswith("…")
+        assert len(service) == st._SERVICE_MAX + 1 and service.endswith("…")
 
 
 class TestMessageIsGone:
@@ -147,6 +166,92 @@ class TestTryPostThreaded:
         assert result is not None
         assert st.placed_thread_ts(result) is None
         assert len(client.sent) == 1
+
+
+class TestRecurrenceFooterAndStub:
+    def test_footer_counts_and_dates(self):
+        block = st.build_recurrence_footer(folded_incident(started_at=datetime(2026, 9, 8, 16, 48, 49)))
+        assert block["block_id"] == st.RECURRENCE_FOOTER_BLOCK_ID
+        text = block["elements"][0]["text"]
+        assert "3 occurrences" in text
+        assert "<!date^" in text
+        assert "2026-09-08 16:48 UTC" in text
+
+    def test_footer_without_time(self):
+        text = st.build_recurrence_footer(folded_incident(started_at=None, group_size=None))["elements"][0]["text"]
+        assert "1 occurrence," not in text and "1 occurrence" in text
+        assert "last" not in text
+
+    def test_footer_uses_group_last_fired_over_own_started_at(self):
+        # Siblings complete out of order: the footer must not regress to an older occurrence.
+        text = st.build_recurrence_footer(folded_incident(
+            started_at=datetime(2026, 9, 8, 9, 0), group_last_fired_at=datetime(2026, 9, 8, 10, 0),
+        ))["elements"][0]["text"]
+        assert "2026-09-08 10:00 UTC" in text
+        assert "09:00" not in text
+
+    def test_update_anchor_footer_takes_a_prefetched_message(self, make_client):
+        client = make_client()
+        message = client.get_message(CHAN, ANCHOR_TS)
+        client.lookups.clear()
+        assert st.update_anchor_recurrence_footer(client, channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident(), message=message) is True
+        assert client.lookups == []
+        assert client.updated[-1]["blocks"][-1]["block_id"] == st.RECURRENCE_FOOTER_BLOCK_ID
+
+    def test_update_anchor_footer_preserves_card_and_replaces_footer(self, make_client):
+        client = make_client()
+        assert st.update_anchor_recurrence_footer(client, channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident()) is True
+        assert st.update_anchor_recurrence_footer(client, channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident(group_size=4)) is True
+        blocks = client.updated[-1]["blocks"]
+        assert blocks[0]["type"] == "header"
+        assert [b for b in blocks if b.get("block_id") == st.RECURRENCE_FOOTER_BLOCK_ID][0]["elements"][0]["text"].startswith(":repeat: *Still firing* — 4 occurrences")
+        assert sum(1 for b in blocks if b.get("block_id") == st.RECURRENCE_FOOTER_BLOCK_ID) == 1
+
+    def test_update_anchor_footer_never_raises(self, make_client):
+        assert st.update_anchor_recurrence_footer(make_client(missing={ANCHOR_TS}), channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident()) is False
+        assert st.update_anchor_recurrence_footer(make_client(transport_error=True), channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident()) is False
+        assert st.update_anchor_recurrence_footer(make_client(fail_all=True, reject_with="not_in_channel"), channel=CHAN, anchor_ts=ANCHOR_TS, incident_data=folded_incident()) is False
+
+    def test_folded_stub_shape_and_escaping(self):
+        text, blocks = st.build_folded_stub(
+            folded_incident(alert_title="<!channel> down", anchor_alert_title="a & b"),
+            incident_url="http://f/incidents/" + CHILD_ID, anchor_url="http://f/incidents/" + ANCHOR_ID, error_text="boom <x>")
+        json.dumps(blocks)
+        section = blocks[0]["text"]["text"]
+        assert f"Folded into <http://f/incidents/{ANCHOR_ID}|a &amp; b>" in section
+        assert "occurrence 2 of 3" in section
+        assert "&lt;!channel&gt; down" in section
+        assert "<!channel>" not in section
+        assert blocks[0]["accessory"]["url"].endswith(CHILD_ID)
+        assert ":x: *Error:* boom &lt;x&gt;" in blocks[1]["text"]["text"]
+        assert text.startswith("Folded into a &amp; b — occurrence 2 of 3")
+
+
+class TestTryUpdateInPlace:
+    def test_updates_and_returns_result(self, make_client):
+        client = make_client()
+        result = st.try_update_in_place(client, channel=CHAN, ts=ANCHOR_TS, text="t", blocks=[{"type": "divider"}])
+        assert result["ts"] == ANCHOR_TS
+        assert client.updated == [{"channel": CHAN, "ts": ANCHOR_TS, "text": "t", "blocks": [{"type": "divider"}]}]
+
+    def test_plain_text_clears_old_blocks(self, make_client):
+        client = make_client()
+        st.try_update_in_place(client, channel=CHAN, ts=ANCHOR_TS, text="t", blocks=None)
+        assert client.updated[0]["blocks"] == []
+
+    def test_uneditable_message_returns_none(self, make_client):
+        assert st.try_update_in_place(make_client(fail_update=True), channel=CHAN, ts=ANCHOR_TS, text="t", blocks=None) is None
+        assert st.try_update_in_place(make_client(missing={ANCHOR_TS}), channel=CHAN, ts=ANCHOR_TS, text="t", blocks=None) is None
+
+    def test_other_rejection_propagates(self, make_client):
+        client = make_client(fail_all=True, reject_with="not_in_channel")
+        with pytest.raises(SlackAPIError):
+            st.try_update_in_place(client, channel=CHAN, ts=ANCHOR_TS, text="t", blocks=None)
+
+    def test_transport_error_propagates(self, make_client):
+        client = make_client(transport_error=True)
+        with pytest.raises(ValueError):
+            st.try_update_in_place(client, channel=CHAN, ts=ANCHOR_TS, text="t", blocks=None)
 
 
 class TestPostWithThreadFallback:

--- a/server/tests/utils/notifications/test_slack_threading.py
+++ b/server/tests/utils/notifications/test_slack_threading.py
@@ -50,7 +50,8 @@ class TestBuildRecurrenceReply:
             folded(alert_title="<!channel> down", service="<a|b>"), incident_url="u", anchor_url="a",
             error_text="boom <here>")
         section = blocks[0]["text"]["text"]
-        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section
+        assert "<!channel>" not in section
+        assert "&lt;!channel&gt; down" in section
         assert "&lt;a|b&gt;" in section
         assert "&lt;here&gt;" in blocks[1]["text"]["text"]
         assert "<!channel>" not in text

--- a/server/tests/utils/notifications/test_slack_threading.py
+++ b/server/tests/utils/notifications/test_slack_threading.py
@@ -1,0 +1,331 @@
+"""slack_threading helpers: compact reply, post fallback, Started-message retirement, DB writes."""
+
+import html
+import json
+
+import pytest
+
+from connectors.slack_connector.client import SlackAPIError
+from utils.notifications import slack_threading as st
+
+from .slack_fakes import ANCHOR_ID, ANCHOR_TS, CHAN, CHILD_ID, CHILD_TS, FIRST_POSTED_TS
+
+
+class TestIsFoldedChild:
+    def test_reads_recurrence_of(self, folded, standalone):
+        assert st.is_folded_child(folded()) is True
+        assert st.is_folded_child(standalone()) is False
+
+
+class TestBuildRecurrenceReply:
+    def test_completed_reply_shape(self, folded):
+        text, blocks = st.build_recurrence_reply(
+            folded(), incident_url="http://f/incidents/" + CHILD_ID, anchor_url="http://f/incidents/" + ANCHOR_ID)
+        json.dumps(blocks)
+        section = blocks[0]
+        assert section["type"] == "section"
+        assert "occurrence 2 of 3" in section["text"]["text"]
+        assert "*Alert:* High CPU" in section["text"]["text"]
+        assert len(section["text"]["text"]) < 3000
+        assert section["accessory"]["url"] == "http://f/incidents/" + CHILD_ID
+        assert section["accessory"]["text"]["text"] == "View Occurrence"
+        assert blocks[-1]["type"] == "context"
+        assert f"<http://f/incidents/{ANCHOR_ID}|High CPU>" in blocks[-1]["elements"][0]["text"]
+        assert "occurrence 2 of 3" in text
+        assert CHILD_ID in text
+        assert not any(b["type"] == "header" for b in blocks)
+
+    def test_anchor_title_is_escaped_and_capped(self, folded):
+        long_title = "a<b>&c" * 40
+        _, blocks = st.build_recurrence_reply(
+            folded(anchor_alert_title=long_title), incident_url="u", anchor_url="http://a")
+        ctx = blocks[-1]["elements"][0]["text"]
+        assert "<b>" not in ctx.split("|", 1)[1]
+        assert "&lt;b&gt;&amp;c" in ctx
+        label = ctx.split("|", 1)[1].rstrip(">")
+        assert label == html.escape(long_title[:st._ANCHOR_TITLE_MAX], quote=False) + "…"
+
+    def test_child_fields_are_escaped(self, folded):
+        text, blocks = st.build_recurrence_reply(
+            folded(alert_title="<!channel> down", service="<a|b>"), incident_url="u", anchor_url="a",
+            error_text="boom <here>")
+        section = blocks[0]["text"]["text"]
+        assert "<!channel>" not in section and "&lt;!channel&gt; down" in section
+        assert "&lt;a|b&gt;" in section
+        assert "&lt;here&gt;" in blocks[1]["text"]["text"]
+        assert "<!channel>" not in text
+
+    def test_failed_variant_has_error_line(self, folded):
+        text, blocks = st.build_recurrence_reply(folded(), incident_url="u", anchor_url="a", error_text="boom")
+        assert blocks[1]["type"] == "section"
+        assert ":x: *Error:* boom" in blocks[1]["text"]["text"]
+        assert blocks[-1]["type"] == "context"
+        assert text.startswith("Investigation failed — ")
+
+    def test_no_error_text_means_no_error_line(self, folded):
+        _, blocks = st.build_recurrence_reply(folded(), incident_url="u", anchor_url="a")
+        assert [b["type"] for b in blocks] == ["section", "context"]
+
+
+class TestBuildFoldPointer:
+    def test_links_anchor_with_escaped_title(self, folded):
+        text = st.build_fold_pointer(folded(anchor_alert_title="<!channel> CPU"), anchor_url="http://a")
+        assert "<http://a|&lt;!channel&gt; CPU>" in text
+        assert "<!channel>" not in text
+
+
+class TestMessageIsGone:
+    def test_missing_is_gone(self, make_client):
+        assert st.message_is_gone(make_client(missing={ANCHOR_TS}), channel=CHAN, ts=ANCHOR_TS) is True
+
+    def test_present_is_not_gone(self, make_client):
+        assert st.message_is_gone(make_client(), channel=CHAN, ts=ANCHOR_TS) is False
+
+    def test_lookup_failure_counts_as_present(self, make_client):
+        client = make_client()
+        client.get_message = lambda channel, ts: (_ for _ in ()).throw(ValueError("Slack API error: ratelimited"))
+        assert st.message_is_gone(client, channel=CHAN, ts=ANCHOR_TS) is False
+
+
+class TestTryPostThreaded:
+    def test_forwards_thread_ts(self, make_client):
+        client = make_client()
+        result = st.try_post_threaded(client, channel=CHAN, text="t", blocks=[{"type": "divider"}], thread_ts=ANCHOR_TS)
+        assert result["ts"]
+        assert client.sent == [{"channel": CHAN, "text": "t", "thread_ts": ANCHOR_TS, "blocks": [{"type": "divider"}]}]
+
+    def test_thread_rejection_returns_none_single_call(self, make_client):
+        client = make_client(fail_thread=True)
+        assert st.try_post_threaded(client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS) is None
+        assert client.sent == []
+        assert client.attempts == 1
+
+    @pytest.mark.parametrize("code", ["not_in_channel", "invalid_auth", "msg_too_long", "invalid_blocks"])
+    def test_other_rejection_propagates(self, make_client, code):
+        # Would fail identically top-level: no degrade, no second call.
+        client = make_client(fail_thread=True, reject_with=code)
+        with pytest.raises(SlackAPIError) as exc:
+            st.try_post_threaded(client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS)
+        assert exc.value.error == code
+        assert client.attempts == 1
+
+    def test_transport_error_propagates(self, make_client):
+        # The post may have landed: never swallow, so the caller cannot double-post.
+        client = make_client(transport_error=True)
+        with pytest.raises(ValueError):
+            st.try_post_threaded(client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS)
+
+    def test_require_threaded_removes_stray_top_level_post(self, make_client):
+        # Slack silently posts top-level when the parent is missing/deleted.
+        client = make_client(ignore_thread=True)
+        result = st.try_post_threaded(
+            client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS, require_threaded=True)
+        assert result is None
+        assert len(client.sent) == 1
+        assert client.deleted == [(CHAN, FIRST_POSTED_TS)]  # the stray, never the parent
+
+    def test_require_threaded_accepts_real_reply(self, make_client):
+        client = make_client()
+        result = st.try_post_threaded(
+            client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS, require_threaded=True)
+        assert result["message"]["thread_ts"] == ANCHOR_TS
+        assert client.deleted == []
+
+    def test_lenient_keeps_top_level_placement(self, make_client):
+        client = make_client(ignore_thread=True)
+        result = st.try_post_threaded(client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS)
+        assert result is not None
+        assert st.placed_thread_ts(result) is None
+        assert client.deleted == []
+
+    def test_require_threaded_stray_delete_failure_returns_top_level_result(self, make_client):
+        # The stray is already visible: keep it, and let the caller see it was not threaded.
+        client = make_client(ignore_thread=True, fail_delete=True)
+        result = st.try_post_threaded(
+            client, channel=CHAN, text="t", blocks=None, thread_ts=ANCHOR_TS, require_threaded=True)
+        assert result is not None
+        assert st.placed_thread_ts(result) is None
+        assert len(client.sent) == 1
+
+
+class TestPostWithThreadFallback:
+    def test_threaded_ok_is_one_call(self, make_client):
+        client = make_client()
+        result = st.post_with_thread_fallback(client, channel=CHAN, text="t", thread_ts=ANCHOR_TS)
+        assert len(client.sent) == 1
+        assert client.sent[0]["thread_ts"] == ANCHOR_TS
+        assert st.placed_thread_ts(result) == ANCHOR_TS
+
+    def test_thread_rejection_retries_top_level(self, make_client):
+        client = make_client(fail_thread=True)
+        result = st.post_with_thread_fallback(client, channel=CHAN, text="t", blocks=[{"type": "divider"}], thread_ts=ANCHOR_TS)
+        assert result["ts"]
+        assert len(client.sent) == 1  # the threaded attempt was rejected before recording
+        assert client.attempts == 2
+        assert client.sent[0]["thread_ts"] is None
+        assert client.sent[0]["blocks"] == [{"type": "divider"}]
+
+    def test_other_rejection_is_single_attempt(self, make_client):
+        client = make_client(fail_thread=True, reject_with="not_in_channel")
+        with pytest.raises(SlackAPIError):
+            st.post_with_thread_fallback(client, channel=CHAN, text="t", thread_ts=ANCHOR_TS)
+        assert client.attempts == 1
+
+    def test_transport_error_is_not_retried(self, make_client):
+        client = make_client(transport_error=True)
+        with pytest.raises(ValueError):
+            st.post_with_thread_fallback(client, channel=CHAN, text="t", thread_ts=ANCHOR_TS)
+        assert client.sent == []
+
+    def test_no_thread_ts_is_plain_post(self, make_client):
+        client = make_client()
+        st.post_with_thread_fallback(client, channel=CHAN, text="t")
+        assert client.sent[0]["thread_ts"] is None
+
+    def test_top_level_failure_propagates(self, make_client):
+        client = make_client(fail_all=True)
+        with pytest.raises(ValueError):
+            st.post_with_thread_fallback(client, channel=CHAN, text="t", thread_ts=ANCHOR_TS)
+
+
+class TestClearChildStartedMessage:
+    def test_releases_ts_then_deletes(self, make_client, patched_db, folded):
+        client = make_client()
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.RELEASED
+        assert client.deleted == [(CHAN, CHILD_TS)]
+        sql, params = patched_db.updates[0]
+        assert "SET slack_message_ts = NULL" in sql
+        assert "AND slack_message_ts = %s" in sql
+        assert "AND recurrence_of_incident_id = %s" in sql  # only while the fold still holds
+        assert params == (CHILD_ID, CHILD_TS, ANCHOR_ID)
+        assert patched_db.conn.commit.called
+
+    def test_message_with_replies_is_kept(self, make_client, patched_db, folded):
+        # A human thread already hangs off the Started message: keep it and its routing key.
+        client = make_client(replies={CHILD_TS: 2})
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.KEPT_REPLIES
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_already_gone_message_only_clears_ts(self, make_client, patched_db, folded):
+        client = make_client(missing={CHILD_TS})
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.RELEASED
+        assert client.deleted == []
+        assert len(patched_db.updates) == 1
+        assert patched_db.updates[0][1] == (CHILD_ID, CHILD_TS, ANCHOR_ID)
+
+    def test_lookup_failure_leaves_everything(self, make_client, patched_db, folded):
+        client = make_client()
+        client.get_message = lambda channel, ts: (_ for _ in ()).throw(ValueError("Slack API error: ratelimited"))
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.KEPT
+        assert client.deleted == []
+        assert patched_db.updates == []
+
+    def test_fold_no_longer_holding_keeps_message(self, make_client, patched_db, folded):
+        # Layer 1 unfolded this incident concurrently (mutual-fold tie-break): the CAS
+        # matches nothing, so the Started message and its ts survive.
+        client = make_client()
+        patched_db.cursor.rowcount = 0
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.KEPT
+        assert client.deleted == []
+        assert len(patched_db.updates) == 1
+
+    def test_delete_failure_after_release(self, make_client, patched_db, folded):
+        client = make_client(fail_delete=True)
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.RELEASED
+        assert client.deleted == []
+        assert len(patched_db.updates) == 1
+
+    def test_no_ts_is_noop(self, make_client, patched_db, folded):
+        client = make_client()
+        outcome = st.clear_child_started_message(
+            client, channel=CHAN, user_id="u1", incident_data=folded(slack_message_ts=None))
+        assert outcome == st.KEPT
+        assert client.deleted == []
+        assert patched_db.executes == []
+
+    def test_db_failure_skips_delete(self, make_client, patched_db, folded):
+        client = make_client()
+        patched_db.cursor.execute.side_effect = RuntimeError("db down")
+        outcome = st.clear_child_started_message(client, channel=CHAN, user_id="u1", incident_data=folded())
+        assert outcome == st.KEPT
+        assert client.deleted == []
+
+
+class TestClearAnchorMessageTs:
+    def test_compare_and_set_to_null(self, patched_db):
+        st.clear_anchor_message_ts("u1", ANCHOR_ID, ANCHOR_TS)
+        sql, params = patched_db.updates[0]
+        assert "SET slack_message_ts = NULL" in sql
+        assert "AND slack_message_ts = %s" in sql
+        assert params == (ANCHOR_ID, ANCHOR_TS)
+
+
+class TestBackfillThreadParentTs:
+    def test_update_is_compare_and_set_on_null(self, patched_db):
+        assert st.backfill_thread_parent_ts("u1", ANCHOR_ID, ANCHOR_TS) is True
+        sql, params = patched_db.updates[0]
+        assert "SET slack_message_ts = %s" in sql
+        assert "slack_message_ts IS NOT DISTINCT FROM %s" in sql
+        assert params == (ANCHOR_TS, ANCHOR_ID, None)
+        assert patched_db.conn.commit.called
+
+    def test_replacing_a_stale_ts(self, patched_db):
+        st.backfill_thread_parent_ts("u1", ANCHOR_ID, "1700000000.000009", replacing=ANCHOR_TS)
+        assert patched_db.updates[0][1] == ("1700000000.000009", ANCHOR_ID, ANCHOR_TS)
+
+    def test_db_error_swallowed(self, patched_db):
+        patched_db.cursor.execute.side_effect = RuntimeError("db down")
+        assert st.backfill_thread_parent_ts("u1", ANCHOR_ID, ANCHOR_TS) is False
+
+    def test_empty_ts_is_noop(self, patched_db):
+        assert st.backfill_thread_parent_ts("u1", ANCHOR_ID, "") is False
+        assert patched_db.executes == []
+
+
+class TestRecordThreadParent:
+    def _post(self, client, thread_ts=None):
+        return client.send_message(CHAN, "t", thread_ts=thread_ts)
+
+    def test_threaded_post_is_not_a_parent(self, make_client, patched_db):
+        client = make_client()
+        result = self._post(client, ANCHOR_TS)
+        assert st.record_thread_parent(client, channel=CHAN, user_id="u1", incident_id=ANCHOR_ID,
+                                       result=result, stored=ANCHOR_TS) is False
+        assert patched_db.executes == []
+
+    def test_top_level_without_stored_parent_is_recorded(self, make_client, patched_db):
+        client = make_client()
+        result = self._post(client)
+        assert st.record_thread_parent(client, channel=CHAN, user_id="u1", incident_id=ANCHOR_ID,
+                                       result=result, stored=None) is True
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, None)
+
+    def test_live_stored_parent_is_never_replaced(self, make_client, patched_db):
+        # Landed top-level (thread rejection / other channel) but the Started message still exists.
+        client = make_client(ignore_thread=True)
+        result = self._post(client, ANCHOR_TS)
+        assert st.record_thread_parent(client, channel=CHAN, user_id="u1", incident_id=ANCHOR_ID,
+                                       result=result, stored=ANCHOR_TS) is False
+        assert patched_db.updates == []
+
+    def test_gone_stored_parent_is_replaced(self, make_client, patched_db):
+        client = make_client(missing={ANCHOR_TS})
+        result = self._post(client, ANCHOR_TS)
+        assert st.record_thread_parent(client, channel=CHAN, user_id="u1", incident_id=ANCHOR_ID,
+                                       result=result, stored=ANCHOR_TS) is True
+        assert patched_db.updates[0][1] == (FIRST_POSTED_TS, ANCHOR_ID, ANCHOR_TS)
+
+    def test_lookup_failure_keeps_stored_parent(self, make_client, patched_db):
+        client = make_client(ignore_thread=True)
+        result = self._post(client, ANCHOR_TS)
+        client.get_message = lambda channel, ts: (_ for _ in ()).throw(ValueError("Slack API error: ratelimited"))
+        assert st.record_thread_parent(client, channel=CHAN, user_id="u1", incident_id=ANCHOR_ID,
+                                       result=result, stored=ANCHOR_TS) is False
+        assert patched_db.updates == []

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -72,20 +72,46 @@ def _has_google_chat_connected(user_id: str) -> bool:
 
 
 def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch incident data from database."""
+    """Fetch incident data from database.
+
+    Also carries the recurrence-group context Slack threading (dedup layer 3)
+    needs: the anchor's Slack ts/title and this incident's position in its
+    group. Group membership mirrors _group_is_stale (recurrence_fold.py) and
+    the detail-view occurrences query (pointer-only); ordering mirrors
+    lastFire in the client so "occurrence N" agrees with the UI. The group
+    always contains the incident itself, so a standalone incident gets
+    recurrence_of=None, occurrence_number=1, group_size=1.
+    """
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix="[Dispatcher:GetIncident]")
                 cursor.execute(
                     """
-                    SELECT id, user_id, source_type, status, severity, alert_title,
-                           alert_service, aurora_status, aurora_summary, started_at,
-                           analyzed_at, created_at, slack_message_ts, google_chat_message_name
-                    FROM incidents
-                    WHERE id = %s
+                    WITH me AS (
+                        SELECT COALESCE(recurrence_of_incident_id, id) AS root_id
+                        FROM incidents WHERE id = %s
+                    ),
+                    grp AS (
+                        SELECT g.id,
+                               ROW_NUMBER() OVER (
+                                   ORDER BY COALESCE(g.alert_fired_at, g.started_at), g.started_at, g.id
+                               ) AS occurrence_number,
+                               COUNT(*) OVER () AS group_size
+                        FROM incidents g
+                        JOIN me ON g.id = me.root_id OR g.recurrence_of_incident_id = me.root_id
+                    )
+                    SELECT i.id, i.user_id, i.source_type, i.status, i.severity, i.alert_title,
+                           i.alert_service, i.aurora_status, i.aurora_summary, i.started_at,
+                           i.analyzed_at, i.created_at, i.slack_message_ts, i.google_chat_message_name,
+                           i.recurrence_of_incident_id, anchor.slack_message_ts, anchor.alert_title,
+                           grp.occurrence_number, grp.group_size
+                    FROM incidents i
+                    LEFT JOIN incidents anchor ON anchor.id = i.recurrence_of_incident_id
+                    JOIN grp ON grp.id = i.id
+                    WHERE i.id = %s
                     """,
-                    (incident_id,),
+                    (incident_id, incident_id),
                 )
                 result = cursor.fetchone()
                 if result:
@@ -104,6 +130,11 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
                         'created_at': result[11],
                         'slack_message_ts': result[12],
                         'google_chat_message_name': result[13],
+                        'recurrence_of': str(result[14]) if result[14] else None,
+                        'anchor_slack_message_ts': result[15],
+                        'anchor_alert_title': result[16],
+                        'occurrence_number': int(result[17]),
+                        'group_size': int(result[18]),
                     }
         return None
     except Exception:

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -75,11 +75,13 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
     """Fetch incident data from database.
 
     Also carries the recurrence-group context Slack threading (dedup layer 3)
-    needs: the anchor's Slack ts/title and this incident's position in its
-    group. Group membership mirrors _group_is_stale (recurrence_fold.py) and
-    the detail-view occurrences query (pointer-only); ordering mirrors
-    lastFire in the client so "occurrence N" agrees with the UI. The group
-    always contains the incident itself, so a standalone incident gets
+    needs: the anchor's Slack ts/title, this incident's position in its
+    group and when the group last fired. Group membership mirrors
+    _group_is_stale (recurrence_fold.py) and the detail-view occurrences
+    query (pointer-only; 'merged' cannot occur inside a group — the fold
+    rejects merged members and the status has no writer left); ordering
+    mirrors lastFire in the client so "occurrence N" agrees with the UI. The
+    group always contains the incident itself, so a standalone incident gets
     recurrence_of=None, occurrence_number=1, group_size=1.
     """
     try:
@@ -97,7 +99,8 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
                                ROW_NUMBER() OVER (
                                    ORDER BY COALESCE(g.alert_fired_at, g.started_at), g.started_at, g.id
                                ) AS occurrence_number,
-                               COUNT(*) OVER () AS group_size
+                               COUNT(*) OVER () AS group_size,
+                               MAX(COALESCE(g.alert_fired_at, g.started_at)) OVER () AS last_fired_at
                         FROM incidents g
                         JOIN me ON g.id = me.root_id OR g.recurrence_of_incident_id = me.root_id
                     )
@@ -105,7 +108,7 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
                            i.alert_service, i.aurora_status, i.aurora_summary, i.started_at,
                            i.analyzed_at, i.created_at, i.slack_message_ts, i.google_chat_message_name,
                            i.recurrence_of_incident_id, anchor.slack_message_ts, anchor.alert_title,
-                           grp.occurrence_number, grp.group_size
+                           grp.occurrence_number, grp.group_size, grp.last_fired_at
                     FROM incidents i
                     LEFT JOIN incidents anchor ON anchor.id = i.recurrence_of_incident_id
                     JOIN grp ON grp.id = i.id
@@ -135,6 +138,7 @@ def _get_incident_data(incident_id: str, user_id: str) -> Optional[Dict[str, Any
                         'anchor_alert_title': result[16],
                         'occurrence_number': int(result[17]),
                         'group_size': int(result[18]),
+                        'group_last_fired_at': result[19],
                     }
         return None
     except Exception:
@@ -410,8 +414,14 @@ def notify_investigation_started(user_id: str, incident_id: str) -> None:
         logger.exception("[Dispatcher] Error in notify_investigation_started")
 
 
-def notify_investigation_completed(user_id: str, incident_id: str, session_id: Optional[str] = None) -> None:
-    """Send notifications for investigation completed event across all enabled channels."""
+def notify_investigation_completed(user_id: str, incident_id: str, session_id: Optional[str] = None,
+                                   refresh_only: bool = False) -> None:
+    """Send notifications for investigation completed event across all enabled channels.
+
+    refresh_only: the completion was already announced (a follow-up chat
+    re-summarized the incident): no email, no Slack post; only the Google
+    Chat card, which is edited in place, is refreshed to match the summary.
+    """
     try:
         org_id = get_org_id_for_user(user_id)
         if not org_id:
@@ -427,12 +437,12 @@ def notify_investigation_completed(user_id: str, incident_id: str, session_id: O
 
         # --- Email ---
         email_enabled = bool(get_org_preference(org_id, 'rca_email_notifications', default=False))
-        if email_enabled:
+        if email_enabled and not refresh_only:
             _send_emails(org_id, user_id, 'send_investigation_completed_email', incident_data)
 
         # --- Slack ---
         slack_enabled = bool(get_org_preference(org_id, 'slack_investigation_complete_notifications', default=True))
-        if slack_enabled and _has_slack_connected(user_id):
+        if slack_enabled and not refresh_only and _has_slack_connected(user_id):
             try:
                 from utils.notifications.slack_notification_service import (
                     send_slack_investigation_completed_notification,
@@ -441,14 +451,18 @@ def notify_investigation_completed(user_id: str, incident_id: str, session_id: O
             except Exception:
                 logger.exception("[Dispatcher] Slack completed notification failed")
 
-        # --- Google Chat ---
+        # --- Google Chat --- (edited in place: a refresh needs an existing card)
         google_chat_enabled = bool(get_org_preference(org_id, 'google_chat_investigation_notifications', default=True))
+        if refresh_only and not incident_data.get('google_chat_message_name'):
+            google_chat_enabled = False
         if google_chat_enabled and _has_google_chat_connected(user_id):
             try:
                 from utils.notifications.google_chat_notification_service import (
                     send_google_chat_investigation_completed_notification,
                 )
-                send_google_chat_investigation_completed_notification(user_id, incident_data)
+                send_google_chat_investigation_completed_notification(
+                    user_id, incident_data, allow_new_message=not refresh_only,
+                )
             except Exception:
                 logger.exception("[Dispatcher] Google Chat completed notification failed")
 

--- a/server/utils/notifications/google_chat_notification_service.py
+++ b/server/utils/notifications/google_chat_notification_service.py
@@ -159,9 +159,13 @@ def send_google_chat_investigation_started_notification(user_id: str, incident_d
 
 
 def send_google_chat_investigation_completed_notification(
-    user_id: str, incident_data: Dict[str, Any],
+    user_id: str, incident_data: Dict[str, Any], *, allow_new_message: bool = True,
 ) -> bool:
-    """Send Google Chat notification when RCA investigation completes."""
+    """Send Google Chat notification when RCA investigation completes.
+
+    The existing card (google_chat_message_name) is edited in place; a new
+    message is posted only when there is none or the edit failed, and only
+    when allow_new_message (False for a refresh after a follow-up chat)."""
     try:
         client = _get_chat_client(user_id)
         if not client:
@@ -266,6 +270,10 @@ def send_google_chat_investigation_completed_notification(
                     return True
             except Exception as e:
                 logger.warning(f"[GChatNotification] Failed to update message, sending new: {e}")
+
+        if not allow_new_message:
+            logger.info(f"[GChatNotification] No card refreshed for incident {incident_id}; not posting a new one")
+            return False
 
         try:
             result = client.send_message(

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -10,6 +10,21 @@ from datetime import datetime
 from connectors.slack_connector.client import SlackClient, get_slack_client_for_user
 from utils.db.connection_pool import db_pool
 from utils.auth.stateless_auth import set_rls_context
+from utils.notifications.slack_threading import (
+    KEPT_REPLIES,
+    backfill_thread_parent_ts,
+    build_fold_pointer,
+    build_recurrence_reply,
+    clear_anchor_message_ts,
+    clear_child_started_message,
+    escape_mrkdwn,
+    is_folded_child,
+    message_is_gone,
+    placed_thread_ts,
+    post_with_thread_fallback,
+    record_thread_parent,
+    try_post_threaded,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,12 +99,12 @@ def send_slack_investigation_started_notification(user_id: str, incident_data: D
             logger.error(f"[SlackNotification] Could not find incidents channel for user {user_id}")
             return False
         
-        # Extract incident data
+        # Extract incident data (mrkdwn-escaped: titles come from webhooks)
         incident_id = incident_data.get('incident_id', 'unknown')
-        alert_title = incident_data.get('alert_title', _DEFAULT_ALERT_TITLE)
-        severity = incident_data.get('severity', 'unknown')
-        service = incident_data.get('service', 'unknown')
-        source_type = incident_data.get('source_type', 'monitoring platform')
+        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
+        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
+        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
+        source_type = escape_mrkdwn(incident_data.get('source_type', 'monitoring platform'))
         started_at = incident_data.get('started_at')
         
         # Format data
@@ -140,53 +155,130 @@ def send_slack_investigation_started_notification(user_id: str, incident_data: D
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity.title()}\n*Service:* {service}\n*Status:* In Progress\n\nAurora is analyzing this incident from {source_type}"
+                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity}\n*Service:* {service}\n*Status:* In Progress\n\nAurora is analyzing this incident from {source_type}"
                 }
             }
         ]
         
         # Validate blocks
         from routes.slack.slack_events_helpers import validate_slack_blocks
+        text = f"Investigation Started: {alert_title}"  # Fallback text
         if not validate_slack_blocks(blocks):
-            logger.error(f"[SlackNotification] Block validation failed for 'started' notification")
-            # Fallback to simple text
-            simple_text = f"*Investigation Started*\n\n{alert_title}\n\nView: {incident_url}"
-            result = client.send_message(channel=channel_id, text=simple_text)
-            return result is not None
-        
-        # Send message
-        result = client.send_message(
-            channel=channel_id,
-            text=f"Investigation Started: {alert_title}",  # Fallback text
-            blocks=blocks
-        )
-        
-        if result:
-            # Store message timestamp in database for later updates
-            message_ts = result.get('ts')
-            if message_ts:
-                try:
-                    with db_pool.get_admin_connection() as conn:
-                        with conn.cursor() as cursor:
-                            set_rls_context(cursor, conn, user_id, log_prefix="[SlackNotification:storeTs]")
-                            cursor.execute(
-                                "UPDATE incidents SET slack_message_ts = %s WHERE id = %s",
-                                (message_ts, incident_id)
-                            )
-                            conn.commit()
-                except Exception as e:
-                    logger.warning(f"[SlackNotification] Failed to store message timestamp: {e}", exc_info=True)
-            
-            logger.info(f"[SlackNotification] Sent 'started' notification for incident {incident_id}")
-            return True
-        else:
-            logger.warning(f"[SlackNotification] Failed to send 'started' notification")
-            return False
+            logger.error("[SlackNotification] Block validation failed for 'started' notification")
+            text, blocks = f"*Investigation Started*\n\n{alert_title}\n\nView: {incident_url}", None
+
+        # A late or re-started investigation joins the incident's existing
+        # thread (e.g. a Failed card the stall sweep already posted) instead
+        # of opening a second top-level card. The post becomes the thread
+        # parent only when it landed top-level and no live parent is stored.
+        stored_ts = incident_data.get('slack_message_ts')
+        result = post_with_thread_fallback(client, channel=channel_id, text=text, blocks=blocks, thread_ts=stored_ts)
+        record_thread_parent(client, channel=channel_id, user_id=user_id, incident_id=incident_id,
+                             result=result, stored=stored_ts)
+        logger.info(f"[SlackNotification] Sent 'started' notification for incident {incident_id}")
+        return True
             
     except Exception:
         logger.exception("[SlackNotification] Error sending started notification")
         return False
     
+def _post_recurrence_reply(client: SlackClient, channel_id: str, user_id: str, incident_data: Dict[str, Any], *,
+                           incident_url: str, error_text: Optional[str] = None) -> bool:
+    """Folded child: compact reply under the anchor's Started message, then
+    retire the child's own Started message. False when the incident is not a
+    folded child, the anchor has no live thread parent, or the reply could
+    not be threaded (the caller posts the full card instead)."""
+    thread_ts = incident_data.get('anchor_slack_message_ts')
+    if not is_folded_child(incident_data) or not thread_ts:
+        return False
+    incident_id = incident_data.get('incident_id')
+    anchor_id = incident_data['recurrence_of']
+    if message_is_gone(client, channel=channel_id, ts=thread_ts):
+        # Forget it so later siblings stop trying, and so the next top-level
+        # card can seed a new parent (see _post_incident_card).
+        logger.info(f"[SlackNotification] Anchor {anchor_id} thread parent {thread_ts} is gone; forgetting it")
+        clear_anchor_message_ts(user_id, anchor_id, thread_ts)
+        incident_data['anchor_slack_message_ts'] = None
+        return False
+    from routes.slack.slack_events_helpers import validate_slack_blocks
+    anchor_url = _get_incident_url(anchor_id)
+    text, reply_blocks = build_recurrence_reply(
+        incident_data, incident_url=incident_url, anchor_url=anchor_url, error_text=error_text,
+    )
+    result = try_post_threaded(
+        client,
+        channel=channel_id,
+        text=text,
+        blocks=reply_blocks if validate_slack_blocks(reply_blocks) else None,
+        thread_ts=thread_ts,
+        require_threaded=True,
+    )
+    if not result:
+        return False
+    if placed_thread_ts(result) != thread_ts:
+        # A stray top-level compact card that could not be removed: it is
+        # visible, so no second card — but the child's Started message stays
+        # its thread key.
+        logger.warning(
+            f"[SlackNotification] Recurrence reply for {incident_id} landed top-level "
+            f"(anchor {thread_ts} gone); keeping its Started message"
+        )
+        return True
+    logger.info(
+        f"[SlackNotification] Posted {'failed' if error_text else 'completed'} as recurrence reply for "
+        f"{incident_id} under anchor {anchor_id}"
+    )
+    outcome = clear_child_started_message(client, channel=channel_id, user_id=user_id, incident_data=incident_data)
+    if outcome == KEPT_REPLIES:
+        # People are talking in the child's own thread: tell them where the
+        # outcome went instead of leaving that card "In Progress" forever.
+        try_post_threaded(
+            client, channel=channel_id, text=build_fold_pointer(incident_data, anchor_url=anchor_url),
+            blocks=None, thread_ts=incident_data['slack_message_ts'], require_threaded=True,
+        )
+    return True
+
+
+def _post_incident_card(client: SlackClient, channel_id: str, user_id: str, incident_data: Dict[str, Any], *,
+                        kind: str, blocks: list, error_text: Optional[str] = None) -> bool:
+    """Full Complete/Failed card under the incident's own Started message,
+    or top-level when there is none or Slack no longer has it. A top-level
+    post becomes the incident's thread parent for later recurrences — or,
+    for a folded child whose anchor has no thread parent, the anchor's, so
+    the group consolidates from here on."""
+    incident_id = incident_data.get('incident_id', 'unknown')
+    alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
+    incident_url = _get_incident_url(incident_id)
+    if kind == "failed":
+        text = f"Investigation Failed: {alert_title}"
+        simple_text = (
+            f"*Investigation Failed*\n\n{alert_title}\n\nError: {escape_mrkdwn(error_text)}"
+            f"\n\nView incident: {incident_url}"
+        )
+    else:
+        text = f"Analysis Complete: {alert_title}"
+        simple_text = f"*Analysis Complete*\n\n{alert_title}\n\nView full report: {incident_url}"
+    from routes.slack.slack_events_helpers import validate_slack_blocks
+    if not validate_slack_blocks(blocks):
+        logger.error(f"[SlackNotification] Block validation failed for incident {incident_id}")
+        text, blocks = simple_text, None
+    stored_ts = incident_data.get('slack_message_ts')
+    result = post_with_thread_fallback(client, channel=channel_id, text=text, blocks=blocks, thread_ts=stored_ts)
+    placed_in = placed_thread_ts(result)
+    if not placed_in:
+        if is_folded_child(incident_data):
+            if not incident_data.get('anchor_slack_message_ts'):
+                backfill_thread_parent_ts(user_id, incident_data['recurrence_of'], result.get('ts'), replacing=None)
+        else:
+            record_thread_parent(client, channel=channel_id, user_id=user_id, incident_id=incident_id,
+                                 result=result, stored=stored_ts)
+    logger.info(
+        f"[SlackNotification] Sent '{kind}' notification for incident {incident_id}"
+        + (f" in thread {placed_in}" if placed_in else " top-level")
+    )
+    return True
+
+
 def send_slack_investigation_completed_notification(
     user_id: str,
     incident_data: Dict[str, Any]
@@ -206,6 +298,17 @@ def send_slack_investigation_completed_notification(
             - analyzed_at: Investigation completion timestamp
             - aurora_summary: RCA summary text
             - status: Incident status
+            - slack_message_ts: This incident's "Investigation Started" ts (thread parent)
+            - recurrence_of: Anchor incident id when folded (dedup layer 1), else None
+            - anchor_slack_message_ts: Anchor's "Investigation Started" ts
+            - anchor_alert_title: Anchor's alert title
+            - occurrence_number / group_size: Position in the recurrence group
+
+    Placement (dedup layer 3): standalone → threaded under its own Started
+    message; folded child → compact "Still firing" reply under the anchor's
+    message and the child's own Started message is retired. A child whose
+    anchor thread is unavailable is placed like a standalone incident, and a
+    missing Started message means today's top-level full card.
             
     Returns:
         True if message sent successfully, False otherwise
@@ -220,17 +323,19 @@ def send_slack_investigation_completed_notification(
             logger.error(f"[SlackNotification] Could not find incidents channel for user {user_id}")
             return False
         
-        # Extract incident data
         incident_id = incident_data.get('incident_id', 'unknown')
-        alert_title = incident_data.get('alert_title', _DEFAULT_ALERT_TITLE)
-        severity = incident_data.get('severity', 'unknown')
-        service = incident_data.get('service', 'unknown')
-        started_at = incident_data.get('started_at')
-        analyzed_at = incident_data.get('analyzed_at')
-        aurora_summary = incident_data.get('aurora_summary') or 'Analysis in progress...'
-        
-        # Format data
         incident_url = _get_incident_url(incident_id)
+
+        if _post_recurrence_reply(client, channel_id, user_id, incident_data, incident_url=incident_url):
+            return True
+        # Standalone, or a folded child whose anchor thread is unavailable:
+        # the full card under this incident's own Started message.
+
+        # Extract incident data (mrkdwn-escaped: titles come from webhooks)
+        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
+        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
+        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
+        aurora_summary = incident_data.get('aurora_summary') or 'Analysis in progress...'
         
         # Extract summary section (before "Suggested Next Steps") and format for Slack
         from routes.slack.slack_events_helpers import (
@@ -305,7 +410,7 @@ def send_slack_investigation_completed_notification(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity.title()}\n*Service:* {service}"
+                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity}\n*Service:* {service}"
                 }
             },
             {
@@ -342,29 +447,8 @@ def send_slack_investigation_completed_notification(
             logger.warning(f"[SlackNotification] Truncating blocks from {len(blocks)} to {SLACK_MAX_BLOCKS - 5}")
             blocks = blocks[:SLACK_MAX_BLOCKS - 5]
         
-        # Validate blocks before sending
-        from routes.slack.slack_events_helpers import validate_slack_blocks
-        if not validate_slack_blocks(blocks):
-            logger.error(f"[SlackNotification] Block validation failed for incident {incident_id}")
-            # Fallback to simple text message
-            simple_text = f"*Analysis Complete*\n\n{alert_title}\n\nView full report: {incident_url}"
-            result = client.send_message(
-                channel=channel_id,
-                text=simple_text
-            )
-            return result is not None
-        
-        result = client.send_message(
-            channel=channel_id,
-            text=f"Analysis Complete: {alert_title}",
-            blocks=blocks
-        )
-        
-        if result:
-            return True
-        else:
-            return False
-            
+        return _post_incident_card(client, channel_id, user_id, incident_data, kind="completed", blocks=blocks)
+
     except Exception:
         logger.exception("[SlackNotification] Error sending completed notification")
         return False
@@ -380,8 +464,13 @@ def send_slack_investigation_failed_notification(
 
     Args:
         user_id: User ID
-        incident_data: Dictionary containing incident details
+        incident_data: Dictionary containing incident details (same keys as
+            the completed notification, including the recurrence-group fields)
         error_message: Optional error description
+
+    Placement follows the completed notification: threaded under the
+    incident's own Started message, or a compact failed reply under the
+    anchor's message for a folded child.
 
     Returns:
         True if message sent successfully, False otherwise
@@ -396,15 +485,19 @@ def send_slack_investigation_failed_notification(
             return False
 
         incident_id = incident_data.get('incident_id', 'unknown')
-        alert_title = incident_data.get('alert_title', _DEFAULT_ALERT_TITLE)
-        severity = incident_data.get('severity', 'unknown')
-        service = incident_data.get('service', 'unknown')
-
         incident_url = _get_incident_url(incident_id)
 
         error_text = error_message or "The investigation encountered an error and could not complete."
         if len(error_text) > 300:
             error_text = error_text[:300] + "..."
+
+        if _post_recurrence_reply(client, channel_id, user_id, incident_data,
+                                  incident_url=incident_url, error_text=error_text):
+            return True
+
+        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
+        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
+        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
 
         blocks = [
             {
@@ -434,7 +527,7 @@ def send_slack_investigation_failed_notification(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity.title()}\n*Service:* {service}"
+                    "text": f"*Alert:* {alert_title}\n*Severity:* {severity}\n*Service:* {service}"
                 }
             },
             {
@@ -444,27 +537,13 @@ def send_slack_investigation_failed_notification(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f":x: *Error:* {error_text}"
+                    "text": f":x: *Error:* {escape_mrkdwn(error_text)}"
                 }
             }
         ]
 
-        from routes.slack.slack_events_helpers import validate_slack_blocks
-        if not validate_slack_blocks(blocks):
-            simple_text = f"*Investigation Failed*\n\n{alert_title}\n\nError: {error_text}\n\nView incident: {incident_url}"
-            result = client.send_message(channel=channel_id, text=simple_text)
-            return result is not None
-
-        result = client.send_message(
-            channel=channel_id,
-            text=f"Investigation Failed: {alert_title}",
-            blocks=blocks
-        )
-
-        if result:
-            logger.info(f"[SlackNotification] Sent 'failed' notification for incident {incident_id}")
-            return True
-        return False
+        return _post_incident_card(client, channel_id, user_id, incident_data, kind="failed", blocks=blocks,
+                                   error_text=error_text)
 
     except Exception:
         logger.exception("[SlackNotification] Error sending failed notification")

--- a/server/utils/notifications/slack_notification_service.py
+++ b/server/utils/notifications/slack_notification_service.py
@@ -12,25 +12,30 @@ from utils.db.connection_pool import db_pool
 from utils.auth.stateless_auth import set_rls_context
 from utils.notifications.slack_threading import (
     KEPT_REPLIES,
-    backfill_thread_parent_ts,
+    LOOKUP_FAILED,
     build_fold_pointer,
+    build_folded_stub,
+    build_recurrence_footer,
     build_recurrence_reply,
     clear_anchor_message_ts,
     clear_child_started_message,
+    error_block,
     escape_mrkdwn,
+    escaped_fields,
     is_folded_child,
-    message_is_gone,
+    lookup_message,
     placed_thread_ts,
     post_with_thread_fallback,
     record_thread_parent,
     try_post_threaded,
+    try_update_in_place,
+    update_anchor_recurrence_footer,
 )
 
 logger = logging.getLogger(__name__)
 
 SLACK_MAX_BLOCKS = 50
 FRONTEND_URL = os.getenv("FRONTEND_URL")
-_DEFAULT_ALERT_TITLE = "Unknown Alert"
 
 
 def _get_incidents_channel_id(user_id: str, client: SlackClient) -> Optional[str]:
@@ -101,9 +106,7 @@ def send_slack_investigation_started_notification(user_id: str, incident_data: D
         
         # Extract incident data (mrkdwn-escaped: titles come from webhooks)
         incident_id = incident_data.get('incident_id', 'unknown')
-        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
-        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
-        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
+        alert_title, severity, service = escaped_fields(incident_data)
         source_type = escape_mrkdwn(incident_data.get('source_type', 'monitoring platform'))
         started_at = incident_data.get('started_at')
         
@@ -193,12 +196,12 @@ def _post_recurrence_reply(client: SlackClient, channel_id: str, user_id: str, i
         return False
     incident_id = incident_data.get('incident_id')
     anchor_id = incident_data['recurrence_of']
-    if message_is_gone(client, channel=channel_id, ts=thread_ts):
-        # Forget it so later siblings stop trying, and so the next top-level
-        # card can seed a new parent (see _post_incident_card).
+    anchor_message = lookup_message(client, channel=channel_id, ts=thread_ts)
+    if anchor_message is None:
+        # Forget it so later siblings stop trying; this incident is then
+        # placed like a standalone one (_post_incident_card).
         logger.info(f"[SlackNotification] Anchor {anchor_id} thread parent {thread_ts} is gone; forgetting it")
         clear_anchor_message_ts(user_id, anchor_id, thread_ts)
-        incident_data['anchor_slack_message_ts'] = None
         return False
     from routes.slack.slack_events_helpers import validate_slack_blocks
     anchor_url = _get_incident_url(anchor_id)
@@ -228,27 +231,53 @@ def _post_recurrence_reply(client: SlackClient, channel_id: str, user_id: str, i
         f"[SlackNotification] Posted {'failed' if error_text else 'completed'} as recurrence reply for "
         f"{incident_id} under anchor {anchor_id}"
     )
+    # The channel view only shows the anchor card: mark it as still firing
+    # (reusing the lookup above instead of fetching the card again).
+    update_anchor_recurrence_footer(
+        client, channel=channel_id, anchor_ts=thread_ts, incident_data=incident_data,
+        message=None if anchor_message is LOOKUP_FAILED else anchor_message,
+    )
     outcome = clear_child_started_message(client, channel=channel_id, user_id=user_id, incident_data=incident_data)
     if outcome == KEPT_REPLIES:
-        # People are talking in the child's own thread: tell them where the
-        # outcome went instead of leaving that card "In Progress" forever.
-        try_post_threaded(
-            client, channel=channel_id, text=build_fold_pointer(incident_data, anchor_url=anchor_url),
-            blocks=None, thread_ts=incident_data['slack_message_ts'], require_threaded=True,
+        # People are talking in the child's own thread: turn its card into a
+        # pointer to the anchor instead of leaving it "In Progress" forever,
+        # and post one line in the thread so its followers are told.
+        stub_text, stub_blocks = build_folded_stub(
+            incident_data, incident_url=incident_url, anchor_url=anchor_url, error_text=error_text,
         )
+        try:
+            try_update_in_place(
+                client, channel=channel_id, ts=incident_data['slack_message_ts'], text=stub_text,
+                blocks=stub_blocks if validate_slack_blocks(stub_blocks) else None,
+            )
+            try_post_threaded(
+                client, channel=channel_id, text=build_fold_pointer(incident_data, anchor_url=anchor_url),
+                blocks=None, thread_ts=incident_data['slack_message_ts'], require_threaded=True,
+            )
+        except Exception as e:
+            # Best effort: the outcome already landed in the anchor's thread.
+            logger.warning(f"[SlackNotification] Could not mark kept Started card for {incident_id} as folded: {e}")
     return True
 
 
 def _post_incident_card(client: SlackClient, channel_id: str, user_id: str, incident_data: Dict[str, Any], *,
                         kind: str, blocks: list, error_text: Optional[str] = None) -> bool:
-    """Full Complete/Failed card under the incident's own Started message,
-    or top-level when there is none or Slack no longer has it. A top-level
-    post becomes the incident's thread parent for later recurrences — or,
-    for a folded child whose anchor has no thread parent, the anchor's, so
-    the group consolidates from here on."""
+    """Full Complete/Failed card for the incident. The incident's own Started
+    message is updated in place into the final card when Slack still has it
+    (thread and ts preserved), otherwise the card is posted under it, or
+    top-level when there is no Started message at all. A Failed card never
+    replaces the card of an investigation that already produced a result
+    (analyzed_at set — a follow-up chat or the stall sweep failing after the
+    RCA completed): it is threaded under it instead. A group root's card
+    keeps its recurrence footer. A top-level post becomes the incident's own
+    thread parent — never another incident's, since slack_message_ts also
+    routes @mentions to the incident it belongs to."""
     incident_id = incident_data.get('incident_id', 'unknown')
-    alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
+    alert_title = escaped_fields(incident_data)[0]
     incident_url = _get_incident_url(incident_id)
+    if not is_folded_child(incident_data) and (incident_data.get('group_size') or 1) > 1:
+        # Rebuilding the anchor's card must not drop what its recurrences added.
+        blocks = [*blocks, build_recurrence_footer(incident_data)]
     if kind == "failed":
         text = f"Investigation Failed: {alert_title}"
         simple_text = (
@@ -263,15 +292,14 @@ def _post_incident_card(client: SlackClient, channel_id: str, user_id: str, inci
         logger.error(f"[SlackNotification] Block validation failed for incident {incident_id}")
         text, blocks = simple_text, None
     stored_ts = incident_data.get('slack_message_ts')
+    replace_in_place = kind == "completed" or not incident_data.get('analyzed_at')
+    if stored_ts and replace_in_place and try_update_in_place(client, channel=channel_id, ts=stored_ts, text=text, blocks=blocks):
+        logger.info(f"[SlackNotification] Replaced Started message {stored_ts} with the '{kind}' card for incident {incident_id}")
+        return True
     result = post_with_thread_fallback(client, channel=channel_id, text=text, blocks=blocks, thread_ts=stored_ts)
     placed_in = placed_thread_ts(result)
-    if not placed_in:
-        if is_folded_child(incident_data):
-            if not incident_data.get('anchor_slack_message_ts'):
-                backfill_thread_parent_ts(user_id, incident_data['recurrence_of'], result.get('ts'), replacing=None)
-        else:
-            record_thread_parent(client, channel=channel_id, user_id=user_id, incident_id=incident_id,
-                                 result=result, stored=stored_ts)
+    record_thread_parent(client, channel=channel_id, user_id=user_id, incident_id=incident_id,
+                         result=result, stored=stored_ts)
     logger.info(
         f"[SlackNotification] Sent '{kind}' notification for incident {incident_id}"
         + (f" in thread {placed_in}" if placed_in else " top-level")
@@ -332,9 +360,7 @@ def send_slack_investigation_completed_notification(
         # the full card under this incident's own Started message.
 
         # Extract incident data (mrkdwn-escaped: titles come from webhooks)
-        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
-        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
-        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
+        alert_title, severity, service = escaped_fields(incident_data)
         aurora_summary = incident_data.get('aurora_summary') or 'Analysis in progress...'
         
         # Extract summary section (before "Suggested Next Steps") and format for Slack
@@ -495,9 +521,7 @@ def send_slack_investigation_failed_notification(
                                   incident_url=incident_url, error_text=error_text):
             return True
 
-        alert_title = escape_mrkdwn(incident_data.get('alert_title', _DEFAULT_ALERT_TITLE))
-        severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
-        service = escape_mrkdwn(incident_data.get('service', 'unknown'))
+        alert_title, severity, service = escaped_fields(incident_data)
 
         blocks = [
             {
@@ -533,13 +557,7 @@ def send_slack_investigation_failed_notification(
             {
                 "type": "divider"
             },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f":x: *Error:* {escape_mrkdwn(error_text)}"
-                }
-            }
+            error_block(error_text),
         ]
 
         return _post_incident_card(client, channel_id, user_id, incident_data, kind="failed", blocks=blocks,

--- a/server/utils/notifications/slack_threading.py
+++ b/server/utils/notifications/slack_threading.py
@@ -1,0 +1,312 @@
+"""
+Slack thread consolidation for incident notifications (root-cause dedup layer 3).
+
+One channel message per root cause: an incident's "Analysis Complete" /
+"Investigation Failed" post replies in a thread instead of landing top-level.
+Standalone incidents reply under their own "Investigation Started" message;
+folded recurrences (incidents.recurrence_of_incident_id set) reply under the
+anchor's message with a compact "Still firing" card and retire their own
+Started message. Every failure path degrades to today's top-level post.
+
+incidents.slack_message_ts is the incident's thread parent and the key that
+routes Slack @mentions back to the incident. It is only ever written here by
+compare-and-set, and a stored parent is only replaced or cleared once Slack
+has confirmed it is gone.
+
+The group fields (recurrence_of, anchor_slack_message_ts, anchor_alert_title,
+occurrence_number, group_size) come from dispatcher._get_incident_data.
+"""
+
+import html
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from connectors.slack_connector.client import SlackAPIError, SlackClient
+from utils.auth.stateless_auth import set_rls_context
+from utils.db.connection_pool import db_pool
+from utils.text.text_utils import truncate
+
+logger = logging.getLogger(__name__)
+
+_ANCHOR_TITLE_MAX = 120
+_LOG_PREFIX = "[SlackNotification:thread]"
+
+# chat.postMessage rejections that are about the thread itself, where a
+# top-level retry can succeed. Anything else (not_in_channel, invalid_auth,
+# msg_too_long, invalid_blocks, ...) fails identically top-level.
+_THREAD_ONLY_ERRORS = frozenset({
+    "cannot_reply_to_message",
+    "restricted_action_thread_locked",
+    "restricted_action_non_threadable_channel",
+})
+
+# clear_child_started_message outcomes
+RELEASED = "released"          # stored ts cleared (message deleted or already gone)
+KEPT_REPLIES = "kept_replies"  # message has replies: kept, still the thread key
+KEPT = "kept"                  # nothing changed (no ts, lookup/db failure, fold no longer holds)
+
+
+def is_folded_child(incident_data: Dict[str, Any]) -> bool:
+    """True when this incident has been folded into an anchor (layer 1)."""
+    return bool(incident_data.get('recurrence_of'))
+
+
+def escape_mrkdwn(text: Any) -> str:
+    """Escape a value for Slack mrkdwn (only &, < and > per Slack's formatting
+    rules) so titles from monitoring webhooks cannot inject links, mentions
+    or <!channel>."""
+    return html.escape(str(text), quote=False)
+
+
+def placed_thread_ts(result: Dict[str, Any]) -> Optional[str]:
+    """Parent ts of a chat.postMessage response, or None for a top-level post."""
+    return (result.get('message') or {}).get('thread_ts') or None
+
+
+def message_is_gone(client: SlackClient, *, channel: str, ts: str) -> bool:
+    """True only when Slack confirms `ts` is no longer in `channel`. A failed
+    lookup counts as present so a stored parent is never dropped on a
+    transient error."""
+    try:
+        return client.get_message(channel=channel, ts=ts) is None
+    except ValueError as e:
+        logger.warning(f"{_LOG_PREFIX} Could not look up message {ts}: {e}")
+        return False
+
+
+def try_post_threaded(client: SlackClient, *, channel: str, text: str,
+                      blocks: Optional[List[Dict]], thread_ts: str,
+                      require_threaded: bool = False) -> Optional[Dict[str, Any]]:
+    """chat.postMessage with thread_ts. Returns None when Slack rejected the
+    post for a thread-specific reason (_THREAD_ONLY_ERRORS) so the caller can
+    post top-level. Any other rejection propagates — it would fail the same
+    way top-level — and so does a transport failure (timeout, connection
+    error, exhausted rate-limit retries): the message may already have
+    landed, and a second attempt would duplicate it.
+
+    Slack does not error on a missing or deleted parent: it silently posts
+    the message top-level and omits message.thread_ts from the response
+    (verified live). With require_threaded=True that outcome is treated as a
+    failure — the stray top-level post is removed (best effort) and None is
+    returned. If the stray cannot be removed the response is returned as-is;
+    callers that need a real reply must check placed_thread_ts(result).
+    """
+    try:
+        result = client.send_message(channel=channel, text=text, blocks=blocks, thread_ts=thread_ts)
+    except SlackAPIError as e:
+        if e.error not in _THREAD_ONLY_ERRORS:
+            raise
+        logger.warning(f"{_LOG_PREFIX} Threaded post under {thread_ts} rejected ({e.error}); degrading to top-level")
+        return None
+    if require_threaded and placed_thread_ts(result) != thread_ts:
+        stray_ts = result.get('ts')
+        logger.warning(
+            f"{_LOG_PREFIX} Slack placed reply top-level (parent {thread_ts} missing); "
+            f"removing stray post {stray_ts} and degrading to top-level"
+        )
+        if stray_ts:
+            try:
+                client.delete_message(channel=channel, ts=stray_ts)
+            except Exception as e:
+                # The stray is a visible notification already; keep it rather
+                # than have the caller post a second card for the same incident.
+                logger.warning(f"{_LOG_PREFIX} Failed to remove stray post {stray_ts}; keeping it: {e}")
+                return result
+        return None
+    return result
+
+
+def post_with_thread_fallback(client: SlackClient, *, channel: str, text: str,
+                              blocks: Optional[List[Dict]] = None,
+                              thread_ts: Optional[str] = None) -> Dict[str, Any]:
+    """Post in the thread when thread_ts is set and Slack accepts it; otherwise
+    today's top-level post. A top-level failure propagates to the caller.
+    The response's message.thread_ts tells where the post actually landed."""
+    if thread_ts:
+        result = try_post_threaded(client, channel=channel, text=text, blocks=blocks, thread_ts=thread_ts)
+        if result:
+            return result
+    return client.send_message(channel=channel, text=text, blocks=blocks)
+
+
+def _anchor_title(incident_data: Dict[str, Any]) -> str:
+    return escape_mrkdwn(truncate(
+        (incident_data.get('anchor_alert_title') or 'original incident').strip(), _ANCHOR_TITLE_MAX, "…",
+    ))
+
+
+def build_recurrence_reply(incident_data: Dict[str, Any], *, incident_url: str, anchor_url: str,
+                           error_text: Optional[str] = None) -> Tuple[str, List[Dict]]:
+    """Compact thread reply for a folded child. No RCA paragraph or
+    suggestions: the anchor's thread already carries them. error_text turns
+    it into the failed variant.
+
+    Returns (fallback_text, blocks).
+    """
+    alert_title = escape_mrkdwn(incident_data.get('alert_title') or 'Unknown Alert')
+    severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
+    service = escape_mrkdwn(incident_data.get('service') or 'unknown')
+    label = f"occurrence {incident_data.get('occurrence_number') or 1} of {incident_data.get('group_size') or 1}"
+    anchor_title = _anchor_title(incident_data)
+
+    blocks: List[Dict] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f":repeat: *Still firing — {label}*\n"
+                    f"*Alert:* {alert_title}\n*Severity:* {severity}\n*Service:* {service}"
+                ),
+            },
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "View Occurrence"},
+                "url": incident_url,
+            },
+        },
+    ]
+    if error_text:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f":x: *Error:* {escape_mrkdwn(error_text)}"},
+        })
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": f"Recurrence of <{anchor_url}|{anchor_title}>"},
+        ],
+    })
+
+    text = f"Still firing — {label}: {alert_title} ({incident_url})"
+    if error_text:
+        text = "Investigation failed — " + text
+    return text, blocks
+
+
+def build_fold_pointer(incident_data: Dict[str, Any], *, anchor_url: str) -> str:
+    """One-line reply for a folded child's own Started thread when that
+    thread is kept (it has replies): tells the people talking there where
+    the outcome went."""
+    return (
+        f":repeat: Folded into <{anchor_url}|{_anchor_title(incident_data)}> — "
+        "the analysis for this occurrence is in that incident's thread."
+    )
+
+
+def _write_slack_message_ts(user_id: str, incident_id: str, sql: str, params: tuple, *, what: str) -> int:
+    """One guarded UPDATE of incidents.slack_message_ts under RLS. Returns the
+    number of rows changed (0 when the guard did not match or the write
+    failed). Never raises."""
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                set_rls_context(cursor, conn, user_id, log_prefix=f"[SlackNotification:{what}]")
+                cursor.execute(sql, params)
+                changed = int(cursor.rowcount or 0)
+                conn.commit()
+                return max(changed, 0)
+    except Exception as e:
+        logger.warning(f"{_LOG_PREFIX} Failed to {what} slack_message_ts for incident {incident_id}: {e}")
+        return 0
+
+
+def clear_child_started_message(client: SlackClient, *, channel: str, user_id: str,
+                                incident_data: Dict[str, Any]) -> str:
+    """Retire a folded child's own "Investigation Started" message once its
+    completion has landed in the anchor's thread: release the stored ts,
+    then delete the message. The ts is released first, and only while the
+    fold still holds — layer 1's mutual-fold tie-break can unfold an incident
+    concurrently — so a message is never deleted from under an incident that
+    has just become an anchor again. Later posts for this incident go
+    top-level (unfold) rather than under a deleted parent.
+
+    The message is kept — and stays the incident's thread key — when it
+    already has replies: deleting it would orphan that conversation under a
+    tombstone and stop @mentions there from resolving to the incident. The
+    caller posts a pointer into that thread instead (KEPT_REPLIES).
+    Never raises. Returns RELEASED, KEPT_REPLIES or KEPT."""
+    ts = incident_data.get('slack_message_ts')
+    if not ts:
+        return KEPT
+    incident_id = incident_data.get('incident_id')
+    try:
+        message = client.get_message(channel=channel, ts=ts)
+    except ValueError as e:
+        logger.warning(f"{_LOG_PREFIX} Could not look up started message {ts} for incident {incident_id}: {e}")
+        return KEPT
+    if message is not None and message.get('reply_count'):
+        logger.info(f"{_LOG_PREFIX} Keeping started message {ts} for folded incident {incident_id}: it has replies")
+        return KEPT_REPLIES
+    released = _write_slack_message_ts(
+        user_id, incident_id,
+        "UPDATE incidents SET slack_message_ts = NULL "
+        "WHERE id = %s AND slack_message_ts = %s AND recurrence_of_incident_id = %s",
+        (incident_id, ts, incident_data.get('recurrence_of')), what="clear",
+    )
+    if not released:
+        logger.info(
+            f"{_LOG_PREFIX} Keeping started message {ts} for incident {incident_id}: "
+            "it is no longer a folded child or its thread key changed"
+        )
+        return KEPT
+    if message is None:
+        logger.info(f"{_LOG_PREFIX} Started message {ts} for folded incident {incident_id} is already gone")
+        return RELEASED
+    try:
+        client.delete_message(channel=channel, ts=ts)
+    except Exception as e:
+        logger.warning(
+            f"{_LOG_PREFIX} Failed to delete started message {ts} for incident {incident_id} "
+            f"(its thread key is already released): {e}"
+        )
+        return RELEASED
+    logger.info(f"{_LOG_PREFIX} Deleted started message {ts} for folded incident {incident_id}")
+    return RELEASED
+
+
+def clear_anchor_message_ts(user_id: str, anchor_id: str, ts: str) -> None:
+    """Forget an anchor's thread parent once Slack has confirmed it is gone, so
+    later recurrences stop posting under it (and the next top-level card can
+    seed a new one). Compare-and-set on the value that was read."""
+    _write_slack_message_ts(
+        user_id, anchor_id,
+        "UPDATE incidents SET slack_message_ts = NULL WHERE id = %s AND slack_message_ts = %s",
+        (anchor_id, ts), what="clear-anchor",
+    )
+
+
+def backfill_thread_parent_ts(user_id: str, incident_id: str, message_ts: str, *,
+                              replacing: Optional[str] = None) -> bool:
+    """Record a top-level post as the incident's thread parent so later
+    recurrences can thread under it. Compare-and-set on the value read at
+    notification time (`replacing`; None means "only when unset") so a ts
+    written concurrently is never overwritten. Never raises. True when the
+    row changed."""
+    if not message_ts:
+        return False
+    return bool(_write_slack_message_ts(
+        user_id, incident_id,
+        "UPDATE incidents SET slack_message_ts = %s WHERE id = %s AND slack_message_ts IS NOT DISTINCT FROM %s",
+        (message_ts, incident_id, replacing), what="backfill",
+    ))
+
+
+def record_thread_parent(client: SlackClient, *, channel: str, user_id: str, incident_id: str,
+                         result: Dict[str, Any], stored: Optional[str] = None) -> bool:
+    """After a Started/Complete/Failed post landed top-level, make it the
+    incident's thread parent. A stored parent is replaced only once Slack
+    confirms it is gone — a top-level landing alone is not proof (Slack also
+    posts top-level on a thread-specific rejection, or when the stored ts
+    lives in another channel) — so a live Started thread never loses its
+    @mention key. Never raises. True when the ts was recorded."""
+    ts = result.get('ts')
+    if placed_thread_ts(result) or not ts:
+        return False
+    if stored and not message_is_gone(client, channel=channel, ts=stored):
+        logger.info(
+            f"{_LOG_PREFIX} Post {ts} for incident {incident_id} landed top-level but parent {stored} "
+            "is still in Slack; keeping it as the thread parent"
+        )
+        return False
+    return backfill_thread_parent_ts(user_id, incident_id, ts, replacing=stored)

--- a/server/utils/notifications/slack_threading.py
+++ b/server/utils/notifications/slack_threading.py
@@ -19,6 +19,7 @@ occurrence_number, group_size) come from dispatcher._get_incident_data.
 
 import html
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from connectors.slack_connector.client import SlackAPIError, SlackClient
@@ -40,6 +41,33 @@ _THREAD_ONLY_ERRORS = frozenset({
     "restricted_action_non_threadable_channel",
 })
 
+# chat.update rejections that mean "this message cannot be edited" (gone, not
+# ours, too old), where posting instead is the right move. Anything else
+# (not_in_channel, invalid_auth, msg_too_long, invalid_blocks, ...) would fail
+# the same way as a post.
+_UPDATE_ONLY_ERRORS = frozenset({
+    "message_not_found",
+    "cant_update_message",
+    "edit_window_closed",
+})
+
+# The anchor card carries one marked context block summarising its recurrences;
+# it is replaced (not appended) on every fold. Only cards made of these block
+# types are edited — a plain-text message comes back from Slack as rich_text,
+# which is not ours to rebuild, and image blocks come back with read-only
+# fields (image_width, image_bytes, ...) that chat.update rejects.
+RECURRENCE_FOOTER_BLOCK_ID = "aurora_recurrence_footer"
+_EDITABLE_BLOCK_TYPES = frozenset({"header", "section", "divider", "context", "actions"})
+
+# Caps for webhook-sourced fields that share one Block Kit section (3000
+# chars): past that Slack rejects the whole post as invalid_blocks.
+_ALERT_TITLE_MAX = 1500
+_SERVICE_MAX = 300
+
+# lookup_message: Slack could not be asked (transport error, rate limit, ...).
+LOOKUP_FAILED = object()
+_SLACK_MAX_BLOCKS = 50
+
 # clear_child_started_message outcomes
 RELEASED = "released"          # stored ts cleared (message deleted or already gone)
 KEPT_REPLIES = "kept_replies"  # message has replies: kept, still the thread key
@@ -58,20 +86,42 @@ def escape_mrkdwn(text: Any) -> str:
     return html.escape(str(text), quote=False)
 
 
+def escaped_fields(incident_data: Dict[str, Any]) -> Tuple[str, str, str]:
+    """(alert_title, severity, service) escaped for mrkdwn and capped — the one
+    place every card and reply gets these fields, with one default each."""
+    alert_title = escape_mrkdwn(truncate(incident_data.get('alert_title') or 'Unknown Alert', _ALERT_TITLE_MAX, "…"))
+    severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
+    service = escape_mrkdwn(truncate(incident_data.get('service') or 'unknown', _SERVICE_MAX, "…"))
+    return alert_title, severity, service
+
+
+def occurrence_label(incident_data: Dict[str, Any]) -> str:
+    return f"occurrence {incident_data.get('occurrence_number') or 1} of {incident_data.get('group_size') or 1}"
+
+
+def error_block(error_text: str) -> Dict[str, Any]:
+    return {"type": "section", "text": {"type": "mrkdwn", "text": f":x: *Error:* {escape_mrkdwn(error_text)}"}}
+
+
 def placed_thread_ts(result: Dict[str, Any]) -> Optional[str]:
     """Parent ts of a chat.postMessage response, or None for a top-level post."""
     return (result.get('message') or {}).get('thread_ts') or None
 
 
-def message_is_gone(client: SlackClient, *, channel: str, ts: str) -> bool:
-    """True only when Slack confirms `ts` is no longer in `channel`. A failed
-    lookup counts as present so a stored parent is never dropped on a
-    transient error."""
+def lookup_message(client: SlackClient, *, channel: str, ts: str) -> Any:
+    """The message at `ts`, None when Slack confirms it is gone, or
+    LOOKUP_FAILED when Slack could not be asked. Callers treat LOOKUP_FAILED as
+    "still present" so a stored parent is never dropped on a transient error."""
     try:
-        return client.get_message(channel=channel, ts=ts) is None
+        return client.get_message(channel=channel, ts=ts)
     except ValueError as e:
         logger.warning(f"{_LOG_PREFIX} Could not look up message {ts}: {e}")
-        return False
+        return LOOKUP_FAILED
+
+
+def message_is_gone(client: SlackClient, *, channel: str, ts: str) -> bool:
+    """True only when Slack confirms `ts` is no longer in `channel`."""
+    return lookup_message(client, channel=channel, ts=ts) is None
 
 
 def try_post_threaded(client: SlackClient, *, channel: str, text: str,
@@ -116,6 +166,27 @@ def try_post_threaded(client: SlackClient, *, channel: str, text: str,
     return result
 
 
+def try_update_in_place(client: SlackClient, *, channel: str, ts: str, text: str,
+                        blocks: Optional[List[Dict]]) -> Optional[Dict[str, Any]]:
+    """chat.update the incident's own "Investigation Started" message into its
+    final Complete/Failed card, so the one top-level message always shows the
+    outcome and the thread (and its ts, the @mention key) is preserved for
+    recurrences. blocks=None means plain text: the old blocks are cleared.
+
+    Returns None when Slack says the message cannot be edited
+    (_UPDATE_ONLY_ERRORS) so the caller can post the card instead. Any other
+    rejection propagates, and so does a transport failure — the edit may
+    already have landed, and posting as well would show the outcome twice.
+    """
+    try:
+        return client.update_message(channel=channel, ts=ts, text=text, blocks=blocks if blocks is not None else [])
+    except SlackAPIError as e:
+        if e.error not in _UPDATE_ONLY_ERRORS:
+            raise
+        logger.warning(f"{_LOG_PREFIX} Could not update Started message {ts} in place ({e.error}); posting instead")
+        return None
+
+
 def post_with_thread_fallback(client: SlackClient, *, channel: str, text: str,
                               blocks: Optional[List[Dict]] = None,
                               thread_ts: Optional[str] = None) -> Dict[str, Any]:
@@ -143,10 +214,8 @@ def build_recurrence_reply(incident_data: Dict[str, Any], *, incident_url: str, 
 
     Returns (fallback_text, blocks).
     """
-    alert_title = escape_mrkdwn(incident_data.get('alert_title') or 'Unknown Alert')
-    severity = escape_mrkdwn((incident_data.get('severity') or 'unknown').title())
-    service = escape_mrkdwn(incident_data.get('service') or 'unknown')
-    label = f"occurrence {incident_data.get('occurrence_number') or 1} of {incident_data.get('group_size') or 1}"
+    alert_title, severity, service = escaped_fields(incident_data)
+    label = occurrence_label(incident_data)
     anchor_title = _anchor_title(incident_data)
 
     blocks: List[Dict] = [
@@ -167,10 +236,7 @@ def build_recurrence_reply(incident_data: Dict[str, Any], *, incident_url: str, 
         },
     ]
     if error_text:
-        blocks.append({
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f":x: *Error:* {escape_mrkdwn(error_text)}"},
-        })
+        blocks.append(error_block(error_text))
     blocks.append({
         "type": "context",
         "elements": [
@@ -184,6 +250,96 @@ def build_recurrence_reply(incident_data: Dict[str, Any], *, incident_url: str, 
     return text, blocks
 
 
+def _slack_date(value: Any) -> str:
+    """Viewer-local timestamp via Slack's date token, with a UTC fallback."""
+    if not isinstance(value, datetime):
+        return ""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    epoch = int(value.timestamp())
+    return f"<!date^{epoch}^{{date_short_pretty}} at {{time}}|{value.astimezone(timezone.utc):%Y-%m-%d %H:%M} UTC>"
+
+
+def build_recurrence_footer(incident_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Context block for the anchor card: how many times this root cause has
+    fired and when the group last did (group_last_fired_at from the
+    dispatcher — not this occurrence's own time, which regresses when
+    siblings complete out of order). Marked so the next fold replaces it."""
+    size = incident_data.get('group_size') or 1
+    when = _slack_date(incident_data.get('group_last_fired_at') or incident_data.get('started_at'))
+    text = f":repeat: *Still firing* — {size} occurrence{'s' if size != 1 else ''}"
+    if when:
+        text += f", last {when}"
+    text += " · each occurrence is a reply in this thread"
+    return {
+        "type": "context",
+        "block_id": RECURRENCE_FOOTER_BLOCK_ID,
+        "elements": [{"type": "mrkdwn", "text": text}],
+    }
+
+
+def update_anchor_recurrence_footer(client: SlackClient, *, channel: str, anchor_ts: str,
+                                    incident_data: Dict[str, Any],
+                                    message: Optional[Dict[str, Any]] = None) -> bool:
+    """After a recurrence reply landed under the anchor, mark the anchor card
+    itself so the channel view shows the group is still firing (the replies
+    alone are collapsed). Reads the card (or takes `message`, when the caller
+    has just fetched it), swaps in the footer, writes it back. Best effort:
+    never raises, and leaves the card alone when it is not a Block Kit card
+    we built."""
+    try:
+        if message is None:
+            message = client.get_message(channel=channel, ts=anchor_ts)
+        if not message:
+            return False
+        blocks = message.get('blocks') or []
+        if not blocks or any(b.get('type') not in _EDITABLE_BLOCK_TYPES for b in blocks):
+            logger.info(f"{_LOG_PREFIX} Anchor card {anchor_ts} is not an editable Block Kit card; no recurrence footer")
+            return False
+        blocks = [b for b in blocks if b.get('block_id') != RECURRENCE_FOOTER_BLOCK_ID]
+        blocks.append(build_recurrence_footer(incident_data))
+        if len(blocks) > _SLACK_MAX_BLOCKS:
+            return False
+        client.update_message(channel=channel, ts=anchor_ts, text=message.get('text') or "", blocks=blocks)
+        logger.info(f"{_LOG_PREFIX} Updated recurrence footer on anchor card {anchor_ts}")
+        return True
+    except Exception as e:
+        logger.warning(f"{_LOG_PREFIX} Could not update recurrence footer on anchor card {anchor_ts}: {e}")
+        return False
+
+
+def build_folded_stub(incident_data: Dict[str, Any], *, incident_url: str, anchor_url: str,
+                      error_text: Optional[str] = None) -> Tuple[str, List[Dict]]:
+    """Replacement for a folded child's own Started card when that card is
+    kept (its thread has replies): says where the outcome went instead of
+    reading "In Progress" forever. Returns (fallback_text, blocks)."""
+    alert_title, severity, service = escaped_fields(incident_data)
+    label = occurrence_label(incident_data)
+    anchor_title = _anchor_title(incident_data)
+    blocks: List[Dict] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f":repeat: *Folded into <{anchor_url}|{anchor_title}>* — {label}\n"
+                    f"*Alert:* {alert_title}\n*Severity:* {severity}\n*Service:* {service}\n"
+                    "_The analysis for this occurrence is in that incident's thread._"
+                ),
+            },
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "View Occurrence"},
+                "url": incident_url,
+            },
+        },
+    ]
+    if error_text:
+        blocks.append(error_block(error_text))
+    text = f"Folded into {anchor_title} — {label}: {alert_title}"
+    return text, blocks
+
+
 def build_fold_pointer(incident_data: Dict[str, Any], *, anchor_url: str) -> str:
     """One-line reply for a folded child's own Started thread when that
     thread is kept (it has replies): tells the people talking there where
@@ -194,21 +350,21 @@ def build_fold_pointer(incident_data: Dict[str, Any], *, anchor_url: str) -> str
     )
 
 
-def _write_slack_message_ts(user_id: str, incident_id: str, sql: str, params: tuple, *, what: str) -> int:
-    """One guarded UPDATE of incidents.slack_message_ts under RLS. Returns the
-    number of rows changed (0 when the guard did not match or the write
-    failed). Never raises."""
+def _write_slack_message_ts(user_id: str, incident_id: str, sql: str, params: tuple, *, what: str) -> bool:
+    """One guarded UPDATE of incidents.slack_message_ts under RLS. True when a
+    row changed; False when the guard did not match or the write failed.
+    Never raises."""
     try:
         with db_pool.get_admin_connection() as conn:
             with conn.cursor() as cursor:
                 set_rls_context(cursor, conn, user_id, log_prefix=f"[SlackNotification:{what}]")
                 cursor.execute(sql, params)
-                changed = int(cursor.rowcount or 0)
+                changed = cursor.rowcount > 0
                 conn.commit()
-                return max(changed, 0)
+                return changed
     except Exception as e:
         logger.warning(f"{_LOG_PREFIX} Failed to {what} slack_message_ts for incident {incident_id}: {e}")
-        return 0
+        return False
 
 
 def clear_child_started_message(client: SlackClient, *, channel: str, user_id: str,
@@ -285,11 +441,11 @@ def backfill_thread_parent_ts(user_id: str, incident_id: str, message_ts: str, *
     row changed."""
     if not message_ts:
         return False
-    return bool(_write_slack_message_ts(
+    return _write_slack_message_ts(
         user_id, incident_id,
         "UPDATE incidents SET slack_message_ts = %s WHERE id = %s AND slack_message_ts IS NOT DISTINCT FROM %s",
         (message_ts, incident_id, replacing), what="backfill",
-    ))
+    )
 
 
 def record_thread_parent(client: SlackClient, *, channel: str, user_id: str, incident_id: str,


### PR DESCRIPTION
## Summary

Root-cause dedup layer 3: one Slack channel message per root cause. Layers 1 (#610) and 2 (#611) write and display `incidents.recurrence_of_incident_id`; this PR makes Slack notifications follow it.

- "Analysis Complete" / "Investigation Failed" now post as thread replies under the incident's own "Investigation Started" message instead of a second top-level card.
- A folded recurrence posts a compact ":repeat: Still firing — occurrence N of M" reply under the anchor's message (button to the occurrence, context link to the anchor) and retires its own Started message; its `slack_message_ts` is NULLed so later posts go top-level again.
- Every failure path degrades to today's top-level full card. Slack silently posts top-level when the parent ts is missing or deleted (no error), so placement is verified from the response's `message.thread_ts`; a stray compact post is removed and a stale anchor ts is cleared.
- Standalone incidents with no Started message (start notifications off) get the Complete ts backfilled with a guarded compare-and-set so later recurrences can still thread.
- Dispatcher incident data carries `recurrence_of`, `anchor_slack_message_ts`, `anchor_alert_title`, `occurrence_number`, `group_size` (group membership matches `_group_is_stale` and the layer-2 groups query; ordering matches the UI).
- Follow-up chats on an existing incident no longer re-announce completion (`send_notifications` now also gates summarization).
- Inbound thread @mentions resolve org-wide (RLS-scoped) since a recurrence reply lives in the anchor's thread; the RCA session is reused only for its owner.
- Slack client: `SlackAPIError` (ok=false) distinct from transport errors so only thread-specific rejections retry top-level; `get_message` via `conversations.replies`.

No schema, env, frontend, or Google Chat changes (Google Chat parity deferred).

## Verification

- `tests/utils/notifications`: 77 tests (pure, no DB/network). Full server suite: 1450 passed; the 3 failures in `tests/auth/test_rls_cross_tenant.py` are pre-existing and identical on `main`.
- Live on the dev stack against a real workspace: standalone Complete threaded under its Started; a folded child posted the compact reply under the anchor, its Started message deleted and ts NULLed; anchor ts NULL → full card top-level; bogus/deleted anchor ts → stray removed, full card top-level; inbound `get_message` on live, deleted, and bogus ts.

## Follow-ups (not in this PR)

- Detection agent keeps claiming the first-ever occurrence even after that group is stale (`stale_group` reject), so nothing re-anchors on the fresh incident; needs a layer-1 prompt/fold change.
- `reply_broadcast` on the full cards (thread replies notify nobody; the Started card stays "In Progress").
- Persist `{ts, channel}` for the Started message so a channel switch is not read as "message gone".
- Google Chat parity; docs page for notification behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack incident notifications now consolidate into threads, including recurrence updates and completed or failed investigation messages.
  - Notifications fall back to top-level posts when threads or parent messages are unavailable.
  - Incident searches from Slack can identify incidents across the organization while protecting session access.
  - Recurrence analysis now considers recent related incidents.
  - Background summaries can optionally complete without sending duplicate notifications.
  - Existing Google Chat cards can be refreshed without creating new messages.

- **Bug Fixes**
  - User-provided incident details are escaped before appearing in Slack messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->