### PR TITLE
fix(recommender): Gemini thinking-mode content in all four LLM stages + one shared extract_text_from_content

### DIFF
--- a/server/chat/backend/agent/llm.py
+++ b/server/chat/backend/agent/llm.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from chat.backend.agent.model_mapper import ModelMapper
 from chat.backend.agent.providers import create_chat_model
 from chat.backend.agent.utils.llm_usage_tracker import LLMUsageTracker
+from chat.backend.agent.utils.message_content import extract_text_from_content
 
 logger = logging.getLogger(__name__)
 
@@ -420,22 +421,8 @@ Summary:"""
                 response = isolated_summarizer.invoke(summarization_prompt)
 
             if hasattr(response, "content"):
-                response_content = response.content
-                # Handle Gemini thinking model responses (list with thinking/text blocks)
-                if isinstance(response_content, list):
-                    text_parts = []
-                    for part in response_content:
-                        if isinstance(part, dict):
-                            part_type = part.get("type", "")
-                            if part_type not in ("thinking", "reasoning"):
-                                text = part.get("text", "")
-                                if text:
-                                    text_parts.append(str(text))
-                        elif isinstance(part, str):
-                            text_parts.append(part)
-                    summary = "".join(text_parts)
-                else:
-                    summary = str(response_content)
+                # Gemini thinking models return a list of thinking/text blocks
+                summary = extract_text_from_content(response.content)
             else:
                 summary = str(response)
 

--- a/server/chat/backend/agent/utils/message_content.py
+++ b/server/chat/backend/agent/utils/message_content.py
@@ -1,0 +1,77 @@
+"""Flatten LangChain message ``content`` payloads to plain text.
+
+LangChain hands back ``message.content`` as a plain ``str`` for most models, but as
+a list of typed blocks for models that emit reasoning alongside their answer:
+
+- Gemini 2.5 / 3.x with ``include_thoughts`` on (google and vertex providers, see
+  ``providers.base_provider.apply_gemini_thinking_config``)::
+
+      [{"type": "thinking", "thinking": "..."},
+       {"type": "text", "text": "...", "extras": {"signature": "..."}}]
+
+- OpenAI Responses-API reasoning models::
+
+      [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "..."}]},
+       {"type": "text", "text": "..."}]
+
+- Anthropic extended thinking: same shape as Gemini (``thinking`` + ``text``).
+
+``str(content)`` on the list form yields a Python repr that no JSON or regex parser
+accepts, and ``content.strip()`` raises ``AttributeError``. Both silently broke
+Aurora on Gemini deployments (repo descriptions, recommender stages; Aug-Sept 2026).
+Every place that reads model output should go through :func:`extract_text_from_content`
+instead of re-implementing the block walk.
+"""
+
+from typing import Any
+
+_THINKING_BLOCK_TYPES = ("thinking", "reasoning")
+
+
+def extract_text_from_content(content: Any, include_thinking: bool = False) -> str:
+    """Return the text of a message ``content`` payload as one string.
+
+    Args:
+        content: ``message.content`` from a LangChain message or stream chunk. A
+            ``str``, a list of typed blocks and/or strings, ``None``, or any other
+            value.
+        include_thinking: When ``True``, ``thinking``/``reasoning`` blocks contribute
+            their text (the ``thinking`` field plus any OpenAI ``summary`` entries) in
+            stream order. The RCA background chat uses this because the thought stream
+            is the investigation progress. When ``False`` (default) they are dropped.
+
+    Returns:
+        The concatenated text. ``str`` content is returned untouched and ``None``
+        yields ``""``. No whitespace is stripped, so streamed chunks can be joined
+        safely; callers that want a trimmed value should ``.strip()`` the result.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") in _THINKING_BLOCK_TYPES:
+            if not include_thinking:
+                continue
+            thinking = block.get("thinking")
+            if thinking:
+                parts.append(str(thinking))
+            for item in block.get("summary") or []:
+                if isinstance(item, dict):
+                    summary_text = item.get("text") or item.get("summary_text")
+                    if summary_text:
+                        parts.append(str(summary_text))
+            continue
+        text = block.get("text")
+        if text:
+            parts.append(str(text))
+    return "".join(parts)

--- a/server/chat/backend/agent/workflow.py
+++ b/server/chat/backend/agent/workflow.py
@@ -2,6 +2,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.graph import StateGraph
 from langgraph.graph import START, END
 from chat.backend.agent.utils.safe_memory_saver import SafeMemorySaver
+from chat.backend.agent.utils.message_content import extract_text_from_content
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.messages import AIMessageChunk, AIMessage, SystemMessage
 from chat.backend.agent.agent import Agent
@@ -33,58 +34,11 @@ RCA_SUMMARY_PREFIX = "[RCA Investigation Summary"
 _USER_MESSAGE_RE = re.compile(r'<user_message>\s*([\s\S]*?)\s*</user_message>')
 
 
-def _extract_text_from_content(content: Any, include_thinking: bool = False) -> str:
-    """
-    Extract text content from message content, handling Gemini thinking model responses.
-    
-    Gemini thinking models return content as a list of blocks with types:
-    - {"type": "thinking", "thinking": "..."} - reasoning/thinking blocks (extracted)
-    - {"type": "text", "text": "..."} - actual text response (extracted)
-    
-    For RCA background chats, thinking blocks contain the investigation progress,
-    so we extract them as part of the thought stream.
-    
-    Args:
-        content: Message content (can be string, list, or other types)
-        
-    Returns:
-        Extracted text as string
-    """
-    if isinstance(content, list):
-        text_parts = []
-        for part in content:
-            if isinstance(part, dict):
-                part_type = part.get("type", "")
-
-                # Extract text from thinking, reasoning, and text blocks.
-                # Anthropic / Gemini thinking blocks: use `thinking` key.
-                # OpenAI Responses-API reasoning blocks: text lives inside
-                #   `summary` as a list of {type:'summary_text', text:'…'}.
-                # Regular text blocks: use `text` key.
-                if part_type in ("thinking", "reasoning") and include_thinking:
-                    thinking_text = part.get("thinking", "")
-                    if thinking_text:
-                        text_parts.append(str(thinking_text))
-                    for s_item in part.get("summary") or []:
-                        if isinstance(s_item, dict):
-                            s_text = s_item.get("text") or s_item.get("summary_text", "")
-                            if s_text:
-                                text_parts.append(str(s_text))
-                elif part_type == "text" or not part_type:
-                    text = part.get("text", "")
-                    if text:
-                        text_parts.append(str(text))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        return "".join(text_parts)
-    return str(content)
-
-
 def _get_input_rail_text(question: Any, message_content: Any) -> str:
     """Return the user-authored text that should be evaluated by input rails."""
     if isinstance(question, str):
         return question
-    return _extract_text_from_content(message_content)
+    return extract_text_from_content(message_content)
 
 
 class Workflow:
@@ -1145,7 +1099,7 @@ class Workflow:
                         # this is safe to call unconditionally.
                         is_background = getattr(input_state, "is_background", False)
                         if hasattr(chunk_obj, 'content') and chunk_obj.content:
-                            content = _extract_text_from_content(chunk_obj.content, include_thinking=is_background)
+                            content = extract_text_from_content(chunk_obj.content, include_thinking=is_background)
 
                         # For background RCA chats, reasoning feeds into incident thoughts
                         if not content and reasoning and is_background:
@@ -1237,7 +1191,7 @@ class Workflow:
                             content = ""
                             is_background = getattr(input_state, "is_background", False)
                             if hasattr(output, 'content') and output.content:
-                                content = _extract_text_from_content(output.content, include_thinking=is_background)
+                                content = extract_text_from_content(output.content, include_thinking=is_background)
                             if not content and hasattr(output, 'additional_kwargs'):
                                 reasoning = output.additional_kwargs.get("reasoning_content", "")
                                 if reasoning and is_background:
@@ -1459,7 +1413,7 @@ class Workflow:
                     chunk_builders[msg.id] = builder
 
                 # Accumulate content (handles Gemini thinking model list format)
-                msg_content = _extract_text_from_content(msg.content or "", include_thinking=False)
+                msg_content = extract_text_from_content(msg.content or "", include_thinking=False)
                 builder["content"] += msg_content
 
                 # Process tool calls
@@ -1631,13 +1585,13 @@ class Workflow:
                 if isinstance(raw_content, str) and raw_content.startswith(RCA_SUMMARY_PREFIX):
                     continue
                 # Extract text content (handles Gemini thinking model list format)
-                content = _extract_text_from_content(raw_content)
+                content = extract_text_from_content(raw_content)
                 has_tool_calls = (
                     getattr(msg, 'tool_calls', [])
                     or getattr(msg, 'additional_kwargs', {}).get('tool_calls', [])
                 )
                 if not content and has_tool_calls:
-                    content = _extract_text_from_content(raw_content, include_thinking=False)
+                    content = extract_text_from_content(raw_content, include_thinking=False)
                 
                 # Get the AIMessage's run_id for consistency (needed regardless of tool calls)
                 run_id = getattr(msg, 'id', None)

--- a/server/chat/background/recommender.py
+++ b/server/chat/background/recommender.py
@@ -289,7 +289,7 @@ Return ONLY the JSON object."""
     try:
         llm = create_chat_model(ModelConfig.SUGGESTION_MODEL, temperature=0.1)
         response = llm.invoke([HumanMessage(content=prompt)])
-        text = _strip_code_fences(str(response.content).strip())
+        text = _strip_code_fences(extract_text_from_content(response.content).strip())
 
         data = json.loads(text)
 
@@ -553,7 +553,7 @@ Return ONLY the JSON array."""
     try:
         llm = create_chat_model(ModelConfig.SUGGESTION_MODEL, temperature=0.1)
         response = llm.invoke([HumanMessage(content=prompt)])
-        commands_to_run = _parse_json_list_response(str(response.content))
+        commands_to_run = _parse_json_list_response(extract_text_from_content(response.content))
     except Exception as e:
         logger.warning("[Recommender] Self-exec planning failed: %s", e)
         return []
@@ -914,7 +914,7 @@ Return in this exact format (one block per suggestion):
             model_name=_ENRICHMENT_MODEL,
             request_type="suggestion_enrichment",
         )
-        _apply_enrichment_response(str(response.content).strip(), suggestions)
+        _apply_enrichment_response(extract_text_from_content(response.content).strip(), suggestions)
     except Exception as e:
         logger.warning("[Recommender] Validated fix enrichment failed (non-fatal): %s", e)
         _generate_summaries(suggestions, user_id, session_id)
@@ -977,7 +977,7 @@ Return one summary per line, numbered:"""
             model_name=_ENRICHMENT_MODEL,
             request_type="suggestion_summary",
         )
-        text = str(response.content).strip()
+        text = extract_text_from_content(response.content).strip()
         lines = [l.strip() for l in text.split("\n") if l.strip()]
 
         for line in lines:

--- a/server/chat/background/recommender.py
+++ b/server/chat/background/recommender.py
@@ -23,6 +23,7 @@ from langchain_core.messages import HumanMessage
 
 from chat.background.citation_extractor import Citation
 from chat.background.suggestion_extractor import Suggestion, is_command_safe
+from chat.backend.agent.utils.message_content import extract_text_from_content
 
 from chat.background.citation_extractor import _TOOL_NAME_MAPPING
 
@@ -762,23 +763,6 @@ def _is_redundant(suggestion: Suggestion, executed_commands: set) -> bool:
     return False
 
 
-def _extract_text_part(part: Any) -> str:
-    """Extract text from a single content block, filtering out thinking blocks."""
-    if isinstance(part, str):
-        return part
-    if isinstance(part, dict) and part.get("type") not in ("thinking", "reasoning"):
-        text = part.get("text", "")
-        return str(text) if text else ""
-    return ""
-
-
-def _extract_text_from_content(content: Any) -> str:
-    """Extract plain text from LLM response content (handles Gemini thinking blocks)."""
-    if isinstance(content, list):
-        return "".join(_extract_text_part(part) for part in content).strip()
-    return str(content).strip()
-
-
 def _parse_item_to_suggestion(item: dict) -> Optional[Suggestion]:
     """Convert a single parsed JSON item into a validated Suggestion."""
     if not isinstance(item, dict):
@@ -841,7 +825,7 @@ def _parse_recommendations(content: Any, executed_commands: set) -> List[Suggest
     if not content:
         return []
 
-    text = _strip_code_fences(_extract_text_from_content(content))
+    text = _strip_code_fences(extract_text_from_content(content).strip())
 
     try:
         data = json.loads(text)

--- a/server/chat/background/summarization.py
+++ b/server/chat/background/summarization.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from celery_config import celery_app
@@ -14,39 +14,9 @@ from langchain_core.messages import HumanMessage
 from chat.backend.agent.providers import create_chat_model
 from chat.backend.agent.llm import ModelConfig
 from chat.backend.agent.utils.llm_usage_tracker import tracked_invoke
+from chat.backend.agent.utils.message_content import extract_text_from_content
 from utils.auth.stateless_auth import set_rls_context
 from utils.db.connection_pool import db_pool
-
-
-def _extract_text_from_response(content: Union[str, List[Any]]) -> str:
-    """Extract text content from LLM response, filtering out thinking blocks.
-
-    Gemini thinking models return content as a list with thinking and text blocks.
-    This extracts only the actual response text.
-    """
-    if isinstance(content, str):
-        return content.strip()
-
-    if isinstance(content, list):
-        text_parts = []
-        for part in content:
-            if isinstance(part, dict):
-                part_type = part.get("type", "")
-                if part_type in ("thinking", "reasoning"):
-                    continue
-                elif part_type == "text":
-                    text = part.get("text", "")
-                    if text:
-                        text_parts.append(str(text))
-                else:
-                    text = part.get("text", "")
-                    if text:
-                        text_parts.append(str(text))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        return "".join(text_parts).strip()
-
-    return str(content).strip()
 
 
 from chat.background.citation_extractor import (
@@ -638,11 +608,7 @@ def generate_incident_summary(
             request_type="incident_initial_summary",
         )
 
-        summary = (
-            _extract_text_from_response(response.content)
-            if response.content
-            else "No summary generated"
-        )
+        summary = extract_text_from_content(response.content).strip() or "No summary generated"
 
         logger.info(
             f"{_LOG_PREFIX} Generated summary for incident {incident_id} ({len(summary)} chars)"
@@ -811,11 +777,7 @@ def generate_incident_summary_from_chat(
             model_name=ModelConfig.EMAIL_REPORT_MODEL,
             request_type="incident_rca_summary",
         )
-        summary = (
-            _extract_text_from_response(response.content)
-            if response.content
-            else "No summary generated"
-        )
+        summary = extract_text_from_content(response.content).strip() or "No summary generated"
 
         logger.info(
             f"{_LOG_PREFIX} Generated chat-based summary for incident {incident_id} ({len(summary)} chars)"

--- a/server/chat/background/task.py
+++ b/server/chat/background/task.py
@@ -24,6 +24,7 @@ from connectors.slack_connector.client import get_slack_client_for_user
 from utils.db.connection_pool import db_pool
 from chat.background.visualization_generator import update_visualization
 from chat.backend.constants import MAX_TOOL_OUTPUT_CHARS, INFRASTRUCTURE_TOOLS
+from chat.backend.agent.utils.message_content import extract_text_from_content
 
 
 logger = logging.getLogger(__name__)
@@ -1895,21 +1896,7 @@ Respond with ONLY ONE WORD: critical, high, medium, or low"""
                 # Safely extract content from response - handle both AIMessage and dict responses
                 # Also handle Gemini thinking model responses (list with thinking/text blocks)
                 if hasattr(response, 'content'):
-                    content = response.content
-                    if isinstance(content, list):
-                        text_parts = []
-                        for part in content:
-                            if isinstance(part, dict):
-                                part_type = part.get("type", "")
-                                if part_type not in ("thinking", "reasoning"):
-                                    text = part.get("text", "")
-                                    if text:
-                                        text_parts.append(str(text))
-                            elif isinstance(part, str):
-                                text_parts.append(part)
-                        severity_raw = "".join(text_parts).strip().lower()
-                    else:
-                        severity_raw = str(content).strip().lower()
+                    severity_raw = extract_text_from_content(response.content).strip().lower()
                 elif isinstance(response, dict):
                     severity_raw = str(response.get('content', '')).strip().lower()
                 else:

--- a/server/routes/github/github_repo_metadata.py
+++ b/server/routes/github/github_repo_metadata.py
@@ -11,30 +11,13 @@ the row (no retry — re-auth is a user action, not a transient failure).
 import base64
 import json
 import logging
-from typing import Any, List, Union
+from typing import Any
 import requests
 from celery_config import celery_app
+from chat.backend.agent.utils.message_content import extract_text_from_content
 
 logger = logging.getLogger(__name__)
 
-
-def _extract_text_from_response(content: Union[str, List[Any]]) -> str:
-    """Extract text from a LangChain AIMessage content payload."""
-    if isinstance(content, str):
-        return content.strip()
-    if isinstance(content, list):
-        text_parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict):
-                if part.get("type") in ("thinking", "reasoning"):
-                    continue
-                text = part.get("text", "")
-                if text:
-                    text_parts.append(str(text))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        return "".join(text_parts).strip()
-    return str(content).strip()
 
 METADATA_PROMPT = (
     "Write a 2-3 sentence summary of this GitHub repository. "
@@ -182,9 +165,7 @@ def generate_repo_metadata(self, user_id: str, repo_full_name: str):
             request_type="github_repo_metadata",
         )
 
-        summary = _extract_text_from_response(response.content) if response.content else "No summary generated"
-        if not summary:
-            summary = "No summary generated"
+        summary = extract_text_from_content(response.content).strip() or "No summary generated"
         _update_metadata(user_id, repo_full_name, summary, "ready")
         logger.info(f"Metadata generated for {repo_full_name} via {auth.method}")
 

--- a/server/tests/chat/test_extract_text_from_content.py
+++ b/server/tests/chat/test_extract_text_from_content.py
@@ -1,0 +1,72 @@
+"""The shared text extractor must flatten every content shape LangChain hands back.
+
+``tests/fixtures/gemini_thinking_responses.json`` holds four real gemini-3.6-flash
+responses captured through Aurora's google provider with thinking on: the exact
+payloads the recommender stages receive on a Gemini deployment (Bombora).
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from chat.backend.agent.utils.message_content import extract_text_from_content
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "gemini_thinking_responses.json"
+
+
+def _gemini_responses() -> list[dict]:
+    return json.loads(_FIXTURE.read_text())["responses"]
+
+
+@pytest.mark.parametrize("response", _gemini_responses(), ids=lambda r: r["stage"])
+def test_real_gemini_thinking_responses_yield_the_text_block_only(response):
+    content = response["content"]
+    thinking_block, text_block = content
+    assert thinking_block["type"] == "thinking" and text_block["type"] == "text"
+
+    result = extract_text_from_content(content)
+
+    assert result == text_block["text"]
+    assert thinking_block["thinking"][:40] not in result
+
+
+def test_include_thinking_keeps_thought_text_in_stream_order():
+    thinking_block, text_block = _gemini_responses()[0]["content"]
+    result = extract_text_from_content([thinking_block, text_block], include_thinking=True)
+    assert result == thinking_block["thinking"] + text_block["text"]
+
+
+def test_openai_reasoning_summary_only_when_requested():
+    content = [
+        {"type": "reasoning", "summary": [{"type": "summary_text", "text": "Plan: "}, {"summary_text": "check pods. "}]},
+        {"type": "text", "text": "Restart the pod."},
+    ]
+    assert extract_text_from_content(content) == "Restart the pod."
+    assert extract_text_from_content(content, include_thinking=True) == "Plan: check pods. Restart the pod."
+
+
+def test_string_content_is_returned_untouched():
+    assert extract_text_from_content("  keep my spaces  ") == "  keep my spaces  "
+
+
+def test_none_and_empty_list_yield_empty_string():
+    assert extract_text_from_content(None) == ""
+    assert extract_text_from_content([]) == ""
+
+
+def test_thinking_only_content_yields_empty_string():
+    assert extract_text_from_content([{"type": "thinking", "thinking": "only thoughts"}]) == ""
+
+
+def test_string_parts_and_untyped_text_blocks_are_kept():
+    content = ["a", {"text": "b"}, {"type": "text", "text": "c"}]
+    assert extract_text_from_content(content) == "abc"
+
+
+def test_blocks_without_text_are_ignored():
+    content = [{"type": "image_url", "image_url": {"url": "data:..."}}, 42, None, {"type": "text", "text": "x"}]
+    assert extract_text_from_content(content) == "x"
+
+
+def test_non_string_non_list_content_is_stringified():
+    assert extract_text_from_content(123) == "123"

--- a/server/tests/chat/test_recommender_thinking_content.py
+++ b/server/tests/chat/test_recommender_thinking_content.py
@@ -1,0 +1,117 @@
+"""The four recommender LLM stages must parse Gemini thinking-mode list content.
+
+Review of PR #612 flagged four ``str(response.content)`` call sites in
+``chat/background/recommender.py``. On Gemini thinking models (google/vertex
+providers, ``include_thoughts`` on) ``response.content`` is a list of blocks, so
+``str()`` of it is a Python repr: ``json.loads`` rejects it and the enrichment /
+summary regexes never match. Two stages logged a warning and returned nothing;
+the other two failed silently. The fixture holds the real gemini-3.6-flash
+responses each stage received on 2026-09-08 (see tests/fixtures/).
+"""
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from chat.background import recommender as R
+from chat.background.citation_extractor import Citation
+from chat.background.suggestion_extractor import Suggestion
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "gemini_thinking_responses.json"
+_RESPONSES = {r["stage"]: r["content"] for r in json.loads(_FIXTURE.read_text())["responses"]}
+
+_CREATE = "chat.backend.agent.providers.create_chat_model"
+
+# _extract_hypotheses skips the LLM call for reasoning under 100 characters.
+_REASONING = """Alert: checkout-api p99 latency > 2s. Pod status [1]: 2 of 3 replicas in CrashLoopBackOff.
+Pod logs [2] show OOMKilled events in the last 30 minutes. Deployment spec [3] has memory limit 256Mi,
+while commit abc123 [4] bumped the in-memory cache from 100MB to 400MB. RDS metrics [5] are normal, so a
+database slowdown is ruled out. The ALB target group was not inspected. Root cause confirmed: the memory
+limit is too low for the new cache size; mitigation is a rollback of abc123 or raising the limit to 768Mi."""
+_TRACKED = "chat.backend.agent.utils.llm_usage_tracker.tracked_invoke"
+
+
+def _llm_returning(content):
+    llm = MagicMock(name="llm")
+    llm.invoke.return_value = SimpleNamespace(content=content)
+    return llm
+
+
+def _text_block(stage: str) -> str:
+    return _RESPONSES[stage][1]["text"]
+
+
+def _suggestions() -> list[Suggestion]:
+    return [
+        Suggestion(
+            title="Raise checkout-api memory limit to 768Mi",
+            description="validation: OOMKilled x14 in 30m; limit 256Mi",
+            type="remediate", risk="medium",
+            command="kubectl set resources deploy/checkout-api -n checkout --limits=memory=768Mi",
+            rationale="pods OOMKilled after cache bump in abc123",
+        ),
+        Suggestion(
+            title="Roll back commit abc123",
+            description="validation: cache size 100MB->400MB in abc123",
+            type="mitigation", risk="low",
+            command="git revert abc123",
+            rationale="commit introduced the memory growth",
+        ),
+    ]
+
+
+def test_hypothesis_extraction_reads_the_text_block():
+    expected = json.loads(R._strip_code_fences(_text_block("hypothesis_extraction")))
+
+    with patch(_CREATE, return_value=_llm_returning(_RESPONSES["hypothesis_extraction"])):
+        state = R._extract_hypotheses(_REASONING)
+
+    assert len(state.hypotheses) == len(expected["hypotheses"]) >= 1
+    assert len(state.ruled_out) == len(expected["ruled_out"]) >= 1
+    assert state.unexplored == expected["unexplored"]
+    assert any(h.status == "confirmed" for h in state.hypotheses)
+
+
+def test_self_exec_planning_reads_the_text_block():
+    planned = {c["command"] for c in json.loads(_text_block("self_exec_planning"))}
+    citations = [Citation(1, "kubectl", "kubectl get pods -n checkout", "CrashLoopBackOff", datetime.now(), "c1")]
+    executed: list[str] = []
+
+    def fake_exec(spec, user_id, session_id):
+        executed.append(spec["command"])
+        return {"command": spec["command"], "provider": spec.get("provider", "general"),
+                "output": "<stubbed>", "success": True, "rationale": spec.get("rationale", "")}
+
+    with patch(_CREATE, return_value=_llm_returning(_RESPONSES["self_exec_planning"])), \
+         patch.object(R, "_execute_single_diagnostic", side_effect=fake_exec):
+        results = R._self_execute_safe_diagnostics(citations=citations, user_id="user-1", session_id="sess-1")
+
+    assert 1 <= len(results) <= R._MAX_SELF_EXEC_CALLS
+    assert executed and set(executed) <= planned
+
+
+def test_fix_enrichment_applies_descriptions_and_summaries():
+    suggestions = _suggestions()
+
+    with patch(_CREATE, return_value=MagicMock(name="llm")), \
+         patch(_TRACKED, return_value=SimpleNamespace(content=_RESPONSES["fix_enrichment"])), \
+         patch.object(R, "_generate_summaries") as fallback:
+        R._enrich_validated_fixes(suggestions, "reasoning", "user-1", "sess-1")
+
+    fallback.assert_not_called()
+    assert suggestions[0].description.startswith("Pod logs [2] show OOMKilled")
+    assert suggestions[1].summary == "Restores the 100MB cache size so pods fit within the existing 256Mi limit."
+    assert all(s.summary for s in suggestions)
+    assert not any(s.description.startswith("validation:") for s in suggestions)
+
+
+def test_summary_generation_sets_one_line_summaries():
+    suggestions = _suggestions()
+
+    with patch(_CREATE, return_value=MagicMock(name="llm")), \
+         patch(_TRACKED, return_value=SimpleNamespace(content=_RESPONSES["summary_generation"])):
+        R._generate_summaries(suggestions, "user-1", "sess-1")
+
+    assert suggestions[0].summary == "Cache bump in abc123 exceeds 256Mi limit, causing 14 pod OOMKills in 30m."
+    assert suggestions[1].summary == "Expanding cache size to 400MB introduced severe memory growth across service instances."

--- a/server/tests/fixtures/gemini_thinking_responses.json
+++ b/server/tests/fixtures/gemini_thinking_responses.json
@@ -1,0 +1,73 @@
+{
+  "_captured": "2026-09-08, gemini-3.6-flash through Aurora's google provider with include_thoughts on, inside the celery worker (the four recommender.py LLM calls, synthetic OOM incident). Each 'content' is AIMessage.content verbatim except the opaque thought signature, which is shortened.",
+  "responses": [
+    {
+      "stage": "hypothesis_extraction",
+      "model": "gemini-3.6-flash",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "**My Approach to Hypothesis Extraction**\n\nOkay, so I need to extract hypothesis information from this text and present it as a JSON object, following a specific schema. The user hasn't asked for a Chain of Thought explanation, so I'll keep that internal. My primary focus is on ensuring a valid JSON output that accurately reflects the provided text and adheres to the required structure.\n\nFirst, I need to understand the structure of the JSON output. I've identified three key sections: `hypotheses`, `ruled_out`, and `unexplored`. The `hypotheses` section will contain confirmed hypotheses with high probability, including supporting and contradicting evidence, and a mitigation strategy. The `ruled_out` section will list the hypotheses that have been rejected, along with the reasoning. Lastly, the `unexplored` section will document the areas of investigation that were not pursued and the reasons for their omission.\n\nNow, let's process the provided text. I'll read through it carefully, identifying potential hypotheses, evidence, and rulings. The text describes a latency issue with a checkout API. Based on the logs and deployment spec, it appears that a recent code change increased the in-memory cache size, exceeding the memory limit, causing OOM kills and, consequently, high latency. I will confirm this hypothesis.\n\nAdditionally, I see a database slowdown was considered but ruled out based on normal RDS metrics. This will be added to the ruled-out hypotheses.\n\nFinally, an investigation into a potentially bad load balancer configuration was not completed due to time constraints, so this will be added to the unexplored section.\n\nWith this analysis complete, I'm ready to craft the JSON object, meticulously filling in the requested fields for each hypothesis and evidence with an emphasis on accuracy and adherence to the specified JSON schema.\n\n\n"
+        },
+        {
+          "type": "text",
+          "text": "```json\n{\n  \"hypotheses\": [\n    {\n      \"statement\": \"The memory limit in the deployment spec is too low for the increased cache size from commit abc123, causing OOM kills and driving p99 latency up.\",\n      \"probability\": \"high\",\n      \"supporting_evidence\": [\n        \"1\",\n        \"2\",\n        \"3\",\n        \"4\"\n      ],\n      \"contradicting_evidence\": [],\n      \"mitigation_class\": \"rollback\",\n      \"status\": \"confirmed\"\n    }\n  ],\n  \"ruled_out\": [\n    {\n      \"statement\": \"Database slowdown causing latency spike.\",\n      \"probability\": \"low\",\n      \"supporting_evidence\": [],\n      \"contradicting_evidence\": [\n        \"5\"\n      ],\n      \"mitigation_class\": \"unknown\",\n      \"status\": \"ruled_out\"\n    }\n  ],\n  \"unexplored\": [\n    \"Bad load balancer config was not investigated because there was no time to inspect the ALB target group.\"\n  ]\n}\n```",
+          "extras": {
+            "signature": "EpkYCpYYARFNMg+h3rvcKCXx...<shortened>"
+          }
+        }
+      ]
+    },
+    {
+      "stage": "self_exec_planning",
+      "model": "gemini-3.6-flash",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "**Diagnostic Command Generation Process**\n\nOkay, here's how I approached generating these diagnostic commands. First, I needed to understand the goal: provide a JSON array of up to five safe, read-only commands that would be useful in investigating this `CrashLoopBackOff` pod.\n\nI started by analyzing the available evidence: the pod is `OOMKilled`, and its memory limit is set to 256Mi. This suggested memory exhaustion as the root cause, but I needed more information to confirm and understand the *why*.\n\nThis led me to identify the gaps in the existing information. I needed to know the resource usage of the pod *now* and the general resource health of the node it's running on, along with more details about what's *actually* happening within that pod.\n\nTo fill these gaps, I formulated some candidate commands. Based on the initial evidence, the most valuable commands would be ones that:\n*   give me the full pod description (`describe pod`),\n*   show me current resource usage (`top pod` and `top nodes`),\n*   give events from the namespace (`get events`),\n*   and, check overall node conditions (`get nodes` and `describe node`).\n\nI then filtered and refined these commands, keeping only the most essential and the ones most directly relevant to the OOMKill issue. These will give the best value and are safe and read-only. I ended up with these, since they provide the most detailed insight, covering pod-level events, recent namespace events and resource usage.\n\nFinally, I formatted the output as a JSON array, ensuring that each object contains a `command`, a `provider`, and a `rationale` key, as specified in the instructions. I also checked that the commands were safe, read-only, not duplicates, and within the five-command limit.\n```json\n[\n  {\n    \"command\": \"kubectl describe pod checkout-api-7d9 -n checkout\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Reveals detailed pod state, restart count, specific exit codes, and recent pod-level events.\"\n  },\n  {\n    \"command\": \"kubectl get events -n checkout --sort-by='.metadata.creationTimestamp'\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Shows a chronological timeline of cluster events in the namespace to correlate the OOM kill with other cluster activity.\"\n  },\n  {\n    \"command\": \"kubectl top pod -n checkout\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Provides current memory and CPU usage metrics for active pods in the checkout namespace.\"\n  },\n  {\n    \"command\": \"kubectl top nodes\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Determines if cluster nodes are experiencing overall memory pressure that might affect scheduling or performance.\"\n  }\n]\n```\n\n\n"
+        },
+        {
+          "type": "text",
+          "text": "[\n  {\n    \"command\": \"kubectl describe pod checkout-api-7d9 -n checkout\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Reveals detailed pod execution status, exact exit codes, restart counts, and pod-specific event history.\"\n  },\n  {\n    \"command\": \"kubectl get events -n checkout --sort-by='.metadata.creationTimestamp'\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Provides a chronological timeline of recent namespace events, helping correlate the OOM kill with other cluster activities.\"\n  },\n  {\n    \"command\": \"kubectl top pod -n checkout\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Displays real-time CPU and memory usage across pods in the checkout namespace to identify high memory consumers.\"\n  },\n  {\n    \"command\": \"kubectl top nodes\",\n    \"provider\": \"kubectl\",\n    \"rationale\": \"Checks whether cluster nodes are experiencing overall memory pressure that could impact pod execution.\"\n  }\n]",
+          "extras": {
+            "signature": "EoohCochARFNMg/GzPrzfsYR...<shortened>"
+          }
+        }
+      ]
+    },
+    {
+      "stage": "fix_enrichment",
+      "model": "gemini-3.6-flash",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "**Incident Remediation: Synthesizing Solutions**\n\nOkay, so the goal is clear: I need to generate incident remediation descriptions and concise summaries for two specific suggestions, formatted precisely as requested. It's a structured task.\n\nI've got this context: an alert indicating high checkout-api latency. The investigation points to pods being OOMKilled, directly linked to a recent commit (abc123) that drastically increased the in-memory cache size, exceeding the existing memory limits. RDS/DB is ruled out as the culprit. I need to use the evidence and reference numbers provided [1], [2], [3], [4], and [5].\n\nNow, for each suggestion, I need to craft a short description that clearly articulates the problem and why the suggested fix resolves it, referencing the relevant evidence. I then need to provide a succinct summary – no more than 15 words – that captures the core \"why\" of the solution beyond just the title.\n\nFor Suggestion 1 (\"Raise checkout-api memory limit to 768Mi\"), my initial draft is solid, but I need to ensure it's tight. The description emphasizes the OOMKilled pods due to the increased cache size exceeding the memory limit. The summary needs to go beyond the title and explain that the new memory is required for the new cache size.\n\nFor Suggestion 2 (\"Roll back commit abc123\"), the same process. The description highlights the memory increase and resulting pod crashes. The summary should drive home that we need to restore memory for the pods to fit into existing limits.\n\nAfter refinement, I'm confident in these descriptions and summaries. I've checked and double-checked the format, sentence count, word limits, and evidence references. I can now present the requested output.\n\n\n"
+        },
+        {
+          "type": "text",
+          "text": "1. DESCRIPTION: Pod logs [2] show OOMKilled events because commit abc123 [4] increased the cache size to 400MB against a 256Mi deployment limit [3], causing 2 of 3 replicas to crash [1]. Raising the limit to 768Mi gives the pods enough headroom for the larger cache, stopping the crashes and resolving high p99 latency.\n   SUMMARY: Prevents OOM crashes by providing enough headroom for the enlarged 400MB cache.\n\n2. DESCRIPTION: Commit abc123 [4] expanded the in-memory cache to 400MB, exceeding the 256Mi resource limit [3] and triggering OOMKilled crashes [2] that reduced replica capacity [1]. Reverting this commit reduces cache memory usage back to 100MB, stabilizing the pods within current resource limits.\n   SUMMARY: Restores the 100MB cache size so pods fit within the existing 256Mi limit.",
+          "extras": {
+            "signature": "EuIkCt8kARFNMg/DQ/ilYv8H...<shortened>"
+          }
+        }
+      ]
+    },
+    {
+      "stage": "summary_generation",
+      "model": "gemini-3.6-flash",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "**My Thought Process: Summarizing Memory Issues**\n\nOkay, here's how I'm approaching this. I've got two titles describing memory problems, each linked to a specific change. The task is to concisely explain the \"why\" behind each one, staying under fifteen words per summary and avoiding repetition of the title's action.\n\nFirst, I dissect the requirements: One line, focus on the cause, avoid repeating the action. Now, the first title: \"Raise checkout-api memory limit to 768Mi.\" The details mention OOMKills after a cache bump in commit \"abc123.\" So, the critical point is that the cache increase from \"abc123\" is triggering the OOMs because its exceeding the existing limit. I'll frame it like this: \"Cache bump in abc123 exceeds 256Mi limit, causing 14 pod OOMKills in 30m.\" That hits the \"why,\" avoids the action, and keeps it within the word limit.\n\nNext up, \"Roll back commit abc123.\" The details point out a cache size increase from 100MB to 400MB. The key here is the cache expansion itself. My first thought is: \"Cache size expanded from 100MB to 400MB, triggering uncontrolled pod memory growth.\" I can tighten this. Let's try, \"Expanding cache capacity to 400MB introduced massive memory growth across pods.\" Still the essential cause and under 15 words.\n\nOkay, time for a final check: Both summaries are one line, identify the root cause, and don't repeat the action from the titles. Word counts are good. Let's finalize it!\n\n\n"
+        },
+        {
+          "type": "text",
+          "text": "1. Cache bump in abc123 exceeds 256Mi limit, causing 14 pod OOMKills in 30m.\n2. Expanding cache size to 400MB introduced severe memory growth across service instances.",
+          "extras": {
+            "signature": "ErcYCrQYARFNMg8/CxDU4PQE...<shortened>"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/server/utils/notifications/dispatcher.py
+++ b/server/utils/notifications/dispatcher.py
@@ -254,14 +254,8 @@ One-line summary:"""
         )
 
         if response and response.content:
-            content = response.content
-            if isinstance(content, list):
-                content = " ".join(
-                    str(p.get("text") or "") if isinstance(p, dict) else str(p)
-                    for p in content
-                    if not (isinstance(p, dict) and p.get("type") in ("thinking", "reasoning"))
-                )
-            summary = " ".join(str(content).split())
+            from chat.backend.agent.utils.message_content import extract_text_from_content
+            summary = " ".join(extract_text_from_content(response.content).split())
             if summary:
                 return summary[:300]
         return None

--- a/server/utils/repo_metadata.py
+++ b/server/utils/repo_metadata.py
@@ -220,7 +220,7 @@ def _generate_summary(user_id: str, context: str) -> str:
     from chat.backend.agent.utils.llm_usage_tracker import tracked_invoke
     from langchain_core.messages import HumanMessage
     from utils.hooks import get_hook
-    from chat.background.summarization import _extract_text_from_response
+    from chat.backend.agent.utils.message_content import extract_text_from_content
 
     # Hook: check if LLM call is allowed
     from utils.auth.stateless_auth import get_org_id_for_user
@@ -243,8 +243,8 @@ def _generate_summary(user_id: str, context: str) -> str:
         request_type="repo_metadata",
     )
     # Gemini thinking models return content as a list of thinking/text blocks;
-    # the helper drops the thinking blocks and returns the text (str content passes through).
-    summary = _extract_text_from_response(response.content) if response.content else ""
+    # the shared helper drops the thinking blocks and returns the text (str content passes through).
+    summary = extract_text_from_content(response.content).strip()
     return summary or "No summary generated"
 
 


### PR DESCRIPTION
Follow-up to #612, addressing both review comments there: the four `str(response.content)` sites in `recommender.py` ([comment](https://github.com/Arvo-AI/aurora/pull/612#issuecomment-5585108128)) and the four copies of the text-extraction helper ([comment](https://github.com/Arvo-AI/aurora/pull/612#discussion_r3957975878)).

Stacked on the #612 branch so the diff shows only these two commits. Once #612 is squash-merged I'll rebase this onto `main` (the first commit edits the import line #612 added).

## What changed

**Commit 1 – one shared helper.** `chat/backend/agent/utils/message_content.py` exposes `extract_text_from_content(content, include_thinking=False)`. The four copies (`summarization.py`, `routes/github/github_repo_metadata.py`, `recommender.py`, `workflow.py`) and the three inline re-implementations (`task.py` severity, `llm.py` tool-output summarizer, `notifications/dispatcher.py`) now import it. The module is dependency-free, so `utils/repo_metadata.py` no longer pulls the Celery/background-chat stack in just to get a 25-line function (the #612 import did). Behavior is the `workflow.py` superset (thinking flag, OpenAI reasoning summaries) with two corrections: `None` → `""` instead of the string `"None"`, and no stripping inside the helper (streamed chunks concatenate safely; callers strip). Summary call sites fall back to `"No summary generated"` on thinking-only content instead of storing `""`.

**Commit 2 – the four recommender stages.** `_extract_hypotheses`, `_self_execute_safe_diagnostics`, `_enrich_validated_fixes`, `_generate_summaries` go through the helper. On Gemini thinking models (google/vertex providers, `include_thoughts` on) `response.content` is a list of thinking/text blocks and `str()` of it is a Python repr: the two JSON stages logged a warning and returned nothing, the two regex stages failed silently. Net effect on a Gemini deployment: empty hypothesis ledger and no self-executed diagnostics on every RCA, and no card summaries.

## Tests

- `tests/fixtures/gemini_thinking_responses.json`: four real gemini-3.6-flash responses captured through the google provider (thinking on), one per recommender stage.
- `tests/chat/test_extract_text_from_content.py`: every content shape (Gemini list, OpenAI reasoning summaries, plain string, None, thinking-only, mixed parts).
- `tests/chat/test_recommender_thinking_content.py`: replays the captured responses through each of the four stages. All four fail on the previous code.
- Full suite: 1383 passed, 6 skipped (pre-existing skips for optional packages).

## Verification on real models (local prod-local stack, branch code hash-verified in all containers)

| Run | Result |
|---|---|
| 4 Gemini calls, unfixed code (google provider, gemini-3.6-flash, thinking on) | 0 hypotheses / 0 diagnostics / enrichment and summaries silent no-ops, with the JSON error `Expecting property name enclosed in double quotes: line 1 column 3` |
| Same 4 calls, fixed code | 1 hypothesis (confirmed) + 1 ruled out + 1 unexplored / 4 diagnostics planned / both descriptions+summaries applied / both summaries set |
| End-to-end RCA on Gemini (main, RCA and enrichment on gemini-3.6-flash) | `[Recommender] Extracted hypothesis ledger: 1 open, 2 ruled_out, 2 unexplored` · `Generated 3 recommendations … (hypotheses: 1 confirmed, 0 open \| self-exec: 4 commands)` · 3 cards with summaries |
| Bitbucket repo descriptions on Gemini (the #612 path, now via the shared helper) | 3 repos generated in ~9.5 s each, thinking on |
| End-to-end RCA on OpenRouter + claude-sonnet-4.6 (plain-string path through the six workflow call sites) | `Extracted hypothesis ledger: 2 open, 6 ruled_out, 7 unexplored` · `Generated 3 recommendations … (hypotheses: 2 confirmed, 0 open \| self-exec: 2 commands)` · 3 cards with summaries · 0 tracebacks |
| End-to-end RCA on OpenAI direct gpt-5.2 (Responses API reasoning blocks) | Started on the fixed code (`Enabled reasoning=high+summary=auto + use_responses_api=True for gpt-5.2`), cut short mid-investigation to free the laptop; the OpenAI reasoning shape is covered by the unit tests only |

## Out of scope, found during verification (separate tickets)

- The recommender's self-executed diagnostics can never run: `cloud_exec` resolves the provider from the agent's per-chat context, which the Celery task doesn't set, so every command returns `No cloud provider detected from context` immediately. Pre-existing, model-independent.
- The LLM command-safety judge hit its 10 s timeout 4 times on gemini-3.6-flash with thinking on (fails closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FsSywqQyhBfENUXf2bpex
