### PR TITLE
fix(cloudwatch): trigger RCA via build_rca_prompt (fixes ImportError, restores recurrence folding)

### DIFF
--- a/server/routes/aws/cloudwatch_tasks.py
+++ b/server/routes/aws/cloudwatch_tasks.py
@@ -406,8 +406,10 @@ def _post_incident_actions(
             logger.info("[CLOUDWATCH][ALARM] Skipping RCA — rate limited for user %s", user_id)
             return
 
-        from chat.background.rca_prompt_builder import build_cloudwatch_rca_prompt
-        rca_prompt, rail_text = build_cloudwatch_rca_prompt(payload, user_id=user_id)
+        from chat.background.rca_prompt_builder import build_rca_prompt
+        rca_prompt, rail_text = build_rca_prompt(
+            "cloudwatch", alarm_name, payload, user_id=user_id
+        )
         chat_title = f"RCA: {alarm_name}"
         session_id = create_background_chat_session(
             user_id=user_id,


### PR DESCRIPTION
## Problem

CloudWatch alarm ingestion never triggers RCA. In `server/routes/aws/cloudwatch_tasks.py::_post_incident_actions` the code imports and calls `build_cloudwatch_rca_prompt`, but `server/chat/background/rca_prompt_builder.py` only defines `build_rca_prompt`. Result:

```
[CLOUDWATCH][ALARM] Failed to trigger RCA: cannot import name 'build_cloudwatch_rca_prompt'
from 'chat.background.rca_prompt_builder'
ImportError: cannot import name 'build_cloudwatch_rca_prompt' ...
```

The incident still gets a lightweight summary, but **RCA never runs** — so the incident stays `status=investigating`/`aurora_status=idle`, and the post-RCA recurrence/folding step (`run_recurrence_check`, invoked after RCA in `summarization.py`) never fires. **Incident folding is therefore broken for the CloudWatch source.**

## Fix

Call the unified entry point `build_rca_prompt(source, title, payload, user_id=...)`, matching every other connector (grafana, datadog, sentry, pagerduty, jenkins, jira, spinnaker, newrelic, dynatrace, opsgenie, bigpanda, incidentio, splunk, netdata). For CloudWatch: `source='cloudwatch'`, `title=alarm_name`.

```python
from chat.background.rca_prompt_builder import build_rca_prompt
rca_prompt, rail_text = build_rca_prompt("cloudwatch", alarm_name, payload, user_id=user_id)
```

## Verification

Reproduced on live staging (chart `aurora-oss-1.2.21`): published a real CloudWatch-alarm SNS notification → incident created → summary generated → RCA trigger raised the ImportError above → recurrence never ran. With this change the caller matches `build_rca_prompt`'s signature so RCA (and downstream folding) proceed.

## Scope

One-line call-site fix; no behavior change for other sources.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CloudWatch alarm analysis to use the shared RCA prompt-building flow.
  * Preserved delivery of generated analysis to background chat processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->