### PR TITLE
Port recurrence RCA search off weaviate (memory system)

### DIFF
--- a/server/services/correlation/recurrence_agent.py
+++ b/server/services/correlation/recurrence_agent.py
@@ -186,8 +186,96 @@ def make_submit_verdict_tool(captured: Dict[str, Any]):
     )
 
 
+def _search_similar_rcas_impl(
+    user_id: str,
+    query_title: str,
+    query_service: str = "",
+    source_type: str = "",
+    limit: int = 5,
+    min_score: float = 0.5,
+) -> list:
+    """Semantic search over this org's completed incident RCAs.
+
+    Replaces the deleted weaviate store (search_similar_good_rcas): reads
+    candidate incidents under RLS from the incidents table, then ranks them by
+    similarity of the query against each candidate's title/service using the
+    shared embedding client, with a Jaccard token fallback when EMBEDDING_MODEL
+    is unconfigured. Only incidents that actually completed an RCA
+    (aurora_summary present) are considered — that mirrors the old
+    "good RCA" corpus without needing a separate feedback store.
+    """
+    from services.correlation.strategies.similarity import SimilarityStrategy
+
+    limit = max(1, min(int(limit), 10))
+    strategy = SimilarityStrategy()
+
+    try:
+        with db_pool.get_admin_connection() as conn:
+            with conn.cursor() as cursor:
+                org_id = set_rls_context(cursor, conn, user_id, log_prefix=_LOG_PREFIX)
+                # No org context under RLS — return nothing rather than leak
+                # cross-tenant rows or error the whole recurrence check.
+                if not org_id:
+                    logger.warning(
+                        "%s[RLS-MISS] No org for user %s; skipping RCA search",
+                        _LOG_PREFIX, user_id,
+                    )
+                    return []
+
+                # Only incidents with a written conclusion are useful matches;
+                # merged incidents are excluded (their content lives on the root).
+                sql = """
+                    SELECT id, alert_title, alert_service, source_type, severity,
+                           aurora_summary
+                      FROM incidents
+                     WHERE status <> 'merged'
+                       AND aurora_summary IS NOT NULL
+                       AND aurora_summary <> ''
+                """
+                params: list = []
+                # Optional source_type narrowing keeps the candidate set cheap
+                # when the caller knows the alert source.
+                if source_type:
+                    sql += " AND source_type = %s"
+                    params.append(source_type)
+                sql += " ORDER BY COALESCE(analyzed_at, started_at) DESC LIMIT 200"
+                cursor.execute(sql, params)
+                rows = cursor.fetchall()
+    except Exception:
+        logger.exception("%s RCA search DB query failed", _LOG_PREFIX)
+        return []
+
+    scored = []
+    for r in rows:
+        cand_id, cand_title, cand_service, cand_source, cand_sev, cand_summary = r
+        if not cand_title:
+            continue
+        # Reuse the correlation SimilarityStrategy so RCA search and alert
+        # correlation score titles/services identically (embedding + fallback).
+        score = strategy.score(
+            alert_title=query_title,
+            alert_service=query_service or "",
+            incident_title=cand_title,
+            incident_services=[cand_service] if cand_service else [],
+        )
+        if score < min_score:
+            continue
+        scored.append({
+            "incident_id": str(cand_id),
+            "alert_title": cand_title or "",
+            "alert_service": cand_service or "",
+            "source_type": cand_source or "",
+            "severity": cand_sev or "",
+            "aurora_summary": cand_summary or "",
+            "similarity": round(float(score), 3),
+        })
+
+    scored.sort(key=lambda x: x["similarity"], reverse=True)
+    return scored[:limit]
+
+
 def make_search_similar_rcas_tool(user_id: str):
-    """StructuredTool over search_similar_good_rcas: semantic search across the
+    """StructuredTool over past-incident RCA search: semantic search across the
     org's past investigations, returning incident_id + similarity."""
     from langchain_core.tools import StructuredTool
     from pydantic import BaseModel, Field
@@ -208,19 +296,30 @@ def make_search_similar_rcas_tool(user_id: str):
         source_type: str = "",
         limit: int = 5,
     ) -> str:
-        # TODO(memory-system merge): semantic RCA search was backed by the
-        # deleted weaviate store (routes.incident_feedback.weaviate_client
-        # .search_similar_good_rcas). Re-implement on top of services/memory
-        # + services.correlation.embedding_client, then restore real results.
-        # Until then return an empty, well-formed result: the recurrence agent
-        # still runs (fold/clamp/verdict logic is intact) and falls back to
-        # list_incidents/get_incident, it just loses semantic similarity search.
-        logger.warning(
-            "%s search_similar_rcas is stubbed (weaviate removed in "
-            "memory-system merge); returning no results",
-            _LOG_PREFIX,
-        )
-        return json.dumps({"results": []})
+        try:
+            results = _search_similar_rcas_impl(
+                user_id,
+                query_title,
+                query_service,
+                source_type,
+                limit=limit,
+                min_score=0.5,
+            )
+            # Trim summaries to keep the agent's context small; it can call
+            # get_incident for the full conclusion of any candidate.
+            out = [
+                {
+                    "incident_id": r.get("incident_id", ""),
+                    "alert_title": r.get("alert_title", ""),
+                    "alert_service": r.get("alert_service", ""),
+                    "similarity": r.get("similarity"),
+                    "summary": (r.get("aurora_summary") or "")[:600],
+                }
+                for r in results
+            ]
+            return json.dumps({"results": out})
+        except Exception as e:
+            return json.dumps({"error": f"search failed: {e}"})
 
     return StructuredTool.from_function(
         func=search_similar_rcas,
@@ -508,8 +607,9 @@ async def _run_agent(
     ]
 
     postgres_client = PostgreSQLClient()
-    # NOTE(memory-system merge): Agent no longer takes a weaviate_client — the
-    # weaviate store was removed on this branch. Constructed with postgres only.
+    # NOTE: Agent takes postgres only on this branch — the weaviate store was
+    # removed; RCA similarity search now runs via _search_similar_rcas_impl
+    # (incidents table + embedding_client) exposed as make_search_similar_rcas_tool.
     try:
         agent = Agent(
             postgres_client=postgres_client,

--- a/server/tests/services/correlation/test_recurrence_rca_search.py
+++ b/server/tests/services/correlation/test_recurrence_rca_search.py
@@ -1,0 +1,97 @@
+"""_search_similar_rcas_impl: DB candidate fetch + similarity ranking.
+
+The embedding-backed SimilarityStrategy is patched to a deterministic scorer so
+these tests exercise the query construction, RLS handling, filtering, sorting
+and limiting without needing a real DB or embedding provider.
+"""
+
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_server_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+if os.path.abspath(_server_dir) not in sys.path:
+    sys.path.insert(0, os.path.abspath(_server_dir))
+
+import services.correlation.recurrence_agent as ra  # noqa: E402
+
+
+def _mk_row(title, service="api", source="datadog", severity="high", summary="rca"):
+    return (str(uuid.uuid4()), title, service, source, severity, summary)
+
+
+@pytest.fixture
+def db(monkeypatch):
+    """Patch db_pool + set_rls_context; return the cursor mock for assertions."""
+    cursor = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+    conn.cursor.return_value.__exit__.return_value = False
+    pool = MagicMock()
+    pool.get_admin_connection.return_value.__enter__.return_value = conn
+    pool.get_admin_connection.return_value.__exit__.return_value = False
+    monkeypatch.setattr(ra, "db_pool", pool)
+    monkeypatch.setattr(ra, "set_rls_context", lambda c, cn, u, log_prefix="": "org-1")
+    return cursor
+
+
+def _patch_strategy(monkeypatch, score_by_title):
+    """Make SimilarityStrategy.score return a lookup by candidate title."""
+    from services.correlation.strategies import similarity as sim
+
+    def _score(self, alert_title, alert_service, incident_title, incident_services):
+        return score_by_title.get(incident_title, 0.0)
+
+    monkeypatch.setattr(sim.SimilarityStrategy, "score", _score)
+
+
+class TestSearchSimilarRcas:
+    def test_rls_miss_returns_empty(self, db, monkeypatch):
+        monkeypatch.setattr(ra, "set_rls_context", lambda c, cn, u, log_prefix="": None)
+        out = ra._search_similar_rcas_impl("u1", "High CPU")
+        assert out == []
+        db.execute.assert_not_called()
+
+    def test_filters_below_min_score(self, db, monkeypatch):
+        db.fetchall.return_value = [_mk_row("High CPU on api"), _mk_row("Unrelated disk alert")]
+        _patch_strategy(monkeypatch, {"High CPU on api": 0.9, "Unrelated disk alert": 0.1})
+        out = ra._search_similar_rcas_impl("u1", "High CPU", min_score=0.5)
+        assert [r["alert_title"] for r in out] == ["High CPU on api"]
+        assert out[0]["similarity"] == 0.9
+
+    def test_sorts_desc_and_limits(self, db, monkeypatch):
+        rows = [_mk_row("a"), _mk_row("b"), _mk_row("c")]
+        db.fetchall.return_value = rows
+        _patch_strategy(monkeypatch, {"a": 0.6, "b": 0.95, "c": 0.7})
+        out = ra._search_similar_rcas_impl("u1", "q", min_score=0.5, limit=2)
+        assert [r["alert_title"] for r in out] == ["b", "c"]
+
+    def test_source_type_narrows_query(self, db, monkeypatch):
+        db.fetchall.return_value = []
+        _patch_strategy(monkeypatch, {})
+        ra._search_similar_rcas_impl("u1", "q", source_type="datadog")
+        sql, params = db.execute.call_args.args
+        assert "source_type = %s" in sql
+        assert params == ["datadog"]
+
+    def test_no_source_type_omits_filter(self, db, monkeypatch):
+        db.fetchall.return_value = []
+        _patch_strategy(monkeypatch, {})
+        ra._search_similar_rcas_impl("u1", "q")
+        sql, params = db.execute.call_args.args
+        assert "source_type = %s" not in sql
+        assert params == []
+
+    def test_skips_candidates_without_title(self, db, monkeypatch):
+        db.fetchall.return_value = [_mk_row(""), _mk_row("Real incident")]
+        _patch_strategy(monkeypatch, {"Real incident": 0.8})
+        out = ra._search_similar_rcas_impl("u1", "q", min_score=0.5)
+        assert [r["alert_title"] for r in out] == ["Real incident"]
+
+    def test_db_exception_degrades_to_empty(self, db, monkeypatch):
+        db.execute.side_effect = RuntimeError("boom")
+        _patch_strategy(monkeypatch, {})
+        assert ra._search_similar_rcas_impl("u1", "q") == []


### PR DESCRIPTION
## Context
The `main` → `feat/memory-system` merge (PR #556 / the merge commit) left one functional stub: `search_similar_rcas` in the recurrence dedup agent returned no results because its weaviate backend was deleted. This PR restores it on the memory-system architecture.

**Merge target is `feat/memory-system`.** Please hold until someone verifies end-to-end recurrence detection works with the new similarity backend.

## What changed
- **`_search_similar_rcas_impl()`** (new): reads candidate incidents under RLS from the `incidents` table — only those with a written `aurora_summary`, excluding `merged` — and ranks them with the shared `SimilarityStrategy` (embedding cosine when `EMBEDDING_MODEL` is set, Jaccard token fallback otherwise). Same scoring path as alert correlation, so RCA search and correlation stay consistent.
- **`make_search_similar_rcas_tool()`**: now returns real matches (`incident_id` + `similarity` + trimmed summary). The agent can `get_incident` for full conclusions.
- **Safe degradation**: RLS-miss / DB error / empty corpus → `[]`, never raises — preserves `run_recurrence_check`'s never-raises contract.

## Difference vs the old weaviate path
- Old: semantic search over a separate weaviate "good RCA" corpus (feedback-gated).
- New: searches all completed-RCA incidents directly (no separate store, no feedback dependency). "Good RCA" ≈ "has an `aurora_summary`."

## Tests
- New `test_recurrence_rca_search.py` (7 tests): RLS-miss, min_score filter, sort+limit, source_type narrowing, missing-title skip, DB-exception degrade.
- Full suite green: **178** correlation + architectural tests pass.

## Verification checklist for the tester
- [ ] Set `RECURRENCE_DETECTION_MODE=shadow`, trigger a repeat incident, confirm a `recurrence_verdicts` row is written and `search_similar_rcas` surfaces the prior incident.
- [ ] Confirm behavior with `EMBEDDING_MODEL` set (cosine) vs unset (Jaccard fallback).
- [ ] Flip to `live` and confirm folding via `recurrence_of_incident_id`.

Made with [Cursor](https://cursor.com)